### PR TITLE
scripts/pre-commit: check only staged files

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -3,7 +3,7 @@
 
 RET=0
 
-for file in `git diff --name-only`; do
+for file in `git diff --name-only --staged`; do
     ext=${file##*.}
     if [ "$ext" == "rs" ]; then
         rustfmt --unstable-features --check --edition 2021 --skip-children $file > /dev/null 2>&1


### PR DESCRIPTION
Without this files about to be commited are not checked, and unstaged files are checked, which is the opposite of what we want.