### PR TITLE
ImmutAfterInit: misuse runtime detection

### DIFF
--- a/src/console.rs
+++ b/src/console.rs
@@ -44,7 +44,7 @@ pub static WRITER: SpinLock<Console> = SpinLock::new(unsafe {
 static CONSOLE_INITIALIZED: ImmutAfterInitCell<bool> = ImmutAfterInitCell::new(false);
 
 pub fn init_console() {
-    unsafe { CONSOLE_INITIALIZED.reinit(&true) };
+    CONSOLE_INITIALIZED.reinit(&true);
 }
 
 #[doc(hidden)]
@@ -121,7 +121,9 @@ static CONSOLE_LOGGER: ImmutAfterInitCell<ConsoleLogger> = ImmutAfterInitCell::u
 
 pub fn install_console_logger(component: &'static str) {
     let logger = ConsoleLogger::new(component);
-    unsafe { CONSOLE_LOGGER.init(&logger) };
+    CONSOLE_LOGGER
+        .init(&logger)
+        .expect("Already initialized console logger");
 
     if let Err(e) = log::set_logger(&*CONSOLE_LOGGER) {
         // Failed to install the ConsoleLogger, presumably because something had

--- a/src/cpu/cpuid.rs
+++ b/src/cpu/cpuid.rs
@@ -35,7 +35,9 @@ pub struct SnpCpuidTable {
 }
 
 pub fn register_cpuid_table(table: &'static SnpCpuidTable) {
-    unsafe { CPUID_PAGE.init_from_ref(table) };
+    CPUID_PAGE
+        .init_from_ref(table)
+        .expect("Could not initialize CPUID page");
 }
 
 pub struct CpuidResult {

--- a/src/mm/address_space.rs
+++ b/src/mm/address_space.rs
@@ -15,18 +15,7 @@ struct KernelMapping {
     phys_start: PhysAddr,
 }
 
-impl KernelMapping {
-    pub const fn new() -> Self {
-        KernelMapping {
-            virt_start: VirtAddr::null(),
-            virt_end: VirtAddr::null(),
-            phys_start: PhysAddr::null(),
-        }
-    }
-}
-
-static KERNEL_MAPPING: ImmutAfterInitCell<KernelMapping> =
-    ImmutAfterInitCell::new(KernelMapping::new());
+static KERNEL_MAPPING: ImmutAfterInitCell<KernelMapping> = ImmutAfterInitCell::uninit();
 
 pub fn init_kernel_mapping_info(vstart: VirtAddr, vend: VirtAddr, pstart: PhysAddr) {
     let km = KernelMapping {

--- a/src/mm/address_space.rs
+++ b/src/mm/address_space.rs
@@ -23,9 +23,9 @@ pub fn init_kernel_mapping_info(vstart: VirtAddr, vend: VirtAddr, pstart: PhysAd
         virt_end: vend,
         phys_start: pstart,
     };
-    unsafe {
-        KERNEL_MAPPING.init(&km);
-    }
+    KERNEL_MAPPING
+        .init(&km)
+        .expect("Already initialized kernel mapping info");
 }
 
 #[cfg(not(test))]

--- a/src/mm/pagetable.rs
+++ b/src/mm/pagetable.rs
@@ -32,7 +32,7 @@ pub fn paging_init_early() {
     let mut feature_mask = PTEntryFlags::all();
     feature_mask.remove(PTEntryFlags::NX);
     feature_mask.remove(PTEntryFlags::GLOBAL);
-    unsafe { FEATURE_MASK.reinit(&feature_mask) };
+    FEATURE_MASK.reinit(&feature_mask);
 }
 
 pub fn paging_init() {
@@ -45,7 +45,7 @@ pub fn paging_init() {
     if !cpu_has_pge() {
         feature_mask.remove(PTEntryFlags::GLOBAL);
     }
-    unsafe { FEATURE_MASK.reinit(&feature_mask) };
+    FEATURE_MASK.reinit(&feature_mask);
 }
 
 fn init_encrypt_mask() {
@@ -53,7 +53,7 @@ fn init_encrypt_mask() {
     let res = cpuid_table(0x8000001f).expect("Can not get C-Bit position from CPUID table");
     let c_bit = res.ebx & 0x3f;
     let mask = 1u64 << c_bit;
-    unsafe { ENCRYPT_MASK.reinit(&(mask as usize)) };
+    ENCRYPT_MASK.reinit(&(mask as usize));
 
     // Find physical address size.
     let res = cpuid_table(0x80000008).expect("Can not get physical address size from CPUID table");
@@ -74,9 +74,7 @@ fn init_encrypt_mask() {
     let effective_phys_addr_size = cmp::min(c_bit, phys_addr_size);
 
     let max_addr = 1 << effective_phys_addr_size;
-    unsafe {
-        MAX_PHYS_ADDR.reinit(&max_addr);
-    }
+    MAX_PHYS_ADDR.reinit(&max_addr);
 
     // KVM currently sets all bits when executing the launch update for the
     // launch vCPU's VMSA, but the firmware will truncate the gPA to the limit
@@ -85,9 +83,7 @@ fn init_encrypt_mask() {
     // future. This can be removed once the patches for that land.
     let launch_vmsa_addr = (1u64 << phys_addr_size) - 0x1000;
     let launch_vmsa_addr = PhysAddr::from(launch_vmsa_addr);
-    unsafe {
-        LAUNCH_VMSA_ADDR.reinit(&launch_vmsa_addr);
-    }
+    LAUNCH_VMSA_ADDR.reinit(&launch_vmsa_addr);
 }
 
 fn encrypt_mask() -> usize {

--- a/src/sev/status.rs
+++ b/src/sev/status.rs
@@ -139,7 +139,9 @@ fn sev_flags() -> SEVStatusFlags {
 
 pub fn sev_status_init() {
     let status: SEVStatusFlags = read_sev_status();
-    unsafe { SEV_FLAGS.init(&status) };
+    SEV_FLAGS
+        .init(&status)
+        .expect("Already initialized SEV flags");
 }
 
 pub fn sev_es_enabled() -> bool {

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -327,12 +327,16 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: VirtAddr) {
     load_gdt();
     early_idt_init();
 
-    unsafe {
-        LAUNCH_INFO.init(li);
-    }
+    LAUNCH_INFO
+        .init(li)
+        .expect("Already initialized launch info");
 
     let cpuid_table_virt = VirtAddr::from(launch_info.cpuid_page);
-    unsafe { CPUID_PAGE.init(&*(cpuid_table_virt.as_ptr::<SnpCpuidTable>())) };
+    unsafe {
+        CPUID_PAGE
+            .init(&*(cpuid_table_virt.as_ptr::<SnpCpuidTable>()))
+            .expect("Already initialized CPUID page")
+    };
     register_cpuid_table(&CPUID_PAGE);
     dump_cpuid_table();
 

--- a/src/utils/immut_after_init.rs
+++ b/src/utils/immut_after_init.rs
@@ -67,7 +67,7 @@ pub enum ImmutAfterInitError {
 /// }
 /// ```
 ///
-pub struct ImmutAfterInitCell<T: Copy> {
+pub struct ImmutAfterInitCell<T> {
     #[doc(hidden)]
     data: UnsafeCell<MaybeUninit<T>>,
     // Used to keep track of the initialization state. Even though this
@@ -76,7 +76,7 @@ pub struct ImmutAfterInitCell<T: Copy> {
     init: AtomicBool,
 }
 
-impl<T: Copy> ImmutAfterInitCell<T> {
+impl<T> ImmutAfterInitCell<T> {
     /// Create an unitialized `ImmutAfterInitCell` instance. The value must get
     /// initialized by means of [`Self::init()`] before first usage.
     pub const fn uninit() -> Self {
@@ -159,7 +159,7 @@ impl<T: Copy> ImmutAfterInitCell<T> {
     }
 }
 
-impl<T: Copy> Deref for ImmutAfterInitCell<T> {
+impl<T> Deref for ImmutAfterInitCell<T> {
     type Target = T;
 
     /// Dereference the wrapped value. Must **only ever** get called on an
@@ -169,8 +169,8 @@ impl<T: Copy> Deref for ImmutAfterInitCell<T> {
     }
 }
 
-unsafe impl<T: Copy> Send for ImmutAfterInitCell<T> {}
-unsafe impl<T: Copy> Sync for ImmutAfterInitCell<T> {}
+unsafe impl<T> Send for ImmutAfterInitCell<T> {}
+unsafe impl<T> Sync for ImmutAfterInitCell<T> {}
 
 /// A reference to a memory location which is effectively immutable after
 /// initalization code has run.
@@ -296,7 +296,7 @@ impl<'a, T> ImmutAfterInitRef<'a, T> {
     }
 }
 
-impl<'a, T: Copy> ImmutAfterInitRef<'a, T> {
+impl<'a, T> ImmutAfterInitRef<'a, T> {
     /// Initialize an uninitialized `ImmutAfterInitRef` instance to point to
     /// value wrapped in a [`ImmutAfterInitCell`].
     ///


### PR DESCRIPTION
* Use `SyncUnsafeCell` instead of `UnsafeCell` + `unsafe impl Sync`.
* Pass Copy types by value in `ImmutAfterInitCell` methods.
* Remove a double initialization before implementing runtime detection of this condition.
* Back `ImmutAfterInitCell` by an `Option` in order to be able to detect uninitialized cells.
* Return `Result` from public API calls to handle double initialization and uninitialized access.