### PR TITLE
Stage2: Extract C-bit position from CPUID page

### DIFF
--- a/src/cpu/cpuid.rs
+++ b/src/cpu/cpuid.rs
@@ -36,7 +36,6 @@ pub struct SnpCpuidTable {
 
 pub fn register_cpuid_table(table: &'static SnpCpuidTable) {
     unsafe { CPUID_PAGE.init_from_ref(table) };
-    dump_cpuid_table();
 }
 
 pub struct CpuidResult {
@@ -71,7 +70,7 @@ pub fn cpuid_table(eax: u32) -> Option<CpuidResult> {
     cpuid_table_raw(eax, 0, 0, 0)
 }
 
-fn dump_cpuid_table() {
+pub fn dump_cpuid_table() {
     let count = CPUID_PAGE.count as usize;
 
     log::trace!("CPUID Table entry count: {}", count);

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -15,7 +15,7 @@ use core::arch::asm;
 use core::panic::PanicInfo;
 use log;
 use svsm::console::{init_console, install_console_logger, WRITER};
-use svsm::cpu::cpuid::{register_cpuid_table, SnpCpuidTable};
+use svsm::cpu::cpuid::{dump_cpuid_table, register_cpuid_table, SnpCpuidTable};
 use svsm::cpu::msr;
 use svsm::cpu::percpu::{this_cpu_mut, PerCpu};
 use svsm::fw_cfg::{FwCfg, MemoryRegion};
@@ -165,6 +165,7 @@ fn sev_ghcb_msr_available() -> Result<u64, ()> {
 fn setup_env() {
     install_console_logger("Stage2");
     init_kernel_mapping_info(0, 640 * 1024, 0);
+    register_cpuid_table(unsafe { &CPUID_PAGE });
 
     // Under SVM-ES, the only means to communicate with the user is through the
     // SVSMIOPort console, which requires a functional GHCB protocol. If the
@@ -197,10 +198,8 @@ fn setup_env() {
 
     // Console is fully working now and any unsupported configuration can be
     // properly reported.
+    dump_cpuid_table();
     sev_status_verify();
-
-    // At this point, SEV-SNP is confirmed. Register the supplied CPUID page.
-    register_cpuid_table(unsafe { &CPUID_PAGE });
 
     // At this point SEV-SNP is confirmed to be active and the CPUID table
     // should be available. Fully initialize the paging subsystem now. In

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -23,8 +23,8 @@ use svsm::kernel_launch::KernelLaunchInfo;
 use svsm::mm::alloc::{memory_info, print_memory_info, root_mem_init};
 use svsm::mm::init_kernel_mapping_info;
 use svsm::mm::pagetable::{
-    get_init_pgtable_locked, paging_init, paging_init_early, set_init_pgtable, PTEntryFlags,
-    PageTable, PageTableRef,
+    get_init_pgtable_locked, paging_init_early, set_init_pgtable, PTEntryFlags, PageTable,
+    PageTableRef,
 };
 use svsm::mm::validate::{init_valid_bitmap_alloc, valid_bitmap_addr, valid_bitmap_set_valid_2m};
 use svsm::serial::{SerialPort, DEFAULT_SERIAL_PORT, SERIAL_PORT};
@@ -200,12 +200,6 @@ fn setup_env() {
     // properly reported.
     dump_cpuid_table();
     sev_status_verify();
-
-    // At this point SEV-SNP is confirmed to be active and the CPUID table
-    // should be available. Fully initialize the paging subsystem now. In
-    // particular this verifies that the C-bit from the CPUID table matches what
-    // has been obtained above.
-    paging_init();
 }
 
 fn map_kernel_region(vaddr: VirtAddr, region: &MemoryRegion) -> Result<(), ()> {

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -175,7 +175,7 @@ fn setup_env() {
     // SVSMIOPort needs the GHCB initialized, which in turn requires the paging
     // subsystem to be in a tentative working state.
     match sev_ghcb_msr_available() {
-        Ok(encrypt_mask) => paging_init_early(encrypt_mask),
+        Ok(_) => paging_init_early(),
         Err(_) => {
             unsafe {
                 DEFAULT_SERIAL_PORT.init();

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -16,7 +16,7 @@ use core::panic::PanicInfo;
 use svsm::acpi::tables::load_acpi_cpu_info;
 use svsm::console::{init_console, install_console_logger, WRITER};
 use svsm::cpu::control_regs::{cr0_init, cr4_init};
-use svsm::cpu::cpuid::{register_cpuid_table, SnpCpuidTable};
+use svsm::cpu::cpuid::{register_cpuid_table, SnpCpuidTable, dump_cpuid_table};
 use svsm::cpu::efer::efer_init;
 use svsm::cpu::gdt::load_gdt;
 use svsm::cpu::idt::{early_idt_init, idt_init};
@@ -315,6 +315,7 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: VirtAddr) {
     let cpuid_table_virt = launch_info.cpuid_page as VirtAddr;
     unsafe { CPUID_PAGE.init(&*(cpuid_table_virt as *const SnpCpuidTable)) };
     register_cpuid_table(&CPUID_PAGE);
+    dump_cpuid_table();
 
     unsafe {
         let secrets_page_virt = launch_info.secrets_page as VirtAddr;


### PR DESCRIPTION
Previously the C-bit position was requested from the hypervisor by executing a SEV Information request via the GHCB MSR protocol. This allows a malicous host to feed us an incorrect value. Instead the C-bit position should be extracted from the CPUID page.