### PR TITLE
Improve error typing

### DIFF
--- a/src/cpu/percpu.rs
+++ b/src/cpu/percpu.rs
@@ -520,10 +520,15 @@ impl PerCpuVmsas {
             .any(|vmsa| vmsa.paddr == paddr)
     }
 
-    pub fn register(&self, paddr: PhysAddr, apic_id: u32, guest_owned: bool) -> Result<(), ()> {
+    pub fn register(
+        &self,
+        paddr: PhysAddr,
+        apic_id: u32,
+        guest_owned: bool,
+    ) -> Result<(), SvsmError> {
         let mut guard = self.vmsas.lock_write();
         if guard.iter().any(|vmsa| vmsa.paddr == paddr) {
-            return Err(());
+            return Err(SvsmError::InvalidAddress);
         }
 
         guard.push(VmsaRegistryEntry::new(paddr, apic_id, guest_owned));

--- a/src/cpu/percpu.rs
+++ b/src/cpu/percpu.rs
@@ -10,6 +10,7 @@ use super::gdt::load_tss;
 use super::tss::{X86Tss, IST_DF};
 use crate::cpu::tss::TSS_LIMIT;
 use crate::cpu::vmsa::init_guest_vmsa;
+use crate::error::SvsmError;
 use crate::locking::{LockGuard, RWLock, SpinLock};
 use crate::mm::alloc::{allocate_page, allocate_zeroed_page};
 use crate::mm::pagetable::{get_init_pgtable_locked, PageTable, PageTableRef};
@@ -196,7 +197,7 @@ impl PerCpu {
         }
     }
 
-    pub fn alloc(apic_id: u32) -> Result<*mut PerCpu, ()> {
+    pub fn alloc(apic_id: u32) -> Result<*mut PerCpu, SvsmError> {
         let vaddr = allocate_zeroed_page()?;
         unsafe {
             let percpu = vaddr as *mut PerCpu;
@@ -219,7 +220,7 @@ impl PerCpu {
         self.apic_id
     }
 
-    fn allocate_page_table(&mut self) -> Result<(), ()> {
+    fn allocate_page_table(&mut self) -> Result<(), SvsmError> {
         let pgtable_ref = get_init_pgtable_locked().clone_shared()?;
         self.set_pgtable(pgtable_ref);
         Ok(())
@@ -230,14 +231,14 @@ impl PerCpu {
         *my_pgtable = pgtable;
     }
 
-    fn allocate_init_stack(&mut self) -> Result<(), ()> {
+    fn allocate_init_stack(&mut self) -> Result<(), SvsmError> {
         allocate_stack_addr(SVSM_STACKS_INIT_TASK, &mut self.get_pgtable())
             .expect("Failed to allocate per-cpu init stack");
         self.init_stack = Some(SVSM_STACKS_INIT_TASK);
         Ok(())
     }
 
-    fn allocate_ist_stacks(&mut self) -> Result<(), ()> {
+    fn allocate_ist_stacks(&mut self) -> Result<(), SvsmError> {
         allocate_stack_addr(SVSM_STACK_IST_DF_BASE, &mut self.get_pgtable())
             .expect("Failed to allocate percpu double-fault stack");
 
@@ -249,14 +250,14 @@ impl PerCpu {
         self.pgtbl.lock()
     }
 
-    pub fn setup_ghcb(&mut self) -> Result<(), ()> {
+    pub fn setup_ghcb(&mut self) -> Result<(), SvsmError> {
         let ghcb_page = allocate_page().expect("Failed to allocate GHCB page");
         self.ghcb = ghcb_page as *mut GHCB;
-        unsafe { (*self.ghcb).init().map_err(|_| ()) }
+        unsafe { (*self.ghcb).init() }
     }
 
-    pub fn register_ghcb(&self) -> Result<(), ()> {
-        unsafe { self.ghcb.as_ref().unwrap().register().map_err(|_| ()) }
+    pub fn register_ghcb(&self) -> Result<(), SvsmError> {
+        unsafe { self.ghcb.as_ref().unwrap().register() }
     }
 
     pub fn get_top_of_stack(&self) -> VirtAddr {
@@ -267,7 +268,7 @@ impl PerCpu {
         self.tss.ist_stacks[IST_DF] = stack_base_pointer(self.ist.double_fault_stack.unwrap());
     }
 
-    pub fn map_self(&mut self) -> Result<(), ()> {
+    pub fn map_self(&mut self) -> Result<(), SvsmError> {
         let vaddr = (self as *const PerCpu) as VirtAddr;
         let paddr = virt_to_phys(vaddr);
         let flags = PageTable::data_flags();
@@ -275,7 +276,7 @@ impl PerCpu {
         self.get_pgtable().map_4k(SVSM_PERCPU_BASE, paddr, flags)
     }
 
-    pub fn setup(&mut self) -> Result<(), ()> {
+    pub fn setup(&mut self) -> Result<(), SvsmError> {
         // Allocate page-table
         self.allocate_page_table()?;
 
@@ -298,7 +299,7 @@ impl PerCpu {
     }
 
     // Setup code which needs to run on the target CPU
-    pub fn setup_on_cpu(&self) -> Result<(), ()> {
+    pub fn setup_on_cpu(&self) -> Result<(), SvsmError> {
         self.register_ghcb()
     }
 
@@ -315,12 +316,12 @@ impl PerCpu {
         self.load_tss();
     }
 
-    pub fn shutdown(&mut self) -> Result<(), ()> {
+    pub fn shutdown(&mut self) -> Result<(), SvsmError> {
         if self.ghcb == ptr::null_mut() {
             return Ok(());
         }
 
-        unsafe { (*self.ghcb).shutdown().map_err(|_| ()) }
+        unsafe { (*self.ghcb).shutdown() }
     }
 
     pub fn set_reset_ip(&mut self, reset_ip: u64) {
@@ -331,9 +332,10 @@ impl PerCpu {
         unsafe { self.ghcb.as_mut().unwrap() }
     }
 
-    pub fn alloc_svsm_vmsa(&mut self) -> Result<(), ()> {
+    pub fn alloc_svsm_vmsa(&mut self) -> Result<(), SvsmError> {
         if let Some(_) = self.svsm_vmsa {
-            return Err(());
+            // FIXME: add a more explicit error variant for this condition
+            return Err(SvsmError::Mem);
         }
 
         let vaddr = allocate_new_vmsa(RMPFlags::VMPL1)?;
@@ -362,7 +364,7 @@ impl PerCpu {
         self.get_pgtable().unmap_4k(SVSM_PERCPU_VMSA_BASE);
     }
 
-    pub fn map_guest_vmsa(&self, paddr: PhysAddr) -> Result<(), ()> {
+    pub fn map_guest_vmsa(&self, paddr: PhysAddr) -> Result<(), SvsmError> {
         assert!(self.apic_id == this_cpu().get_apic_id());
 
         let flags = PageTable::data_flags();
@@ -412,7 +414,7 @@ impl PerCpu {
         unsafe { (SVSM_PERCPU_VMSA_BASE as *mut VMSA).as_mut().unwrap() }
     }
 
-    pub fn alloc_guest_vmsa(&mut self) -> Result<(), ()> {
+    pub fn alloc_guest_vmsa(&mut self) -> Result<(), SvsmError> {
         let vaddr = allocate_new_vmsa(RMPFlags::VMPL1)?;
         let paddr = virt_to_phys(vaddr);
 
@@ -428,7 +430,7 @@ impl PerCpu {
         self.get_pgtable().unmap_4k(SVSM_PERCPU_CAA_BASE);
     }
 
-    pub fn map_guest_caa(&self, paddr: PhysAddr) -> Result<(), ()> {
+    pub fn map_guest_caa(&self, paddr: PhysAddr) -> Result<(), SvsmError> {
         self.unmap_caa();
 
         let paddr_aligned = page_align(paddr);

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,4 +23,6 @@ pub enum SvsmError {
     MissingCAA,
     // Invalid address, usually provided by the guest
     InvalidAddress,
+    // Errors related to firmware parsing
+    Firmware,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,24 @@
+use crate::sev::ghcb::GhcbError;
+use crate::sev::msr_protocol::GhcbMsrError;
+use crate::sev::SevSnpError;
+
+// As a general rule, functions private to a given module may use the
+// leaf error types. Public functions should return an SvsmError
+// containing a leaf error type, usually the one corresponding to
+// that module. We always provide a way to convert a leaf error into
+// a SvsmError via the From trait at the module level.
+#[derive(Clone, Copy, Debug)]
+pub enum SvsmError {
+    // Errors related to GHCB
+    Ghcb(GhcbError),
+    // Errors related to MSR protocol
+    GhcbMsr(GhcbMsrError),
+    // Errors related to SEV-SNP operations, like PVALIDATE or RMPUPDATE
+    SevSnp(SevSnpError),
+    // Errors related to memory management
+    Mem,
+    // There is no VMSA
+    MissingVMSA,
+    // There is no CAA
+    MissingCAA,
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,4 +21,6 @@ pub enum SvsmError {
     MissingVMSA,
     // There is no CAA
     MissingCAA,
+    // Invalid address, usually provided by the guest
+    InvalidAddress,
 }

--- a/src/fw_meta.rs
+++ b/src/fw_meta.rs
@@ -7,6 +7,7 @@
 extern crate alloc;
 
 use crate::cpu::percpu::this_cpu_mut;
+use crate::error::SvsmError;
 use crate::mm::PerCPUPageMappingGuard;
 use crate::mm::SIZE_1G;
 use crate::sev::ghcb::PageStateChangeOp;
@@ -226,18 +227,18 @@ const SEV_META_DESC_TYPE_SECRETS: u32 = 2;
 const SEV_META_DESC_TYPE_CPUID: u32 = 3;
 const SEV_META_DESC_TYPE_CAA: u32 = 4;
 
-pub fn parse_fw_meta_data() -> Result<SevFWMetaData, ()> {
+pub fn parse_fw_meta_data() -> Result<SevFWMetaData, SvsmError> {
     let pstart: PhysAddr = (4 * SIZE_1G) - PAGE_SIZE;
     let mut meta_data = SevFWMetaData::new();
 
     // Map meta-data location, it starts at 32 bytes below 4GiB
-    let guard = PerCPUPageMappingGuard::create(pstart, 0, false).map_err(|_e| ())?;
+    let guard = PerCPUPageMappingGuard::create(pstart, 0, false)?;
     let vstart = guard.virt_addr();
     let vend: VirtAddr = vstart + PAGE_SIZE;
 
     let mut curr = vend - 32;
 
-    let meta_uuid = Uuid::from_str(OVMF_TABLE_FOOTER_GUID)?;
+    let meta_uuid = Uuid::from_str(OVMF_TABLE_FOOTER_GUID).map_err(|()| SvsmError::Firmware)?;
 
     curr -= mem::size_of::<Uuid>();
     let ptr = curr as *const u8;
@@ -246,7 +247,7 @@ pub fn parse_fw_meta_data() -> Result<SevFWMetaData, ()> {
         let uuid = Uuid::from_mem(ptr);
 
         if uuid != meta_uuid {
-            return Err(());
+            return Err(SvsmError::Firmware);
         }
 
         curr -= mem::size_of::<u16>();
@@ -256,25 +257,27 @@ pub fn parse_fw_meta_data() -> Result<SevFWMetaData, ()> {
         let len = full_len - mem::size_of::<u16>() + mem::size_of::<Uuid>();
 
         // First check if this is the SVSM itself instead of OVMF
-        let svsm_info_uuid = Uuid::from_str(SVSM_INFO_GUID).unwrap();
+        let svsm_info_uuid = Uuid::from_str(SVSM_INFO_GUID).map_err(|()| SvsmError::Firmware)?;
         if let Ok(_v) = find_table(&svsm_info_uuid, curr, len) {
-            return Err(());
+            return Err(SvsmError::Firmware);
         }
 
         // Search SEV_INFO_BLOCK_GUID
-        let sev_info_uuid = Uuid::from_str(SEV_INFO_BLOCK_GUID).unwrap();
+        let sev_info_uuid =
+            Uuid::from_str(SEV_INFO_BLOCK_GUID).map_err(|()| SvsmError::Firmware)?;
         let ret = find_table(&sev_info_uuid, curr, len);
         if let Ok(tbl) = ret {
             let (base, len) = tbl;
             if len != mem::size_of::<u32>() {
-                return Err(());
+                return Err(SvsmError::Firmware);
             }
             let info_ptr = base as *const u32;
             meta_data.reset_ip = Some(info_ptr.read() as PhysAddr);
         }
 
         // Search and parse Meta Data
-        let sev_meta_uuid = Uuid::from_str(OVMF_SEV_META_DATA_GUID).unwrap();
+        let sev_meta_uuid =
+            Uuid::from_str(OVMF_SEV_META_DATA_GUID).map_err(|()| SvsmError::Firmware)?;
         let ret = find_table(&sev_meta_uuid, curr, len);
         if let Ok(tbl) = ret {
             let (base, _len) = tbl;
@@ -295,19 +298,19 @@ pub fn parse_fw_meta_data() -> Result<SevFWMetaData, ()> {
                     SEV_META_DESC_TYPE_MEM => meta_data.add_valid_mem(base, len),
                     SEV_META_DESC_TYPE_SECRETS => {
                         if len != PAGE_SIZE {
-                            return Err(());
+                            return Err(SvsmError::Firmware);
                         }
                         meta_data.secrets_page = Some(base);
                     }
                     SEV_META_DESC_TYPE_CPUID => {
                         if len != PAGE_SIZE {
-                            return Err(());
+                            return Err(SvsmError::Firmware);
                         }
                         meta_data.cpuid_page = Some(base);
                     }
                     SEV_META_DESC_TYPE_CAA => {
                         if len != PAGE_SIZE {
-                            return Err(());
+                            return Err(SvsmError::Firmware);
                         }
                         meta_data.caa_page = Some(base);
                     }
@@ -320,7 +323,7 @@ pub fn parse_fw_meta_data() -> Result<SevFWMetaData, ()> {
     Ok(meta_data)
 }
 
-fn validate_fw_mem_region(region: SevPreValidMem) -> Result<(), ()> {
+fn validate_fw_mem_region(region: SevPreValidMem) -> Result<(), SvsmError> {
     let pstart: PhysAddr = region.base;
     let pend: PhysAddr = region.end();
 
@@ -332,17 +335,13 @@ fn validate_fw_mem_region(region: SevPreValidMem) -> Result<(), ()> {
         .expect("GHCB PSC call failed to validate firmware memory");
 
     for paddr in (pstart..pend).step_by(PAGE_SIZE) {
-        let guard = PerCPUPageMappingGuard::create(paddr, 0, false).map_err(|_e| ())?;
+        let guard = PerCPUPageMappingGuard::create(paddr, 0, false)?;
         let vaddr = guard.virt_addr();
 
-        if pvalidate(vaddr, false, true).is_err() {
-            return Err(());
-        }
+        pvalidate(vaddr, false, true)?;
 
         // Make page accessible to VMPL1
-        if rmp_adjust(vaddr, RMPFlags::VMPL1 | RMPFlags::RWX, false).is_err() {
-            return Err(());
-        }
+        rmp_adjust(vaddr, RMPFlags::VMPL1 | RMPFlags::RWX, false)?;
 
         zero_mem_region(vaddr, vaddr + PAGE_SIZE);
     }
@@ -350,7 +349,7 @@ fn validate_fw_mem_region(region: SevPreValidMem) -> Result<(), ()> {
     Ok(())
 }
 
-fn validate_fw_memory_vec(regions: Vec<SevPreValidMem>) -> Result<(), ()> {
+fn validate_fw_memory_vec(regions: Vec<SevPreValidMem>) -> Result<(), SvsmError> {
     if regions.is_empty() {
         return Ok(());
     }
@@ -370,7 +369,7 @@ fn validate_fw_memory_vec(regions: Vec<SevPreValidMem>) -> Result<(), ()> {
     validate_fw_memory_vec(next_vec)
 }
 
-pub fn validate_fw_memory(fw_meta: &SevFWMetaData) -> Result<(), ()> {
+pub fn validate_fw_memory(fw_meta: &SevFWMetaData) -> Result<(), SvsmError> {
     // Initalize vector with regions from the FW
     let mut regions = fw_meta.valid_mem.clone();
 

--- a/src/fw_meta.rs
+++ b/src/fw_meta.rs
@@ -231,7 +231,7 @@ pub fn parse_fw_meta_data() -> Result<SevFWMetaData, ()> {
     let mut meta_data = SevFWMetaData::new();
 
     // Map meta-data location, it starts at 32 bytes below 4GiB
-    let guard = PerCPUPageMappingGuard::create(pstart, 0, false)?;
+    let guard = PerCPUPageMappingGuard::create(pstart, 0, false).map_err(|_e| ())?;
     let vstart = guard.virt_addr();
     let vend: VirtAddr = vstart + PAGE_SIZE;
 
@@ -332,7 +332,7 @@ fn validate_fw_mem_region(region: SevPreValidMem) -> Result<(), ()> {
         .expect("GHCB PSC call failed to validate firmware memory");
 
     for paddr in (pstart..pend).step_by(PAGE_SIZE) {
-        let guard = PerCPUPageMappingGuard::create(paddr, 0, false)?;
+        let guard = PerCPUPageMappingGuard::create(paddr, 0, false).map_err(|_e| ())?;
         let vaddr = guard.virt_addr();
 
         if pvalidate(vaddr, false, true).is_err() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod acpi;
 pub mod console;
 pub mod cpu;
 pub mod debug;
+pub mod error;
 pub mod fw_cfg;
 pub mod fw_meta;
 pub mod io;

--- a/src/mm/address_space.rs
+++ b/src/mm/address_space.rs
@@ -4,6 +4,7 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
+use crate::error::SvsmError;
 use crate::types::{PhysAddr, VirtAddr};
 use crate::utils::immut_after_init::ImmutAfterInitCell;
 
@@ -146,16 +147,16 @@ pub const SVSM_PERCPU_TEMP_4K_SLOTS: usize =
 pub const SVSM_PERCPU_TEMP_2M_SLOTS: usize =
     ((SVSM_PERCPU_TEMP_END_2M - SVSM_PERCPU_TEMP_BASE_2M) / PAGE_SIZE_2M) / 2;
 
-pub fn percpu_4k_slot_addr(slot: usize) -> Result<VirtAddr, ()> {
+pub fn percpu_4k_slot_addr(slot: usize) -> Result<VirtAddr, SvsmError> {
     if slot >= SVSM_PERCPU_TEMP_4K_SLOTS {
-        return Err(());
+        return Err(SvsmError::Mem);
     }
     Ok(SVSM_PERCPU_TEMP_BASE_4K + (2 * slot * PAGE_SIZE))
 }
 
-pub fn percpu_2m_slot_addr(slot: usize) -> Result<VirtAddr, ()> {
+pub fn percpu_2m_slot_addr(slot: usize) -> Result<VirtAddr, SvsmError> {
     if slot >= SVSM_PERCPU_TEMP_2M_SLOTS {
-        return Err(());
+        return Err(SvsmError::Mem);
     }
     Ok(SVSM_PERCPU_TEMP_BASE_2M + (2 * slot * PAGE_SIZE_2M))
 }

--- a/src/mm/validate.rs
+++ b/src/mm/validate.rs
@@ -4,6 +4,7 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
+use crate::error::SvsmError;
 use crate::locking::SpinLock;
 use crate::mm::alloc::{allocate_pages, get_order};
 use crate::mm::virt_to_phys;
@@ -25,7 +26,7 @@ pub fn init_valid_bitmap_ptr(pbase: PhysAddr, pend: PhysAddr, bitmap: *mut u64) 
     vb_ref.set_bitmap(bitmap);
 }
 
-pub fn init_valid_bitmap_alloc(pbase: PhysAddr, pend: PhysAddr) -> Result<(), ()> {
+pub fn init_valid_bitmap_alloc(pbase: PhysAddr, pend: PhysAddr) -> Result<(), SvsmError> {
     let order: usize = bitmap_alloc_order(pbase, pend);
     let bitmap_addr = allocate_pages(order)?;
 
@@ -37,7 +38,7 @@ pub fn init_valid_bitmap_alloc(pbase: PhysAddr, pend: PhysAddr) -> Result<(), ()
     Ok(())
 }
 
-pub fn migrate_valid_bitmap() -> Result<(), ()> {
+pub fn migrate_valid_bitmap() -> Result<(), SvsmError> {
     let order: usize = VALID_BITMAP.lock().alloc_order();
     let bitmap_addr = allocate_pages(order)?;
 

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -177,9 +177,7 @@ fn core_create_vcpu(params: &RequestParams) -> Result<(), SvsmReqError> {
         .ok_or_else(SvsmReqError::invalid_parameter)?;
 
     // Got valid gPAs and APIC ID, register VMSA immediately to avoid races
-    PERCPU_VMSAS
-        .register(paddr, apic_id, true)
-        .map_err(|_| SvsmReqError::invalid_address())?;
+    PERCPU_VMSAS.register(paddr, apic_id, true)?;
 
     // Time to map the VMSA. No need to clean up the registered VMSA on the
     // error path since this is a fatal error anyway.

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -524,8 +524,12 @@ pub fn request_loop() {
                 );
                 code.into()
             }
-            Err(SvsmReqError::FatalError(..)) => {
-                log::error!("Fatal error handling core protocol request {}", request);
+            Err(SvsmReqError::FatalError(err)) => {
+                log::error!(
+                    "Fatal error handling core protocol request {}: {:?}",
+                    request,
+                    err
+                );
                 break;
             }
         };

--- a/src/sev/ghcb.rs
+++ b/src/sev/ghcb.rs
@@ -153,9 +153,7 @@ impl GHCB {
         }
 
         // Map page unencrypted
-        if let Err(()) = get_init_pgtable_locked().set_shared_4k(vaddr) {
-            return Err(SvsmError::Mem);
-        }
+        get_init_pgtable_locked().set_shared_4k(vaddr)?;
 
         flush_tlb_global_sync();
 
@@ -175,9 +173,7 @@ impl GHCB {
         let paddr = virt_to_phys(vaddr);
 
         // Re-encrypt page
-        get_init_pgtable_locked()
-            .set_encrypted_4k(vaddr)
-            .map_err(|()| SvsmError::Mem)?;
+        get_init_pgtable_locked().set_encrypted_4k(vaddr)?;
 
         // Unregister GHCB PA
         register_ghcb_gpa_msr(0usize)?;

--- a/src/sev/msr_protocol.rs
+++ b/src/sev/msr_protocol.rs
@@ -5,6 +5,7 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 
 use crate::cpu::msr::{read_msr, write_msr, SEV_GHCB};
+use crate::error::SvsmError;
 use crate::types::{PhysAddr, VirtAddr};
 use crate::utils::halt;
 
@@ -17,6 +18,12 @@ pub enum GhcbMsrError {
     // The data section of the response did not match our request,
     // or it was malformed altogether.
     DataMismatch,
+}
+
+impl From<GhcbMsrError> for SvsmError {
+    fn from(e: GhcbMsrError) -> Self {
+        Self::GhcbMsr(e)
+    }
 }
 
 #[non_exhaustive]

--- a/src/sev/utils.rs
+++ b/src/sev/utils.rs
@@ -4,6 +4,7 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
+use crate::error::SvsmError;
 use crate::types::{VirtAddr, PAGE_SIZE, PAGE_SIZE_2M};
 use crate::utils::is_aligned;
 use core::arch::asm;
@@ -18,6 +19,12 @@ pub enum SevSnpError {
     // Not a real error value, but we want to keep track of this,
     // especially for protocol-specific messaging
     FAIL_UNCHANGED(u64),
+}
+
+impl From<SevSnpError> for SvsmError {
+    fn from(e: SevSnpError) -> Self {
+        Self::SevSnp(e)
+    }
 }
 
 impl SevSnpError {

--- a/src/sev/utils.rs
+++ b/src/sev/utils.rs
@@ -50,7 +50,7 @@ impl fmt::Display for SevSnpError {
     }
 }
 
-fn pvalidate_range_4k(start: VirtAddr, end: VirtAddr, valid: bool) -> Result<(), SevSnpError> {
+fn pvalidate_range_4k(start: VirtAddr, end: VirtAddr, valid: bool) -> Result<(), SvsmError> {
     for addr in (start..end).step_by(PAGE_SIZE) {
         pvalidate(addr, false, valid)?;
     }
@@ -58,7 +58,7 @@ fn pvalidate_range_4k(start: VirtAddr, end: VirtAddr, valid: bool) -> Result<(),
     Ok(())
 }
 
-pub fn pvalidate_range(start: VirtAddr, end: VirtAddr, valid: bool) -> Result<(), SevSnpError> {
+pub fn pvalidate_range(start: VirtAddr, end: VirtAddr, valid: bool) -> Result<(), SvsmError> {
     let mut addr = start;
 
     while addr < end {
@@ -66,7 +66,7 @@ pub fn pvalidate_range(start: VirtAddr, end: VirtAddr, valid: bool) -> Result<()
             // Try to validate as a huge page.
             // If we fail, try to fall back to regular-sized pages.
             pvalidate(addr, true, valid).or_else(|err| match err {
-                SevSnpError::FAIL_SIZEMISMATCH(_) => {
+                SvsmError::SevSnp(SevSnpError::FAIL_SIZEMISMATCH(_)) => {
                     pvalidate_range_4k(addr, addr + PAGE_SIZE_2M, valid)
                 }
                 _ => Err(err),
@@ -81,7 +81,7 @@ pub fn pvalidate_range(start: VirtAddr, end: VirtAddr, valid: bool) -> Result<()
     Ok(())
 }
 
-pub fn pvalidate(vaddr: VirtAddr, huge_page: bool, valid: bool) -> Result<(), SevSnpError> {
+pub fn pvalidate(vaddr: VirtAddr, huge_page: bool, valid: bool) -> Result<(), SvsmError> {
     let rax = vaddr;
     let rcx = huge_page as u64;
     let rdx = valid as u64;
@@ -106,9 +106,9 @@ pub fn pvalidate(vaddr: VirtAddr, huge_page: bool, valid: bool) -> Result<(), Se
 
     match ret {
         0 if changed => Ok(()),
-        0 if !changed => Err(SevSnpError::FAIL_UNCHANGED(0x10)),
-        1 => Err(SevSnpError::FAIL_INPUT(ret)),
-        6 => Err(SevSnpError::FAIL_SIZEMISMATCH(ret)),
+        0 if !changed => Err(SevSnpError::FAIL_UNCHANGED(0x10).into()),
+        1 => Err(SevSnpError::FAIL_INPUT(ret).into()),
+        6 => Err(SevSnpError::FAIL_SIZEMISMATCH(ret).into()),
         _ => {
             log::error!("PVALIDATE: unexpected return value: {}", ret);
             unreachable!();
@@ -139,7 +139,7 @@ bitflags::bitflags! {
     }
 }
 
-pub fn rmp_adjust(addr: VirtAddr, flags: RMPFlags, huge: bool) -> Result<(), SevSnpError> {
+pub fn rmp_adjust(addr: VirtAddr, flags: RMPFlags, huge: bool) -> Result<(), SvsmError> {
     let rcx: usize = if huge { 1 } else { 0 };
     let rax: u64 = addr as u64;
     let rdx: u64 = flags.bits();
@@ -163,14 +163,14 @@ pub fn rmp_adjust(addr: VirtAddr, flags: RMPFlags, huge: bool) -> Result<(), Sev
 
     if ex != 0 {
         // Report exceptions just as FAIL_INPUT
-        return Err(SevSnpError::FAIL_INPUT(1));
+        return Err(SevSnpError::FAIL_INPUT(1).into());
     }
 
     match ret {
         0 => Ok(()),
-        1 => Err(SevSnpError::FAIL_INPUT(ret)),
-        2 => Err(SevSnpError::FAIL_PERMISSION(ret)),
-        6 => Err(SevSnpError::FAIL_SIZEMISMATCH(ret)),
+        1 => Err(SevSnpError::FAIL_INPUT(ret).into()),
+        2 => Err(SevSnpError::FAIL_PERMISSION(ret).into()),
+        6 => Err(SevSnpError::FAIL_SIZEMISMATCH(ret).into()),
         _ => {
             log::error!("RMPADJUST: Unexpected return value: {:#x}", ret);
             unreachable!();
@@ -178,22 +178,22 @@ pub fn rmp_adjust(addr: VirtAddr, flags: RMPFlags, huge: bool) -> Result<(), Sev
     }
 }
 
-pub fn rmp_revoke_guest_access(vaddr: VirtAddr, huge: bool) -> Result<(), SevSnpError> {
+pub fn rmp_revoke_guest_access(vaddr: VirtAddr, huge: bool) -> Result<(), SvsmError> {
     rmp_adjust(vaddr, RMPFlags::VMPL1 | RMPFlags::NONE, huge)?;
     rmp_adjust(vaddr, RMPFlags::VMPL2 | RMPFlags::NONE, huge)?;
     rmp_adjust(vaddr, RMPFlags::VMPL3 | RMPFlags::NONE, huge)
 }
 
-pub fn rmp_grant_guest_access(vaddr: VirtAddr, huge: bool) -> Result<(), SevSnpError> {
+pub fn rmp_grant_guest_access(vaddr: VirtAddr, huge: bool) -> Result<(), SvsmError> {
     rmp_adjust(vaddr, RMPFlags::VMPL1 | RMPFlags::RWX, huge)
 }
 
-pub fn rmp_set_guest_vmsa(vaddr: VirtAddr) -> Result<(), SevSnpError> {
+pub fn rmp_set_guest_vmsa(vaddr: VirtAddr) -> Result<(), SvsmError> {
     rmp_revoke_guest_access(vaddr, false)?;
     rmp_adjust(vaddr, RMPFlags::VMPL1 | RMPFlags::VMSA, false)
 }
 
-pub fn rmp_clear_guest_vmsa(vaddr: VirtAddr) -> Result<(), SevSnpError> {
+pub fn rmp_clear_guest_vmsa(vaddr: VirtAddr) -> Result<(), SvsmError> {
     rmp_revoke_guest_access(vaddr, false)?;
     rmp_grant_guest_access(vaddr, false)
 }

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -397,15 +397,22 @@ pub extern "C" fn svsm_main() {
 
     start_secondary_cpus(&cpus);
 
-    let fw_meta = parse_fw_meta_data().expect("Failed to parse FW SEV meta-data");
+    let fw_meta = parse_fw_meta_data()
+        .unwrap_or_else(|e| panic!("Failed to parse FW SEV meta-data: {:#?}", e));
 
     print_fw_meta(&fw_meta);
 
-    validate_fw_memory(&fw_meta).expect("Failed to validate firmware memory");
+    if let Err(e) = validate_fw_memory(&fw_meta) {
+        panic!("Failed to validate firmware memory: {:#?}", e);
+    }
 
-    copy_tables_to_fw(&fw_meta).expect("Failed to copy firmware tables");
+    if let Err(e) = copy_tables_to_fw(&fw_meta) {
+        panic!("Failed to copy firmware tables: {:#?}", e);
+    }
 
-    validate_flash().expect("Failed to validate flash memory");
+    if let Err(e) = validate_flash() {
+        panic!("Failed to validate flash memory: {:#?}", e);
+    }
 
     prepare_fw_launch(&fw_meta).expect("Failed to setup guest VMSA");
 

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -24,6 +24,7 @@ use svsm::cpu::percpu::PerCpu;
 use svsm::cpu::percpu::{this_cpu, this_cpu_mut};
 use svsm::cpu::smp::start_secondary_cpus;
 use svsm::debug::stacktrace::print_stack;
+use svsm::error::SvsmError;
 use svsm::fw_cfg::FwCfg;
 use svsm::kernel_launch::KernelLaunchInfo;
 use svsm::mm::alloc::{memory_info, print_memory_info, root_mem_init};
@@ -33,7 +34,6 @@ use svsm::mm::{init_kernel_mapping_info, PerCPUPageMappingGuard};
 use svsm::requests::{request_loop, update_mappings};
 use svsm::serial::SerialPort;
 use svsm::serial::SERIAL_PORT;
-use svsm::sev::ghcb::GhcbError;
 use svsm::sev::secrets_page::{copy_secrets_page, SecretsPage};
 use svsm::sev::sev_status_init;
 use svsm::sev::utils::{rmp_adjust, RMPFlags};
@@ -217,7 +217,7 @@ fn prepare_fw_launch(fw_meta: &SevFWMetaData) -> Result<(), ()> {
     Ok(())
 }
 
-fn launch_fw() -> Result<(), GhcbError> {
+fn launch_fw() -> Result<(), SvsmError> {
     let vmsa_pa = this_cpu_mut().guest_vmsa_ref().vmsa_phys().unwrap();
     let vmsa = this_cpu_mut().guest_vmsa();
 

--- a/src/svsm_paging.rs
+++ b/src/svsm_paging.rs
@@ -6,6 +6,7 @@
 
 use crate::heap_start;
 use svsm::cpu::percpu::this_cpu_mut;
+use svsm::error::SvsmError;
 use svsm::kernel_launch::KernelLaunchInfo;
 use svsm::mm;
 use svsm::mm::pagetable::{set_init_pgtable, PageTable, PageTableRef};
@@ -76,7 +77,7 @@ pub fn init_page_table(launch_info: &KernelLaunchInfo) {
     set_init_pgtable(pgtable);
 }
 
-pub fn invalidate_stage2() -> Result<(), ()> {
+pub fn invalidate_stage2() -> Result<(), SvsmError> {
     let pstart: PhysAddr = 0;
     let pend = pstart + (640 * 1024);
     let mut paddr = pstart;
@@ -88,7 +89,7 @@ pub fn invalidate_stage2() -> Result<(), ()> {
         let guard = PerCPUPageMappingGuard::create(paddr, 0, false)?;
         let vaddr = guard.virt_addr();
 
-        pvalidate(vaddr, false, false).expect("PINVALIDATE failed");
+        pvalidate(vaddr, false, false)?;
 
         paddr += PAGE_SIZE;
     }


### PR DESCRIPTION
Add a new generic error type, `SvsmError`. This type can be expanded over time with additional carried information or new variants to represent different error conditions.

In general, internally each subsystem may have its own internal error type (e.g. `GhcbError`), but must return in its public interface(s) an `SvsmError`, which may contain this internal (but not private) error type with additional details (e.g. `SvsmError::Ghcb`).

For guest requests, we define a way to translate these general errors to error codes (`SvsmError` -> `SvsmReqError`) via the From trait.

Unfortunately, due to the pervasiveness of error handling and strong typing, this requires a lot of small cascading changes, so making commits self-contained was not an easy task :)