### PR TITLE
Fix trivial clippy warnings

### DIFF
--- a/src/cpu/idt.rs
+++ b/src/cpu/idt.rs
@@ -142,11 +142,9 @@ pub fn idt_base_limit() -> (u64, u32) {
 
 fn init_idt(idt: &mut Idt) {
     // Set IDT handlers
-    for i in 0..IDT_ENTRIES {
-        unsafe {
-            let handler = ((&idt_handler_array as *const u8) as VirtAddr) + (32 * i);
-            idt[i] = IdtEntry::entry(handler);
-        }
+    for (i, entry) in idt.iter_mut().enumerate() {
+        let handler = unsafe { ((&idt_handler_array as *const u8) as VirtAddr) + (32 * i) };
+        *entry = IdtEntry::entry(handler);
     }
 }
 

--- a/src/cpu/percpu.rs
+++ b/src/cpu/percpu.rs
@@ -333,7 +333,7 @@ impl PerCpu {
     }
 
     pub fn alloc_svsm_vmsa(&mut self) -> Result<(), SvsmError> {
-        if let Some(_) = self.svsm_vmsa {
+        if self.svsm_vmsa.is_some() {
             // FIXME: add a more explicit error variant for this condition
             return Err(SvsmError::Mem);
         }

--- a/src/cpu/percpu.rs
+++ b/src/cpu/percpu.rs
@@ -317,7 +317,7 @@ impl PerCpu {
     }
 
     pub fn shutdown(&mut self) -> Result<(), SvsmError> {
-        if self.ghcb == ptr::null_mut() {
+        if self.ghcb.is_null() {
             return Ok(());
         }
 

--- a/src/cpu/percpu.rs
+++ b/src/cpu/percpu.rs
@@ -445,12 +445,8 @@ impl PerCpu {
 
     pub fn caa_addr(&self) -> Option<VirtAddr> {
         let locked = self.guest_vmsa.lock();
-
-        if locked.caa_phys().is_none() {
-            return None;
-        }
-
-        let offset = page_offset(locked.caa_phys().unwrap());
+        let caa_phys = locked.caa_phys()?;
+        let offset = page_offset(caa_phys);
 
         Some((SVSM_PERCPU_CAA_BASE + offset) as VirtAddr)
     }

--- a/src/cpu/vmsa.rs
+++ b/src/cpu/vmsa.rs
@@ -36,8 +36,8 @@ fn svsm_gdt_segment() -> VMSASegment {
     VMSASegment {
         selector: 0,
         flags: 0,
-        limit: limit,
-        base: base,
+        limit,
+        base,
     }
 }
 
@@ -46,8 +46,8 @@ fn svsm_idt_segment() -> VMSASegment {
     VMSASegment {
         selector: 0,
         flags: 0,
-        limit: limit,
-        base: base,
+        limit,
+        base,
     }
 }
 
@@ -101,7 +101,7 @@ fn real_mode_sys_seg(flags: u16) -> VMSASegment {
         selector: 0,
         base: 0,
         limit: 0xffff,
-        flags: flags,
+        flags,
     }
 }
 

--- a/src/sev/vmsa.rs
+++ b/src/sev/vmsa.rs
@@ -205,7 +205,7 @@ pub fn allocate_new_vmsa(vmpl: RMPFlags) -> Result<VirtAddr, SvsmError> {
 
     if let Err(e) = rmp_adjust(vmsa_page, RMPFlags::VMSA | vmpl, false) {
         free_page(vmsa_page);
-        return Err(e.into());
+        return Err(e);
     }
     Ok(vmsa_page)
 }


### PR DESCRIPTION
A few fixes for some clippy warnings which should not introduce any functional changes.