### PR TITLE
Allow guest VMPL compile-time configuration

### DIFF
--- a/src/cpu/percpu.rs
+++ b/src/cpu/percpu.rs
@@ -338,7 +338,7 @@ impl PerCpu {
             return Err(SvsmError::Mem);
         }
 
-        let vaddr = allocate_new_vmsa(RMPFlags::VMPL1)?;
+        let vaddr = allocate_new_vmsa(RMPFlags::GUEST_VMPL)?;
         let paddr = virt_to_phys(vaddr);
 
         self.svsm_vmsa = Some(VmsaRef::new(vaddr, paddr, false));
@@ -415,7 +415,7 @@ impl PerCpu {
     }
 
     pub fn alloc_guest_vmsa(&mut self) -> Result<(), SvsmError> {
-        let vaddr = allocate_new_vmsa(RMPFlags::VMPL1)?;
+        let vaddr = allocate_new_vmsa(RMPFlags::GUEST_VMPL)?;
         let paddr = virt_to_phys(vaddr);
 
         let vmsa = VMSA::from_virt_addr(vaddr);

--- a/src/cpu/vmsa.rs
+++ b/src/cpu/vmsa.rs
@@ -5,7 +5,7 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 
 use crate::sev::vmsa::{VMSASegment, VMSA};
-use crate::types::{SVSM_CS, SVSM_CS_FLAGS, SVSM_DS, SVSM_DS_FLAGS};
+use crate::types::{GUEST_VMPL, SVSM_CS, SVSM_CS_FLAGS, SVSM_DS, SVSM_DS_FLAGS};
 
 use super::control_regs::{read_cr0, read_cr3, read_cr4};
 use super::efer::read_efer;
@@ -129,6 +129,6 @@ pub fn init_guest_vmsa(vmsa: *mut VMSA, rip: u64) {
     v.x87_ftw = 0x5555;
     v.x87_fcw = 0x0040;
 
-    v.vmpl = 1;
+    v.vmpl = GUEST_VMPL as u8;
     v.sev_features = read_msr(0xc0010131) >> 2;
 }

--- a/src/fw_meta.rs
+++ b/src/fw_meta.rs
@@ -340,8 +340,8 @@ fn validate_fw_mem_region(region: SevPreValidMem) -> Result<(), SvsmError> {
 
         pvalidate(vaddr, false, true)?;
 
-        // Make page accessible to VMPL1
-        rmp_adjust(vaddr, RMPFlags::VMPL1 | RMPFlags::RWX, false)?;
+        // Make page accessible to guest VMPL
+        rmp_adjust(vaddr, RMPFlags::GUEST_VMPL | RMPFlags::RWX, false)?;
 
         zero_mem_region(vaddr, vaddr + PAGE_SIZE);
     }

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -14,7 +14,7 @@ use crate::sev::utils::{
     rmp_set_guest_vmsa, RMPFlags, SevSnpError,
 };
 use crate::sev::vmsa::{GuestVMExit, VMSA};
-use crate::types::{PhysAddr, VirtAddr, PAGE_SIZE, PAGE_SIZE_2M};
+use crate::types::{PhysAddr, VirtAddr, GUEST_VMPL, PAGE_SIZE, PAGE_SIZE_2M};
 use crate::utils::{crosses_page, halt, is_aligned, page_align, page_offset};
 
 #[derive(Debug, Clone, Copy)]
@@ -151,7 +151,7 @@ fn core_create_vcpu_error_restore(vaddr: VirtAddr) -> Result<(), SvsmReqError> {
 
 // VMSA validity checks according to SVSM spec
 fn check_vmsa(new: &VMSA, sev_features: u64, svme_mask: u64) -> bool {
-    new.vmpl == RMPFlags::VMPL1.bits() as u8
+    new.vmpl == RMPFlags::GUEST_VMPL.bits() as u8
         && new.efer & svme_mask == svme_mask
         && new.sev_features == sev_features
 }
@@ -546,8 +546,8 @@ pub fn request_loop() {
         if update_mappings().is_ok() {
             this_cpu_mut()
                 .ghcb()
-                .run_vmpl(1)
-                .expect("Failed to run VMPL 1");
+                .run_vmpl(GUEST_VMPL as u64)
+                .expect("Failed to run guest VMPL");
         }
     }
 }

--- a/src/sev/secrets_page.rs
+++ b/src/sev/secrets_page.rs
@@ -4,6 +4,7 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
+use crate::sev::vmsa::VMPL_MAX;
 use crate::types::VirtAddr;
 
 #[derive(Copy, Clone)]
@@ -14,10 +15,7 @@ pub struct SecretsPage {
     pub fms: u32,
     reserved_00c: u32,
     pub gosvw: [u8; 16],
-    pub vmpck0: [u8; 32],
-    pub vmpck1: [u8; 32],
-    pub vmpck2: [u8; 32],
-    pub vmpck3: [u8; 32],
+    pub vmpck: [[u8; 32]; VMPL_MAX],
     reserved_0a0: [u8; 96],
     pub vmsa_tweak_bmp: [u64; 8],
     pub svsm_base: u64,

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -158,9 +158,7 @@ fn copy_secrets_page_to_fw(fw_addr: PhysAddr, caa_addr: PhysAddr) -> Result<(), 
         let mut fw_sp = target.as_mut();
 
         // Zero VMCK0 key
-        for i in 0..32 {
-            fw_sp.vmpck0[i] = 0;
-        }
+        fw_sp.vmpck0.fill(0);
 
         let &li = &*LAUNCH_INFO;
 

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -158,7 +158,7 @@ fn copy_secrets_page_to_fw(fw_addr: PhysAddr, caa_addr: PhysAddr) -> Result<(), 
         let mut fw_sp = target.as_mut();
 
         // Zero VMCK0 key
-        fw_sp.vmpck0.fill(0);
+        fw_sp.vmpck[0].fill(0);
 
         let &li = &*LAUNCH_INFO;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -19,6 +19,8 @@ pub const SVSM_CS_FLAGS: u16 = 0x29b;
 pub const SVSM_DS_FLAGS: u16 = 0xc93;
 pub const SVSM_TR_FLAGS: u16 = 0x89;
 
+pub const GUEST_VMPL: usize = 1;
+
 pub type PhysAddr = usize;
 pub type VirtAddr = usize;
 


### PR DESCRIPTION
Remove all hardcoded instances of VMPL=1 for the guest, and replace them with a new constant, `GUEST_VMPL`. Introduce as well a new value in RMPFlags so that users of the structure can easily refer to the guest VMPL.

The best home for the new constant seems to be `src/types.rs`, but this could be changed.

I have verified that a guest can be booted in VMPL 2 by simply changing the value of the constant.

Fixes #11.