### PR TITLE
SVSM: Use fixed layout for `KernelLaunchInfo`

### DIFF
--- a/src/kernel_launch.rs
+++ b/src/kernel_launch.rs
@@ -5,6 +5,7 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 
 #[derive(Copy, Clone)]
+#[repr(C)]
 pub struct KernelLaunchInfo {
     pub kernel_start: u64,
     pub kernel_end: u64,


### PR DESCRIPTION
Previously the default representation was used which doesn't guarantee a stable layout. This is problematic because `KernelLaunchInfo` is passed from the loader to the kernel and any differences in layout would cause a crash. Using the C representation guarantees a stable layout.

Previously a crash could be provoked by setting `randomize-layout`:
```shell
RUSTFLAGS="-Z randomize-layout -Z layout-seed=2" cargo build --bin stage2
RUSTFLAGS="-Z randomize-layout -Z layout-seed=3" cargo build --bin svsm
```