### PR TITLE
svsm/types: check at compile time that guest VMPL is valid

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -4,6 +4,8 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
+use crate::sev::vmsa::VMPL_MAX;
+
 pub const PAGE_SHIFT: usize = 12;
 pub const PAGE_SIZE: usize = 1 << PAGE_SHIFT;
 pub const PAGE_SIZE_2M: usize = PAGE_SIZE * 512;
@@ -20,6 +22,9 @@ pub const SVSM_DS_FLAGS: u16 = 0xc93;
 pub const SVSM_TR_FLAGS: u16 = 0x89;
 
 pub const GUEST_VMPL: usize = 1;
+
+#[allow(clippy::assertions_on_constants)]
+const _: () = assert!(GUEST_VMPL > 0 && GUEST_VMPL < VMPL_MAX);
 
 pub type PhysAddr = usize;
 pub type VirtAddr = usize;


### PR DESCRIPTION
If an invalid guest VMPL is specified, the user will get the following error at compile time:

```
$ make
cargo build  --bin stage2
   Compiling svsm v0.1.0 (/home/user/svsm)
error[E0080]: evaluation of constant value failed
  --> src/types.rs:27:15
   |
27 | const _: () = assert!(GUEST_VMPL > 0 && GUEST_VMPL < VMPL_MAX);
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: GUEST_VMPL > 0 && GUEST_VMPL < VMPL_MAX', src/types.rs:27:15
   |
   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0080`.
error: could not compile `svsm` due to previous error
make: *** [Makefile:30: stage1/stage2.bin] Error 101
```