### PR TITLE
Replace slot-based virtual memory allocation with bitmap allocator

### DIFF
--- a/src/fw_meta.rs
+++ b/src/fw_meta.rs
@@ -232,7 +232,7 @@ pub fn parse_fw_meta_data() -> Result<SevFWMetaData, SvsmError> {
     let mut meta_data = SevFWMetaData::new();
 
     // Map meta-data location, it starts at 32 bytes below 4GiB
-    let guard = PerCPUPageMappingGuard::create(pstart, 0, false)?;
+    let guard = PerCPUPageMappingGuard::create_4k(pstart)?;
     let vstart = guard.virt_addr();
     let vend: VirtAddr = vstart + PAGE_SIZE;
 
@@ -335,7 +335,7 @@ fn validate_fw_mem_region(region: SevPreValidMem) -> Result<(), SvsmError> {
         .expect("GHCB PSC call failed to validate firmware memory");
 
     for paddr in (pstart..pend).step_by(PAGE_SIZE) {
-        let guard = PerCPUPageMappingGuard::create(paddr, 0, false)?;
+        let guard = PerCPUPageMappingGuard::create_4k(paddr)?;
         let vaddr = guard.virt_addr();
 
         pvalidate(vaddr, false, true)?;

--- a/src/mm/address_space.rs
+++ b/src/mm/address_space.rs
@@ -4,7 +4,6 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
-use crate::error::SvsmError;
 use crate::types::{PhysAddr, VirtAddr};
 use crate::utils::immut_after_init::ImmutAfterInitCell;
 
@@ -140,23 +139,3 @@ pub const SVSM_PERCPU_TEMP_END_4K: usize = SVSM_PERCPU_TEMP_BASE_4K + SIZE_LEVEL
 /// Start and End for PAGE_SIZEed temporary mappings
 pub const SVSM_PERCPU_TEMP_BASE_2M: usize = SVSM_PERCPU_TEMP_BASE + SIZE_LEVEL1;
 pub const SVSM_PERCPU_TEMP_END_2M: usize = SVSM_PERCPU_TEMP_BASE + SIZE_LEVEL2;
-
-/// Number of slots - only use half of them to leave guard pages between the mappings
-pub const SVSM_PERCPU_TEMP_4K_SLOTS: usize =
-    ((SVSM_PERCPU_TEMP_END_4K - SVSM_PERCPU_TEMP_BASE_4K) / PAGE_SIZE) / 2;
-pub const SVSM_PERCPU_TEMP_2M_SLOTS: usize =
-    ((SVSM_PERCPU_TEMP_END_2M - SVSM_PERCPU_TEMP_BASE_2M) / PAGE_SIZE_2M) / 2;
-
-pub fn percpu_4k_slot_addr(slot: usize) -> Result<VirtAddr, SvsmError> {
-    if slot >= SVSM_PERCPU_TEMP_4K_SLOTS {
-        return Err(SvsmError::Mem);
-    }
-    Ok(SVSM_PERCPU_TEMP_BASE_4K + (2 * slot * PAGE_SIZE))
-}
-
-pub fn percpu_2m_slot_addr(slot: usize) -> Result<VirtAddr, SvsmError> {
-    if slot >= SVSM_PERCPU_TEMP_2M_SLOTS {
-        return Err(SvsmError::Mem);
-    }
-    Ok(SVSM_PERCPU_TEMP_BASE_2M + (2 * slot * PAGE_SIZE_2M))
-}

--- a/src/mm/mod.rs
+++ b/src/mm/mod.rs
@@ -8,6 +8,7 @@ pub mod address_space;
 pub mod alloc;
 pub mod guestmem;
 pub mod memory;
+pub mod virtualrange;
 pub mod pagetable;
 pub mod ptguards;
 pub mod stack;

--- a/src/mm/virtualrange.rs
+++ b/src/mm/virtualrange.rs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2022-2023 SUSE LLC
+//
+// Author: Roy Hopkins <rhopkins@suse.de>
+
+use crate::types::{VirtAddr, PAGE_SHIFT, PAGE_SIZE, PAGE_SIZE_2M, PAGE_SHIFT_2M};
+use crate::locking::SpinLock;
+use crate::error::SvsmError;
+use crate::utils::bitmap_allocator::{BitmapAllocator1024, BitmapAllocator};
+
+use super::{SVSM_PERCPU_TEMP_BASE_4K, SVSM_PERCPU_TEMP_END_4K, SVSM_PERCPU_TEMP_BASE_2M, SVSM_PERCPU_TEMP_END_2M};
+
+pub const VIRT_ALIGN_4K: usize = PAGE_SHIFT - 12;
+pub const VIRT_ALIGN_2M: usize = PAGE_SHIFT_2M - 12;
+
+pub struct VirtualRange {
+    start_virt: VirtAddr,
+    page_count: usize,
+    bits: BitmapAllocator1024,
+}
+
+impl VirtualRange {
+    pub const fn new() -> VirtualRange {
+        VirtualRange {
+            start_virt: 0,
+            page_count: 0,
+            bits: BitmapAllocator1024::new()
+        }
+    }
+
+    pub fn map_pages(self: &mut Self, page_count: usize, alignment: usize) -> Result<VirtAddr, SvsmError> {
+        // Always reserve an extra page to leave a guard between virtual memory allocations
+        match self.bits.alloc(page_count + 1, alignment) {
+            Some(offset) => Ok(self.start_virt + (offset << PAGE_SHIFT)),
+            None => Err(SvsmError::Mem)
+        }
+    }
+
+    pub fn unmap_pages(self: &mut Self, vaddr: VirtAddr, page_count: usize) {
+        let offset = (vaddr - self.start_virt) >> PAGE_SHIFT;
+        // Add 1 to the page count for the VM guard
+        self.bits.free(offset, page_count + 1);
+    }
+
+    pub fn used_pages(&self) -> usize {
+        self.bits.used()
+    }
+}
+
+static VIRTUAL_MAP_4K: SpinLock<VirtualRange> = SpinLock::new(VirtualRange::new());
+static VIRTUAL_MAP_2M: SpinLock<VirtualRange> = SpinLock::new(VirtualRange::new());
+
+pub fn virt_range_init() {
+    let mut pm4k = VIRTUAL_MAP_4K.lock();
+    let page_count = (SVSM_PERCPU_TEMP_END_4K - SVSM_PERCPU_TEMP_BASE_4K) / PAGE_SIZE;
+    if page_count > BitmapAllocator1024::CAPACITY {
+        panic!("Attempted to allocate page map with more than 4K pages");
+    }
+    pm4k.start_virt = SVSM_PERCPU_TEMP_BASE_4K;
+    pm4k.page_count = page_count;
+    pm4k.bits.set(0, page_count, false);
+
+    let mut pm2m = VIRTUAL_MAP_2M.lock();
+    let page_count = (SVSM_PERCPU_TEMP_END_2M - SVSM_PERCPU_TEMP_BASE_2M) / PAGE_SIZE_2M;
+    if page_count > BitmapAllocator1024::CAPACITY {
+        panic!("Attempted to allocate page map with more than 4K pages");
+    }
+    pm2m.start_virt = SVSM_PERCPU_TEMP_BASE_2M;
+    pm2m.page_count = page_count;
+    pm2m.bits.set(0, page_count, false);
+}
+
+pub fn virt_log_usage() {
+    let page_count4k = (SVSM_PERCPU_TEMP_END_4K - SVSM_PERCPU_TEMP_BASE_4K) / PAGE_SIZE;
+    let page_count2m = (SVSM_PERCPU_TEMP_END_2M - SVSM_PERCPU_TEMP_BASE_2M) / PAGE_SIZE_2M;
+    let unused_cap_4k = BitmapAllocator1024::CAPACITY - page_count4k;
+    let unused_cap_2m = BitmapAllocator1024::CAPACITY - page_count2m;
+
+    log::info!("Virtual memory pages used: {} * 4K, {} * 2M", 
+        VIRTUAL_MAP_4K.lock().used_pages() - unused_cap_4k,
+        VIRTUAL_MAP_2M.lock().used_pages() - unused_cap_2m);
+}
+
+pub fn virt_alloc_range_4k(size_bytes: usize, alignment: usize) -> Result<VirtAddr, SvsmError> {
+    // Each bit in our bitmap represents a 4K page
+    if (size_bytes & (PAGE_SIZE - 1)) != 0 {
+        return Err(SvsmError::Mem);
+    }
+    let page_count = size_bytes >> PAGE_SHIFT;
+    let mut pm = VIRTUAL_MAP_4K.lock();
+    pm.map_pages(page_count, alignment)
+}
+
+pub fn virt_free_range_4k(vaddr: VirtAddr, size_bytes: usize) {
+    VIRTUAL_MAP_4K.lock().unmap_pages(vaddr, size_bytes >> PAGE_SHIFT);
+}
+
+pub fn virt_alloc_range_2m(size_bytes: usize, alignment: usize) -> Result<VirtAddr, SvsmError> {
+    // Each bit in our bitmap represents a 2M page
+    if (size_bytes & (PAGE_SIZE_2M - 1)) != 0 {
+        return Err(SvsmError::Mem);
+    }
+    let page_count = size_bytes >> PAGE_SHIFT_2M;
+    let mut pm = VIRTUAL_MAP_2M.lock();
+    pm.map_pages(page_count, alignment)
+}
+
+pub fn virt_free_range_2m(vaddr: VirtAddr, size_bytes: usize) {
+    VIRTUAL_MAP_2M.lock().unmap_pages(vaddr, size_bytes >> PAGE_SHIFT_2M);
+}

--- a/src/mm/virtualrange.rs
+++ b/src/mm/virtualrange.rs
@@ -55,7 +55,7 @@ pub fn virt_range_init() {
     let mut pm4k = VIRTUAL_MAP_4K.lock();
     let page_count = (SVSM_PERCPU_TEMP_END_4K - SVSM_PERCPU_TEMP_BASE_4K) / PAGE_SIZE;
     if page_count > BitmapAllocator1024::CAPACITY {
-        panic!("Attempted to allocate page map with more than 4K pages");
+        panic!("Attempted to allocate 4K page map with more than 1024 pages");
     }
     pm4k.start_virt = SVSM_PERCPU_TEMP_BASE_4K;
     pm4k.page_count = page_count;
@@ -64,7 +64,7 @@ pub fn virt_range_init() {
     let mut pm2m = VIRTUAL_MAP_2M.lock();
     let page_count = (SVSM_PERCPU_TEMP_END_2M - SVSM_PERCPU_TEMP_BASE_2M) / PAGE_SIZE_2M;
     if page_count > BitmapAllocator1024::CAPACITY {
-        panic!("Attempted to allocate page map with more than 4K pages");
+        panic!("Attempted to allocate 2M page map with more than 1024 pages");
     }
     pm2m.start_virt = SVSM_PERCPU_TEMP_BASE_2M;
     pm2m.page_count = page_count;

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -36,6 +36,7 @@ use svsm::mm::alloc::{memory_info, print_memory_info, root_mem_init};
 use svsm::mm::memory::init_memory_map;
 use svsm::mm::pagetable::paging_init;
 use svsm::mm::{init_kernel_mapping_info, PerCPUPageMappingGuard};
+use svsm::mm::virtualrange::{virt_range_init, virt_log_usage};
 use svsm::requests::{request_loop, update_mappings};
 use svsm::serial::SerialPort;
 use svsm::serial::SERIAL_PORT;
@@ -104,7 +105,7 @@ static LAUNCH_INFO: ImmutAfterInitCell<KernelLaunchInfo> = ImmutAfterInitCell::u
 pub static mut PERCPU: PerCpu = PerCpu::new();
 
 fn copy_cpuid_table_to_fw(fw_addr: PhysAddr) -> Result<(), SvsmError> {
-    let guard = PerCPUPageMappingGuard::create(fw_addr, 0, false)?;
+    let guard = PerCPUPageMappingGuard::create_4k(fw_addr)?;
     let start = guard.virt_addr();
     let end = start + PAGE_SIZE;
 
@@ -123,7 +124,7 @@ fn copy_cpuid_table_to_fw(fw_addr: PhysAddr) -> Result<(), SvsmError> {
 }
 
 fn copy_secrets_page_to_fw(fw_addr: PhysAddr, caa_addr: PhysAddr) -> Result<(), SvsmError> {
-    let guard = PerCPUPageMappingGuard::create(fw_addr, 0, false)?;
+    let guard = PerCPUPageMappingGuard::create_4k(fw_addr)?;
     let start = guard.virt_addr();
 
     let mut target = ptr::NonNull::new(start as *mut SecretsPage).unwrap();
@@ -160,7 +161,7 @@ fn copy_secrets_page_to_fw(fw_addr: PhysAddr, caa_addr: PhysAddr) -> Result<(), 
 }
 
 fn zero_caa_page(fw_addr: PhysAddr) -> Result<(), SvsmError> {
-    let guard = PerCPUPageMappingGuard::create(fw_addr, 0, false)?;
+    let guard = PerCPUPageMappingGuard::create_4k(fw_addr)?;
     let vaddr = guard.virt_addr();
 
     zero_mem_region(vaddr, vaddr + PAGE_SIZE);
@@ -261,7 +262,7 @@ fn validate_flash() -> Result<(), SvsmError> {
         );
 
         for paddr in (pstart..pend).step_by(PAGE_SIZE) {
-            let guard = PerCPUPageMappingGuard::create(paddr, 0, false)?;
+            let guard = PerCPUPageMappingGuard::create_4k(paddr)?;
             let vaddr = guard.virt_addr();
             if let Err(e) = rmp_adjust(vaddr, RMPFlags::GUEST_VMPL | RMPFlags::RWX, false) {
                 log::info!("rmpadjust failed for addr {:#018x}", vaddr);
@@ -352,6 +353,8 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: VirtAddr) {
     paging_init();
     init_page_table(&launch_info, &kernel_elf);
 
+    virt_range_init();
+
     unsafe {
         let bsp_percpu = PerCpu::alloc(0)
             .expect("Failed to allocate BSP per-cpu data")
@@ -434,6 +437,8 @@ pub extern "C" fn svsm_main() {
 
     prepare_fw_launch(&fw_meta).expect("Failed to setup guest VMSA");
 
+    virt_log_usage();
+    
     if let Err(e) = launch_fw() {
         panic!("Failed to launch FW: {:#?}", e);
     }

--- a/src/svsm_paging.rs
+++ b/src/svsm_paging.rs
@@ -68,7 +68,7 @@ pub fn invalidate_stage2() -> Result<(), SvsmError> {
     // because before that the stage2 page-table is still active, which is in
     // stage2 memory, causing invalidation of page-table pages.
     while paddr < pend {
-        let guard = PerCPUPageMappingGuard::create(paddr, 0, false)?;
+        let guard = PerCPUPageMappingGuard::create_4k(paddr)?;
         let vaddr = guard.virt_addr();
 
         pvalidate(vaddr, false, false)?;

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,6 +7,7 @@
 use crate::sev::vmsa::VMPL_MAX;
 
 pub const PAGE_SHIFT: usize = 12;
+pub const PAGE_SHIFT_2M: usize = 21;
 pub const PAGE_SIZE: usize = 1 << PAGE_SHIFT;
 pub const PAGE_SIZE_2M: usize = PAGE_SIZE * 512;
 

--- a/src/utils/bitmap_allocator.rs
+++ b/src/utils/bitmap_allocator.rs
@@ -1,4 +1,8 @@
-
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2022-2023 SUSE LLC
+//
+// Author: Roy Hopkins <rhopkins@suse.de>
 
 pub trait BitmapAllocator {
     const CAPACITY: usize;
@@ -64,11 +68,11 @@ impl BitmapAllocator for BitmapAllocator64 {
 
     fn get(&self, offset: usize) -> bool {
         assert!(offset < BitmapAllocator64::CAPACITY);
-        return (self.bits & (1 << offset)) != 0
+        (self.bits & (1 << offset)) != 0
     }
 
     fn empty(&self) -> bool {
-        return self.bits == 0;
+        self.bits == 0
     }
 
     fn capacity(&self) -> usize {
@@ -163,7 +167,7 @@ impl<T: BitmapAllocator> BitmapAllocator for BitmapAllocatorTree<T> {
     }
 
     fn empty(&self) -> bool {
-        return self.bits == 0;
+        self.bits == 0
     }
 
     fn capacity(&self) -> usize {
@@ -222,7 +226,7 @@ fn alloc_aligned(ba: &mut impl BitmapAllocator, entries: usize, align: usize) ->
 
 #[cfg(test)]
 mod tests {
-    use crate::bitmapallocator::{BitmapAllocator64, BitmapAllocator};
+    use super::{BitmapAllocator64, BitmapAllocator};
 
     use super::BitmapAllocatorTree;
 

--- a/src/utils/bitmap_allocator.rs
+++ b/src/utils/bitmap_allocator.rs
@@ -1,0 +1,493 @@
+
+
+pub trait BitmapAllocator {
+    const CAPACITY: usize;
+
+    fn alloc(&mut self, entries: usize, align: usize) -> Option<usize>;
+    fn free(&mut self, start: usize, entries: usize);
+
+    fn set(&mut self, start: usize, entries: usize, value: bool);
+    fn next_free(&self, start: usize) -> Option<usize>;
+    fn get(&self, offset: usize) -> bool;
+    fn empty(&self) -> bool;
+    fn capacity(&self) -> usize;
+    fn used(&self) -> usize;
+}
+
+pub type BitmapAllocator1024 = BitmapAllocatorTree::<BitmapAllocator64>;
+
+pub struct BitmapAllocator64 {
+    bits: u64
+}
+
+impl BitmapAllocator64 {
+    pub const fn new() -> Self {
+        Self { bits: u64::MAX }
+    }
+}
+
+impl BitmapAllocator for BitmapAllocator64 {
+    const CAPACITY: usize = u64::BITS as usize;
+
+    fn alloc(&mut self, entries: usize, align: usize) -> Option<usize> {
+        alloc_aligned(self, entries, align)
+    }
+
+    fn free(&mut self, start: usize, entries: usize) {
+        self.set(start, entries, false);
+    }
+
+    fn set(&mut self, start: usize, entries: usize, value: bool) {
+        assert!((start + entries) <= BitmapAllocator64::CAPACITY);
+        // Create a mask for changing the bitmap
+        let start_mask = !((1 << start) - 1);
+        // Need to do some bit shifting to avoid overflow when top bit set
+        let end_mask = (((1 << (start + entries - 1)) - 1) << 1) + 1;
+        let mask = start_mask & end_mask;
+
+        if value {
+            self.bits |= mask;
+        } else {
+            self.bits &= !mask;
+        }
+    }
+
+    fn next_free(&self, start: usize) -> Option<usize> {
+        assert!(start < BitmapAllocator64::CAPACITY);
+        for offset in start..BitmapAllocator64::CAPACITY {
+            if ((1 << offset) & self.bits) == 0 {
+                return Some(offset);
+            }
+        }
+        None
+    }
+
+    fn get(&self, offset: usize) -> bool {
+        assert!(offset < BitmapAllocator64::CAPACITY);
+        return (self.bits & (1 << offset)) != 0
+    }
+
+    fn empty(&self) -> bool {
+        return self.bits == 0;
+    }
+
+    fn capacity(&self) -> usize {
+        Self::CAPACITY
+    }
+
+    fn used(&self) -> usize {
+        let mut count = 0;
+        let mut bits = self.bits;
+        while bits != 0 {
+            count += 1;
+            bits &= bits - 1;
+        }
+        count
+    }
+}
+
+pub struct BitmapAllocatorTree<T: BitmapAllocator> {
+    bits: u16,
+    child: [T; 16],
+}
+
+impl BitmapAllocatorTree<BitmapAllocator64> {
+    pub const fn new() -> Self {
+        Self {
+            bits: u16::MAX,
+            // FIXME: Is there a better way of doing this in rust?
+            child: [
+                BitmapAllocator64::new(), BitmapAllocator64::new(), BitmapAllocator64::new(), BitmapAllocator64::new(),
+                BitmapAllocator64::new(), BitmapAllocator64::new(), BitmapAllocator64::new(), BitmapAllocator64::new(),
+                BitmapAllocator64::new(), BitmapAllocator64::new(), BitmapAllocator64::new(), BitmapAllocator64::new(),
+                BitmapAllocator64::new(), BitmapAllocator64::new(), BitmapAllocator64::new(), BitmapAllocator64::new(),
+            ]
+        }
+    }
+}
+
+impl<T: BitmapAllocator> BitmapAllocator for BitmapAllocatorTree<T> {
+    const CAPACITY: usize = T::CAPACITY * 16;
+
+    fn alloc(&mut self, entries: usize, align: usize) -> Option<usize> {
+        alloc_aligned(self, entries, align)
+    }
+
+    fn free(&mut self, start: usize, entries: usize) {
+        self.set(start, entries, false);
+    }
+
+    fn set(&mut self, start: usize, entries: usize, value: bool) {
+        assert!((start + entries) <= Self::CAPACITY);
+        let mut offset = start % T::CAPACITY;
+        let mut remain = entries;
+        for index in (start / T::CAPACITY)..16 {
+            let child_size = if remain > (T::CAPACITY - offset) {
+                T::CAPACITY - offset
+            } else {
+                remain
+            };
+            remain -= child_size;
+
+            self.child[index].set(offset, child_size, value);
+            if self.child[index].empty() {
+                self.bits &= !(1 << index);
+            } else {
+                self.bits |= 1 << index;
+            }
+            if remain == 0 {
+                break;
+            }
+            // Only the first loop iteration uses a non-zero offset
+            offset = 0;
+        }
+    }
+
+    fn next_free(&self, start: usize) -> Option<usize> {
+        assert!(start < Self::CAPACITY);
+        let mut offset = start % T::CAPACITY;
+        for index in (start / T::CAPACITY)..16 {
+            if let Some(next_offset) = self.child[index].next_free(offset) {
+                return Some(next_offset + (index * T::CAPACITY));
+            }
+            // Only the first loop iteration uses a non-zero offset
+            offset = 0;
+        }
+        None
+    }
+
+    fn get(&self, offset: usize) -> bool {
+        assert!(offset < Self::CAPACITY);
+        let index = offset / T::CAPACITY;
+        self.child[index].get(offset % T::CAPACITY)
+    }
+
+    fn empty(&self) -> bool {
+        return self.bits == 0;
+    }
+
+    fn capacity(&self) -> usize {
+        Self::CAPACITY
+    }
+
+    fn used(&self) -> usize {
+        let mut count = 0;
+        for index in 0..16 {
+            if !self.child[index].empty() {
+                count += self.child[index].used();
+            }
+        }
+        count
+    }
+}
+
+fn alloc_aligned(ba: &mut impl BitmapAllocator, entries: usize, align: usize) -> Option<usize> {
+    // Iterate through the bitmap checking on each alignment boundary
+    // for a free range of the requested size
+    let align_mask = (1 << align) - 1;
+    let mut offset = 0;
+    while (offset + entries) <= ba.capacity() {
+        if let Some(offset_free) = ba.next_free(offset) {
+            // If the next free offset does not match the current aligned
+            // offset then move forward to the next aligned offset
+            if offset_free != offset {
+                offset = ((offset_free - 1) & !align_mask) + (1 << align);
+                continue;
+            }
+            // The aligned offset is free. Keep checking the next bit until we
+            // reach the requested size
+            assert!((offset + entries) <= ba.capacity());
+            let mut free_entries = 0;
+            for size_check in offset..(offset + entries) {
+                if !ba.get(size_check) {
+                    free_entries += 1;
+                } else {
+                    break;
+                }
+            }
+            if free_entries == entries {
+                // Mark the range as in-use
+                ba.set(offset, entries, true);
+                return Some(offset);
+            }
+        }
+        offset += 1 << align;
+    }
+    None
+}
+
+//
+// Tests
+//
+
+#[cfg(test)]
+mod tests {
+    use crate::bitmapallocator::{BitmapAllocator64, BitmapAllocator};
+
+    use super::BitmapAllocatorTree;
+
+    #[test]
+    fn test_set_single() {
+        let mut b = BitmapAllocator64 { bits: 0 };
+        b.set(0, 1, true);
+        assert_eq!(b.bits, 0x0000000000000001);
+        b.set(8, 1, true);
+        assert_eq!(b.bits, 0x0000000000000101);
+        b.set(63, 1, true);
+        assert_eq!(b.bits, 0x8000000000000101);
+        assert_eq!(b.used(), 3);
+    }
+
+    #[test]
+    fn test_clear_single() {
+        let mut b = BitmapAllocator64 { bits: u64::MAX };
+        b.set(0, 1, false);
+        assert_eq!(b.bits, 0xfffffffffffffffe);
+        b.set(8, 1, false);
+        assert_eq!(b.bits, 0xfffffffffffffefe);
+        b.set(63, 1, false);
+        assert_eq!(b.bits, 0x7ffffffffffffefe);
+        assert_eq!(b.used(), 64 - 3);
+    }
+
+    #[test]
+    fn test_set_range() {
+        let mut b = BitmapAllocator64 { bits: 0 };
+        b.set(0, 9, true);
+        assert_eq!(b.bits, 0x00000000000001ff);
+        b.set(11, 4, true);
+        assert_eq!(b.bits, 0x00000000000079ff);
+        b.set(61, 3, true);
+        assert_eq!(b.bits, 0xe0000000000079ff);
+        assert_eq!(b.used(), 16);
+    }
+
+    #[test]
+    fn test_clear_range() {
+        let mut b = BitmapAllocator64 { bits: u64::MAX };
+        b.set(0, 9, false);
+        assert_eq!(b.bits, !0x00000000000001ff);
+        b.set(11, 4, false);
+        assert_eq!(b.bits, !0x00000000000079ff);
+        b.set(61, 3, false);
+        assert_eq!(b.bits, !0xe0000000000079ff);
+        assert_eq!(b.used(), 64 - 16);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_exceed_range() {
+        let mut b = BitmapAllocator64 { bits: 0 };
+        b.set(0, 65, true);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_exceed_start() {
+        let mut b = BitmapAllocator64 { bits: 0 };
+        b.set(64, 1, true);
+    }
+
+    #[test]
+    fn test_next_free() {
+        let mut b = BitmapAllocator64 { bits: !0x8000000000000101 };
+        assert_eq!(b.next_free(0), Some(0));
+        assert_eq!(b.next_free(1), Some(8));
+        assert_eq!(b.next_free(9), Some(63));
+        b.set(63, 1, true);
+        assert_eq!(b.next_free(9), None);
+    }
+
+    #[test]
+    fn alloc_simple() {
+        let mut b = BitmapAllocator64 { bits: 0 };
+        assert_eq!(b.alloc(1, 0), Some(0));
+        assert_eq!(b.alloc(1, 0), Some(1));
+        assert_eq!(b.alloc(1, 0), Some(2));
+    }
+
+    #[test]
+    fn alloc_aligned() {
+        let mut b = BitmapAllocator64 { bits: 0 };
+        // Alignment of 1 << 4 bits : 16 bit alignment
+        assert_eq!(b.alloc(1, 4), Some(0));
+        assert_eq!(b.alloc(1, 4), Some(16));
+        assert_eq!(b.alloc(1, 4), Some(32));
+    }
+
+    #[test]
+    fn alloc_large_aligned() {
+        let mut b = BitmapAllocator64 { bits: 0 };
+        // Alignment of 1 << 4 bits : 16 bit alignment
+        assert_eq!(b.alloc(17, 4), Some(0));
+        assert_eq!(b.alloc(1, 4), Some(32));
+    }
+
+    #[test]
+    fn alloc_out_of_space() {
+        let mut b = BitmapAllocator64 { bits: 0 };
+        // Alignment of 1 << 4 bits : 16 bit alignment
+        assert_eq!(b.alloc(50, 4), Some(0));
+        assert_eq!(b.alloc(1, 4), None);
+    }
+
+    #[test]
+    fn free_space() {
+        let mut b = BitmapAllocator64 { bits: 0 };
+        // Alignment of 1 << 4 bits : 16 bit alignment
+        assert_eq!(b.alloc(50, 4), Some(0));
+        assert_eq!(b.alloc(1, 4), None);
+        b.free(0, 50);
+        assert_eq!(b.alloc(1, 4), Some(0));
+    }
+
+    #[test]
+    fn free_multiple() {
+        let mut b = BitmapAllocator64 { bits: u64::MAX };
+        b.free(0, 16);
+        b.free(23, 16);
+        b.free(41, 16);
+        assert_eq!(b.alloc(16, 0), Some(0));
+        assert_eq!(b.alloc(16, 0), Some(23));
+        assert_eq!(b.alloc(16, 0), Some(41));
+        assert_eq!(b.alloc(16, 0), None);
+    }
+
+    #[test]
+    fn tree_set_all() {
+        let mut b = BitmapAllocatorTree::<BitmapAllocator64>::new();
+        b.set(0, 64 * 16, false);
+        for i in 0..16 {
+            assert_eq!(b.child[i].bits, 0);
+        }
+        assert_eq!(b.bits, 0);
+        assert_eq!(b.used(), 0);
+    }
+
+    #[test]
+    fn tree_clear_all() {
+        let mut b = BitmapAllocatorTree::<BitmapAllocator64>::new();
+        b.set(0, 64 * 16, true);
+        for i in 0..16 {
+            assert_eq!(b.child[i].bits, u64::MAX);
+        }
+        assert_eq!(b.bits, u16::MAX);
+        assert_eq!(b.used(), 1024);
+    }
+
+    #[test]
+    fn tree_set_some() {
+        let mut b = BitmapAllocatorTree::<BitmapAllocator64>::new();
+
+        // First child
+        b.set(0, BitmapAllocatorTree::<BitmapAllocator64>::CAPACITY, false);
+        b.set(11, 17, true);
+        for i in 0..16 {
+            if i == 0 {
+                assert_eq!(b.child[i].bits, 0x000000000ffff800);
+            } else {
+                assert_eq!(b.child[i].bits, 0);
+            }
+        }
+        assert_eq!(b.bits, 0x0001);
+        assert_eq!(b.used(), 17);
+
+        // Last child
+        b.set(0, BitmapAllocatorTree::<BitmapAllocator64>::CAPACITY, false);
+        b.set((15 * 64) + 11, 17, true);
+        for i in 0..16 {
+            if i == 15 {
+                assert_eq!(b.child[i].bits, 0x000000000ffff800);
+            } else {
+                assert_eq!(b.child[i].bits, 0);
+            }
+        }
+        assert_eq!(b.bits, 0x8000);
+        assert_eq!(b.used(), 17);
+
+        // Traverse child boundary
+        b.set(0, BitmapAllocatorTree::<BitmapAllocator64>::CAPACITY, false);
+        b.set(50, 28, true);
+        for i in 0..16 {
+            if i == 0 {
+                assert_eq!(b.child[i].bits, 0xfffc000000000000);
+            } else if i == 1 {
+                assert_eq!(b.child[i].bits, 0x0000000000003fff);
+            } else {
+                assert_eq!(b.child[i].bits, 0);
+            }
+        }
+        assert_eq!(b.bits, 0x0003);
+        assert_eq!(b.used(), 28);
+    }
+
+    #[test]
+    fn tree_alloc_simple() {
+        let mut b = BitmapAllocatorTree::<BitmapAllocator64>::new();
+        b.set(0, BitmapAllocatorTree::<BitmapAllocator64>::CAPACITY, false);
+        for i in 0..256 {
+            assert_eq!(b.alloc(1, 0), Some(i));
+        }
+        assert_eq!(b.used(), 256);
+    }
+
+    #[test]
+    fn tree_alloc_aligned() {
+        let mut b = BitmapAllocatorTree::<BitmapAllocator64>::new();
+        b.set(0, BitmapAllocatorTree::<BitmapAllocator64>::CAPACITY, false);
+        // Alignment of 1 << 5 bits : 32 bit alignment
+        assert_eq!(b.alloc(1, 5), Some(0));
+        assert_eq!(b.alloc(1, 5), Some(32));
+        assert_eq!(b.alloc(1, 5), Some(64));
+        assert_eq!(b.alloc(1, 5), Some(96));
+        assert_eq!(b.alloc(1, 5), Some(128));
+        assert_eq!(b.alloc(1, 0), Some(1));
+        assert_eq!(b.used(), 6);
+    }
+
+    #[test]
+    fn tree_alloc_large_aligned() {
+        let mut b = BitmapAllocatorTree::<BitmapAllocator64>::new();
+        b.set(0, BitmapAllocatorTree::<BitmapAllocator64>::CAPACITY, false);
+        // Alignment of 1 << 4 bits : 16 bit alignment
+        assert_eq!(b.alloc(500, 4), Some(0));
+        assert_eq!(b.alloc(400, 4), Some(512));
+        assert_eq!(b.used(), 900);
+    }
+
+    #[test]
+    fn tree_alloc_out_of_space() {
+        let mut b = BitmapAllocatorTree::<BitmapAllocator64>::new();
+        b.set(0, BitmapAllocatorTree::<BitmapAllocator64>::CAPACITY, false);
+        // Alignment of 1 << 4 bits : 16 bit alignment
+        assert_eq!(b.alloc(1000, 4), Some(0));
+        assert_eq!(b.alloc(BitmapAllocatorTree::<BitmapAllocator64>::CAPACITY - 100, 4), None);
+        assert_eq!(b.used(), 1000);
+    }
+
+    #[test]
+    fn tree_free_space() {
+        let mut b = BitmapAllocatorTree::<BitmapAllocator64>::new();
+        b.set(0, BitmapAllocatorTree::<BitmapAllocator64>::CAPACITY, false);
+        // Alignment of 1 << 4 bits : 16 bit alignment
+        assert_eq!(b.alloc(BitmapAllocatorTree::<BitmapAllocator64>::CAPACITY - 10, 4), Some(0));
+        assert_eq!(b.alloc(1, 4), None);
+        b.free(0, 50);
+        assert_eq!(b.alloc(1, 4), Some(0));
+        assert_eq!(b.used(), 965);
+    }
+
+    #[test]
+    fn tree_free_multiple() {
+        let mut b = BitmapAllocatorTree::<BitmapAllocator64>::new();
+        b.set(0, BitmapAllocatorTree::<BitmapAllocator64>::CAPACITY, true);
+        b.free(0, 16);
+        b.free(765, 16);
+        b.free(897, 16);
+        assert_eq!(b.alloc(16, 0), Some(0));
+        assert_eq!(b.alloc(16, 0), Some(765));
+        assert_eq!(b.alloc(16, 0), Some(897));
+        assert_eq!(b.alloc(16, 0), None);
+        assert_eq!(b.used(), 1024);
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod immut_after_init;
 pub mod util;
+pub mod bitmap_allocator;
 
 pub use util::{
     align_up, crosses_page, ffs, halt, is_aligned, overlap, page_align, page_align_up, page_offset,


### PR DESCRIPTION
The current method of mapping a virtual memory address to a physical address involves mapping individual pages using slots, with a guard page between each virtual address. It is not possible to create a virtual memory mapping that spans multiple pages.

This new virtual address allocator allows dynamic allocation of virtual addresses that can span multiple 4K or 2M pages using a bitmap to keep track of virtual pages that are in use.

This simplifies the development of future capabilities and in particular simplifies parsing of variable size structures such as those used in the files of a firmware file system.