### PR TITLE
Introduce VirtAddr and PhysAddr types.

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -1,3 +1,9 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2022-2023 SUSE LLC
+//
+// Author: Carlos López <carlos.lopez@suse.com>
+
 use crate::types::PAGE_SIZE;
 use core::fmt;
 use core::ops;
@@ -40,6 +46,18 @@ pub trait Address:
 
     fn offset(&self, off: InnerAddr) -> Self {
         Self::from(self.bits() + off)
+    }
+
+    fn checked_offset(&self, off: InnerAddr) -> Option<Self> {
+        self.bits().checked_add(off).map(|addr| addr.into())
+    }
+
+    fn sub(&self, off: InnerAddr) -> Self {
+        Self::from(self.bits() - off)
+    }
+
+    fn checked_sub(&self, off: InnerAddr) -> Option<Self> {
+        self.bits().checked_sub(off).map(|addr| addr.into())
     }
 
     fn page_offset(&self) -> usize {
@@ -113,3 +131,85 @@ impl ops::Sub for PhysAddr {
 }
 
 impl Address for PhysAddr {}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct VirtAddr(InnerAddr);
+
+impl VirtAddr {
+    pub const fn null() -> Self {
+        Self(0)
+    }
+
+    // const traits experimental, so for now we need this to make up
+    // for the lack of VirtAddr::from() in const contexts.
+    pub const fn new(addr: InnerAddr) -> Self {
+        Self(addr)
+    }
+
+    pub fn as_ptr<T>(&self) -> *const T {
+        self.0 as *const T
+    }
+
+    pub fn as_mut_ptr<T>(&self) -> *mut T {
+        self.0 as *mut T
+    }
+}
+
+impl fmt::Display for VirtAddr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl fmt::LowerHex for VirtAddr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.0, f)
+    }
+}
+
+impl From<InnerAddr> for VirtAddr {
+    fn from(addr: InnerAddr) -> Self {
+        Self(addr)
+    }
+}
+
+impl From<VirtAddr> for InnerAddr {
+    fn from(addr: VirtAddr) -> Self {
+        addr.0
+    }
+}
+
+impl From<u64> for VirtAddr {
+    fn from(addr: u64) -> Self {
+        let addr: usize = addr.try_into().unwrap();
+        VirtAddr::from(addr)
+    }
+}
+
+impl From<VirtAddr> for u64 {
+    fn from(addr: VirtAddr) -> Self {
+        addr.0 as u64
+    }
+}
+
+impl<T> From<*const T> for VirtAddr {
+    fn from(ptr: *const T) -> Self {
+        Self(ptr as InnerAddr)
+    }
+}
+
+impl<T> From<*mut T> for VirtAddr {
+    fn from(ptr: *mut T) -> Self {
+        Self(ptr as InnerAddr)
+    }
+}
+
+impl ops::Sub for VirtAddr {
+    type Output = InnerAddr;
+    fn sub(self, other: Self) -> Self::Output {
+        self.0 - other.0
+    }
+}
+
+impl Address for VirtAddr {}

--- a/src/address.rs
+++ b/src/address.rs
@@ -1,0 +1,115 @@
+use crate::types::PAGE_SIZE;
+use core::fmt;
+use core::ops;
+
+// The backing type to represent an address;
+type InnerAddr = usize;
+
+pub trait Address:
+    Copy + From<InnerAddr> + Into<InnerAddr> + PartialEq + Eq + PartialOrd + Ord
+{
+    // Transform the address into its inner representation for easier
+    /// arithmetic manipulation
+    fn bits(&self) -> InnerAddr {
+        (*self).into()
+    }
+
+    fn is_null(&self) -> bool {
+        self.bits() == 0
+    }
+
+    fn align_up(&self, align: InnerAddr) -> Self {
+        Self::from((self.bits() + (align - 1)) & !(align - 1))
+    }
+
+    fn page_align_up(&self) -> Self {
+        self.align_up(PAGE_SIZE)
+    }
+
+    fn page_align(&self) -> Self {
+        Self::from(self.bits() & !(PAGE_SIZE - 1))
+    }
+
+    fn is_aligned(&self, align: InnerAddr) -> bool {
+        (self.bits() & (align - 1)) == 0
+    }
+
+    fn is_page_aligned(&self) -> bool {
+        self.is_aligned(PAGE_SIZE)
+    }
+
+    fn offset(&self, off: InnerAddr) -> Self {
+        Self::from(self.bits() + off)
+    }
+
+    fn page_offset(&self) -> usize {
+        self.bits() & (PAGE_SIZE - 1)
+    }
+
+    fn crosses_page(&self, size: usize) -> bool {
+        let start = self.bits();
+        let x1 = start / PAGE_SIZE;
+        let x2 = (start + size - 1) / PAGE_SIZE;
+        x1 != x2
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct PhysAddr(InnerAddr);
+
+impl PhysAddr {
+    pub const fn null() -> Self {
+        Self(0)
+    }
+}
+
+impl fmt::Display for PhysAddr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl fmt::LowerHex for PhysAddr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.0, f)
+    }
+}
+
+impl From<InnerAddr> for PhysAddr {
+    fn from(addr: InnerAddr) -> PhysAddr {
+        Self(addr)
+    }
+}
+
+impl From<PhysAddr> for InnerAddr {
+    fn from(addr: PhysAddr) -> InnerAddr {
+        addr.0
+    }
+}
+
+impl From<u64> for PhysAddr {
+    fn from(addr: u64) -> PhysAddr {
+        // The unwrap will get optimized away on 64bit platforms,
+        // which should be our only target anyway
+        let addr: usize = addr.try_into().unwrap();
+        PhysAddr::from(addr)
+    }
+}
+
+impl From<PhysAddr> for u64 {
+    fn from(addr: PhysAddr) -> u64 {
+        addr.0 as u64
+    }
+}
+
+// Substracting two addresses produces an usize instead of an address,
+// since we normally do this to compute the size of a memory region.
+impl ops::Sub for PhysAddr {
+    type Output = InnerAddr;
+    fn sub(self, other: Self) -> Self::Output {
+        self.0 - other.0
+    }
+}
+
+impl Address for PhysAddr {}

--- a/src/cpu/control_regs.rs
+++ b/src/cpu/control_regs.rs
@@ -5,6 +5,7 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 
 use super::features::cpu_has_pge;
+use crate::address::{Address, PhysAddr};
 use bitflags::bitflags;
 use core::arch::asm;
 
@@ -86,20 +87,20 @@ pub fn write_cr2(cr2: usize) {
     }
 }
 
-pub fn read_cr3() -> usize {
+pub fn read_cr3() -> PhysAddr {
     let ret: usize;
     unsafe {
         asm!("mov %cr3, %rax",
              out("rax") ret,
              options(att_syntax));
     }
-    ret
+    PhysAddr::from(ret)
 }
 
-pub fn write_cr3(cr3: usize) {
+pub fn write_cr3(cr3: PhysAddr) {
     unsafe {
         asm!("mov %rax, %cr3",
-             in("rax") cr3,
+             in("rax") cr3.bits(),
              options(att_syntax));
     }
 }

--- a/src/cpu/gdt.rs
+++ b/src/cpu/gdt.rs
@@ -5,7 +5,8 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 
 use super::tss::{X86Tss, TSS_LIMIT};
-use crate::types::{VirtAddr, SVSM_CS, SVSM_DS, SVSM_TSS};
+use crate::address::VirtAddr;
+use crate::types::{SVSM_CS, SVSM_DS, SVSM_TSS};
 use core::arch::asm;
 use core::mem;
 
@@ -58,7 +59,10 @@ pub fn load_tss(tss: &X86Tss) {
     }
 }
 
-static mut GDT_DESC: GdtDesc = GdtDesc { size: 0, addr: 0 };
+static mut GDT_DESC: GdtDesc = GdtDesc {
+    size: 0,
+    addr: VirtAddr::null(),
+};
 
 pub fn gdt_base_limit() -> (u64, u32) {
     unsafe {
@@ -71,7 +75,7 @@ pub fn gdt_base_limit() -> (u64, u32) {
 
 pub fn load_gdt() {
     unsafe {
-        let vaddr = GDT.as_ptr() as VirtAddr;
+        let vaddr = VirtAddr::from(GDT.as_ptr());
 
         GDT_DESC.addr = vaddr;
         GDT_DESC.size = (GDT_SIZE * 8) - 1;

--- a/src/cpu/tlb.rs
+++ b/src/cpu/tlb.rs
@@ -4,8 +4,7 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
-use crate::types::VirtAddr;
-use crate::utils::page_align;
+use crate::address::{Address, VirtAddr};
 use core::arch::asm;
 
 const INVLPGB_VALID_VA: u64 = 1u64 << 0;
@@ -52,8 +51,10 @@ pub fn flush_tlb_global_sync() {
 }
 
 pub fn flush_address(va: VirtAddr) {
-    let rax: u64 =
-        (page_align(va) as u64) | INVLPGB_VALID_VA | INVLPGB_VALID_ASID | INVLPGB_VALID_GLOBAL;
+    let rax: u64 = (va.page_align().bits() as u64)
+        | INVLPGB_VALID_VA
+        | INVLPGB_VALID_ASID
+        | INVLPGB_VALID_GLOBAL;
     do_invlpgb(rax, 0, 0);
 }
 

--- a/src/cpu/tss.rs
+++ b/src/cpu/tss.rs
@@ -4,6 +4,8 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
+use crate::address::VirtAddr;
+
 // IST offsets
 pub const _IST_INVALID: usize = 0;
 pub const IST_DF: usize = 1;
@@ -11,8 +13,8 @@ pub const IST_DF: usize = 1;
 #[repr(C, packed)]
 pub struct X86Tss {
     reserved1: u32,
-    pub stacks: [usize; 3],
-    pub ist_stacks: [usize; 8],
+    pub stacks: [VirtAddr; 3],
+    pub ist_stacks: [VirtAddr; 8],
     reserved2: u64,
     reserved3: u16,
     io_bmp_base: u16,
@@ -24,8 +26,8 @@ impl X86Tss {
     pub const fn new() -> Self {
         X86Tss {
             reserved1: 0,
-            stacks: [0; 3],
-            ist_stacks: [0; 8],
+            stacks: [VirtAddr::null(); 3],
+            ist_stacks: [VirtAddr::null(); 8],
             reserved2: 0,
             reserved3: 0,
             io_bmp_base: (TSS_LIMIT + 1) as u16,

--- a/src/cpu/vmsa.rs
+++ b/src/cpu/vmsa.rs
@@ -4,6 +4,7 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
+use crate::address::Address;
 use crate::sev::vmsa::{VMSASegment, VMSA};
 use crate::types::{GUEST_VMPL, SVSM_CS, SVSM_CS_FLAGS, SVSM_DS, SVSM_DS_FLAGS};
 
@@ -62,7 +63,7 @@ pub fn init_svsm_vmsa(vmsa: &mut VMSA) {
     vmsa.idt = svsm_idt_segment();
 
     vmsa.cr0 = read_cr0().bits();
-    vmsa.cr3 = read_cr3() as u64;
+    vmsa.cr3 = read_cr3().bits() as u64;
     vmsa.cr4 = read_cr4().bits();
     vmsa.efer = read_efer().bits();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 #![feature(sync_unsafe_cell)]
 
 pub mod acpi;
+pub mod address;
 pub mod console;
 pub mod cpu;
 pub mod debug;

--- a/src/mm/address_space.rs
+++ b/src/mm/address_space.rs
@@ -4,8 +4,7 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
-use crate::address::{Address, PhysAddr};
-use crate::types::VirtAddr;
+use crate::address::{Address, PhysAddr, VirtAddr};
 use crate::utils::immut_after_init::ImmutAfterInitCell;
 
 #[derive(Copy, Clone)]
@@ -18,8 +17,8 @@ struct KernelMapping {
 impl KernelMapping {
     pub const fn new() -> Self {
         KernelMapping {
-            virt_start: 0,
-            virt_end: 0,
+            virt_start: VirtAddr::null(),
+            virt_end: VirtAddr::null(),
             phys_start: PhysAddr::null(),
         }
     }
@@ -57,7 +56,7 @@ pub fn phys_to_virt(paddr: PhysAddr) -> VirtAddr {
 
     let offset: usize = paddr - KERNEL_MAPPING.phys_start;
 
-    KERNEL_MAPPING.virt_start + offset
+    KERNEL_MAPPING.virt_start.offset(offset)
 }
 
 // Address space definitions for SVSM virtual memory layout

--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -4,10 +4,10 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
-use crate::address::{Address, PhysAddr};
+use crate::address::{Address, PhysAddr, VirtAddr};
 use crate::error::SvsmError;
 use crate::locking::SpinLock;
-use crate::types::{VirtAddr, PAGE_SHIFT, PAGE_SIZE};
+use crate::types::{PAGE_SHIFT, PAGE_SIZE};
 use crate::utils::{align_up, zero_mem_region};
 use core::alloc::{GlobalAlloc, Layout};
 use core::mem::size_of;
@@ -49,7 +49,7 @@ impl PageStorageType {
     }
 
     fn encode_slab(slab: VirtAddr) -> Self {
-        PageStorageType(PAGE_TYPE_SLABPAGE | (slab as u64) & PAGE_TYPE_SLABPAGE_MASK)
+        PageStorageType(PAGE_TYPE_SLABPAGE | (slab.bits() as u64) & PAGE_TYPE_SLABPAGE_MASK)
     }
 
     fn encode_refcount(&self, refcount: u64) -> PageStorageType {
@@ -127,7 +127,7 @@ impl SlabPageInfo {
 
     pub fn decode(mem: PageStorageType) -> Self {
         SlabPageInfo {
-            slab: (mem.0 & PAGE_TYPE_SLABPAGE_MASK) as VirtAddr,
+            slab: VirtAddr::from(mem.0 & PAGE_TYPE_SLABPAGE_MASK),
         }
     }
 }
@@ -240,7 +240,7 @@ impl MemoryRegion {
     pub const fn new() -> Self {
         MemoryRegion {
             start_phys: PhysAddr::null(),
-            start_virt: 0,
+            start_virt: VirtAddr::null(),
             page_count: 0,
             nr_pages: [0; MAX_ORDER],
             next_page: [0; MAX_ORDER],
@@ -255,20 +255,20 @@ impl MemoryRegion {
         if paddr < self.start_phys || paddr >= end_phys {
             // For the initial stage2 identity mapping, the root page table
             // pages are static and outside of the heap memory region.
-            if self.start_phys.bits() as VirtAddr == self.start_virt {
-                return Some(paddr.bits() as VirtAddr);
+            if VirtAddr::from(self.start_phys.bits()) == self.start_virt {
+                return Some(VirtAddr::from(paddr.bits()));
             }
             return None;
         }
 
         let offset = paddr - self.start_phys;
 
-        Some((self.start_virt + offset) as VirtAddr)
+        Some(self.start_virt.offset(offset))
     }
 
     #[allow(dead_code)]
     pub fn virt_to_phys(&self, vaddr: VirtAddr) -> Option<PhysAddr> {
-        let end_virt = self.start_virt + (self.page_count * PAGE_SIZE);
+        let end_virt = self.start_virt.offset(self.page_count * PAGE_SIZE);
 
         if vaddr < self.start_virt || vaddr >= end_virt {
             return None;
@@ -282,7 +282,7 @@ impl MemoryRegion {
     fn page_info_virt_addr(&self, pfn: usize) -> VirtAddr {
         let size = size_of::<PageStorageType>();
         let virt = self.start_virt;
-        virt + (pfn * size)
+        virt.offset(pfn * size)
     }
 
     fn check_pfn(&self, pfn: usize) {
@@ -293,7 +293,7 @@ impl MemoryRegion {
 
     fn check_virt_addr(&self, vaddr: VirtAddr) -> bool {
         let start = self.start_virt;
-        let end = self.start_virt + (self.page_count * PAGE_SIZE);
+        let end = self.start_virt.offset(self.page_count * PAGE_SIZE);
 
         vaddr >= start && vaddr < end
     }
@@ -303,7 +303,9 @@ impl MemoryRegion {
 
         let info: PageStorageType = pi.to_mem();
         unsafe {
-            let ptr: *mut PageStorageType = self.page_info_virt_addr(pfn) as *mut PageStorageType;
+            let ptr = self
+                .page_info_virt_addr(pfn)
+                .as_mut_ptr::<PageStorageType>();
             (*ptr) = info;
         }
     }
@@ -311,14 +313,14 @@ impl MemoryRegion {
     fn read_page_info(&self, pfn: usize) -> Page {
         self.check_pfn(pfn);
 
-        let virt = self.page_info_virt_addr(pfn);
-        let info: PageStorageType = PageStorageType(unsafe { *(virt as *const u64) });
+        let virt = self.page_info_virt_addr(pfn).as_ptr::<u64>();
+        let info = unsafe { PageStorageType(*virt) };
 
         Page::from_mem(info)
     }
 
     pub fn get_page_info(&self, vaddr: VirtAddr) -> Result<Page, SvsmError> {
-        if vaddr == 0 || !self.check_virt_addr(vaddr) {
+        if vaddr.is_null() || !self.check_virt_addr(vaddr) {
             return Err(SvsmError::Mem);
         }
 
@@ -403,14 +405,10 @@ impl MemoryRegion {
 
     pub fn allocate_pages(&mut self, order: usize) -> Result<VirtAddr, SvsmError> {
         self.refill_page_list(order)?;
-        if let Ok(pfn) = self.get_next_page(order) {
-            let pg = Page::Allocated(AllocatedInfo { order });
-            self.write_page_info(pfn, pg);
-            let vaddr = self.start_virt + (pfn * PAGE_SIZE);
-            Ok(vaddr)
-        } else {
-            Err(SvsmError::Mem)
-        }
+        let pfn = self.get_next_page(order)?;
+        let pg = Page::Allocated(AllocatedInfo { order });
+        self.write_page_info(pfn, pg);
+        Ok(self.start_virt.offset(pfn * PAGE_SIZE))
     }
 
     pub fn allocate_page(&mut self) -> Result<VirtAddr, SvsmError> {
@@ -420,7 +418,7 @@ impl MemoryRegion {
     pub fn allocate_zeroed_page(&mut self) -> Result<VirtAddr, SvsmError> {
         let vaddr = self.allocate_page()?;
 
-        zero_mem_region(vaddr, vaddr + PAGE_SIZE);
+        zero_mem_region(vaddr, vaddr.offset(PAGE_SIZE));
 
         Ok(vaddr)
     }
@@ -428,28 +426,20 @@ impl MemoryRegion {
     pub fn allocate_slab_page(&mut self, slab: Option<VirtAddr>) -> Result<VirtAddr, SvsmError> {
         self.refill_page_list(0)?;
 
-        let slab_vaddr = slab.unwrap_or(0);
-        if let Ok(pfn) = self.get_next_page(0) {
-            assert_eq!(slab_vaddr & (PAGE_TYPE_MASK as usize), 0);
-            let pg = Page::SlabPage(SlabPageInfo { slab: slab_vaddr });
-            self.write_page_info(pfn, pg);
-            let vaddr = self.start_virt + (pfn * PAGE_SIZE);
-            Ok(vaddr)
-        } else {
-            Err(SvsmError::Mem)
-        }
+        let slab_vaddr = slab.unwrap_or(VirtAddr::null());
+        let pfn = self.get_next_page(0)?;
+        assert_eq!(slab_vaddr.bits() & (PAGE_TYPE_MASK as usize), 0);
+        let pg = Page::SlabPage(SlabPageInfo { slab: slab_vaddr });
+        self.write_page_info(pfn, pg);
+        Ok(self.start_virt.offset(pfn * PAGE_SIZE))
     }
 
     pub fn allocate_file_page(&mut self) -> Result<VirtAddr, SvsmError> {
         self.refill_page_list(0)?;
-        if let Ok(pfn) = self.get_next_page(0) {
-            let pg = Page::FilePage(FileInfo::new(1));
-            self.write_page_info(pfn, pg);
-            let vaddr = self.start_virt + (pfn * PAGE_SIZE);
-            Ok(vaddr)
-        } else {
-            Err(SvsmError::Mem)
-        }
+        let pfn = self.get_next_page(0)?;
+        let pg = Page::FilePage(FileInfo::new(1));
+        self.write_page_info(pfn, pg);
+        Ok(self.start_virt.offset(pfn * PAGE_SIZE))
     }
 
     pub fn get_file_page(&mut self, vaddr: VirtAddr) -> Result<(), SvsmError> {
@@ -755,12 +745,12 @@ struct SlabPage {
 impl SlabPage {
     pub const fn new() -> Self {
         SlabPage {
-            vaddr: 0,
+            vaddr: VirtAddr::null(),
             capacity: 0,
             free: 0,
             item_size: 0,
             used_bitmap: [0; 2],
-            next_page: 0,
+            next_page: VirtAddr::null(),
         }
     }
 
@@ -774,26 +764,23 @@ impl SlabPage {
         }
 
         assert!(item_size <= (PAGE_SIZE / 2) as u16);
-        assert_eq!(self.vaddr, 0);
+        assert!(self.vaddr.is_null());
 
         if item_size < 32 {
             item_size = 32;
         }
 
-        if let Ok(vaddr) = allocate_slab_page(slab_vaddr) {
-            self.vaddr = vaddr;
-            self.item_size = item_size;
-            self.capacity = (PAGE_SIZE as u16) / item_size;
-            self.free = self.capacity;
-        } else {
-            return Err(SvsmError::Mem);
-        }
+        let vaddr = allocate_slab_page(slab_vaddr)?;
+        self.vaddr = vaddr;
+        self.item_size = item_size;
+        self.capacity = (PAGE_SIZE as u16) / item_size;
+        self.free = self.capacity;
 
         Ok(())
     }
 
     pub fn destroy(&mut self) {
-        if self.vaddr == 0 {
+        if self.vaddr.is_null() {
             return;
         }
 
@@ -828,8 +815,7 @@ impl SlabPage {
             if self.used_bitmap[idx] & mask == 0 {
                 self.used_bitmap[idx] |= mask;
                 self.free -= 1;
-                let offset = (self.item_size * i) as VirtAddr;
-                return Ok(self.vaddr + offset);
+                return Ok(self.vaddr.offset((self.item_size * i) as usize));
             }
         }
 
@@ -837,13 +823,13 @@ impl SlabPage {
     }
 
     pub fn free(&mut self, vaddr: VirtAddr) -> Result<(), SvsmError> {
-        if vaddr < self.vaddr || vaddr >= self.vaddr + PAGE_SIZE {
+        if vaddr < self.vaddr || vaddr >= self.vaddr.offset(PAGE_SIZE) {
             return Err(SvsmError::Mem);
         }
 
         assert!(self.item_size > 0);
 
-        let item_size = self.item_size as VirtAddr;
+        let item_size = self.item_size as usize;
         let offset = vaddr - self.vaddr;
         let i = offset / item_size;
         let idx = i / 64;
@@ -898,7 +884,7 @@ impl SlabCommon {
         let old_next_page = self.page.get_next_page();
         new_page.set_next_page(old_next_page);
         self.page
-            .set_next_page((new_page as *mut SlabPage) as VirtAddr);
+            .set_next_page(VirtAddr::from(new_page as *mut SlabPage));
 
         let capacity = new_page.get_capacity() as u32;
         self.pages += 1;
@@ -938,8 +924,8 @@ impl SlabCommon {
             }
 
             let next_page = (*page).get_next_page();
-            assert_ne!(next_page, 0); // Cannot happen with free slots on entry.
-            page = unsafe { &mut *(next_page as *mut SlabPage) };
+            assert!(!next_page.is_null()); // Cannot happen with free slots on entry.
+            page = unsafe { &mut *next_page.as_mut_ptr::<SlabPage>() };
         }
     }
 
@@ -962,8 +948,8 @@ impl SlabCommon {
             }
 
             let next_page = page.get_next_page();
-            assert_ne!(next_page, 0); // Object does not belong to this Slab.
-            page = unsafe { &mut *(next_page as *mut SlabPage) };
+            assert!(!next_page.is_null()); // Object does not belong to this Slab.
+            page = unsafe { &mut *next_page.as_mut_ptr::<SlabPage>() };
         }
     }
 }
@@ -996,7 +982,7 @@ impl SlabPageSlab {
         assert_ne!(self.common.free, 0);
 
         let page_vaddr = self.common.allocate_slot();
-        let slab_page = unsafe { &mut *(page_vaddr as *mut SlabPage) };
+        let slab_page = unsafe { &mut *page_vaddr.as_mut_ptr::<SlabPage>() };
 
         *slab_page = SlabPage::new();
         if let Err(_e) = slab_page.init(None, self.common.item_size) {
@@ -1016,10 +1002,10 @@ impl SlabPageSlab {
             let mut next_page_vaddr = self.common.page.get_next_page();
             let mut freed_one = false;
             loop {
-                if next_page_vaddr == 0 {
+                if next_page_vaddr.is_null() {
                     break;
                 }
-                let slab_page = unsafe { &mut *(next_page_vaddr as *mut SlabPage) };
+                let slab_page = unsafe { &mut *next_page_vaddr.as_mut_ptr::<SlabPage>() };
                 next_page_vaddr = slab_page.get_next_page();
 
                 let capacity = slab_page.get_capacity();
@@ -1029,7 +1015,7 @@ impl SlabPageSlab {
                         .remove_slab_page(unsafe { &mut *last_page }, slab_page);
                     slab_page.destroy();
                     self.common
-                        .deallocate_slot(slab_page as *mut SlabPage as VirtAddr);
+                        .deallocate_slot(VirtAddr::from(slab_page as *mut SlabPage));
                     freed_one = true;
                 } else {
                     last_page = slab_page;
@@ -1044,11 +1030,11 @@ impl SlabPageSlab {
             return Err(SvsmError::Mem);
         }
 
-        Ok(unsafe { &mut *(self.common.allocate_slot() as *mut SlabPage) })
+        Ok(unsafe { &mut *self.common.allocate_slot().as_mut_ptr::<SlabPage>() })
     }
 
     fn deallocate(&mut self, slab_page: *mut SlabPage) {
-        self.common.deallocate_slot(slab_page as VirtAddr);
+        self.common.deallocate_slot(VirtAddr::from(slab_page));
         self.shrink_slab();
     }
 }
@@ -1065,7 +1051,7 @@ impl Slab {
     }
 
     fn init(&mut self) -> Result<(), SvsmError> {
-        let slab_vaddr = (self as *mut Slab) as VirtAddr;
+        let slab_vaddr = VirtAddr::from(self as *mut Slab);
         self.common.init(Some(slab_vaddr))
     }
 
@@ -1085,7 +1071,7 @@ impl Slab {
             Ok(slab_page) => unsafe { &mut *slab_page },
             Err(_) => return Err(SvsmError::Mem),
         };
-        let slab_vaddr = (self as *mut Slab) as VirtAddr;
+        let slab_vaddr = VirtAddr::from(self as *mut Slab);
         *slab_page = SlabPage::new();
         if let Err(_e) = slab_page.init(Some(slab_vaddr), self.common.item_size) {
             SLAB_PAGE_SLAB.lock().deallocate(slab_page);
@@ -1108,10 +1094,10 @@ impl Slab {
         }
 
         loop {
-            if next_page_vaddr == 0 {
+            if next_page_vaddr.is_null() {
                 break;
             }
-            let slab_page = unsafe { &mut *(next_page_vaddr as *mut SlabPage) };
+            let slab_page = unsafe { &mut *(next_page_vaddr.as_mut_ptr::<SlabPage>()) };
             next_page_vaddr = slab_page.get_next_page();
 
             let capacity = slab_page.get_capacity();
@@ -1203,11 +1189,11 @@ unsafe impl GlobalAlloc for SvsmAllocator {
             return ptr::null_mut();
         }
 
-        ret.unwrap() as *mut u8
+        ret.unwrap().as_mut_ptr::<u8>()
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
-        let virt_addr = ptr as VirtAddr;
+        let virt_addr = VirtAddr::from(ptr);
 
         let result = ROOT_MEM.lock().get_page_info(virt_addr);
 
@@ -1222,8 +1208,8 @@ unsafe impl GlobalAlloc for SvsmAllocator {
                 free_page(virt_addr);
             }
             Page::SlabPage(si) => {
-                assert_ne!(si.slab, 0);
-                let slab = si.slab as *mut Slab;
+                assert!(!si.slab.is_null());
+                let slab = si.slab.as_mut_ptr::<Slab>();
 
                 (*slab).deallocate(virt_addr);
             }
@@ -1290,8 +1276,8 @@ fn setup_test_root_mem(size: usize) -> LockGuard<'static, ()> {
 
     let page_count = layout.size() / PAGE_SIZE;
     let lock = TEST_ROOT_MEM_LOCK.lock();
-    let vaddr = ptr as VirtAddr;
-    let paddr = PhysAddr::from(vaddr);
+    let vaddr = VirtAddr::from(ptr);
+    let paddr = PhysAddr::from(vaddr.bits()); // Identity mapping
     root_mem_init(paddr, vaddr, page_count);
     lock
 }
@@ -1304,7 +1290,7 @@ fn destroy_test_root_mem(lock: LockGuard<'static, ()>) {
 
     let mut root_mem = ROOT_MEM.lock();
     let layout = Layout::from_size_align(root_mem.page_count * PAGE_SIZE, PAGE_SIZE).unwrap();
-    unsafe { dealloc(root_mem.start_virt as *mut u8, layout) };
+    unsafe { dealloc(root_mem.start_virt.as_mut_ptr::<u8>(), layout) };
     *root_mem = MemoryRegion::new();
 
     // Reset the Slabs
@@ -1331,7 +1317,7 @@ fn test_page_alloc_one() {
 
     let info_before = root_mem.memory_info();
     let page = root_mem.allocate_page().unwrap();
-    assert_ne!(page, 0);
+    assert!(!page.is_null());
     assert_ne!(info_before.free_pages, root_mem.memory_info().free_pages);
     root_mem.free_page(page);
     assert_eq!(info_before.free_pages, root_mem.memory_info().free_pages);
@@ -1355,7 +1341,7 @@ fn test_page_alloc_all_compound() {
     for o in 0..MAX_ORDER {
         for _i in 0..info_before.free_pages[o] {
             let pages = root_mem.allocate_pages(o).unwrap();
-            assert_ne!(pages, 0);
+            assert!(!pages.is_null());
             allocs[o].push(pages);
         }
     }
@@ -1391,7 +1377,7 @@ fn test_page_alloc_all_single() {
         for _i in 0..info_before.free_pages[o] {
             for _j in 0..(1usize << o) {
                 let page = root_mem.allocate_page().unwrap();
-                assert_ne!(page, 0);
+                assert!(!page.is_null());
                 allocs.push(page);
             }
         }
@@ -1425,7 +1411,7 @@ fn test_page_alloc_oom() {
     for o in 0..MAX_ORDER {
         for _i in 0..info_before.free_pages[o] {
             let pages = root_mem.allocate_pages(o).unwrap();
-            assert_ne!(pages, 0);
+            assert!(!pages.is_null());
             allocs[o].push(pages);
         }
     }

--- a/src/mm/memory.rs
+++ b/src/mm/memory.rs
@@ -6,13 +6,12 @@
 
 extern crate alloc;
 
+use crate::address::{Address, PhysAddr};
 use crate::cpu::percpu::PERCPU_VMSAS;
 use crate::error::SvsmError;
 use crate::fw_cfg::{FwCfg, MemoryRegion};
 use crate::kernel_launch::KernelLaunchInfo;
 use crate::locking::RWLock;
-use crate::types::PhysAddr;
-use crate::utils::page_align;
 use alloc::vec::Vec;
 use log;
 
@@ -42,8 +41,8 @@ pub fn init_memory_map(fwcfg: &FwCfg, launch_info: &KernelLaunchInfo) -> Result<
 }
 
 pub fn valid_phys_address(paddr: PhysAddr) -> bool {
-    let page_addr = page_align(paddr);
-    let addr = paddr as u64;
+    let page_addr = paddr.page_align();
+    let addr = paddr.bits() as u64;
 
     if PERCPU_VMSAS.exists(page_addr) {
         return false;

--- a/src/sev/ghcb.rs
+++ b/src/sev/ghcb.rs
@@ -4,6 +4,7 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
+use crate::address::{Address, PhysAddr};
 use crate::cpu::flush_tlb_global_sync;
 use crate::cpu::msr::{write_msr, SEV_GHCB};
 use crate::error::SvsmError;
@@ -15,8 +16,7 @@ use crate::mm::validate::{
 use crate::mm::virt_to_phys;
 use crate::sev::sev_snp_enabled;
 use crate::sev::utils::raw_vmgexit;
-use crate::types::{PhysAddr, VirtAddr, PAGE_SIZE, PAGE_SIZE_2M};
-use crate::utils::is_aligned;
+use crate::types::{VirtAddr, PAGE_SIZE, PAGE_SIZE_2M};
 use core::cell::RefCell;
 use core::{mem, ptr};
 
@@ -176,7 +176,7 @@ impl GHCB {
         get_init_pgtable_locked().set_encrypted_4k(vaddr)?;
 
         // Unregister GHCB PA
-        register_ghcb_gpa_msr(0usize)?;
+        register_ghcb_gpa_msr(PhysAddr::null())?;
 
         // Make page guest-invalid
         validate_page_msr(paddr)?;
@@ -242,7 +242,7 @@ impl GHCB {
         self.set_valid(OFF_SW_EXIT_INFO_2);
 
         let ghcb_address = (self as *const GHCB) as VirtAddr;
-        let ghcb_pa: u64 = virt_to_phys(ghcb_address) as u64;
+        let ghcb_pa = u64::from(virt_to_phys(ghcb_address));
         write_msr(SEV_GHCB, ghcb_pa);
         raw_vmgexit();
 
@@ -374,9 +374,10 @@ impl GHCB {
     }
 
     pub fn psc_entry(&self, paddr: PhysAddr, op_mask: u64, current_page: u64, huge: bool) -> u64 {
-        assert!(!huge || is_aligned(paddr, PAGE_SIZE_2M));
+        assert!(!huge || paddr.is_aligned(PAGE_SIZE_2M));
 
-        let mut entry: u64 = ((paddr as u64) & PSC_GFN_MASK) | op_mask | (current_page & 0xfffu64);
+        let mut entry: u64 =
+            ((paddr.bits() as u64) & PSC_GFN_MASK) | op_mask | (current_page & 0xfffu64);
         if huge {
             entry |= PSC_FLAG_HUGE;
         }
@@ -394,7 +395,7 @@ impl GHCB {
         // Maximum entries (8 bytes each_ minus 8 bytes for header
         let max_entries: u16 = ((GHCB_BUFFER_SIZE - 8) / 8).try_into().unwrap();
         let mut entries: u16 = 0;
-        let mut vaddr = start;
+        let mut paddr = start;
         let op_mask: u64 = match op {
             PageStateChangeOp::PscPrivate => PSC_OP_PRIVATE,
             PageStateChangeOp::PscShared => PSC_OP_SHARED,
@@ -404,17 +405,17 @@ impl GHCB {
 
         self.clear();
 
-        while vaddr < end {
-            let huge = huge && is_aligned(vaddr, PAGE_SIZE_2M) && vaddr + PAGE_SIZE_2M <= end;
+        while paddr < end {
+            let huge = huge && paddr.is_aligned(PAGE_SIZE_2M) && paddr.offset(PAGE_SIZE_2M) <= end;
             let pgsize: usize = match huge {
                 true => PAGE_SIZE_2M,
                 false => PAGE_SIZE,
             };
-            let entry = self.psc_entry(vaddr, op_mask, 0, huge);
+            let entry = self.psc_entry(paddr, op_mask, 0, huge);
             let offset: isize = (entries as isize) * 8 + 8;
             self.write_buffer(&entry, offset)?;
             entries += 1;
-            vaddr += pgsize;
+            paddr = paddr.offset(pgsize);
 
             if entries == max_entries {
                 let header = PageStateChangeHeader {
@@ -425,7 +426,7 @@ impl GHCB {
                 self.write_buffer(&header, 0)?;
 
                 let buffer_va = self.buffer.as_ptr() as VirtAddr;
-                let buffer_pa: u64 = virt_to_phys(buffer_va) as u64;
+                let buffer_pa = u64::from(virt_to_phys(buffer_va));
                 self.set_sw_scratch(buffer_pa);
 
                 if let Err(mut e) = self.vmgexit(GHCBExitCode::SNP_PSC, 0, 0) {
@@ -461,7 +462,7 @@ impl GHCB {
     ) -> Result<(), SvsmError> {
         self.clear();
         let exit_info_1: u64 = 1 | (vmpl & 0xf) << 16 | apic_id << 32;
-        let exit_info_2: u64 = vmsa_gpa as u64;
+        let exit_info_2: u64 = vmsa_gpa.into();
         self.set_rax(sev_features);
         self.vmgexit(GHCBExitCode::AP_CREATE, exit_info_1, exit_info_2)?;
         Ok(())

--- a/src/sev/msr_protocol.rs
+++ b/src/sev/msr_protocol.rs
@@ -4,9 +4,9 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
+use crate::address::{Address, PhysAddr};
 use crate::cpu::msr::{read_msr, write_msr, SEV_GHCB};
 use crate::error::SvsmError;
-use crate::types::{PhysAddr, VirtAddr};
 use crate::utils::halt;
 
 use super::utils::raw_vmgexit;
@@ -65,8 +65,8 @@ pub fn verify_ghcb_version() {
     );
 }
 
-pub fn register_ghcb_gpa_msr(addr: VirtAddr) -> Result<(), GhcbMsrError> {
-    let mut info: u64 = addr as u64;
+pub fn register_ghcb_gpa_msr(addr: PhysAddr) -> Result<(), GhcbMsrError> {
+    let mut info = addr.bits() as u64;
 
     info |= GHCBMsr::SNP_REG_GHCB_GPA_REQ;
     write_msr(SEV_GHCB, info);
@@ -77,7 +77,7 @@ pub fn register_ghcb_gpa_msr(addr: VirtAddr) -> Result<(), GhcbMsrError> {
         return Err(GhcbMsrError::InfoMismatch);
     }
 
-    if (info & !0xfff) != (addr as u64) {
+    if (info & !0xfff) != (addr.bits() as u64) {
         return Err(GhcbMsrError::DataMismatch);
     }
 
@@ -85,7 +85,7 @@ pub fn register_ghcb_gpa_msr(addr: VirtAddr) -> Result<(), GhcbMsrError> {
 }
 
 fn set_page_valid_status_msr(addr: PhysAddr, valid: bool) -> Result<(), GhcbMsrError> {
-    let mut info: u64 = (addr as u64) & 0x000f_ffff_ffff_f000;
+    let mut info: u64 = (addr.bits() as u64) & 0x000f_ffff_ffff_f000;
 
     if valid {
         info |= 1u64 << 52;

--- a/src/sev/secrets_page.rs
+++ b/src/sev/secrets_page.rs
@@ -4,8 +4,8 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
+use crate::address::VirtAddr;
 use crate::sev::vmsa::VMPL_MAX;
-use crate::types::VirtAddr;
 
 #[derive(Copy, Clone)]
 #[repr(C, packed)]
@@ -29,7 +29,7 @@ pub struct SecretsPage {
 }
 
 pub fn copy_secrets_page(target: &mut SecretsPage, source: VirtAddr) {
-    let table = source as *const SecretsPage;
+    let table = source.as_ptr::<SecretsPage>();
 
     unsafe {
         *target = *table;

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -18,7 +18,7 @@ use core::arch::{asm, global_asm};
 use core::panic::PanicInfo;
 use core::slice;
 use svsm::acpi::tables::load_acpi_cpu_info;
-use svsm::address::{Address, PhysAddr};
+use svsm::address::{Address, PhysAddr, VirtAddr};
 use svsm::console::{init_console, install_console_logger, WRITER};
 use svsm::cpu::control_regs::{cr0_init, cr4_init};
 use svsm::cpu::cpuid::{dump_cpuid_table, register_cpuid_table, SnpCpuidTable};
@@ -45,7 +45,7 @@ use svsm::sev::secrets_page::{copy_secrets_page, SecretsPage};
 use svsm::sev::sev_status_init;
 use svsm::sev::utils::{rmp_adjust, RMPFlags};
 use svsm::svsm_console::SVSMIOPort;
-use svsm::types::{VirtAddr, GUEST_VMPL, PAGE_SIZE};
+use svsm::types::{GUEST_VMPL, PAGE_SIZE};
 use svsm::utils::{halt, immut_after_init::ImmutAfterInitCell, zero_mem_region};
 use svsm_paging::{init_page_table, invalidate_stage2};
 
@@ -108,9 +108,9 @@ pub static mut PERCPU: PerCpu = PerCpu::new();
 fn copy_cpuid_table_to_fw(fw_addr: PhysAddr) -> Result<(), SvsmError> {
     let guard = PerCPUPageMappingGuard::create_4k(fw_addr)?;
     let start = guard.virt_addr();
-    let end = start + PAGE_SIZE;
+    let end = start.offset(PAGE_SIZE);
 
-    let target = ptr::NonNull::new(start as *mut SnpCpuidTable).unwrap();
+    let target = ptr::NonNull::new(start.as_mut_ptr::<SnpCpuidTable>()).unwrap();
 
     // Zero target
     zero_mem_region(start, end);
@@ -128,7 +128,7 @@ fn copy_secrets_page_to_fw(fw_addr: PhysAddr, caa_addr: PhysAddr) -> Result<(), 
     let guard = PerCPUPageMappingGuard::create_4k(fw_addr)?;
     let start = guard.virt_addr();
 
-    let mut target = ptr::NonNull::new(start as *mut SecretsPage).unwrap();
+    let mut target = ptr::NonNull::new(start.as_mut_ptr::<SecretsPage>()).unwrap();
 
     // Zero target
     unsafe {
@@ -165,7 +165,7 @@ fn zero_caa_page(fw_addr: PhysAddr) -> Result<(), SvsmError> {
     let guard = PerCPUPageMappingGuard::create_4k(fw_addr)?;
     let vaddr = guard.virt_addr();
 
-    zero_mem_region(vaddr, vaddr + PAGE_SIZE);
+    zero_mem_region(vaddr, vaddr.offset(PAGE_SIZE));
 
     Ok(())
 }
@@ -284,7 +284,7 @@ fn validate_flash() -> Result<(), SvsmError> {
 pub fn memory_init(launch_info: &KernelLaunchInfo) {
     root_mem_init(
         PhysAddr::from(launch_info.heap_area_phys_start),
-        launch_info.heap_area_virt_start as VirtAddr,
+        VirtAddr::from(launch_info.heap_area_virt_start),
         launch_info.heap_area_size() as usize / PAGE_SIZE,
     );
 }
@@ -297,15 +297,15 @@ static mut CONSOLE_SERIAL: SerialPort = SerialPort {
 
 pub fn boot_stack_info() {
     unsafe {
-        let vaddr = (&bsp_stack_end as *const u8) as VirtAddr;
+        let vaddr = VirtAddr::from(&bsp_stack_end as *const u8);
         log::info!("Boot stack starts        @ {:#018x}", vaddr);
     }
 }
 
 fn mapping_info_init(launch_info: &KernelLaunchInfo) {
     init_kernel_mapping_info(
-        launch_info.heap_area_virt_start as VirtAddr,
-        launch_info.heap_area_virt_end() as VirtAddr,
+        VirtAddr::from(launch_info.heap_area_virt_start),
+        VirtAddr::from(launch_info.heap_area_virt_end()),
         PhysAddr::from(launch_info.heap_area_phys_start),
     );
 }
@@ -313,7 +313,7 @@ fn mapping_info_init(launch_info: &KernelLaunchInfo) {
 #[no_mangle]
 pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: VirtAddr) {
     let launch_info: KernelLaunchInfo = *li;
-    let vb_ptr = vb_addr as *mut u64;
+    let vb_ptr = vb_addr.as_mut_ptr::<u64>();
 
     mapping_info_init(&launch_info);
 
@@ -330,13 +330,13 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: VirtAddr) {
         LAUNCH_INFO.init(li);
     }
 
-    let cpuid_table_virt = launch_info.cpuid_page as VirtAddr;
-    unsafe { CPUID_PAGE.init(&*(cpuid_table_virt as *const SnpCpuidTable)) };
+    let cpuid_table_virt = VirtAddr::from(launch_info.cpuid_page);
+    unsafe { CPUID_PAGE.init(&*(cpuid_table_virt.as_ptr::<SnpCpuidTable>())) };
     register_cpuid_table(&CPUID_PAGE);
     dump_cpuid_table();
 
     unsafe {
-        let secrets_page_virt = launch_info.secrets_page as VirtAddr;
+        let secrets_page_virt = VirtAddr::from(launch_info.secrets_page);
         copy_secrets_page(&mut SECRETS_PAGE, secrets_page_virt);
     }
 
@@ -399,7 +399,7 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: VirtAddr) {
     unsafe {
         asm!("movq  %rax, %rsp
               jmp   svsm_main",
-              in("rax") bp,
+              in("rax") bp.bits(),
               options(att_syntax));
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -27,6 +27,4 @@ pub const GUEST_VMPL: usize = 1;
 #[allow(clippy::assertions_on_constants)]
 const _: () = assert!(GUEST_VMPL > 0 && GUEST_VMPL < VMPL_MAX);
 
-pub type VirtAddr = usize;
-
 pub const MAX_CPUS: usize = 512;

--- a/src/types.rs
+++ b/src/types.rs
@@ -27,7 +27,6 @@ pub const GUEST_VMPL: usize = 1;
 #[allow(clippy::assertions_on_constants)]
 const _: () = assert!(GUEST_VMPL > 0 && GUEST_VMPL < VMPL_MAX);
 
-pub type PhysAddr = usize;
 pub type VirtAddr = usize;
 
 pub const MAX_CPUS: usize = 512;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -8,7 +8,4 @@ pub mod bitmap_allocator;
 pub mod immut_after_init;
 pub mod util;
 
-pub use util::{
-    align_up, crosses_page, ffs, halt, is_aligned, overlap, page_align, page_align_up, page_offset,
-    zero_mem_region,
-};
+pub use util::{align_up, ffs, halt, overlap, zero_mem_region};

--- a/src/utils/util.rs
+++ b/src/utils/util.rs
@@ -4,9 +4,9 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
-use crate::types::{VirtAddr, PAGE_SIZE};
+use crate::address::{Address, VirtAddr};
+use crate::types::PAGE_SIZE;
 use core::arch::asm;
-use core::ptr;
 
 pub fn align_up(addr: usize, align: usize) -> usize {
     (addr + (align - 1)) & !(align - 1)
@@ -67,11 +67,10 @@ pub fn crosses_page(start: usize, size: usize) -> bool {
 
 pub fn zero_mem_region(start: VirtAddr, end: VirtAddr) {
     let size = end - start;
-
-    let mut target = ptr::NonNull::new(start as *mut u8).unwrap();
+    if start.is_null() {
+        panic!("Attempted to zero out a NULL pointer");
+    }
 
     // Zero region
-    unsafe {
-        ptr::write_bytes(target.as_mut(), 0, size);
-    }
+    unsafe { start.as_mut_ptr::<u8>().write_bytes(0, size) }
 }

--- a/src/utils/util.rs
+++ b/src/utils/util.rs
@@ -5,27 +5,10 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 
 use crate::address::{Address, VirtAddr};
-use crate::types::PAGE_SIZE;
 use core::arch::asm;
 
 pub fn align_up(addr: usize, align: usize) -> usize {
     (addr + (align - 1)) & !(align - 1)
-}
-
-pub fn page_offset(addr: usize) -> usize {
-    addr & (PAGE_SIZE - 1)
-}
-
-pub fn page_align(addr: usize) -> usize {
-    addr & !(PAGE_SIZE - 1)
-}
-
-pub fn page_align_up(addr: usize) -> usize {
-    (addr + PAGE_SIZE - 1) & !(PAGE_SIZE - 1)
-}
-
-pub fn is_aligned(addr: usize, align: usize) -> bool {
-    (addr & (align - 1)) == 0
 }
 
 #[inline(always)]
@@ -56,13 +39,6 @@ where
     T: core::cmp::PartialOrd,
 {
     x1 <= y2 && y1 <= x2
-}
-
-pub fn crosses_page(start: usize, size: usize) -> bool {
-    let x1 = start / PAGE_SIZE;
-    let x2 = (start + size - 1) / PAGE_SIZE;
-
-    x1 != x2
 }
 
 pub fn zero_mem_region(start: VirtAddr, end: VirtAddr) {


### PR DESCRIPTION
At the moment, `VirtAddr` and `PhysAddr` are simply typedefs, meaning that one might use either one interchangeably without the compiler giving any warnings. Introduce two distinct new types, plus an `Address` trait implemented by both for common operations.

The new types provide several facilities to convert easily to and from other types such as `usize`, `u64` and raw pointers via the `From` trait.