### PR TITLE
Make virtualrange allocators per-cpu

### DIFF
--- a/src/mm/virtualrange.rs
+++ b/src/mm/virtualrange.rs
@@ -39,7 +39,7 @@ impl VirtualRange {
         self.bits.set(0, page_count, false);
     }
 
-    pub fn map_pages(
+    pub fn alloc(
         self: &mut Self,
         page_count: usize,
         alignment: usize,
@@ -51,7 +51,7 @@ impl VirtualRange {
         }
     }
 
-    pub fn unmap_pages(self: &mut Self, vaddr: VirtAddr, page_count: usize) {
+    pub fn free(self: &mut Self, vaddr: VirtAddr, page_count: usize) {
         let offset = (vaddr - self.start_virt) >> PAGE_SHIFT;
         // Add 1 to the page count for the VM guard
         self.bits.free(offset, page_count + 1);
@@ -101,13 +101,11 @@ pub fn virt_alloc_range_4k(size_bytes: usize, alignment: usize) -> Result<VirtAd
     }
     let page_count = size_bytes >> PAGE_SHIFT;
     let mut pm = VIRTUAL_MAP_4K.lock();
-    pm.map_pages(page_count, alignment)
+    pm.alloc(page_count, alignment)
 }
 
 pub fn virt_free_range_4k(vaddr: VirtAddr, size_bytes: usize) {
-    VIRTUAL_MAP_4K
-        .lock()
-        .unmap_pages(vaddr, size_bytes >> PAGE_SHIFT);
+    VIRTUAL_MAP_4K.lock().free(vaddr, size_bytes >> PAGE_SHIFT);
 }
 
 pub fn virt_alloc_range_2m(size_bytes: usize, alignment: usize) -> Result<VirtAddr, SvsmError> {
@@ -117,11 +115,11 @@ pub fn virt_alloc_range_2m(size_bytes: usize, alignment: usize) -> Result<VirtAd
     }
     let page_count = size_bytes >> PAGE_SHIFT_2M;
     let mut pm = VIRTUAL_MAP_2M.lock();
-    pm.map_pages(page_count, alignment)
+    pm.alloc(page_count, alignment)
 }
 
 pub fn virt_free_range_2m(vaddr: VirtAddr, size_bytes: usize) {
     VIRTUAL_MAP_2M
         .lock()
-        .unmap_pages(vaddr, size_bytes >> PAGE_SHIFT_2M);
+        .free(vaddr, size_bytes >> PAGE_SHIFT_2M);
 }

--- a/src/mm/virtualrange.rs
+++ b/src/mm/virtualrange.rs
@@ -33,6 +33,12 @@ impl VirtualRange {
         }
     }
 
+    pub fn init(&mut self, start_virt: VirtAddr, page_count: usize) {
+        self.start_virt = start_virt;
+        self.page_count = page_count;
+        self.bits.set(0, page_count, false);
+    }
+
     pub fn map_pages(
         self: &mut Self,
         page_count: usize,
@@ -65,18 +71,14 @@ pub fn virt_range_init() {
     if page_count > BitmapAllocator1024::CAPACITY {
         panic!("Attempted to allocate 4K page map with more than 1024 pages");
     }
-    pm4k.start_virt = VirtAddr::from(SVSM_PERCPU_TEMP_BASE_4K);
-    pm4k.page_count = page_count;
-    pm4k.bits.set(0, page_count, false);
+    pm4k.init(VirtAddr::from(SVSM_PERCPU_TEMP_BASE_4K), page_count);
 
     let mut pm2m = VIRTUAL_MAP_2M.lock();
     let page_count = (SVSM_PERCPU_TEMP_END_2M - SVSM_PERCPU_TEMP_BASE_2M) / PAGE_SIZE_2M;
     if page_count > BitmapAllocator1024::CAPACITY {
         panic!("Attempted to allocate 2M page map with more than 1024 pages");
     }
-    pm2m.start_virt = VirtAddr::from(SVSM_PERCPU_TEMP_BASE_2M);
-    pm2m.page_count = page_count;
-    pm2m.bits.set(0, page_count, false);
+    pm2m.init(VirtAddr::from(SVSM_PERCPU_TEMP_BASE_2M), page_count);
 }
 
 pub fn virt_log_usage() {

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -36,7 +36,7 @@ use svsm::kernel_launch::KernelLaunchInfo;
 use svsm::mm::alloc::{memory_info, print_memory_info, root_mem_init};
 use svsm::mm::memory::init_memory_map;
 use svsm::mm::pagetable::paging_init;
-use svsm::mm::virtualrange::{virt_log_usage, virt_range_init};
+use svsm::mm::virtualrange::virt_log_usage;
 use svsm::mm::{init_kernel_mapping_info, PerCPUPageMappingGuard};
 use svsm::requests::{request_loop, update_mappings};
 use svsm::serial::SerialPort;
@@ -359,8 +359,6 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: VirtAddr) {
 
     paging_init();
     init_page_table(&launch_info, &kernel_elf);
-
-    virt_range_init();
 
     unsafe {
         let bsp_percpu = PerCpu::alloc(0)


### PR DESCRIPTION
The virtualrange allocators are global, but the address-space areas it covers are per-cpu. Change it to make the allocators per-cpu too.