### PR TITLE
Add rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
coconut requires rust nightly. Add a `rust-toolchain.toml` to make that happen automatically, without user running
`rustup default nightly`