### PR TITLE
Remove use of nightly features

### DIFF
--- a/src/console.rs
+++ b/src/console.rs
@@ -15,11 +15,11 @@ pub trait ConsoleWriter {
 }
 
 pub struct Console {
-    writer: *mut dyn ConsoleWriter,
+    writer: *const dyn ConsoleWriter,
 }
 
 impl Console {
-    pub fn set(&mut self, w: *mut dyn ConsoleWriter) {
+    pub fn set(&mut self, w: *const dyn ConsoleWriter) {
         self.writer = w;
     }
 }
@@ -42,7 +42,7 @@ impl fmt::Write for Console {
 
 pub static WRITER: SpinLock<Console> = SpinLock::new(unsafe {
     Console {
-        writer: &mut DEFAULT_SERIAL_PORT,
+        writer: &DEFAULT_SERIAL_PORT,
     }
 });
 static CONSOLE_INITIALIZED: ImmutAfterInitCell<bool> = ImmutAfterInitCell::new(false);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@
 // Author: Nicolai Stange <nstange@suse.de>
 
 #![no_std]
-#![feature(const_mut_refs)]
 
 pub mod acpi;
 pub mod address;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,6 @@
 
 #![no_std]
 #![feature(const_mut_refs)]
-#![feature(maybe_uninit_uninit_array)]
-#![feature(maybe_uninit_array_assume_init)]
 
 pub mod acpi;
 pub mod address;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@
 #![feature(const_mut_refs)]
 #![feature(maybe_uninit_uninit_array)]
 #![feature(maybe_uninit_array_assume_init)]
-#![feature(sync_unsafe_cell)]
 
 pub mod acpi;
 pub mod address;

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -6,7 +6,7 @@
 
 #![no_std]
 #![no_main]
-#![feature(const_mut_refs, rustc_private)]
+#![feature(rustc_private)]
 
 pub mod boot_stage2;
 
@@ -102,7 +102,7 @@ fn setup_env() {
     init_percpu();
 
     unsafe {
-        WRITER.lock().set(&mut CONSOLE_SERIAL);
+        WRITER.lock().set(&CONSOLE_SERIAL);
     }
     init_console();
 

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -6,7 +6,6 @@
 
 #![no_std]
 #![no_main]
-#![feature(rustc_private)]
 
 pub mod boot_stage2;
 

--- a/src/string.rs
+++ b/src/string.rs
@@ -103,3 +103,33 @@ impl<const T: usize> fmt::Display for FixedString<T> {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    extern crate alloc;
+    use super::*;
+    use alloc::string::String;
+    use core::fmt::Write;
+
+    #[test]
+    fn from_u8_array1() {
+        let st = FixedString::from([b'a', b'b', b'c', b'd', b'z']);
+        assert_eq!(st, "abcdz");
+        assert_eq!(st.len, 5);
+    }
+
+    #[test]
+    fn from_u8_array2() {
+        let st = FixedString::from([b'a', b'b', b'c', b'\0', b'd', b'e']);
+        assert_eq!(st, "abc");
+        assert_eq!(st.len, 3);
+    }
+
+    #[test]
+    fn display() {
+        let mut buf = String::new();
+        let st = FixedString::from([b's', b'v', b's', b'm', b'\0', b'x', b'y']);
+        write!(&mut buf, "{}", st).unwrap();
+        assert_eq!(buf.as_str(), "svsm");
+    }
+}

--- a/src/string.rs
+++ b/src/string.rs
@@ -4,6 +4,7 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
+use core::array;
 use core::fmt;
 use core::mem::MaybeUninit;
 
@@ -39,7 +40,7 @@ impl<const T: usize> FixedString<T> {
 
 impl<const N: usize> From<[u8; N]> for FixedString<N> {
     fn from(arr: [u8; N]) -> FixedString<N> {
-        let mut data = MaybeUninit::<char>::uninit_array::<N>();
+        let mut data: [MaybeUninit<char>; N] = array::from_fn(|_| MaybeUninit::uninit());
         let mut len = N;
 
         for (i, (d, val)) in data.iter_mut().zip(&arr).enumerate() {
@@ -50,7 +51,7 @@ impl<const N: usize> From<[u8; N]> for FixedString<N> {
             d.write(val as char);
         }
 
-        let data = unsafe { MaybeUninit::array_assume_init(data) };
+        let data = unsafe { *(data.as_ptr().cast::<[char; N]>()) };
         FixedString { data, len }
     }
 }

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -6,7 +6,6 @@
 
 #![no_std]
 #![no_main]
-#![feature(const_mut_refs)]
 pub mod svsm_paging;
 
 extern crate alloc;

--- a/src/utils/immut_after_init.rs
+++ b/src/utils/immut_after_init.rs
@@ -183,7 +183,7 @@ pub struct ImmutAfterInitRef<'a, T: 'a> {
     #[doc(hidden)]
     ptr: ImmutAfterInitCell<*const T>,
     #[doc(hidden)]
-    _phantom: PhantomData<&'a mut &'a T>,
+    _phantom: PhantomData<&'a &'a T>,
 }
 
 impl<'a, T> ImmutAfterInitRef<'a, T> {
@@ -248,19 +248,6 @@ impl<'a, T: Copy> ImmutAfterInitRef<'a, T> {
         'b: 'a,
     {
         self.ptr.init(&(*cell.data.get()).as_ptr());
-    }
-
-    /// Create an initialized `ImmutAfterInitRef` instance pointing to a value
-    /// wrapped in a [`ImmutAfterInitCell`].
-    ///
-    /// * `cell` - The value to make the `ImmutAfterInitRef` to refer to. By
-    ///            convention, the referenced value must have been initialized
-    ///            already.
-    pub const fn new_from_cell(cell: &'a ImmutAfterInitCell<T>) -> Self {
-        Self {
-            ptr: ImmutAfterInitCell::new(unsafe { &*cell.data.get() }.as_ptr()),
-            _phantom: PhantomData,
-        }
     }
 }
 


### PR DESCRIPTION
In order to achieve #15, remove nightly features:
* Remove use of `sync_unsafe_cell` feature by replacing `SyncUnsafeCell` with `UnsafeCell` + `unsafe impl Sync`.
* Remove use of `maybe_uninit_uninit_array` and `maybe_uninit_array_assume_init` features by using an array of `MaybeUninit` and raw pointers.
* Add extra tests to verify that the previous change did not break anything.
* Remove use of `const_mut_refs` feature by changing mutable references to immutable ones where possible.
    - I could not find a way to keep `ImmutAfterInitRef::new_from_cell()` in, please review this change.
* Remove unused `rustc_private` feature.