### PR TITLE
fix memory region checks

### DIFF
--- a/src/mm/memory.rs
+++ b/src/mm/memory.rs
@@ -15,6 +15,8 @@ use crate::locking::RWLock;
 use alloc::vec::Vec;
 use log;
 
+use super::pagetable::LAUNCH_VMSA_ADDR;
+
 static MEMORY_MAP: RWLock<Vec<MemoryRegion>> = RWLock::new(Vec::new());
 
 pub fn init_memory_map(fwcfg: &FwCfg, launch_info: &KernelLaunchInfo) -> Result<(), SvsmError> {
@@ -45,6 +47,9 @@ pub fn valid_phys_address(paddr: PhysAddr) -> bool {
     let addr = paddr.bits() as u64;
 
     if PERCPU_VMSAS.exists(page_addr) {
+        return false;
+    }
+    if page_addr == *LAUNCH_VMSA_ADDR {
         return false;
     }
 

--- a/src/mm/memory.rs
+++ b/src/mm/memory.rs
@@ -23,11 +23,48 @@ pub fn init_memory_map(fwcfg: &FwCfg, launch_info: &KernelLaunchInfo) -> Result<
     let mut regions = fwcfg.get_memory_regions()?;
 
     // Remove SVSM memory from guest memory map
-    for mut region in regions.iter_mut() {
-        if (launch_info.kernel_region_phys_start > region.start)
-            && (launch_info.kernel_region_phys_start < region.end)
-        {
-            region.end = launch_info.kernel_region_phys_start;
+    let mut i = 0;
+    while i < regions.len() {
+        // Check if the region overlaps with SVSM memory.
+        let region = regions[i];
+        if !region.overlaps(
+            launch_info.kernel_region_phys_start,
+            launch_info.kernel_region_phys_end,
+        ) {
+            // Check the next region.
+            i += 1;
+            continue;
+        }
+
+        // 1. Remove the region.
+        regions.remove(i);
+
+        // 2. Insert a region up until the start of SVSM memory (if non-empty).
+        let region_before_start = region.start;
+        let region_before_end = launch_info.kernel_region_phys_start;
+        if region_before_start < region_before_end {
+            regions.insert(
+                i,
+                MemoryRegion {
+                    start: region_before_start,
+                    end: region_before_end,
+                },
+            );
+            i += 1;
+        }
+
+        // 3. Insert a region up after the end of SVSM memory (if non-empty).
+        let region_after_start = launch_info.kernel_region_phys_end;
+        let region_after_end = region.end;
+        if region_after_start < region_after_end {
+            regions.insert(
+                i,
+                MemoryRegion {
+                    start: region_after_start,
+                    end: region_after_end,
+                },
+            );
+            i += 1;
         }
     }
 

--- a/src/mm/pagetable.rs
+++ b/src/mm/pagetable.rs
@@ -22,6 +22,7 @@ use core::{cmp, ptr};
 const ENTRY_COUNT: usize = 512;
 static ENCRYPT_MASK: ImmutAfterInitCell<usize> = ImmutAfterInitCell::new(0);
 static MAX_PHYS_ADDR: ImmutAfterInitCell<u64> = ImmutAfterInitCell::uninit();
+pub static LAUNCH_VMSA_ADDR: ImmutAfterInitCell<PhysAddr> = ImmutAfterInitCell::uninit();
 static FEATURE_MASK: ImmutAfterInitCell<PTEntryFlags> =
     ImmutAfterInitCell::new(PTEntryFlags::empty());
 
@@ -75,6 +76,17 @@ fn init_encrypt_mask() {
     let max_addr = 1 << effective_phys_addr_size;
     unsafe {
         MAX_PHYS_ADDR.reinit(&max_addr);
+    }
+
+    // KVM currently sets all bits when executing the launch update for the
+    // launch vCPU's VMSA, but the firmware will truncate the gPA to the limit
+    // specified in Fn8000_0008h_EAX.
+    // FIXME: It looks like this will be changed to a fixed address in the
+    // future. This can be removed once the patches for that land.
+    let launch_vmsa_addr = (1u64 << phys_addr_size) - 0x1000;
+    let launch_vmsa_addr = PhysAddr::from(launch_vmsa_addr);
+    unsafe {
+        LAUNCH_VMSA_ADDR.reinit(&launch_vmsa_addr);
     }
 }
 


### PR DESCRIPTION
This pr fixes two checks for the memory map:
1. The launch vCPU's VMSA shouldn't be considered valid memory.
2. The SVSM's memory check was corrected.

Closes #22