### PR TITLE
scripts/check-signed-off: display email on mismatch

### DIFF
--- a/scripts/check-signed-off.sh
+++ b/scripts/check-signed-off.sh
@@ -27,8 +27,8 @@ for c in ${commits[@]}; do
 
 	if [ "$commit_email" != "$sign_email" ]; then
 		echo "Author email mismatch on commit $c"
-		echo "    Commit author name: $commit_name"
-		echo "    Signed-off-by name: $sign_name"
+		echo "    Commit author email: $commit_email"
+		echo "    Signed-off-by email: $sign_email"
 		exit 1
 	fi
 


### PR DESCRIPTION
Fix a small copy-paste error on the check-signed-off.sh script.

Fixes: 21bd15ab09dc ("Actions: add a Signed-off-by check for incoming PRs")