### PR TITLE
mm: minor error handling cleanups

### DIFF
--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -685,12 +685,12 @@ impl PageRef {
     }
 
     pub fn as_ref(&self) -> &[u8; PAGE_SIZE] {
-        let ptr = self.virt_addr.as_mut_ptr() as *mut [u8; PAGE_SIZE];
-        unsafe { ptr.as_mut().unwrap() }
+        let ptr = self.virt_addr.as_ptr::<[u8; PAGE_SIZE]>();
+        unsafe { ptr.as_ref().unwrap() }
     }
 
     pub fn as_mut_ref(&mut self) -> &mut [u8; PAGE_SIZE] {
-        let ptr = self.virt_addr.as_mut_ptr() as *mut [u8; PAGE_SIZE];
+        let ptr = self.virt_addr.as_mut_ptr::<[u8; PAGE_SIZE]>();
         unsafe { ptr.as_mut().unwrap() }
     }
 

--- a/src/mm/ptguards.rs
+++ b/src/mm/ptguards.rs
@@ -47,24 +47,26 @@ impl PerCPUPageMappingGuard {
             && ((paddr_end.bits() & (PAGE_SIZE_2M - 1)) == 0);
         let vaddr = if huge {
             let vaddr = virt_alloc_range_2m(size, 0)?;
-            if this_cpu_mut()
-                .get_pgtable()
-                .map_region_2m(vaddr, vaddr.offset(size), paddr_start, flags)
-                .is_err()
-            {
+            if let Err(e) = this_cpu_mut().get_pgtable().map_region_2m(
+                vaddr,
+                vaddr.offset(size),
+                paddr_start,
+                flags,
+            ) {
                 virt_free_range_2m(vaddr, size);
-                return Err(SvsmError::Mem);
+                return Err(e);
             }
             vaddr
         } else {
             let vaddr = virt_alloc_range_4k(size, 0)?;
-            if this_cpu_mut()
-                .get_pgtable()
-                .map_region_4k(vaddr, vaddr.offset(size), paddr_start, flags)
-                .is_err()
-            {
+            if let Err(e) = this_cpu_mut().get_pgtable().map_region_4k(
+                vaddr,
+                vaddr.offset(size),
+                paddr_start,
+                flags,
+            ) {
                 virt_free_range_4k(vaddr, size);
-                return Err(SvsmError::Mem);
+                return Err(e);
             }
             vaddr
         };


### PR DESCRIPTION
Minor cleanups for error handling in the mm subsystem. Should resolve some clippy warnings along the way.