### PR TITLE
Fix rounding error in kernel filesystem binary size in stage 1 loader

### DIFF
--- a/stage1/stage1.S
+++ b/stage1/stage1.S
@@ -81,8 +81,8 @@ kernel_elf_end:
 
 kernel_fs_bin:
 	.incbin "stage1/svsm-fs.bin"
-	.align 4
 kernel_fs_bin_end:
 
+	.align 4
 stage2_size:
 	.long	stage2_bin_end - stage2_bin


### PR DESCRIPTION
The size of the embedded filesystem image is rounded up on a 4 byte boundary. The end address passed to stage 2 for the filesystem uses this rounded value meaning that the code that unpacks the archive does not know the exact size of the archive. When rounding occurs, the unpacker wrongly assumes there is another file at the end and panics.

This patch retains the alignment but reports the exact archive size to stage2.