### PR TITLE
Fix even more clippy warnings

### DIFF
--- a/src/cpu/gdt.rs
+++ b/src/cpu/gdt.rs
@@ -52,7 +52,7 @@ pub fn load_tss(tss: &X86Tss) {
 
     unsafe {
         let idx = (SVSM_TSS / 8) as usize;
-        GDT[idx + 0] = desc0;
+        GDT[idx] = desc0;
         GDT[idx + 1] = desc1;
 
         asm!("ltr %ax", in("ax") SVSM_TSS, options(att_syntax));

--- a/src/cpu/gdt.rs
+++ b/src/cpu/gdt.rs
@@ -42,7 +42,7 @@ pub fn load_tss(tss: &X86Tss) {
     // Address
     desc0 |= (addr & 0x00ff_ffffu64) << 16;
     desc0 |= (addr & 0xff00_0000u64) << 32;
-    desc1 |= (addr >> 32) as u64;
+    desc1 |= addr >> 32;
 
     // Present
     desc0 |= 1u64 << 47;

--- a/src/cpu/vmsa.rs
+++ b/src/cpu/vmsa.rs
@@ -106,9 +106,7 @@ fn real_mode_sys_seg(flags: u16) -> VMSASegment {
     }
 }
 
-pub fn init_guest_vmsa(vmsa: *mut VMSA, rip: u64) {
-    let v = unsafe { vmsa.as_mut().unwrap() };
-
+pub fn init_guest_vmsa(v: &mut VMSA, rip: u64) {
     v.cr0 = 0x6000_0010;
     v.rflags = 0x2;
     v.rip = rip & 0xffff;

--- a/src/debug/stacktrace.rs
+++ b/src/debug/stacktrace.rs
@@ -185,16 +185,12 @@ impl Iterator for StackUnwinder {
                     UnwoundStackFrame::Valid(cur_frame) => {
                         if cur_frame.is_last {
                             self.next_frame = None
+                        } else if cur_frame.is_exception_frame {
+                            self.next_frame =
+                                Some(Self::unwind_exception_frame(cur_frame.rsp, &self.stacks));
                         } else {
-                            if cur_frame.is_exception_frame {
-                                self.next_frame =
-                                    Some(Self::unwind_exception_frame(cur_frame.rsp, &self.stacks));
-                            } else {
-                                self.next_frame = Some(Self::unwind_framepointer_frame(
-                                    cur_frame.rbp,
-                                    &self.stacks,
-                                ));
-                            }
+                            self.next_frame =
+                                Some(Self::unwind_framepointer_frame(cur_frame.rbp, &self.stacks));
                         }
                     }
                 };

--- a/src/fs/fs.rs
+++ b/src/fs/fs.rs
@@ -143,7 +143,7 @@ fn uninitialize_fs() {
 }
 
 fn split_path_allow_empty(path: &str) -> Vec<&str> {
-    path.split('/').filter(|x| x.len() > 0).collect()
+    path.split('/').filter(|x| !x.is_empty()).collect()
 }
 
 fn split_path(path: &str) -> Result<Vec<&str>, SvsmError> {

--- a/src/fs/fs.rs
+++ b/src/fs/fs.rs
@@ -39,8 +39,8 @@ impl RawFileHandle {
 
     pub fn write(&mut self, buf: &[u8]) -> Result<usize, SvsmError> {
         let result = self.file.write(buf, self.current);
-        if result.is_ok() {
-            self.current += result.unwrap();
+        if let Ok(num) = result {
+            self.current += num;
         }
         result
     }

--- a/src/fs/fs.rs
+++ b/src/fs/fs.rs
@@ -156,7 +156,7 @@ fn split_path(path: &str) -> Result<Vec<&str>, SvsmError> {
     Ok(path_items)
 }
 
-fn walk_path(path_items: &Vec<&str>) -> Result<Arc<dyn Directory>, SvsmError> {
+fn walk_path(path_items: &[&str]) -> Result<Arc<dyn Directory>, SvsmError> {
     let mut current_dir = unsafe { FS_ROOT.root_dir() };
 
     for item in path_items.iter() {
@@ -171,7 +171,7 @@ fn walk_path(path_items: &Vec<&str>) -> Result<Arc<dyn Directory>, SvsmError> {
     Ok(current_dir)
 }
 
-fn walk_path_create(path_items: &Vec<&str>) -> Result<Arc<dyn Directory>, SvsmError> {
+fn walk_path_create(path_items: &[&str]) -> Result<Arc<dyn Directory>, SvsmError> {
     let mut current_dir = unsafe { FS_ROOT.root_dir() };
 
     for item in path_items.iter() {

--- a/src/fs/init.rs
+++ b/src/fs/init.rs
@@ -153,7 +153,7 @@ pub fn populate_ram_fs(kernel_fs_start: u64, kernel_fs_end: u64) -> Result<(), S
             .get(start..end)
             .ok_or(SvsmError::FileSystem(FsError::inval()))?;
         file.truncate(0)?;
-        let written = file.write(&file_data)?;
+        let written = file.write(file_data)?;
         if written != fh.file_size() {
             log::error!("Incomplete data write to {}", fh.file_name());
             return Err(SvsmError::FileSystem(FsError::inval()));

--- a/src/fs/ramfs.rs
+++ b/src/fs/ramfs.rs
@@ -70,7 +70,7 @@ impl RawRamFile {
 
         assert!(page_end <= PAGE_SIZE);
 
-        let page_buf = self.pages[index].as_mut_ref();
+        let page_buf = self.pages[index].as_mut();
         page_buf[page_index..page_end].copy_from_slice(buf);
     }
 

--- a/src/mm/address_space.rs
+++ b/src/mm/address_space.rs
@@ -86,7 +86,9 @@ pub const PAGE_SIZE_2M: usize = SIZE_1M * 2;
 /// More size helpers
 pub const SIZE_LEVEL3: usize = 1usize << ((9 * 3) + 12);
 pub const SIZE_LEVEL2: usize = 1usize << ((9 * 2) + 12);
+#[allow(clippy::identity_op)]
 pub const SIZE_LEVEL1: usize = 1usize << ((9 * 1) + 12);
+#[allow(clippy::erasing_op, clippy::identity_op)]
 pub const SIZE_LEVEL0: usize = 1usize << ((9 * 0) + 12);
 
 // Stack definitions

--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -367,7 +367,7 @@ impl MemoryRegion {
     }
 
     fn split_page(&mut self, pfn: usize, order: usize) -> Result<(), SvsmError> {
-        if order < 1 || order >= MAX_ORDER {
+        if !(1..MAX_ORDER).contains(&order) {
             return Err(SvsmError::Mem);
         }
 

--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -684,18 +684,22 @@ impl PageRef {
         }
     }
 
-    pub fn as_ref(&self) -> &[u8; PAGE_SIZE] {
+    pub fn virt_addr(&self) -> VirtAddr {
+        self.virt_addr
+    }
+}
+
+impl AsRef<[u8; PAGE_SIZE]> for PageRef {
+    fn as_ref(&self) -> &[u8; PAGE_SIZE] {
         let ptr = self.virt_addr.as_ptr::<[u8; PAGE_SIZE]>();
         unsafe { ptr.as_ref().unwrap() }
     }
+}
 
-    pub fn as_mut_ref(&mut self) -> &mut [u8; PAGE_SIZE] {
+impl AsMut<[u8; PAGE_SIZE]> for PageRef {
+    fn as_mut(&mut self) -> &mut [u8; PAGE_SIZE] {
         let ptr = self.virt_addr.as_mut_ptr::<[u8; PAGE_SIZE]>();
         unsafe { ptr.as_mut().unwrap() }
-    }
-
-    pub fn virt_addr(&self) -> VirtAddr {
-        self.virt_addr
     }
 }
 

--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -1135,9 +1135,7 @@ impl Slab {
         let mut next_page_vaddr = self.common.page.get_next_page();
         let mut freed_one = false;
 
-        if self.common.free_pages <= 1 {
-            return;
-        } else if 2 * self.common.free < self.common.capacity {
+        if self.common.free_pages <= 1 || 2 * self.common.free < self.common.capacity {
             return;
         }
 


### PR DESCRIPTION
More clippy fixes. There are still a few remaining, out of which some more will be removed via #2. Once we have all of them gone, we can add clippy checks to our automated actions.