### PR TITLE
Zero memory before giving access to guest

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -77,6 +77,10 @@ pub trait Address:
 pub struct PhysAddr(InnerAddr);
 
 impl PhysAddr {
+    pub const fn new(p: InnerAddr) -> Self {
+        Self(p)
+    }
+
     pub const fn null() -> Self {
         Self(0)
     }

--- a/src/mm/memory.rs
+++ b/src/mm/memory.rs
@@ -95,3 +95,15 @@ pub fn valid_phys_address(paddr: PhysAddr) -> bool {
         .iter()
         .any(|region| addr >= region.start && addr < region.end)
 }
+
+const ISA_RANGE_START: PhysAddr = PhysAddr::new(0xa0000);
+const ISA_RANGE_END: PhysAddr = PhysAddr::new(0x100000);
+
+pub fn writable_phys_addr(paddr: PhysAddr) -> bool {
+    // The ISA range is not writable
+    if paddr >= ISA_RANGE_START && paddr < ISA_RANGE_END {
+        return false;
+    }
+
+    valid_phys_address(paddr)
+}

--- a/src/mm/mod.rs
+++ b/src/mm/mod.rs
@@ -16,7 +16,7 @@ pub mod virtualrange;
 
 pub use address_space::*;
 pub use guestmem::GuestPtr;
-pub use memory::valid_phys_address;
+pub use memory::{valid_phys_address, writable_phys_addr};
 pub use ptguards::*;
 
 pub use alloc::{


### PR DESCRIPTION
Zero out a page when it is validated and before giving other VMPLs access to it. This is necessary to prevent a possible HV attack:

Attack scenario:

1. SVSM stores secrets in VMPL0 memory at GPA A
2. HV invalidates GPA A and maps the SPA to GPA B, which is in the OS range of GPAs
3. Guest OS asks SVSM to validate GPA B
4. SVSM validates page and gives OS access
5. OS can now read SVSM secrets from GPA B

The SVSM will not notice the attack until it tries to access GPA A again. Prevent it by clearing every page before giving access to other VMPLs.