### PR TITLE
Address: remove offset() and sub() methods

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -48,10 +48,6 @@ pub trait Address:
         self.bits().checked_add(off).map(|addr| addr.into())
     }
 
-    fn sub(&self, off: InnerAddr) -> Self {
-        Self::from(self.bits() - off)
-    }
-
     fn checked_sub(&self, off: InnerAddr) -> Option<Self> {
         self.bits().checked_sub(off).map(|addr| addr.into())
     }

--- a/src/address.rs
+++ b/src/address.rs
@@ -44,10 +44,6 @@ pub trait Address:
         self.is_aligned(PAGE_SIZE)
     }
 
-    fn offset(&self, off: InnerAddr) -> Self {
-        Self::from(self.bits() + off)
-    }
-
     fn checked_offset(&self, off: InnerAddr) -> Option<Self> {
         self.bits().checked_add(off).map(|addr| addr.into())
     }

--- a/src/cpu/extable.rs
+++ b/src/cpu/extable.rs
@@ -35,7 +35,7 @@ fn check_exception_table(rip: VirtAddr) -> VirtAddr {
                 return end;
             }
 
-            current = current.offset(mem::size_of::<ExceptionTableEntry>());
+            current = current + mem::size_of::<ExceptionTableEntry>();
             if current >= ex_table_end {
                 break;
             }
@@ -59,7 +59,7 @@ pub fn dump_exception_table() {
 
             log::info!("Extable Entry {:#018x}-{:#018x}", start, end);
 
-            current = current.offset(mem::size_of::<ExceptionTableEntry>());
+            current = current + mem::size_of::<ExceptionTableEntry>();
             if current >= ex_table_end {
                 break;
             }

--- a/src/cpu/idt.rs
+++ b/src/cpu/idt.rs
@@ -143,12 +143,12 @@ fn init_idt(idt: &mut Idt) {
     // Set IDT handlers
     let handlers = unsafe { VirtAddr::from(&idt_handler_array as *const u8) };
     for (i, entry) in idt.iter_mut().enumerate() {
-        *entry = IdtEntry::entry(handlers.offset(32 * i));
+        *entry = IdtEntry::entry(handlers + (32 * i));
     }
 }
 
 unsafe fn init_ist_vectors(idt: &mut Idt) {
-    let handler = VirtAddr::from(&idt_handler_array as *const u8).offset(32 * DF_VECTOR);
+    let handler = VirtAddr::from(&idt_handler_array as *const u8) + (32 * DF_VECTOR);
     idt[DF_VECTOR] = IdtEntry::ist_entry(handler, IST_DF.try_into().unwrap());
 }
 

--- a/src/cpu/percpu.rs
+++ b/src/cpu/percpu.rs
@@ -465,7 +465,7 @@ impl PerCpu {
         let caa_phys = locked.caa_phys()?;
         let offset = caa_phys.page_offset();
 
-        Some(VirtAddr::from(SVSM_PERCPU_CAA_BASE).offset(offset))
+        Some(VirtAddr::from(SVSM_PERCPU_CAA_BASE) + offset)
     }
 
     fn vmsa_tr_segment(&self) -> VMSASegment {

--- a/src/debug/stacktrace.rs
+++ b/src/debug/stacktrace.rs
@@ -134,9 +134,9 @@ impl StackUnwinder {
         }
 
         let rbp = unsafe { rsp.as_ptr::<VirtAddr>().read_unaligned() };
-        let rsp = rsp.offset(mem::size_of::<VirtAddr>());
+        let rsp = rsp + mem::size_of::<VirtAddr>();
         let rip = unsafe { rsp.as_ptr::<VirtAddr>().read_unaligned() };
-        let rsp = rsp.offset(mem::size_of::<VirtAddr>());
+        let rsp = rsp + mem::size_of::<VirtAddr>();
 
         Self::check_unwound_frame(rbp, rsp, rip, stacks)
     }

--- a/src/fs/init.rs
+++ b/src/fs/init.rs
@@ -132,7 +132,7 @@ pub fn populate_ram_fs(kernel_fs_start: u64, kernel_fs_end: u64) -> Result<(), S
     log::info!("Unpacking FS archive...");
 
     let guard = PerCPUPageMappingGuard::create(pstart.page_align(), pend.page_align_up(), 0)?;
-    let vstart = guard.virt_addr().offset(pstart.page_offset());
+    let vstart = guard.virt_addr() + pstart.page_offset();
 
     let data: &[u8] = unsafe { slice::from_raw_parts(vstart.as_ptr(), size) };
     let hdr = PackItHeader::load(data)?;

--- a/src/fw_meta.rs
+++ b/src/fw_meta.rs
@@ -39,7 +39,7 @@ impl SevPreValidMem {
 
     #[inline]
     fn end(&self) -> PhysAddr {
-        self.base.offset(self.length)
+        self.base + self.length
     }
 
     fn overlap(&self, other: &Self) -> bool {
@@ -230,7 +230,7 @@ pub fn parse_fw_meta_data() -> Result<SevFWMetaData, SvsmError> {
     // Map meta-data location, it starts at 32 bytes below 4GiB
     let guard = PerCPUPageMappingGuard::create_4k(pstart)?;
     let vstart = guard.virt_addr();
-    let vend = vstart.offset(PAGE_SIZE);
+    let vend = vstart + PAGE_SIZE;
 
     let mut curr = vend.sub(32);
 
@@ -342,7 +342,7 @@ fn validate_fw_mem_region(region: SevPreValidMem) -> Result<(), SvsmError> {
         // Make page accessible to guest VMPL
         rmp_adjust(vaddr, RMPFlags::GUEST_VMPL | RMPFlags::RWX, false)?;
 
-        zero_mem_region(vaddr, vaddr.offset(PAGE_SIZE));
+        zero_mem_region(vaddr, vaddr + PAGE_SIZE);
     }
 
     Ok(())

--- a/src/fw_meta.rs
+++ b/src/fw_meta.rs
@@ -172,15 +172,15 @@ const SVSM_INFO_GUID: &str = "a789a612-0597-4c4b-a49f-cbb1fe9d1ddd";
 
 unsafe fn find_table(uuid: &Uuid, start: VirtAddr, len: usize) -> Option<(VirtAddr, usize)> {
     let mut curr = start;
-    let end = start.sub(len);
+    let end = start - len;
 
     while curr >= end {
-        curr = curr.sub(mem::size_of::<Uuid>());
+        curr = curr - mem::size_of::<Uuid>();
 
         let ptr = curr.as_ptr::<u8>();
         let curr_uuid = Uuid::from_mem(ptr);
 
-        curr = curr.sub(mem::size_of::<u16>());
+        curr = curr - mem::size_of::<u16>();
         if curr < end {
             break;
         }
@@ -193,7 +193,7 @@ unsafe fn find_table(uuid: &Uuid, start: VirtAddr, len: usize) -> Option<(VirtAd
         }
         let len = orig_len - (mem::size_of::<Uuid>() + mem::size_of::<u16>());
 
-        curr = curr.sub(len);
+        curr = curr - len;
 
         if *uuid == curr_uuid {
             return Some((curr, len));
@@ -232,11 +232,11 @@ pub fn parse_fw_meta_data() -> Result<SevFWMetaData, SvsmError> {
     let vstart = guard.virt_addr();
     let vend = vstart + PAGE_SIZE;
 
-    let mut curr = vend.sub(32);
+    let mut curr = vend - 32;
 
     let meta_uuid = Uuid::from_str(OVMF_TABLE_FOOTER_GUID).map_err(|()| SvsmError::Firmware)?;
 
-    curr = curr.sub(mem::size_of::<Uuid>());
+    curr = curr - mem::size_of::<Uuid>();
     let ptr = curr.as_ptr::<u8>();
 
     unsafe {
@@ -246,7 +246,7 @@ pub fn parse_fw_meta_data() -> Result<SevFWMetaData, SvsmError> {
             return Err(SvsmError::Firmware);
         }
 
-        curr = curr.sub(mem::size_of::<u16>());
+        curr = curr - mem::size_of::<u16>();
         let ptr = curr.as_ptr::<u16>();
 
         let full_len = ptr.read() as usize;
@@ -280,7 +280,7 @@ pub fn parse_fw_meta_data() -> Result<SevFWMetaData, SvsmError> {
             let off_ptr = base.as_ptr::<u32>();
             let offset = off_ptr.read_unaligned() as usize;
 
-            let meta_ptr = vend.sub(offset).as_ptr::<SevMetaDataHeader>();
+            let meta_ptr = (vend - offset).as_ptr::<SevMetaDataHeader>();
             //let len = meta_ptr.read().len;
             let num_descs = meta_ptr.read().num_desc as isize;
             let desc_ptr = meta_ptr.offset(1).cast::<SevMetaDataDesc>();

--- a/src/mm/address_space.rs
+++ b/src/mm/address_space.rs
@@ -4,7 +4,9 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
-use crate::address::{Address, PhysAddr, VirtAddr};
+#[cfg(test)]
+use crate::address::Address;
+use crate::address::{PhysAddr, VirtAddr};
 use crate::utils::immut_after_init::ImmutAfterInitCell;
 
 #[derive(Copy, Clone)]
@@ -47,19 +49,19 @@ pub fn virt_to_phys(vaddr: VirtAddr) -> PhysAddr {
 
     let offset: usize = vaddr - KERNEL_MAPPING.virt_start;
 
-    KERNEL_MAPPING.phys_start.offset(offset)
+    KERNEL_MAPPING.phys_start + offset
 }
 
 #[cfg(not(test))]
 pub fn phys_to_virt(paddr: PhysAddr) -> VirtAddr {
     let size: usize = KERNEL_MAPPING.virt_end - KERNEL_MAPPING.virt_start;
-    if paddr < KERNEL_MAPPING.phys_start || paddr >= KERNEL_MAPPING.phys_start.offset(size) {
+    if paddr < KERNEL_MAPPING.phys_start || paddr >= KERNEL_MAPPING.phys_start + size {
         panic!("Invalid physical address {:#018x}", paddr);
     }
 
     let offset: usize = paddr - KERNEL_MAPPING.phys_start;
 
-    KERNEL_MAPPING.virt_start.offset(offset)
+    KERNEL_MAPPING.virt_start + offset
 }
 
 #[cfg(test)]

--- a/src/mm/pagetable.rs
+++ b/src/mm/pagetable.rs
@@ -409,7 +409,7 @@ impl PageTable {
 
         // Prepare PTE leaf page
         for i in 0..512 {
-            let addr_4k = addr_2m.offset(i * PAGE_SIZE);
+            let addr_4k = addr_2m + (i * PAGE_SIZE);
             unsafe {
                 (*page).entries[i].clear();
                 (*page).entries[i].set(set_c_bit(addr_4k), flags);
@@ -548,7 +548,7 @@ impl PageTable {
                 if !entry.flags().contains(PTEntryFlags::PRESENT) {
                     return Err(SvsmError::Mem);
                 }
-                Ok(entry.address().offset(offset))
+                Ok(entry.address() + offset)
             }
             Mapping::Level1(entry) => {
                 let offset = vaddr.bits() & (PAGE_SIZE_2M - 1);
@@ -558,7 +558,7 @@ impl PageTable {
                     return Err(SvsmError::Mem);
                 }
 
-                Ok(entry.address().offset(offset))
+                Ok(entry.address() + offset)
             }
             Mapping::Level2(_entry) => Err(SvsmError::Mem),
             Mapping::Level3(_entry) => Err(SvsmError::Mem),
@@ -577,7 +577,7 @@ impl PageTable {
             .map(VirtAddr::from)
         {
             let offset = addr - start;
-            self.map_4k(addr, phys.offset(offset), flags)?;
+            self.map_4k(addr, phys + offset, flags)?;
         }
         Ok(())
     }
@@ -603,7 +603,7 @@ impl PageTable {
             .map(VirtAddr::from)
         {
             let offset = addr - start;
-            self.map_2m(addr, phys.offset(offset), flags)?;
+            self.map_2m(addr, phys + offset, flags)?;
         }
         Ok(())
     }
@@ -630,17 +630,17 @@ impl PageTable {
         while vaddr < end {
             if vaddr.is_aligned(PAGE_SIZE_2M)
                 && paddr.is_aligned(PAGE_SIZE_2M)
-                && vaddr.offset(PAGE_SIZE_2M) <= end
+                && vaddr + PAGE_SIZE_2M <= end
                 && self.map_2m(vaddr, paddr, flags).is_ok()
             {
-                vaddr = vaddr.offset(PAGE_SIZE_2M);
-                paddr = paddr.offset(PAGE_SIZE_2M);
+                vaddr = vaddr + PAGE_SIZE_2M;
+                paddr = paddr + PAGE_SIZE_2M;
                 continue;
             }
 
             self.map_4k(vaddr, paddr, flags)?;
-            vaddr = vaddr.offset(PAGE_SIZE);
-            paddr = paddr.offset(PAGE_SIZE);
+            vaddr = vaddr + PAGE_SIZE;
+            paddr = paddr + PAGE_SIZE;
         }
 
         Ok(())
@@ -655,11 +655,11 @@ impl PageTable {
             match mapping {
                 Mapping::Level0(entry) => {
                     entry.clear();
-                    vaddr = vaddr.offset(PAGE_SIZE);
+                    vaddr = vaddr + PAGE_SIZE;
                 }
                 Mapping::Level1(entry) => {
                     entry.clear();
-                    vaddr = vaddr.offset(PAGE_SIZE_2M);
+                    vaddr = vaddr + PAGE_SIZE_2M;
                 }
                 _ => {
                     log::debug!("Can't unmap - address not mapped {:#x}", vaddr);

--- a/src/mm/stack.rs
+++ b/src/mm/stack.rs
@@ -49,7 +49,7 @@ impl StackRange {
 
             self.alloc_bitmap[i] |= mask;
 
-            return Ok(self.start.offset((i * 64 + idx) * STACK_TOTAL_SIZE));
+            return Ok(self.start + ((i * 64 + idx) * STACK_TOTAL_SIZE));
         }
 
         Err(SvsmError::Mem)
@@ -84,7 +84,7 @@ pub fn allocate_stack_addr(stack: VirtAddr, pgtable: &mut PageTableRef) -> Resul
     for i in 0..STACK_PAGES {
         let page = allocate_zeroed_page()?;
         let paddr = virt_to_phys(page);
-        pgtable.map_4k(stack.offset(i * PAGE_SIZE), paddr, flags)?;
+        pgtable.map_4k(stack + (i * PAGE_SIZE), paddr, flags)?;
     }
 
     Ok(())
@@ -105,7 +105,7 @@ pub fn free_stack(stack: VirtAddr) {
 
     let mut pgtable = get_init_pgtable_locked();
     for (i, page) in pages.iter_mut().enumerate() {
-        let addr = stack.offset(i * PAGE_SIZE);
+        let addr = stack + (i * PAGE_SIZE);
         let paddr = pgtable
             .phys_addr(addr)
             .expect("Failed to get stack physical address");

--- a/src/mm/virtualrange.rs
+++ b/src/mm/virtualrange.rs
@@ -4,7 +4,7 @@
 //
 // Author: Roy Hopkins <rhopkins@suse.de>
 
-use crate::address::{Address, VirtAddr};
+use crate::address::VirtAddr;
 use crate::cpu::percpu::{this_cpu, this_cpu_mut};
 use crate::error::SvsmError;
 use crate::types::{PAGE_SHIFT, PAGE_SHIFT_2M, PAGE_SIZE, PAGE_SIZE_2M};
@@ -47,7 +47,7 @@ impl VirtualRange {
     pub fn alloc(&mut self, page_count: usize, alignment: usize) -> Result<VirtAddr, SvsmError> {
         // Always reserve an extra page to leave a guard between virtual memory allocations
         match self.bits.alloc(page_count + 1, alignment) {
-            Some(offset) => Ok(self.start_virt.offset(offset << self.page_shift)),
+            Some(offset) => Ok(self.start_virt + (offset << self.page_shift)),
             None => Err(SvsmError::Mem),
         }
     }

--- a/src/protocols/core.rs
+++ b/src/protocols/core.rs
@@ -225,7 +225,7 @@ fn core_pvalidate_one(entry: u64, flush: &mut bool) -> Result<(), SvsmReqError> 
         return Err(SvsmReqError::invalid_address());
     }
 
-    let guard = PerCPUPageMappingGuard::create(paddr, paddr.offset(page_size_bytes), valign)?;
+    let guard = PerCPUPageMappingGuard::create(paddr, paddr + page_size_bytes, valign)?;
     let vaddr = guard.virt_addr();
 
     if !valid {
@@ -258,7 +258,7 @@ fn core_pvalidate(params: &RequestParams) -> Result<(), SvsmReqError> {
     let guard = PerCPUPageMappingGuard::create_4k(paddr)?;
     let start = guard.virt_addr();
 
-    let guest_page = GuestPtr::<PValidateRequest>::new(start.offset(offset));
+    let guest_page = GuestPtr::<PValidateRequest>::new(start + offset);
     let mut request = guest_page.read()?;
 
     let entries = request.entries;
@@ -316,7 +316,7 @@ fn core_remap_ca(params: &RequestParams) -> Result<(), SvsmReqError> {
 
     // Temporarily map new CAA to clear it
     let mapping_guard = PerCPUPageMappingGuard::create_4k(paddr)?;
-    let vaddr = mapping_guard.virt_addr().offset(offset);
+    let vaddr = mapping_guard.virt_addr() + offset;
 
     let pending = GuestPtr::<u64>::new(vaddr);
     pending.write(0)?;

--- a/src/sev/ghcb.rs
+++ b/src/sev/ghcb.rs
@@ -406,7 +406,7 @@ impl GHCB {
         self.clear();
 
         while paddr < end {
-            let huge = huge && paddr.is_aligned(PAGE_SIZE_2M) && paddr.offset(PAGE_SIZE_2M) <= end;
+            let huge = huge && paddr.is_aligned(PAGE_SIZE_2M) && paddr + PAGE_SIZE_2M <= end;
             let pgsize: usize = match huge {
                 true => PAGE_SIZE_2M,
                 false => PAGE_SIZE,
@@ -415,7 +415,7 @@ impl GHCB {
             let offset: isize = (entries as isize) * 8 + 8;
             self.write_buffer(&entry, offset)?;
             entries += 1;
-            paddr = paddr.offset(pgsize);
+            paddr = paddr + pgsize;
 
             if entries == max_entries {
                 let header = PageStateChangeHeader {

--- a/src/sev/utils.rs
+++ b/src/sev/utils.rs
@@ -65,19 +65,19 @@ pub fn pvalidate_range(start: VirtAddr, end: VirtAddr, valid: bool) -> Result<()
     let mut addr = start;
 
     while addr < end {
-        if addr.is_aligned(PAGE_SIZE_2M) && addr.offset(PAGE_SIZE_2M) <= end {
+        if addr.is_aligned(PAGE_SIZE_2M) && addr + PAGE_SIZE_2M <= end {
             // Try to validate as a huge page.
             // If we fail, try to fall back to regular-sized pages.
             pvalidate(addr, true, valid).or_else(|err| match err {
                 SvsmError::SevSnp(SevSnpError::FAIL_SIZEMISMATCH(_)) => {
-                    pvalidate_range_4k(addr, addr.offset(PAGE_SIZE_2M), valid)
+                    pvalidate_range_4k(addr, addr + PAGE_SIZE_2M, valid)
                 }
                 _ => Err(err),
             })?;
-            addr = addr.offset(PAGE_SIZE_2M);
+            addr = addr + PAGE_SIZE_2M;
         } else {
             pvalidate(addr, false, valid)?;
-            addr = addr.offset(PAGE_SIZE);
+            addr = addr + PAGE_SIZE;
         }
     }
 

--- a/src/sev/vmsa.rs
+++ b/src/sev/vmsa.rs
@@ -195,11 +195,11 @@ pub fn allocate_new_vmsa(vmpl: RMPFlags) -> Result<VirtAddr, SvsmError> {
         free_page(vmsa_page);
         vmsa_page = allocate_pages(1)?;
         if vmsa_page.is_aligned(PAGE_SIZE_2M) {
-            vmsa_page = vmsa_page.offset(PAGE_SIZE);
+            vmsa_page = vmsa_page + PAGE_SIZE;
         }
     }
 
-    zero_mem_region(vmsa_page, vmsa_page.offset(PAGE_SIZE));
+    zero_mem_region(vmsa_page, vmsa_page + PAGE_SIZE);
 
     if let Err(e) = rmp_adjust(vmsa_page, RMPFlags::VMSA | vmpl, false) {
         free_page(vmsa_page);

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -119,20 +119,15 @@ fn map_and_validate(vaddr: VirtAddr, paddr: PhysAddr, len: usize) {
 
     let mut pgtbl = get_init_pgtable_locked();
     pgtbl
-        .map_region(vaddr, vaddr.offset(len), paddr, flags)
+        .map_region(vaddr, vaddr + len, paddr, flags)
         .expect("Error mapping kernel region");
 
     this_cpu_mut()
         .ghcb()
-        .page_state_change(
-            paddr,
-            paddr.offset(len),
-            true,
-            PageStateChangeOp::PscPrivate,
-        )
+        .page_state_change(paddr, paddr + len, true, PageStateChangeOp::PscPrivate)
         .expect("GHCB::PAGE_STATE_CHANGE call failed for kernel region");
-    pvalidate_range(vaddr, vaddr.offset(len), true).expect("PVALIDATE kernel region failed");
-    valid_bitmap_set_valid_range(paddr, paddr.offset(len));
+    pvalidate_range(vaddr, vaddr + len, true).expect("PVALIDATE kernel region failed");
+    valid_bitmap_set_valid_range(paddr, paddr + len);
 }
 
 // Launch info from stage1, usually at the bottom of the stack
@@ -209,7 +204,7 @@ pub extern "C" fn stage2_main(launch_info: &Stage1LaunchInfo) {
 
         let segment_len = aligned_vaddr_end - vaddr_start;
         let paddr_start = loaded_kernel_phys_end;
-        loaded_kernel_phys_end = loaded_kernel_phys_end.offset(segment_len);
+        loaded_kernel_phys_end = loaded_kernel_phys_end + segment_len;
 
         map_and_validate(vaddr_start, paddr_start, segment_len);
 

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -109,7 +109,7 @@ pub static mut PERCPU: PerCpu = PerCpu::new();
 fn copy_cpuid_table_to_fw(fw_addr: PhysAddr) -> Result<(), SvsmError> {
     let guard = PerCPUPageMappingGuard::create_4k(fw_addr)?;
     let start = guard.virt_addr();
-    let end = start.offset(PAGE_SIZE);
+    let end = start + PAGE_SIZE;
 
     let target = ptr::NonNull::new(start.as_mut_ptr::<SnpCpuidTable>()).unwrap();
 
@@ -166,7 +166,7 @@ fn zero_caa_page(fw_addr: PhysAddr) -> Result<(), SvsmError> {
     let guard = PerCPUPageMappingGuard::create_4k(fw_addr)?;
     let vaddr = guard.virt_addr();
 
-    zero_mem_region(vaddr, vaddr.offset(PAGE_SIZE));
+    zero_mem_region(vaddr, vaddr + PAGE_SIZE);
 
     Ok(())
 }

--- a/src/svsm_paging.rs
+++ b/src/svsm_paging.rs
@@ -41,7 +41,7 @@ pub fn init_page_table(launch_info: &KernelLaunchInfo, kernel_elf: &elf::Elf64Fi
             .map_region(vaddr_start, aligned_vaddr_end, phys, flags)
             .expect("Failed to map kernel ELF segment");
 
-        phys = phys.offset(segment_len);
+        phys = phys + segment_len;
     }
 
     // Map subsequent heap area.
@@ -61,7 +61,7 @@ pub fn init_page_table(launch_info: &KernelLaunchInfo, kernel_elf: &elf::Elf64Fi
 
 pub fn invalidate_stage2() -> Result<(), SvsmError> {
     let pstart = PhysAddr::null();
-    let pend = pstart.offset(640 * 1024);
+    let pend = pstart + (640 * 1024);
     let mut paddr = pstart;
 
     // Stage2 memory must be invalidated when already on the SVSM page-table,
@@ -73,7 +73,7 @@ pub fn invalidate_stage2() -> Result<(), SvsmError> {
 
         pvalidate(vaddr, false, false)?;
 
-        paddr = paddr.offset(PAGE_SIZE);
+        paddr = paddr + PAGE_SIZE;
     }
 
     this_cpu_mut()


### PR DESCRIPTION
Remove needless `Address::{offset, sub}` methods, and use the `Add` and `Sub` traits.