### PR TITLE
Tasks: Add support for task context switching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "intrusive-collections"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4f90afb01281fdeffb0f8e082d230cbe4f888f837cc90759696b858db1a700"
+dependencies = [
+ "memoffset",
+]
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,6 +73,15 @@ name = "managed"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
+
+[[package]]
+name = "memoffset"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "num-traits"
@@ -88,5 +106,6 @@ dependencies = [
  "cc",
  "gdbstub",
  "gdbstub_arch",
+ "intrusive-collections",
  "log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ doctest = false
 bitflags = "1.3.2"
 gdbstub = { version = "0.6.6", default-features = false }
 gdbstub_arch = "0.2.4"
+intrusive-collections = "0.9"
 log = { version = "0.4.17", features = ["max_level_info", "release_max_level_info"] }
 
 [build-dependencies]

--- a/src/cpu/extable.rs
+++ b/src/cpu/extable.rs
@@ -9,8 +9,8 @@ extern "C" {
     pub static exception_table_end: u8;
 }
 
+use super::idt::X86ExceptionContext;
 use crate::address::{Address, VirtAddr};
-use crate::cpu::X86Regs;
 use core::mem;
 
 #[repr(C, packed)]
@@ -67,14 +67,14 @@ pub fn dump_exception_table() {
     }
 }
 
-pub fn handle_exception_table(regs: &mut X86Regs) -> bool {
-    let ex_rip = VirtAddr::from(regs.rip);
+pub fn handle_exception_table(ctx: &mut X86ExceptionContext) -> bool {
+    let ex_rip = VirtAddr::from(ctx.frame.rip);
     let new_rip = check_exception_table(ex_rip);
 
     // If an exception hit in an area covered by the exception table, set rcx to -1
     if new_rip != ex_rip {
-        regs.rcx = !0usize;
-        regs.rip = new_rip.bits();
+        ctx.regs.rcx = !0usize;
+        ctx.frame.rip = new_rip.bits();
         return true;
     }
 

--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -13,11 +13,13 @@ pub mod gdt;
 pub mod idt;
 pub mod msr;
 pub mod percpu;
+pub mod registers;
 pub mod smp;
 pub mod tlb;
 pub mod tss;
 pub mod vc;
 pub mod vmsa;
 
-pub use idt::X86Regs;
+pub use idt::X86ExceptionContext;
+pub use registers::{X86GeneralRegs, X86InterruptFrame, X86SegmentRegs};
 pub use tlb::*;

--- a/src/cpu/msr.rs
+++ b/src/cpu/msr.rs
@@ -37,3 +37,16 @@ pub fn write_msr(msr: u32, val: u64) {
              options(att_syntax));
     }
 }
+
+pub fn rdtsc() -> u64 {
+    let eax: u32;
+    let edx: u32;
+
+    unsafe {
+        asm!("rdtsc",
+             out("eax") eax,
+             out("edx") edx,
+             options(att_syntax));
+    }
+    (eax as u64) | (edx as u64) << 32
+}

--- a/src/cpu/msr.rs
+++ b/src/cpu/msr.rs
@@ -50,3 +50,17 @@ pub fn rdtsc() -> u64 {
     }
     (eax as u64) | (edx as u64) << 32
 }
+
+pub fn read_flags() -> u64 {
+    let rax: u64;
+    unsafe {
+        asm!(
+            r#"
+                pushfq
+                pop     %rax
+            "#,
+             out("rax") rax,
+             options(att_syntax));
+    }
+    rax
+}

--- a/src/cpu/percpu.rs
+++ b/src/cpu/percpu.rs
@@ -25,6 +25,7 @@ use crate::mm::{
 use crate::sev::ghcb::GHCB;
 use crate::sev::utils::RMPFlags;
 use crate::sev::vmsa::{allocate_new_vmsa, VMSASegment, VMSA};
+use crate::task::TaskPointer;
 use crate::types::{PAGE_SHIFT, PAGE_SHIFT_2M, PAGE_SIZE, PAGE_SIZE_2M, SVSM_TR_FLAGS, SVSM_TSS};
 use alloc::vec::Vec;
 use core::cell::UnsafeCell;
@@ -182,6 +183,8 @@ pub struct PerCpu {
     pub vrange_4k: VirtualRange,
     /// Address allocator for per-cpu 2m temporary mappings
     pub vrange_2m: VirtualRange,
+
+    pub current_task: Option<TaskPointer>,
 }
 
 impl PerCpu {
@@ -199,6 +202,7 @@ impl PerCpu {
             reset_ip: 0xffff_fff0u64,
             vrange_4k: VirtualRange::new(),
             vrange_2m: VirtualRange::new(),
+            current_task: None,
         }
     }
 

--- a/src/cpu/registers.rs
+++ b/src/cpu/registers.rs
@@ -5,32 +5,7 @@
 // Author: Roy Hopkins <rhopkins@suse.de>
 
 #[repr(C, packed)]
-pub struct X86Regs {
-    pub r15: usize,
-    pub r14: usize,
-    pub r13: usize,
-    pub r12: usize,
-    pub r11: usize,
-    pub r10: usize,
-    pub r9: usize,
-    pub r8: usize,
-    pub rbp: usize,
-    pub rdi: usize,
-    pub rsi: usize,
-    pub rdx: usize,
-    pub rcx: usize,
-    pub rbx: usize,
-    pub rax: usize,
-    pub vector: usize,
-    pub error_code: usize,
-    pub rip: usize,
-    pub cs: usize,
-    pub flags: usize,
-    pub rsp: usize,
-    pub ss: usize,
-}
-
-#[repr(C, packed)]
+#[derive(Default)]
 pub struct X86GeneralRegs {
     pub r15: usize,
     pub r14: usize,
@@ -50,6 +25,7 @@ pub struct X86GeneralRegs {
 }
 
 #[repr(C, packed)]
+#[derive(Default)]
 pub struct X86SegmentRegs {
     pub cs: usize,
     pub ds: usize,

--- a/src/cpu/registers.rs
+++ b/src/cpu/registers.rs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2022-2023 SUSE LLC
+//
+// Author: Roy Hopkins <rhopkins@suse.de>
+
+#[repr(C, packed)]
+pub struct X86Regs {
+    pub r15: usize,
+    pub r14: usize,
+    pub r13: usize,
+    pub r12: usize,
+    pub r11: usize,
+    pub r10: usize,
+    pub r9: usize,
+    pub r8: usize,
+    pub rbp: usize,
+    pub rdi: usize,
+    pub rsi: usize,
+    pub rdx: usize,
+    pub rcx: usize,
+    pub rbx: usize,
+    pub rax: usize,
+    pub vector: usize,
+    pub error_code: usize,
+    pub rip: usize,
+    pub cs: usize,
+    pub flags: usize,
+    pub rsp: usize,
+    pub ss: usize,
+}
+
+#[repr(C, packed)]
+pub struct X86GeneralRegs {
+    pub r15: usize,
+    pub r14: usize,
+    pub r13: usize,
+    pub r12: usize,
+    pub r11: usize,
+    pub r10: usize,
+    pub r9: usize,
+    pub r8: usize,
+    pub rbp: usize,
+    pub rdi: usize,
+    pub rsi: usize,
+    pub rdx: usize,
+    pub rcx: usize,
+    pub rbx: usize,
+    pub rax: usize,
+}
+
+#[repr(C, packed)]
+pub struct X86SegmentRegs {
+    pub cs: usize,
+    pub ds: usize,
+    pub es: usize,
+    pub fs: usize,
+    pub gs: usize,
+    pub ss: usize,
+}
+
+#[repr(C, packed)]
+pub struct X86InterruptFrame {
+    pub rip: usize,
+    pub cs: usize,
+    pub flags: usize,
+    pub rsp: usize,
+    pub ss: usize,
+}

--- a/src/cpu/smp.rs
+++ b/src/cpu/smp.rs
@@ -51,7 +51,7 @@ pub fn start_secondary_cpus(cpus: &[ACPICPUInfo]) {
         start_cpu(c.apic_id);
         count += 1;
     }
-    log::info!("Brough {} AP(s) online", count);
+    log::info!("Brought {} AP(s) online", count);
 }
 
 #[no_mangle]

--- a/src/cpu/smp.rs
+++ b/src/cpu/smp.rs
@@ -7,9 +7,10 @@
 extern crate alloc;
 
 use crate::acpi::tables::ACPICPUInfo;
-use crate::cpu::percpu::{this_cpu_mut, PerCpu};
+use crate::cpu::percpu::{this_cpu, this_cpu_mut, PerCpu};
 use crate::cpu::vmsa::init_svsm_vmsa;
 use crate::requests::request_loop;
+use crate::task::{create_initial_task, TASK_FLAG_SHARE_PT};
 
 fn start_cpu(apic_id: u32) {
     unsafe {
@@ -66,8 +67,17 @@ fn start_ap() {
     // Set CPU online so that BSP can proceed
     this_cpu_mut().set_online();
 
-    // Loop for now
-    request_loop();
+    // Create the task making sure the task only runs on this new AP
+    create_initial_task(
+        ap_request_loop,
+        TASK_FLAG_SHARE_PT,
+        Some(this_cpu().get_apic_id()),
+    )
+    .expect("Failed to create AP initial task");
+}
 
+#[no_mangle]
+pub extern "C" fn ap_request_loop() {
+    request_loop();
     panic!("Returned from request_loop!");
 }

--- a/src/cpu/tsc.rs
+++ b/src/cpu/tsc.rs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2022-2023 SUSE LLC
+//
+// Author: Roy Hopkins <rhopkins@suse.de>
+
+use core::arch::asm;
+
+pub fn rdtsc() -> u64 {
+    let eax: u32;
+    let edx: u32;
+
+    unsafe {
+        asm!("rdtsc",
+             out("eax") eax,
+             out("edx") edx,
+             options(att_syntax));
+    }
+    (eax as u64) | (edx as u64) << 32
+}

--- a/src/cpu/vc.rs
+++ b/src/cpu/vc.rs
@@ -4,25 +4,25 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
-use super::idt::X86Regs;
+use super::idt::X86ExceptionContext;
 use crate::cpu::extable::handle_exception_table;
 use crate::debug::gdbstub::svsm_gdbstub::handle_db_exception;
 
 pub const SVM_EXIT_EXCP_BASE: usize = 0x40;
 pub const X86_TRAP_DB: usize = 0x01;
 
-pub fn handle_vc_exception(regs: &mut X86Regs) {
-    let err = regs.error_code;
-    let rip = regs.rip;
+pub fn handle_vc_exception(ctx: &mut X86ExceptionContext) {
+    let err = ctx.error_code;
+    let rip = ctx.frame.rip;
 
     // If the debugger is enabled then handle the DB exception
     // by directly invoking the exception hander
     if err == (SVM_EXIT_EXCP_BASE + X86_TRAP_DB) {
-        handle_db_exception(regs);
+        handle_db_exception(ctx);
         return;
     }
 
-    if !handle_exception_table(regs) {
+    if !handle_exception_table(ctx) {
         panic!(
             "Unhandled #VC exception RIP {:#018x} error code: {:#018x}",
             rip, err

--- a/src/debug/gdbstub.rs
+++ b/src/debug/gdbstub.rs
@@ -11,25 +11,34 @@
 //
 #[cfg(feature = "enable-gdb")]
 pub mod svsm_gdbstub {
+    extern crate alloc;
+
     use crate::address::{Address, VirtAddr};
+    use crate::cpu::control_regs::read_cr3;
+    use crate::cpu::idt::X86ExceptionContext;
     use crate::cpu::percpu::this_cpu;
-    use crate::cpu::X86ExceptionContext;
     use crate::error::SvsmError;
+    use crate::locking::SpinLock;
     use crate::mm::guestmem::{read_u8, write_u8};
     use crate::mm::PerCPUPageMappingGuard;
     use crate::serial::{SerialPort, Terminal};
     use crate::svsm_console::SVSMIOPort;
+    use crate::task::{is_current_task, TaskContext, TaskState, INITIAL_TASK_ID, TASKS};
     use core::arch::asm;
+    use core::sync::atomic::{AtomicBool, Ordering};
+    use gdbstub::common::{Signal, Tid};
     use gdbstub::conn::Connection;
     use gdbstub::stub::state_machine::GdbStubStateMachine;
-    use gdbstub::stub::{GdbStubBuilder, SingleThreadStopReason};
-    use gdbstub::target::ext::base::singlethread::{
-        SingleThreadBase, SingleThreadResume, SingleThreadResumeOps, SingleThreadSingleStep,
-        SingleThreadSingleStepOps,
+    use gdbstub::stub::{GdbStubBuilder, MultiThreadStopReason};
+    use gdbstub::target::ext::base::multithread::{
+        MultiThreadBase, MultiThreadResume, MultiThreadResumeOps, MultiThreadSingleStep,
+        MultiThreadSingleStepOps,
     };
     use gdbstub::target::ext::base::BaseOps;
     use gdbstub::target::ext::breakpoints::{Breakpoints, SwBreakpoint};
+    use gdbstub::target::ext::thread_extra_info::ThreadExtraInfo;
     use gdbstub::target::{Target, TargetError};
+    use gdbstub_arch::x86::reg::X86_64CoreRegs;
     use gdbstub_arch::x86::X86_64_SSE;
 
     const INT3_INSTR: u8 = 0xcc;
@@ -44,21 +53,45 @@ pub mod svsm_gdbstub {
                 .expect("Failed to initialise GDB stub")
                 .run_state_machine(&mut target)
                 .expect("Failed to start GDB state machine");
-            GDB_STATE = Some(SvsmGdbStub { gdb, target });
+            *GDB_STATE.lock() = Some(SvsmGdbStub { gdb, target });
+            GDB_STACK_TOP = GDB_STACK.as_mut_ptr().offset(GDB_STACK.len() as isize - 1) as u64;
         }
+        GDB_INITIALISED.store(true, Ordering::Relaxed);
         Ok(())
     }
 
+    enum ExceptionType {
+        Debug,
+        SwBreakpoint,
+    }
+
     pub fn handle_bp_exception(ctx: &mut X86ExceptionContext) {
-        handle_stop(ctx, true);
+        handle_exception(ctx, ExceptionType::SwBreakpoint);
     }
 
     pub fn handle_db_exception(ctx: &mut X86ExceptionContext) {
-        handle_stop(ctx, false);
+        handle_exception(ctx, ExceptionType::Debug);
+    }
+
+    fn handle_exception(ctx: &mut X86ExceptionContext, exception_type: ExceptionType) {
+        unsafe {
+            asm!(
+                r#"
+                    movq    %rsp, (%rax)
+                    movq    %rax, %rsp
+                    call    handle_stop
+                    popq    %rax
+                    movq    %rax, %rsp
+                "#,
+                in("rsi") exception_type as u64,
+                in("rdi") ctx,
+                in("rax") GDB_STACK_TOP,
+                options(att_syntax));
+        }
     }
 
     pub fn debug_break() {
-        if unsafe { GDB_STATE.is_some() } {
+        if GDB_INITIALISED.load(Ordering::Acquire) {
             log::info!("***********************************");
             log::info!("* Waiting for connection from GDB *");
             log::info!("***********************************");
@@ -68,27 +101,75 @@ pub mod svsm_gdbstub {
         }
     }
 
-    static mut GDB_STATE: Option<SvsmGdbStub> = None;
+    static GDB_INITIALISED: AtomicBool = AtomicBool::new(false);
+    static GDB_STATE: SpinLock<Option<SvsmGdbStub>> = SpinLock::new(None);
     static GDB_IO: SVSMIOPort = SVSMIOPort::new();
     static mut GDB_SERIAL: SerialPort = SerialPort {
         driver: &GDB_IO,
         port: 0x2f8,
     };
     static mut PACKET_BUFFER: [u8; 4096] = [0; 4096];
+    // Allocate the GDB stack as an array of u64's to ensure 8 byte alignment of the stack.
+    static mut GDB_STACK: [u64; 8192] = [0; 8192];
+    static mut GDB_STACK_TOP: u64 = 0;
+
+    struct GdbTaskContext {
+        cr3: usize,
+    }
+
+    impl GdbTaskContext {
+        fn switch_to_task(id: u32) -> Self {
+            let cr3 = if is_current_task(id) {
+                0
+            } else {
+                let tl = TASKS.lock();
+                let cr3 = read_cr3();
+                let task_node = tl.get_task(id);
+                if let Some(task_node) = task_node {
+                    task_node.task.borrow_mut().page_table.lock().load();
+                    cr3.bits()
+                } else {
+                    0
+                }
+            };
+            Self { cr3 }
+        }
+    }
+
+    impl Drop for GdbTaskContext {
+        fn drop(&mut self) {
+            if self.cr3 != 0 {
+                unsafe {
+                    asm!("mov %rax, %cr3",
+                         in("rax") self.cr3,
+                         options(att_syntax));
+                }
+            }
+        }
+    }
 
     struct SvsmGdbStub<'a> {
         gdb: GdbStubStateMachine<'a, GdbStubTarget, GdbStubConnection>,
         target: GdbStubTarget,
     }
 
+    #[no_mangle]
     fn handle_stop(ctx: &mut X86ExceptionContext, bp_exception: bool) {
-        let SvsmGdbStub { gdb, mut target } = unsafe {
-            GDB_STATE.take().unwrap_or_else(|| {
-                panic!("GDB stub not initialised!");
-            })
-        };
+        // Locking the GDB state for the duration of the stop will cause any other
+        // APs that hit a breakpoint to busy-wait until the current CPU releases
+        // the GDB state. They will then resume and report the stop state
+        // to GDB.
+        // One thing to watch out for - if a breakpoint is inadvertently placed in
+        // the GDB handling code itself then this will cause a re-entrant state
+        // within the same CPU causing a deadlock.
+        let mut gdb_state = GDB_STATE.lock();
+        let SvsmGdbStub { gdb, mut target } = gdb_state.take().unwrap_or_else(|| {
+            panic!("Invalid GDB state");
+        });
 
         target.set_regs(ctx);
+
+        let hardcoded_bp = bp_exception && !target.is_breakpoint(ctx.frame.rip - 1);
 
         // If the current address is on a breakpoint then we need to
         // move the IP back by one byte
@@ -96,9 +177,22 @@ pub mod svsm_gdbstub {
             ctx.frame.rip -= 1;
         }
 
+        let tid = match &this_cpu().current_task {
+            Some(t) => Tid::new(t.task.borrow().id as usize).unwrap(),
+            None => Tid::new(1).unwrap(),
+        };
+
         let mut new_gdb = match gdb {
             GdbStubStateMachine::Running(gdb_inner) => {
-                match gdb_inner.report_stop(&mut target, SingleThreadStopReason::SwBreak(())) {
+                let reason = if hardcoded_bp {
+                    MultiThreadStopReason::SignalWithThread {
+                        tid,
+                        signal: Signal::SIGINT,
+                    }
+                } else {
+                    MultiThreadStopReason::SwBreak(tid)
+                };
+                match gdb_inner.report_stop(&mut target, reason) {
                     Ok(gdb) => gdb,
                     Err(_) => panic!("Failed to handle software breakpoint"),
                 }
@@ -115,7 +209,6 @@ pub mod svsm_gdbstub {
                     let byte = gdb_inner
                         .borrow_conn()
                         .read()
-                        .map_err(|_| 1 as u64)
                         .expect("Failed to read from GDB port");
                     match gdb_inner.incoming_data(&mut target, byte) {
                         Ok(gdb) => gdb,
@@ -128,8 +221,7 @@ pub mod svsm_gdbstub {
                     break;
                 }
                 _ => {
-                    log::info!("Invalid GDB state when handling breakpoint interrupt");
-                    return;
+                    panic!("Invalid GDB state when handling breakpoint interrupt");
                 }
             };
         }
@@ -138,12 +230,10 @@ pub mod svsm_gdbstub {
         } else {
             ctx.frame.flags &= !0x100;
         }
-        unsafe {
-            GDB_STATE = Some(SvsmGdbStub {
-                gdb: new_gdb,
-                target,
-            })
-        };
+        *gdb_state = Some(SvsmGdbStub {
+            gdb: new_gdb,
+            target,
+        });
     }
 
     struct GdbStubConnection;
@@ -154,8 +244,7 @@ pub mod svsm_gdbstub {
         }
 
         pub fn read(&mut self) -> Result<u8, &'static str> {
-            let res = unsafe { Ok(GDB_SERIAL.get_byte()) };
-            res
+            unsafe { Ok(GDB_SERIAL.get_byte()) }
         }
     }
 
@@ -203,10 +292,7 @@ pub mod svsm_gdbstub {
         }
 
         fn is_breakpoint(&self, rip: usize) -> bool {
-            self.breakpoints
-                .iter()
-                .find(|&b| b.addr.bits() == rip)
-                .is_some()
+            self.breakpoints.iter().any(|b| b.addr.bits() == rip)
         }
 
         fn write_bp_address(addr: VirtAddr, value: u8) -> Result<(), SvsmError> {
@@ -221,7 +307,7 @@ pub mod svsm_gdbstub {
             };
 
             let guard = PerCPUPageMappingGuard::create_4k(phys.page_align())?;
-            return unsafe { write_u8(guard.virt_addr().offset(phys.page_offset()), value) };
+            unsafe { write_u8(guard.virt_addr().offset(phys.page_offset()), value) }
         }
     }
 
@@ -231,7 +317,7 @@ pub mod svsm_gdbstub {
         type Error = usize;
 
         fn base_ops(&mut self) -> gdbstub::target::ext::base::BaseOps<'_, Self::Arch, Self::Error> {
-            BaseOps::SingleThread(self)
+            BaseOps::MultiThread(self)
         }
 
         #[inline(always)]
@@ -242,44 +328,101 @@ pub mod svsm_gdbstub {
         }
     }
 
-    impl SingleThreadBase for GdbStubTarget {
+    impl From<&X86ExceptionContext> for X86_64CoreRegs {
+        fn from(value: &X86ExceptionContext) -> Self {
+            let mut regs = X86_64CoreRegs::default();
+            regs.rip = value.frame.rip as u64;
+            regs.regs = [
+                value.regs.rax as u64,
+                value.regs.rbx as u64,
+                value.regs.rcx as u64,
+                value.regs.rdx as u64,
+                value.regs.rsi as u64,
+                value.regs.rdi as u64,
+                value.regs.rbp as u64,
+                value.frame.rsp as u64,
+                value.regs.r8 as u64,
+                value.regs.r9 as u64,
+                value.regs.r10 as u64,
+                value.regs.r11 as u64,
+                value.regs.r12 as u64,
+                value.regs.r13 as u64,
+                value.regs.r14 as u64,
+                value.regs.r15 as u64,
+            ];
+            regs.eflags = value.frame.flags as u32;
+            regs.segments.cs = value.frame.cs as u32;
+            regs.segments.ss = value.frame.ss as u32;
+            regs
+        }
+    }
+
+    impl From<&TaskContext> for X86_64CoreRegs {
+        fn from(value: &TaskContext) -> Self {
+            let mut regs = X86_64CoreRegs::default();
+            regs.rip = value.ret_addr;
+            regs.regs = [
+                value.regs.rax as u64,
+                value.regs.rbx as u64,
+                value.regs.rcx as u64,
+                value.regs.rdx as u64,
+                value.regs.rsi as u64,
+                value.regs.rdi as u64,
+                value.regs.rbp as u64,
+                0_u64,
+                value.regs.r8 as u64,
+                value.regs.r9 as u64,
+                value.regs.r10 as u64,
+                value.regs.r11 as u64,
+                value.regs.r12 as u64,
+                value.regs.r13 as u64,
+                value.regs.r14 as u64,
+                value.regs.r15 as u64,
+            ];
+            regs.eflags = value.flags as u32;
+            regs.segments.cs = value.seg.cs as u32;
+            regs.segments.ds = value.seg.ds as u32;
+            regs.segments.es = value.seg.es as u32;
+            regs.segments.fs = value.seg.fs as u32;
+            regs.segments.gs = value.seg.gs as u32;
+            regs.segments.ss = value.seg.ss as u32;
+            regs
+        }
+    }
+
+    impl MultiThreadBase for GdbStubTarget {
         fn read_registers(
             &mut self,
             regs: &mut <Self::Arch as gdbstub::arch::Arch>::Registers,
+            tid: Tid,
         ) -> gdbstub::target::TargetResult<(), Self> {
-            unsafe {
-                let context = (self.ctx as *mut X86ExceptionContext).as_mut().unwrap();
-
-                regs.rip = context.frame.rip as u64;
-                regs.regs = [
-                    context.regs.rax as u64,
-                    context.regs.rbx as u64,
-                    context.regs.rcx as u64,
-                    context.regs.rdx as u64,
-                    context.regs.rsi as u64,
-                    context.regs.rdi as u64,
-                    context.regs.rbp as u64,
-                    context.frame.rsp as u64,
-                    context.regs.r8 as u64,
-                    context.regs.r9 as u64,
-                    context.regs.r10 as u64,
-                    context.regs.r11 as u64,
-                    context.regs.r12 as u64,
-                    context.regs.r13 as u64,
-                    context.regs.r14 as u64,
-                    context.regs.r15 as u64,
-                ];
-                regs.eflags = context.frame.flags as u32;
-                regs.segments.cs = context.frame.cs as u32;
-                regs.segments.ss = context.frame.ss as u32;
+            if is_current_task(tid.get() as u32) {
+                unsafe {
+                    let context = (self.ctx as *const X86ExceptionContext).as_ref().unwrap();
+                    *regs = X86_64CoreRegs::from(context);
+                }
+            } else {
+                let task = TASKS.lock().get_task(tid.get() as u32);
+                if let Some(task_node) = task {
+                    // The registers are stored in the top of the task stack as part of the
+                    // saved context. We need to switch to the task pagetable to access them.
+                    let _task_context = GdbTaskContext::switch_to_task(tid.get() as u32);
+                    let task = task_node.task.borrow();
+                    unsafe {
+                        *regs = X86_64CoreRegs::from(&*(task.rsp as *const TaskContext));
+                    };
+                    regs.regs[7] = task.rsp;
+                } else {
+                    *regs = <Self::Arch as gdbstub::arch::Arch>::Registers::default();
+                }
             }
-
             Ok(())
         }
 
         fn write_registers(
             &mut self,
             regs: &<Self::Arch as gdbstub::arch::Arch>::Registers,
+            _tid: Tid,
         ) -> gdbstub::target::TargetResult<(), Self> {
             unsafe {
                 let context = (self.ctx as *mut X86ExceptionContext).as_mut().unwrap();
@@ -312,11 +455,15 @@ pub mod svsm_gdbstub {
             &mut self,
             start_addr: <Self::Arch as gdbstub::arch::Arch>::Usize,
             data: &mut [u8],
+            tid: Tid,
         ) -> gdbstub::target::TargetResult<(), Self> {
-            for offset in 0..data.len() {
+            // Switch to the task pagetable if necessary. The switch back will
+            // happen automatically when the variable falls out of scope
+            let _task_context = GdbTaskContext::switch_to_task(tid.get() as u32);
+            for (offset, value) in data.iter_mut().enumerate() {
                 unsafe {
                     match read_u8(VirtAddr::from(start_addr + offset as u64)) {
-                        Ok(val) => data[offset] = val,
+                        Ok(val) => *value = val,
                         Err(_) => {
                             return Err(TargetError::NonFatal);
                         }
@@ -330,10 +477,11 @@ pub mod svsm_gdbstub {
             &mut self,
             start_addr: <Self::Arch as gdbstub::arch::Arch>::Usize,
             data: &[u8],
+            _tid: Tid,
         ) -> gdbstub::target::TargetResult<(), Self> {
-            for offset in 0..data.len() {
+            for (offset, value) in data.iter().enumerate() {
                 unsafe {
-                    if write_u8(VirtAddr::from(start_addr + offset as u64), data[offset]).is_err() {
+                    if write_u8(VirtAddr::from(start_addr + offset as u64), *value).is_err() {
                         return Err(TargetError::NonFatal);
                     }
                 }
@@ -342,25 +490,117 @@ pub mod svsm_gdbstub {
         }
 
         #[inline(always)]
-        fn support_resume(&mut self) -> Option<SingleThreadResumeOps<Self>> {
+        fn support_resume(&mut self) -> Option<MultiThreadResumeOps<Self>> {
+            Some(self)
+        }
+
+        fn list_active_threads(
+            &mut self,
+            thread_is_active: &mut dyn FnMut(gdbstub::common::Tid),
+        ) -> Result<(), Self::Error> {
+            let mut tl = TASKS.lock();
+
+            let mut any_scheduled = false;
+
+            if tl.tree().is_empty() {
+                // Task list has not been initialised yet. Report a single thread
+                // for the current CPU
+                thread_is_active(Tid::new(INITIAL_TASK_ID as usize).unwrap());
+            } else {
+                let mut cursor = tl.tree().front_mut();
+                while cursor.get().is_some() {
+                    if cursor.get().unwrap().task.borrow().state == TaskState::SCHEDULED {
+                        any_scheduled = true;
+                        break;
+                    }
+                    cursor.move_next();
+                }
+                if any_scheduled {
+                    let mut cursor = tl.tree().front_mut();
+                    while cursor.get().is_some() {
+                        thread_is_active(
+                            Tid::new(cursor.get().unwrap().task.borrow().id as usize).unwrap(),
+                        );
+                        cursor.move_next();
+                    }
+                } else {
+                    thread_is_active(Tid::new(INITIAL_TASK_ID as usize).unwrap());
+                }
+            }
+            Ok(())
+        }
+
+        fn support_thread_extra_info(
+            &mut self,
+        ) -> Option<gdbstub::target::ext::thread_extra_info::ThreadExtraInfoOps<'_, Self>> {
             Some(self)
         }
     }
 
-    impl SingleThreadResume for GdbStubTarget {
-        fn resume(&mut self, _signal: Option<gdbstub::common::Signal>) -> Result<(), Self::Error> {
-            self.is_single_step = false;
+    impl ThreadExtraInfo for GdbStubTarget {
+        fn thread_extra_info(&self, tid: Tid, buf: &mut [u8]) -> Result<usize, Self::Error> {
+            // Get the current task from the stopped CPU so we can mark it as stopped
+            let tl = TASKS.lock();
+            let current_task = this_cpu().current_task.as_ref().map(|t| t.task.borrow());
+
+            let str = match tl.get_task(tid.get() as u32) {
+                Some(t) => {
+                    let t = t.task.borrow();
+                    match t.state {
+                        TaskState::RUNNING => "Stopped".as_bytes(),
+                        TaskState::SCHEDULED => {
+                            // The task is running on a CPU. If it is this CPU then the task has
+                            // stopped otherwise we cannot report on its state
+                            if current_task.is_some() && (current_task.unwrap().id == t.id) {
+                                "Stopped".as_bytes()
+                            } else {
+                                "Running".as_bytes()
+                            }
+                        }
+                        TaskState::TERMINATED => "Terminated".as_bytes(),
+                    }
+                }
+                None => "Stopped".as_bytes(),
+            };
+            let mut count = 0;
+            for (dst, src) in buf.iter_mut().zip(str) {
+                *dst = *src;
+                count += 1;
+            }
+            Ok(count)
+        }
+    }
+
+    impl MultiThreadResume for GdbStubTarget {
+        fn resume(&mut self) -> Result<(), Self::Error> {
             Ok(())
         }
 
         #[inline(always)]
-        fn support_single_step(&mut self) -> Option<SingleThreadSingleStepOps<'_, Self>> {
+        fn support_single_step(&mut self) -> Option<MultiThreadSingleStepOps<'_, Self>> {
             Some(self)
+        }
+
+        fn clear_resume_actions(&mut self) -> Result<(), Self::Error> {
+            self.is_single_step = false;
+            Ok(())
+        }
+
+        fn set_resume_action_continue(
+            &mut self,
+            _tid: Tid,
+            _signal: Option<Signal>,
+        ) -> Result<(), Self::Error> {
+            Ok(())
         }
     }
 
-    impl SingleThreadSingleStep for GdbStubTarget {
-        fn step(&mut self, _signal: Option<gdbstub::common::Signal>) -> Result<(), Self::Error> {
+    impl MultiThreadSingleStep for GdbStubTarget {
+        fn set_resume_action_step(
+            &mut self,
+            _tid: Tid,
+            _signal: Option<Signal>,
+        ) -> Result<(), Self::Error> {
             self.is_single_step = true;
             Ok(())
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,4 +33,6 @@ pub enum SvsmError {
     Acpi,
     // Errors from file systems
     FileSystem(FsError),
+    // Task management errors,
+    Task,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod sev;
 pub mod string;
 pub mod svsm_console;
 pub mod svsm_paging;
+pub mod task;
 pub mod types;
 pub mod utils;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub mod serial;
 pub mod sev;
 pub mod string;
 pub mod svsm_console;
+pub mod svsm_paging;
 pub mod types;
 pub mod utils;
 

--- a/src/mm/address_space.rs
+++ b/src/mm/address_space.rs
@@ -159,3 +159,24 @@ pub const SVSM_PERCPU_TEMP_END_4K: usize = SVSM_PERCPU_TEMP_BASE_4K + SIZE_LEVEL
 /// Start and End for PAGE_SIZEed temporary mappings
 pub const SVSM_PERCPU_TEMP_BASE_2M: usize = SVSM_PERCPU_TEMP_BASE + SIZE_LEVEL1;
 pub const SVSM_PERCPU_TEMP_END_2M: usize = SVSM_PERCPU_TEMP_BASE + SIZE_LEVEL2;
+
+/// Per-task memory map
+/// Use the region from 0xfffffe0000000000 - 0xffffff0000000000 for tasks
+pub const PGTABLE_LVL3_IDX_PERTASK: usize = 508;
+/// Layout of the per-task memory space is:
+///
+/// +------------------+------------------+-------------------------------------+
+/// | Start            | End              | Size | Description                  |
+/// +------------------+------------------+------+------------------------------+
+/// | fffffeffffff0000 | ffffff0000000000 | 64K  | Task stack                   |
+/// +------------------+------------------+------+------------------------------+
+/// | fffffe0000000000 | fffffe0004000000 | 64M  | Dynamic memory allocation    |
+/// +------------------+------------------+------+------------------------------+
+pub const SVSM_PERTASK_BASE: usize = sign_extend(PGTABLE_LVL3_IDX_PERTASK << ((3 * 9) + 12));
+
+/// Virtual addresses for dynamic memory allocation
+pub const SVSM_PERTASK_DYNAMIC_MEMORY: usize = SVSM_PERTASK_BASE;
+
+/// Task stack
+pub const SVSM_PERTASK_STACK_BASE: usize = SVSM_PERTASK_BASE + 0xffffff0000;
+pub const SVSM_PERTASK_STACK_TOP: usize = SVSM_PERTASK_STACK_BASE + 0x10000;

--- a/src/mm/pagetable.rs
+++ b/src/mm/pagetable.rs
@@ -217,6 +217,10 @@ impl PageTable {
         })
     }
 
+    pub fn copy_entry(&mut self, other: &PageTable, entry: usize) {
+        self.root.entries[entry] = (*other).root.entries[entry];
+    }
+
     pub fn exec_flags() -> PTEntryFlags {
         PTEntryFlags::PRESENT | PTEntryFlags::GLOBAL | PTEntryFlags::ACCESSED | PTEntryFlags::DIRTY
     }
@@ -233,6 +237,14 @@ impl PageTable {
     pub fn data_ro_flags() -> PTEntryFlags {
         PTEntryFlags::PRESENT
             | PTEntryFlags::GLOBAL
+            | PTEntryFlags::NX
+            | PTEntryFlags::ACCESSED
+            | PTEntryFlags::DIRTY
+    }
+
+    pub fn task_data_flags() -> PTEntryFlags {
+        PTEntryFlags::PRESENT
+            | PTEntryFlags::WRITABLE
             | PTEntryFlags::NX
             | PTEntryFlags::ACCESSED
             | PTEntryFlags::DIRTY

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -6,7 +6,6 @@
 
 #![no_std]
 #![no_main]
-pub mod svsm_paging;
 
 extern crate alloc;
 
@@ -46,9 +45,9 @@ use svsm::sev::secrets_page::{copy_secrets_page, SecretsPage};
 use svsm::sev::sev_status_init;
 use svsm::sev::utils::{rmp_adjust, RMPFlags};
 use svsm::svsm_console::SVSMIOPort;
+use svsm::svsm_paging::{init_page_table, invalidate_stage2};
 use svsm::types::{GUEST_VMPL, PAGE_SIZE};
 use svsm::utils::{halt, immut_after_init::ImmutAfterInitCell, zero_mem_region};
-use svsm_paging::{init_page_table, invalidate_stage2};
 
 use svsm::mm::validate::{init_valid_bitmap_ptr, migrate_valid_bitmap};
 

--- a/src/svsm_paging.rs
+++ b/src/svsm_paging.rs
@@ -4,17 +4,17 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
-use svsm::address::{Address, PhysAddr, VirtAddr};
-use svsm::cpu::percpu::this_cpu_mut;
-use svsm::elf;
-use svsm::error::SvsmError;
-use svsm::kernel_launch::KernelLaunchInfo;
-use svsm::mm;
-use svsm::mm::pagetable::{set_init_pgtable, PageTable, PageTableRef};
-use svsm::mm::PerCPUPageMappingGuard;
-use svsm::sev::ghcb::PageStateChangeOp;
-use svsm::sev::pvalidate;
-use svsm::types::PAGE_SIZE;
+use crate::address::{Address, PhysAddr, VirtAddr};
+use crate::cpu::percpu::this_cpu_mut;
+use crate::elf;
+use crate::error::SvsmError;
+use crate::kernel_launch::KernelLaunchInfo;
+use crate::mm;
+use crate::mm::pagetable::{set_init_pgtable, PageTable, PageTableRef};
+use crate::mm::PerCPUPageMappingGuard;
+use crate::sev::ghcb::PageStateChangeOp;
+use crate::sev::pvalidate;
+use crate::types::PAGE_SIZE;
 
 pub fn init_page_table(launch_info: &KernelLaunchInfo, kernel_elf: &elf::Elf64File) {
     let vaddr = mm::alloc::allocate_zeroed_page().expect("Failed to allocate root page-table");

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2022-2023 SUSE LLC
+//
+// Author: Roy Hopkins <rhopkins@suse.de>
+
+mod schedule;
+mod tasks;
+
+pub use schedule::{
+    close_task, create_initial_task, create_task, is_current_task, schedule, TaskNode, TaskPointer,
+    TASKS,
+};
+pub use tasks::{Task, TaskContext, TaskState, INITIAL_TASK_ID, TASK_FLAG_SHARE_PT};

--- a/src/task/schedule.rs
+++ b/src/task/schedule.rs
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2022-2023 SUSE LLC
+//
+// Author: Roy Hopkins <rhopkins@suse.de>
+
+extern crate alloc;
+
+use core::cell::RefCell;
+
+use super::Task;
+use super::{tasks::TaskRuntime, TaskState, INITIAL_TASK_ID};
+use crate::cpu::percpu::{this_cpu, this_cpu_mut};
+use crate::error::SvsmError;
+use crate::locking::SpinLock;
+use alloc::boxed::Box;
+use alloc::rc::Rc;
+use intrusive_collections::{intrusive_adapter, Bound, KeyAdapter, RBTree, RBTreeLink};
+
+pub type TaskPointer = Rc<TaskNode>;
+
+pub struct TaskNode {
+    link: RBTreeLink,
+    pub task: RefCell<Box<Task>>,
+}
+
+intrusive_adapter!(pub TaskNodeAdapter = Rc<TaskNode>: TaskNode { link: RBTreeLink });
+impl<'a> KeyAdapter<'a> for TaskNodeAdapter {
+    type Key = u64;
+    fn get_key(&self, node: &'a TaskNode) -> u64 {
+        node.task.borrow().runtime.value()
+    }
+}
+
+pub struct TaskRBTree {
+    tree: Option<RBTree<TaskNodeAdapter>>,
+}
+
+impl TaskRBTree {
+    pub fn tree(&mut self) -> &mut RBTree<TaskNodeAdapter> {
+        self.tree
+            .get_or_insert_with(|| RBTree::<TaskNodeAdapter>::new(TaskNodeAdapter::new()))
+    }
+
+    pub fn get_task(&self, id: u32) -> Option<Rc<TaskNode>> {
+        let mut cursor = self.tree.as_ref().unwrap().front();
+        while let Some(task_node) = cursor.get() {
+            if task_node.task.borrow().id == id {
+                return cursor.clone_pointer();
+            }
+            cursor.move_next();
+        }
+        None
+    }
+}
+
+pub static TASKS: SpinLock<TaskRBTree> = SpinLock::new(TaskRBTree { tree: None });
+
+///
+/// Each processor that is assigned to run tasks must call this function
+/// before further tasks can be scheduled onto the CPU by schedule().
+///
+pub fn create_initial_task(
+    entry: extern "C" fn(),
+    flags: u16,
+    affinity: Option<u32>,
+) -> Result<(), SvsmError> {
+    if this_cpu().current_task.is_some() {
+        return Err(SvsmError::Task);
+    }
+    let task_node = create_task(entry, flags, affinity)?;
+    this_cpu_mut().current_task = Some(task_node.clone());
+
+    let task_ptr = {
+        let task_ptr = task_node.task.as_ptr();
+        let mut task = task_node.task.borrow_mut();
+        if task.state != TaskState::RUNNING {
+            panic!("Attempt to launch a non-running initial task");
+        }
+        task.state = TaskState::SCHEDULED;
+        task_ptr
+    };
+    unsafe { (*task_ptr).set_current(core::ptr::null_mut()) };
+    Ok(())
+}
+
+pub fn create_task(
+    entry: extern "C" fn(),
+    flags: u16,
+    affinity: Option<u32>,
+) -> Result<TaskPointer, SvsmError> {
+    let mut task = Task::create(entry, flags)?;
+    task.set_affinity(affinity);
+    let node = Rc::new(TaskNode {
+        link: RBTreeLink::default(),
+        task: RefCell::new(task),
+    });
+    let node_ret = node.clone();
+    TASKS.lock().tree().insert(node);
+    Ok(node_ret)
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub fn close_task(task: TaskPointer) -> Result<(), SvsmError> {
+    // All tasks are protected via the task tree lock
+    let mut tl = TASKS.lock();
+    let mut cursor = unsafe { tl.tree().cursor_mut_from_ptr(task.as_ref()) };
+    if cursor
+        .get()
+        .filter(|task_node| task_node.task.borrow().state == TaskState::TERMINATED)
+        .is_none()
+    {
+        Err(SvsmError::Task)
+    } else {
+        cursor.remove().ok_or(SvsmError::Task).map(|_| ())
+    }
+}
+
+/// Check to see if the task scheduled on the current processor has the given id
+pub fn is_current_task(id: u32) -> bool {
+    match &this_cpu().current_task {
+        Some(current_task) => current_task.task.borrow().id == id,
+        None => id == INITIAL_TASK_ID,
+    }
+}
+
+fn update_current_task(tree: &mut RBTree<TaskNodeAdapter>) -> TaskPointer {
+    // This function leaves the CPU in an invalid state as it takes the current
+    // task, replacing it with None. The caller must assign a new task or reassign
+    // the current task to the CPU before resuming.
+    let task_ptr = this_cpu_mut().current_task.take().unwrap();
+    let mut task_cursor = unsafe { tree.cursor_mut_from_ptr(task_ptr.as_ref()) };
+    let task_node = task_cursor.remove().unwrap();
+    {
+        let mut task = task_node.task.borrow_mut();
+        if task.state == TaskState::SCHEDULED {
+            task.state = TaskState::RUNNING;
+        }
+
+        // If this is the first time the task is considered for scheduling then
+        // take the minimum value from the tree to ensure the new task is not
+        // allocated all of the CPU until it catches up.
+        if task.runtime.first() {
+            let cursor = tree.lower_bound(Bound::Included(&0));
+            if let Some(t) = cursor.get() {
+                task.runtime.set(t.task.borrow().runtime.value());
+            }
+        }
+        task.runtime.schedule_out();
+    }
+    tree.insert(task_node);
+    task_ptr
+}
+
+pub fn schedule() {
+    let (next_task, current_task) = {
+        let mut tl = TASKS.lock();
+
+        // Update the state of the current task. This will change the runtime value which
+        // is used as a key in the RB tree therefore we need to remove and reinsert the
+        // task.
+        let tree = tl.tree();
+        let current_task_node = update_current_task(tree);
+
+        // Find the task with the lowest runtime that is eligible to run
+        // on this CPU
+        let mut cursor = tree.lower_bound(Bound::Included(&0));
+        while let Some(task_node) = cursor.get() {
+            let candidate_task = task_node.task.borrow();
+            // If the runtime of the candidate task is greater than the task that was
+            // current running on the CPU then don't switch
+            if candidate_task.state == TaskState::RUNNING
+                && candidate_task
+                    .affinity
+                    .map_or(true, |a| a == this_cpu().get_apic_id())
+            {
+                break;
+            }
+            cursor.move_next();
+        }
+
+        // The cursor will now be on the next task to schedule. There should always be
+        // a candidate task unless the current cpu task terminated. For now, don't support
+        // termination of the initial thread which means there will always be a task to schedule
+        let next_task_node = cursor.clone_pointer().expect("No task to schedule on CPU");
+        this_cpu_mut().current_task = Some(next_task_node.clone());
+
+        // Update the task we are switching to. Note that the next task may be
+        // the same as the current task so ensure we don't mutably borrow it twice
+        // by restricting the scope of the borrow_mut below.
+        let next_task_ptr = next_task_node.task.as_ptr();
+        let next_task_id = {
+            let mut next_task = next_task_node.task.borrow_mut();
+            next_task.state = TaskState::SCHEDULED;
+            next_task.runtime.schedule_in();
+            next_task.id
+        };
+
+        let mut current_task = current_task_node.task.borrow_mut();
+        let current_task_ptr = current_task.as_mut() as *mut Task;
+        if next_task_id == current_task.id {
+            (None, core::ptr::null_mut())
+        } else {
+            (Some(next_task_ptr), current_task_ptr)
+        }
+    };
+    if let Some(next_task) = next_task {
+        unsafe { (*next_task).set_current(current_task) };
+    }
+}

--- a/src/task/tasks.rs
+++ b/src/task/tasks.rs
@@ -1,0 +1,404 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2022-2023 SUSE LLC
+//
+// Author: Roy Hopkins <rhopkins@suse.de>
+
+extern crate alloc;
+
+use core::arch::{asm, global_asm};
+use core::mem::size_of;
+use core::sync::atomic::{AtomicU32, Ordering};
+
+use alloc::boxed::Box;
+
+use crate::address::{Address, PhysAddr, VirtAddr};
+use crate::cpu::msr::{rdtsc, read_flags};
+use crate::cpu::percpu::{this_cpu, this_cpu_mut};
+use crate::cpu::{X86GeneralRegs, X86SegmentRegs};
+use crate::error::SvsmError;
+use crate::locking::SpinLock;
+use crate::mm::alloc::{allocate_pages, get_order};
+use crate::mm::pagetable::{get_init_pgtable_locked, PageTable, PageTableRef};
+use crate::mm::{
+    virt_to_phys, PAGE_SIZE, PGTABLE_LVL3_IDX_PERCPU, SVSM_PERTASK_STACK_BASE,
+    SVSM_PERTASK_STACK_TOP,
+};
+use crate::utils::zero_mem_region;
+
+use super::schedule::schedule;
+
+pub const INITIAL_TASK_ID: u32 = 1;
+
+const STACK_SIZE: usize = 65536;
+
+#[derive(PartialEq, Debug, Copy, Clone)]
+pub enum TaskState {
+    RUNNING,
+    SCHEDULED,
+    TERMINATED,
+}
+
+pub struct TaskStack {
+    pub virt_base: VirtAddr,
+    pub virt_top: VirtAddr,
+    pub phys: PhysAddr,
+}
+
+pub const TASK_FLAG_SHARE_PT: u16 = 0x01;
+
+struct TaskIDAllocator {
+    next_id: AtomicU32,
+}
+
+impl TaskIDAllocator {
+    const fn new() -> Self {
+        Self {
+            next_id: AtomicU32::new(INITIAL_TASK_ID + 1),
+        }
+    }
+
+    fn next_id(&self) -> u32 {
+        let mut id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        // Reserve IDs of 0 and 1
+        while (id == 0_u32) || (id == INITIAL_TASK_ID) {
+            id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        }
+        id
+    }
+}
+
+static TASK_ID_ALLOCATOR: TaskIDAllocator = TaskIDAllocator::new();
+
+/// This trait is used to implement the strategy that determines
+/// how much CPU time a task has been allocated. The task with the
+/// lowest runtime value is likely to be the next scheduled task
+pub trait TaskRuntime {
+    /// Called when a task is allocated to a CPU just before the task
+    /// context is restored. The task should start tracking the CPU
+    /// execution allocation at this point.
+    fn schedule_in(&mut self);
+
+    /// Called by the scheduler at the point the task is interrupted
+    /// and marked for deallocation from the CPU. The task should
+    /// update the runtime calculation at this point.
+    fn schedule_out(&mut self);
+
+    /// Returns whether this is the first time a task has been
+    /// considered for scheduling.
+    fn first(&self) -> bool;
+
+    /// Overrides the calculated runtime value with the given value.
+    /// This can be used to set or adjust the runtime of a task.
+    fn set(&mut self, runtime: u64);
+
+    /// Flag the runtime as terminated so the scheduler does not
+    /// find terminated tasks before running tasks.
+    fn terminated(&mut self);
+
+    /// Returns a value that represents the amount of CPU the task
+    /// has been allocated
+    fn value(&self) -> u64;
+}
+
+/// Tracks task runtime based on the CPU timestamp counter
+#[derive(Default)]
+#[repr(transparent)]
+pub struct TscRuntime {
+    runtime: u64,
+}
+
+impl TaskRuntime for TscRuntime {
+    fn schedule_in(&mut self) {
+        self.runtime = rdtsc();
+    }
+
+    fn schedule_out(&mut self) {
+        self.runtime += rdtsc() - self.runtime;
+    }
+
+    fn first(&self) -> bool {
+        self.runtime == 0
+    }
+
+    fn set(&mut self, runtime: u64) {
+        self.runtime = runtime;
+    }
+
+    fn terminated(&mut self) {
+        self.runtime = u64::MAX;
+    }
+
+    fn value(&self) -> u64 {
+        self.runtime
+    }
+}
+
+/// Tracks task runtime based on the number of times the task has been
+/// scheduled
+#[derive(Default)]
+#[repr(transparent)]
+pub struct CountRuntime {
+    count: u64,
+}
+
+impl TaskRuntime for CountRuntime {
+    fn schedule_in(&mut self) {
+        self.count += 1;
+    }
+
+    fn schedule_out(&mut self) {}
+
+    fn first(&self) -> bool {
+        self.count == 0
+    }
+
+    fn set(&mut self, runtime: u64) {
+        self.count = runtime;
+    }
+
+    fn terminated(&mut self) {
+        self.count = u64::MAX;
+    }
+
+    fn value(&self) -> u64 {
+        self.count
+    }
+}
+
+// Define which runtime counter to use
+type TaskRuntimeImpl = CountRuntime;
+
+#[repr(C)]
+#[derive(Default)]
+pub struct TaskContext {
+    pub seg: X86SegmentRegs,
+    pub regs: X86GeneralRegs,
+    pub flags: u64,
+    pub ret_addr: u64,
+}
+
+#[repr(C)]
+pub struct Task {
+    pub rsp: u64,
+
+    /// Information about the task stack
+    pub stack: TaskStack,
+
+    /// Page table that is loaded when the task is scheduled
+    pub page_table: SpinLock<PageTableRef>,
+
+    /// Current state of the task
+    pub state: TaskState,
+
+    /// Task affinity
+    /// None: The task can be scheduled to any CPU
+    /// u32:  The APIC ID of the CPU that the task must run on
+    pub affinity: Option<u32>,
+
+    /// ID of the task
+    pub id: u32,
+
+    /// Amount of CPU resource the task has consumed
+    pub runtime: TaskRuntimeImpl,
+}
+
+impl Task {
+    pub fn create(entry: extern "C" fn(), flags: u16) -> Result<Box<Task>, SvsmError> {
+        let mut pgtable = if (flags & TASK_FLAG_SHARE_PT) != 0 {
+            this_cpu().get_pgtable().clone_shared()?
+        } else {
+            Self::allocate_page_table()?
+        };
+
+        let (task_stack, rsp) = Self::allocate_stack(entry, &mut pgtable)?;
+
+        let task: Box<Task> = Box::new(Task {
+            rsp: u64::from(rsp),
+            stack: task_stack,
+            page_table: SpinLock::new(pgtable),
+            state: TaskState::RUNNING,
+            affinity: None,
+            id: TASK_ID_ALLOCATOR.next_id(),
+            runtime: TaskRuntimeImpl::default(),
+        });
+        Ok(task)
+    }
+
+    pub fn set_current(&mut self, previous_task: *mut Task) {
+        // This function is called by one task but returns in the context of
+        // another task. The context of the current task is saved and execution
+        // can resume at the point of the task switch, effectively completing
+        // the function call for the original task.
+        let new_task_addr = (self as *mut Task) as u64;
+
+        // Switch to the new task
+        unsafe {
+            asm!(
+                r#"
+                    call switch_context
+                "#,
+                in("rsi") previous_task as u64,
+                in("rdi") new_task_addr,
+                options(att_syntax));
+        }
+    }
+
+    pub fn set_affinity(&mut self, affinity: Option<u32>) {
+        self.affinity = affinity;
+    }
+
+    fn allocate_stack(
+        entry: extern "C" fn(),
+        pgtable: &mut PageTableRef,
+    ) -> Result<(TaskStack, VirtAddr), SvsmError> {
+        let stack_size = SVSM_PERTASK_STACK_TOP - SVSM_PERTASK_STACK_BASE;
+        let num_pages = 1 << get_order(STACK_SIZE);
+        assert!(stack_size == num_pages * PAGE_SIZE);
+        let pages = allocate_pages(get_order(STACK_SIZE))?;
+        zero_mem_region(pages, pages + stack_size);
+
+        let task_stack = TaskStack {
+            virt_base: VirtAddr::from(SVSM_PERTASK_STACK_BASE),
+            virt_top: VirtAddr::from(SVSM_PERTASK_STACK_TOP),
+            phys: virt_to_phys(pages),
+        };
+
+        // We current have a virtual address in SVSM shared memory for the stack. Configure
+        // the per-task pagetable to map the stack into the task memory map.
+        pgtable.map_region_4k(
+            task_stack.virt_base,
+            task_stack.virt_top,
+            task_stack.phys,
+            PageTable::task_data_flags(),
+        )?;
+
+        // We need to setup a context on the stack that matches the stack layout
+        // defined in switch_context below.
+        let stack_pos = pages + stack_size;
+        let stack_ptr = stack_pos.as_mut_ptr() as *mut u64;
+
+        // 'Push' the task frame onto the stack
+        unsafe {
+            // flags
+            stack_ptr.offset(-3).write(read_flags());
+            // ret_addr
+            stack_ptr.offset(-2).write(entry as *const () as u64);
+            // Task termination handler for when entry point returns
+            stack_ptr.offset(-1).write(task_exit as *const () as u64);
+        }
+
+        let initial_rsp =
+            VirtAddr::from(SVSM_PERTASK_STACK_TOP - (size_of::<TaskContext>() + size_of::<u64>()));
+        Ok((task_stack, initial_rsp))
+    }
+
+    fn allocate_page_table() -> Result<PageTableRef, SvsmError> {
+        // Base the new task page table on the initial SVSM kernel page table.
+        // When the pagetable is schedule to a CPU, the per CPU entry will also
+        // be added to the pagetable.
+        get_init_pgtable_locked().clone_shared()
+    }
+}
+
+extern "C" fn task_exit() {
+    // Restrict the scope of the mutable borrow below otherwise when the task context
+    // is switched via schedule() the borrow remains in scope.
+    {
+        let this_task = this_cpu_mut()
+            .current_task
+            .as_mut()
+            .expect("Invalid state in task_exit()");
+        let mut current_task = this_task.task.borrow_mut();
+        current_task.state = TaskState::TERMINATED;
+        // Ensure the scheduler does not waste time encountering terminated tasks
+        // by setting a high runtime value
+        current_task.runtime.terminated();
+    }
+    schedule();
+}
+
+#[allow(unused)]
+#[no_mangle]
+extern "C" fn apply_new_context(new_task: *mut Task) -> u64 {
+    unsafe {
+        let mut pt = (*new_task).page_table.lock();
+        pt.copy_entry(&this_cpu().get_pgtable(), PGTABLE_LVL3_IDX_PERCPU);
+        pt.cr3_value().bits() as u64
+    }
+}
+
+global_asm!(
+    r#"
+        .text
+
+    switch_context:
+        // Save the current context. The layout must match the TaskContext structure.
+        pushfq
+        pushq   %rax
+        pushq   %rbx
+        pushq   %rcx
+        pushq   %rdx
+        pushq   %rsi
+        pushq   %rdi
+        pushq   %rbp
+        pushq   %r8
+        pushq   %r9
+        pushq   %r10
+        pushq   %r11
+        pushq   %r12
+        pushq   %r13
+        pushq   %r14
+        pushq   %r15
+        
+        movq    %ss, %rax
+        pushq   %rax
+        movq    %gs, %rax
+        pushq   %rax
+        movq    %fs, %rax
+        pushq   %rax
+        movq    %es, %rax
+        pushq   %rax
+        movq    %ds, %rax
+        pushq   %rax
+        movq    %cs, %rax
+        pushq   %rax
+
+        // Save the current stack pointer
+        testq   %rsi, %rsi
+        jz      1f
+        movq    %rsp, (%rsi)
+
+    1:
+        // Switch to the new task state
+        mov     %rdi, %rbx
+        call    apply_new_context
+        mov     %rax, %cr3
+
+        // Switch to the new task stack
+        movq    (%rbx), %rsp
+
+        // Not currently changing segment registers between tasks
+        addq        $6*8, %rsp
+
+        popq        %r15
+        popq        %r14
+        popq        %r13
+        popq        %r12
+        popq        %r11
+        popq        %r10
+        popq        %r9
+        popq        %r8
+        popq        %rbp
+        popq        %rdi
+        popq        %rsi
+        popq        %rdx
+        popq        %rcx
+        popq        %rbx
+        popq        %rax
+        popfq
+
+        ret
+    "#,
+    options(att_syntax)
+);


### PR DESCRIPTION
Draft PR for review and comments.

Implements a mechanism to switch the current CPU between different task contexts that include per-task pagetables and will in the future support per-task virtual memory mapping.

The current version creates a global task list and launches an initial task on each virtual CPU. Additional tasks can be created and added to the task list which will then be activated by a subsequent call to schedule(). This has been tested locally but is not currently called within this PR.