### PR TITLE
SVSM/utils: Fix compile warning in release builds

### DIFF
--- a/src/utils/immut_after_init.rs
+++ b/src/utils/immut_after_init.rs
@@ -5,7 +5,6 @@
 // Author: Nicolai Stange <nstange@suse.de>
 
 use core::cell::UnsafeCell;
-use core::marker::Copy;
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 use core::ops::Deref;


### PR DESCRIPTION
A recent change introduced this new warning in release builds:

warning: unused import: `core::marker::Copy`
 --> src/utils/immut_after_init.rs:8:5
  |
8 | use core::marker::Copy;
  |     ^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

Remove the line and fix it.