### PR TITLE
gdbstub: replace call to offset() with direct addition.

### DIFF
--- a/src/debug/gdbstub.rs
+++ b/src/debug/gdbstub.rs
@@ -221,7 +221,7 @@ pub mod svsm_gdbstub {
             };
 
             let guard = PerCPUPageMappingGuard::create_4k(phys.page_align())?;
-            return unsafe { write_u8(guard.virt_addr().offset(phys.page_offset()), value) };
+            return unsafe { write_u8(guard.virt_addr() + phys.page_offset(), value) };
         }
     }
 


### PR DESCRIPTION
Address::offset() function has been removed in 39b92fb.