### PR TITLE
GitHub/workflows: Test-build with all features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,7 +31,7 @@ jobs:
       # ld to work, so build all the objects without performing the
       # final linking step.
       - name: Build
-        run: make stage1/stage1.o stage1/reset.o
+        run: make FEATURES="default,enable-gdb" stage1/stage1.o stage1/reset.o
 
       - name: Run tests
         run: make test


### PR DESCRIPTION
Enable gdbstub in the test builds to catch build errors in the whole code base.