### PR TITLE
Add #VC handler

### DIFF
--- a/src/cpu/cpuid.rs
+++ b/src/cpu/cpuid.rs
@@ -52,6 +52,30 @@ pub fn register_cpuid_table(table: &'static SnpCpuidTable) {
 }
 
 #[derive(Clone, Copy, Debug)]
+#[repr(C, packed)]
+pub struct CpuidLeaf {
+    pub cpuid_fn: u32,
+    pub cpuid_subfn: u32,
+    pub eax: u32,
+    pub ebx: u32,
+    pub ecx: u32,
+    pub edx: u32,
+}
+
+impl CpuidLeaf {
+    pub fn new(cpuid_fn: u32, cpuid_subfn: u32) -> Self {
+        CpuidLeaf {
+            cpuid_fn,
+            cpuid_subfn,
+            eax: 0,
+            ebx: 0,
+            ecx: 0,
+            edx: 0,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
 pub struct CpuidResult {
     pub eax: u32,
     pub ebx: u32,

--- a/src/cpu/extable.rs
+++ b/src/cpu/extable.rs
@@ -9,7 +9,7 @@ extern "C" {
     pub static exception_table_end: u8;
 }
 
-use super::idt::X86ExceptionContext;
+use super::idt::common::X86ExceptionContext;
 use crate::address::{Address, VirtAddr};
 use core::mem;
 

--- a/src/cpu/idt/common.rs
+++ b/src/cpu/idt/common.rs
@@ -5,7 +5,6 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 
 use crate::address::{Address, VirtAddr};
-use crate::cpu::insn::Instruction;
 use crate::cpu::registers::{X86GeneralRegs, X86InterruptFrame};
 use crate::types::SVSM_CS;
 use core::arch::{asm, global_asm};
@@ -44,7 +43,6 @@ pub struct X86ExceptionContext {
     pub vector: usize,
     pub error_code: usize,
     pub frame: X86InterruptFrame,
-    pub insn: Instruction,
 }
 
 #[derive(Copy, Clone, Default, Debug)]

--- a/src/cpu/idt/common.rs
+++ b/src/cpu/idt/common.rs
@@ -5,6 +5,7 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 
 use crate::address::{Address, VirtAddr};
+use crate::cpu::insn::Instruction;
 use crate::cpu::registers::{X86GeneralRegs, X86InterruptFrame};
 use crate::types::SVSM_CS;
 use core::arch::{asm, global_asm};
@@ -43,6 +44,7 @@ pub struct X86ExceptionContext {
     pub vector: usize,
     pub error_code: usize,
     pub frame: X86InterruptFrame,
+    pub insn: Instruction,
 }
 
 #[derive(Copy, Clone, Default, Debug)]

--- a/src/cpu/idt/mod.rs
+++ b/src/cpu/idt/mod.rs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2022-2023 SUSE LLC
+//
+// Author: Thomas Leroy <tleroy@suse.de>
+
+pub mod common;
+pub mod stage2;
+pub mod svsm;

--- a/src/cpu/idt/stage2.rs
+++ b/src/cpu/idt/stage2.rs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2022-2023 SUSE LLC
+//
+// Author: Joerg Roedel <jroedel@suse.de>
+
+use super::common::{load_idt, Idt, IdtEntry, BP_VECTOR, DF_VECTOR, GLOBAL_IDT, VC_VECTOR};
+use crate::address::VirtAddr;
+use crate::cpu::control_regs::read_cr2;
+use crate::cpu::vc::stage2_handle_vc_exception;
+use crate::cpu::X86ExceptionContext;
+use crate::debug::gdbstub::svsm_gdbstub::handle_debug_exception;
+use core::arch::global_asm;
+
+fn init_idt(idt: &mut Idt) {
+    // Set IDT handlers
+    let handlers = unsafe { VirtAddr::from(&stage2_idt_handler_array as *const u8) };
+    for (i, entry) in idt.iter_mut().enumerate() {
+        *entry = IdtEntry::entry(handlers + (32 * i));
+    }
+}
+
+pub fn early_idt_init() {
+    unsafe {
+        init_idt(&mut GLOBAL_IDT);
+        load_idt(&GLOBAL_IDT);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn stage2_generic_idt_handler(ctx: &mut X86ExceptionContext) {
+    if ctx.vector == DF_VECTOR {
+        let cr2 = read_cr2();
+        let rip = ctx.frame.rip;
+        let rsp = ctx.frame.rsp;
+        panic!(
+            "Double-Fault at RIP {:#018x} RSP: {:#018x} CR2: {:#018x}",
+            rip, rsp, cr2
+        );
+    } else if ctx.vector == VC_VECTOR {
+        stage2_handle_vc_exception(ctx);
+    } else if ctx.vector == BP_VECTOR {
+        handle_debug_exception(ctx, ctx.vector);
+    } else {
+        let err = ctx.error_code;
+        let vec = ctx.vector;
+        let rip = ctx.frame.rip;
+
+        panic!(
+            "Unhandled exception {} RIP {:#018x} error code: {:#018x}",
+            vec, rip, err
+        );
+    }
+}
+
+extern "C" {
+    static stage2_idt_handler_array: u8;
+}
+
+global_asm!(
+    r#"
+         /* Stage 2 handler array setup */
+        .text
+    push_regs:
+        pushq   %rax
+        pushq   %rbx
+        pushq   %rcx
+        pushq   %rdx
+        pushq   %rsi
+        pushq   %rdi
+        pushq   %rbp
+        pushq   %r8
+        pushq   %r9
+        pushq   %r10
+        pushq   %r11
+        pushq   %r12
+        pushq   %r13
+        pushq   %r14
+        pushq   %r15
+
+        movq    %rsp, %rdi
+        call    stage2_generic_idt_handler
+
+        jmp generic_idt_handler_return
+        
+        .align 32
+        .globl stage2_idt_handler_array
+    stage2_idt_handler_array:
+        i = 0
+        .rept 32
+        .align 32
+        .if ((0x20027d00 >> i) & 1) == 0
+        pushq   $0
+        .endif
+        pushq   $i  /* Vector Number */
+        jmp push_regs
+        i = i + 1
+        .endr
+    "#,
+    options(att_syntax)
+);

--- a/src/cpu/idt/stage2.rs
+++ b/src/cpu/idt/stage2.rs
@@ -7,22 +7,32 @@
 use super::common::{load_idt, Idt, IdtEntry, BP_VECTOR, DF_VECTOR, GLOBAL_IDT, VC_VECTOR};
 use crate::address::VirtAddr;
 use crate::cpu::control_regs::read_cr2;
-use crate::cpu::vc::stage2_handle_vc_exception;
+use crate::cpu::vc::{stage2_handle_vc_exception, stage2_handle_vc_exception_no_ghcb};
 use crate::cpu::X86ExceptionContext;
 use crate::debug::gdbstub::svsm_gdbstub::handle_debug_exception;
 use core::arch::global_asm;
 
-fn init_idt(idt: &mut Idt) {
+fn init_idt(idt: &mut Idt, handler_array: *const u8) {
     // Set IDT handlers
-    let handlers = unsafe { VirtAddr::from(&stage2_idt_handler_array as *const u8) };
+    let handlers = VirtAddr::from(handler_array);
     for (i, entry) in idt.iter_mut().enumerate() {
         *entry = IdtEntry::entry(handlers + (32 * i));
     }
 }
 
+pub fn early_idt_init_no_ghcb() {
+    unsafe {
+        init_idt(
+            &mut GLOBAL_IDT,
+            &stage2_idt_handler_array_no_ghcb as *const u8,
+        );
+        load_idt(&GLOBAL_IDT);
+    }
+}
+
 pub fn early_idt_init() {
     unsafe {
-        init_idt(&mut GLOBAL_IDT);
+        init_idt(&mut GLOBAL_IDT, &stage2_idt_handler_array as *const u8);
         load_idt(&GLOBAL_IDT);
     }
 }
@@ -54,13 +64,79 @@ pub extern "C" fn stage2_generic_idt_handler(ctx: &mut X86ExceptionContext) {
     }
 }
 
+#[no_mangle]
+pub extern "C" fn stage2_generic_idt_handler_no_ghcb(ctx: &mut X86ExceptionContext) {
+    match ctx.vector {
+        DF_VECTOR => {
+            let cr2 = read_cr2();
+            let rip = ctx.frame.rip;
+            let rsp = ctx.frame.rsp;
+            panic!(
+                "Double-Fault at RIP {:#018x} RSP: {:#018x} CR2: {:#018x}",
+                rip, rsp, cr2
+            );
+        }
+        VC_VECTOR => stage2_handle_vc_exception_no_ghcb(ctx),
+        BP_VECTOR => handle_debug_exception(ctx, ctx.vector),
+        _ => {
+            let err = ctx.error_code;
+            let vec = ctx.vector;
+            let rip = ctx.frame.rip;
+
+            panic!(
+                "Unhandled exception {} RIP {:#018x} error code: {:#018x}",
+                vec, rip, err
+            );
+        }
+    }
+}
+
 extern "C" {
     static stage2_idt_handler_array: u8;
+    static stage2_idt_handler_array_no_ghcb: u8;
 }
 
 global_asm!(
     r#"
-         /* Stage 2 handler array setup */
+         /* Early tage 2 handler array setup */
+        .text
+    push_regs_no_ghcb:
+        pushq   %rax
+        pushq   %rbx
+        pushq   %rcx
+        pushq   %rdx
+        pushq   %rsi
+        pushq   %rdi
+        pushq   %rbp
+        pushq   %r8
+        pushq   %r9
+        pushq   %r10
+        pushq   %r11
+        pushq   %r12
+        pushq   %r13
+        pushq   %r14
+        pushq   %r15
+
+        movq    %rsp, %rdi
+        call    stage2_generic_idt_handler_no_ghcb
+
+        jmp generic_idt_handler_return
+        
+        .align 32
+        .globl stage2_idt_handler_array_no_ghcb
+    stage2_idt_handler_array_no_ghcb:
+        i = 0
+        .rept 32
+        .align 32
+        .if ((0x20027d00 >> i) & 1) == 0
+        pushq   $0
+        .endif
+        pushq   $i  /* Vector Number */
+        jmp push_regs_no_ghcb
+        i = i + 1
+        .endr
+        
+        /* Stage 2 handler array setup */
         .text
     push_regs:
         pushq   %rax

--- a/src/cpu/idt/svsm.rs
+++ b/src/cpu/idt/svsm.rs
@@ -8,7 +8,7 @@ use super::super::control_regs::read_cr2;
 use super::super::extable::handle_exception_table;
 use super::super::percpu::this_cpu;
 use super::super::tss::IST_DF;
-use super::super::vc::handle_vc_exception;
+use super::super::vc::stage2_handle_vc_exception;
 use super::common::PF_ERROR_WRITE;
 use super::common::{
     load_idt, Idt, IdtEntry, BP_VECTOR, DF_VECTOR, GLOBAL_IDT, GP_VECTOR, PF_VECTOR, VC_VECTOR,
@@ -82,7 +82,7 @@ pub fn generic_idt_handler(ctx: &mut X86ExceptionContext) {
             );
         }
     } else if ctx.vector == VC_VECTOR {
-        handle_vc_exception(ctx);
+        stage2_handle_vc_exception(ctx);
     } else if ctx.vector == BP_VECTOR {
         handle_debug_exception(ctx, ctx.vector);
     } else {

--- a/src/cpu/idt/svsm.rs
+++ b/src/cpu/idt/svsm.rs
@@ -8,7 +8,7 @@ use super::super::control_regs::read_cr2;
 use super::super::extable::handle_exception_table;
 use super::super::percpu::this_cpu;
 use super::super::tss::IST_DF;
-use super::super::vc::stage2_handle_vc_exception;
+use super::super::vc::handle_vc_exception;
 use super::common::PF_ERROR_WRITE;
 use super::common::{
     load_idt, Idt, IdtEntry, BP_VECTOR, DF_VECTOR, GLOBAL_IDT, GP_VECTOR, PF_VECTOR, VC_VECTOR,
@@ -46,7 +46,7 @@ pub fn idt_init() {
 }
 
 #[no_mangle]
-pub fn generic_idt_handler(ctx: &mut X86ExceptionContext) {
+pub extern "C" fn generic_idt_handler(ctx: &mut X86ExceptionContext) {
     if ctx.vector == DF_VECTOR {
         let cr2 = read_cr2();
         let rip = ctx.frame.rip;
@@ -82,7 +82,7 @@ pub fn generic_idt_handler(ctx: &mut X86ExceptionContext) {
             );
         }
     } else if ctx.vector == VC_VECTOR {
-        stage2_handle_vc_exception(ctx);
+        handle_vc_exception(ctx);
     } else if ctx.vector == BP_VECTOR {
         handle_debug_exception(ctx, ctx.vector);
     } else {

--- a/src/cpu/idt/svsm.rs
+++ b/src/cpu/idt/svsm.rs
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2022-2023 SUSE LLC
+//
+// Authors: Joerg Roedel <jroedel@suse.de>
+
+use super::super::control_regs::read_cr2;
+use super::super::extable::handle_exception_table;
+use super::super::percpu::this_cpu;
+use super::super::tss::IST_DF;
+use super::super::vc::handle_vc_exception;
+use super::common::PF_ERROR_WRITE;
+use super::common::{
+    load_idt, Idt, IdtEntry, BP_VECTOR, DF_VECTOR, GLOBAL_IDT, GP_VECTOR, PF_VECTOR, VC_VECTOR,
+};
+use crate::address::VirtAddr;
+use crate::cpu::X86ExceptionContext;
+use crate::debug::gdbstub::svsm_gdbstub::handle_debug_exception;
+use core::arch::global_asm;
+
+fn init_idt(idt: &mut Idt) {
+    // Set IDT handlers
+    let handlers = unsafe { VirtAddr::from(&svsm_idt_handler_array as *const u8) };
+    for (i, entry) in idt.iter_mut().enumerate() {
+        *entry = IdtEntry::entry(handlers + (32 * i));
+    }
+}
+
+unsafe fn init_ist_vectors(idt: &mut Idt) {
+    let handler = VirtAddr::from(&svsm_idt_handler_array as *const u8) + (32 * DF_VECTOR);
+    idt[DF_VECTOR] = IdtEntry::ist_entry(handler, IST_DF.try_into().unwrap());
+}
+
+pub fn early_idt_init() {
+    unsafe {
+        init_idt(&mut GLOBAL_IDT);
+        load_idt(&GLOBAL_IDT);
+    }
+}
+
+pub fn idt_init() {
+    // Set IST vectors
+    unsafe {
+        init_ist_vectors(&mut GLOBAL_IDT);
+    }
+}
+
+#[no_mangle]
+pub fn generic_idt_handler(ctx: &mut X86ExceptionContext) {
+    if ctx.vector == DF_VECTOR {
+        let cr2 = read_cr2();
+        let rip = ctx.frame.rip;
+        let rsp = ctx.frame.rsp;
+        panic!(
+            "Double-Fault at RIP {:#018x} RSP: {:#018x} CR2: {:#018x}",
+            rip, rsp, cr2
+        );
+    } else if ctx.vector == GP_VECTOR {
+        let rip = ctx.frame.rip;
+        let err = ctx.error_code;
+
+        if !handle_exception_table(ctx) {
+            panic!(
+                "Unhandled General-Protection-Fault at RIP {:#018x} error code: {:#018x}",
+                rip, err
+            );
+        }
+    } else if ctx.vector == PF_VECTOR {
+        let cr2 = read_cr2();
+        let rip = ctx.frame.rip;
+        let err = ctx.error_code;
+
+        if this_cpu()
+            .handle_pf(VirtAddr::from(cr2), (err & PF_ERROR_WRITE) != 0)
+            .is_err()
+            && !handle_exception_table(ctx)
+        {
+            handle_debug_exception(ctx, ctx.vector);
+            panic!(
+                "Unhandled Page-Fault at RIP {:#018x} CR2: {:#018x} error code: {:#018x}",
+                rip, cr2, err
+            );
+        }
+    } else if ctx.vector == VC_VECTOR {
+        handle_vc_exception(ctx);
+    } else if ctx.vector == BP_VECTOR {
+        handle_debug_exception(ctx, ctx.vector);
+    } else {
+        let err = ctx.error_code;
+        let vec = ctx.vector;
+        let rip = ctx.frame.rip;
+
+        if !handle_exception_table(ctx) {
+            panic!(
+                "Unhandled exception {} RIP {:#018x} error code: {:#018x}",
+                vec, rip, err
+            );
+        }
+    }
+}
+
+extern "C" {
+    static svsm_idt_handler_array: u8;
+}
+
+global_asm!(
+    r#"
+        .text
+    push_regs:
+        pushq   %rax
+        pushq   %rbx
+        pushq   %rcx
+        pushq   %rdx
+        pushq   %rsi
+        pushq   %rdi
+        pushq   %rbp
+        pushq   %r8
+        pushq   %r9
+        pushq   %r10
+        pushq   %r11
+        pushq   %r12
+        pushq   %r13
+        pushq   %r14
+        pushq   %r15
+
+        movq    %rsp, %rdi
+        call    generic_idt_handler
+
+        jmp generic_idt_handler_return
+    
+        .align 32
+        .globl svsm_idt_handler_array
+    svsm_idt_handler_array:
+        i = 0
+        .rept 32
+        .align 32
+        .if ((0x20027d00 >> i) & 1) == 0
+        pushq   $0
+        .endif
+        pushq   $i  /* Vector Number */
+        jmp push_regs
+        i = i + 1
+        .endr
+    "#,
+    options(att_syntax)
+);

--- a/src/cpu/insn.rs
+++ b/src/cpu/insn.rs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2022-2023 SUSE LLC
+//
+// Author: Thomas Leroy <tleroy@suse.de>
+
+extern crate alloc;
+
+use crate::cpu::vc::VcError;
+use crate::error::SvsmError;
+
+pub const MAX_INSN_SIZE: usize = 15;
+pub const MAX_INSN_FIELD_SIZE: usize = 3;
+
+#[derive(Default, Debug, Copy, Clone)]
+pub struct Instruction {
+    pub prefixes: InstructionField,
+    pub insn_bytes: [u8; MAX_INSN_SIZE],
+    pub length: usize,
+    pub opcode: InstructionField,
+    pub opnd_bytes: usize,
+}
+
+#[derive(Default, Debug, Copy, Clone)]
+pub struct InstructionField {
+    pub bytes: [u8; MAX_INSN_FIELD_SIZE],
+    pub nb_bytes: usize,
+}
+
+impl Instruction {
+    pub fn new(insn_bytes: [u8; MAX_INSN_SIZE]) -> Self {
+        Self {
+            prefixes: InstructionField {
+                bytes: insn_bytes[..MAX_INSN_FIELD_SIZE].try_into().unwrap(),
+                nb_bytes: 0,
+            },
+            insn_bytes,
+            length: 0,
+            opcode: InstructionField::default(), // we'll copy content later
+            opnd_bytes: 4,
+        }
+    }
+
+    pub fn decode(&mut self) -> Result<(), SvsmError> {
+        /*
+         * At this point, we only need to handle IOIO (without string and immediate versions)
+         * and CPUID, that both have a fixed size. No real complex x86 decoder is needed.
+         */
+        match self.insn_bytes[0] {
+            // {in, out}w instructions uses a 0x66 operand-size opcode prefix
+            0x66 => {
+                if self.insn_bytes[1] == 0xED || self.insn_bytes[1] == 0xEF {
+                    self.prefixes.nb_bytes = 1;
+
+                    self.opcode.nb_bytes = 1;
+                    self.opcode.bytes[0] = self.insn_bytes[1];
+
+                    self.length = self.prefixes.nb_bytes + self.opcode.nb_bytes;
+                    self.opnd_bytes = 2;
+                    return Ok(());
+                }
+
+                Err(SvsmError::Vc(VcError::DecodeFailed))
+            }
+            // inb and oub register opcodes
+            0xEC | 0xEE => {
+                self.prefixes.nb_bytes = 0;
+
+                self.opcode.nb_bytes = 1;
+                self.opcode.bytes[0] = self.insn_bytes[0];
+
+                self.length = self.opcode.nb_bytes;
+                self.opnd_bytes = 1;
+                Ok(())
+            }
+            // inl and outl register opcodes
+            0xED | 0xEF => {
+                self.prefixes.nb_bytes = 0;
+
+                self.opcode.nb_bytes = 1;
+                self.opcode.bytes[0] = self.insn_bytes[0];
+
+                self.length = self.opcode.nb_bytes;
+                self.opnd_bytes = 4;
+                Ok(())
+            }
+
+            0x0F => {
+                // CPUID opcode
+                if self.insn_bytes[1] == 0xA2 {
+                    self.prefixes.nb_bytes = 0;
+
+                    self.opcode.nb_bytes = 2;
+                    self.opcode.bytes[..2].clone_from_slice(&self.insn_bytes[..2]);
+
+                    self.length = self.opcode.nb_bytes;
+                    return Ok(());
+                }
+
+                Err(SvsmError::Vc(VcError::DecodeFailed))
+            }
+            _ => Err(SvsmError::Vc(VcError::DecodeFailed)),
+        }
+    }
+}
+
+/// # Safety
+///
+///  The caller should validate that `rip` is set to a valid address
+///  and that the next [`MAX_INSN_SIZE`] bytes are within valid memory.
+pub unsafe fn insn_fetch(rip: *const u8) -> [u8; MAX_INSN_SIZE] {
+    rip.cast::<[u8; MAX_INSN_SIZE]>().read()
+}

--- a/src/cpu/insn.rs
+++ b/src/cpu/insn.rs
@@ -7,6 +7,7 @@
 extern crate alloc;
 
 use crate::cpu::vc::VcError;
+use crate::cpu::vc::VcErrorType;
 use crate::error::SvsmError;
 
 pub const MAX_INSN_SIZE: usize = 15;
@@ -60,7 +61,11 @@ impl Instruction {
                     return Ok(());
                 }
 
-                Err(SvsmError::Vc(VcError::DecodeFailed))
+                Err(SvsmError::Vc(VcError {
+                    rip: 0,
+                    code: 0,
+                    error_type: VcErrorType::DecodeFailed,
+                }))
             }
             // inb and oub register opcodes
             0xEC | 0xEE => {
@@ -97,9 +102,17 @@ impl Instruction {
                     return Ok(());
                 }
 
-                Err(SvsmError::Vc(VcError::DecodeFailed))
+                Err(SvsmError::Vc(VcError {
+                    rip: 0,
+                    code: 0,
+                    error_type: VcErrorType::DecodeFailed,
+                }))
             }
-            _ => Err(SvsmError::Vc(VcError::DecodeFailed)),
+            _ => Err(SvsmError::Vc(VcError {
+                rip: 0,
+                code: 0,
+                error_type: VcErrorType::DecodeFailed,
+            })),
         }
     }
 }

--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -11,6 +11,7 @@ pub mod extable;
 pub mod features;
 pub mod gdt;
 pub mod idt;
+pub mod insn;
 pub mod msr;
 pub mod percpu;
 pub mod registers;

--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -20,6 +20,6 @@ pub mod tss;
 pub mod vc;
 pub mod vmsa;
 
-pub use idt::X86ExceptionContext;
+pub use idt::common::X86ExceptionContext;
 pub use registers::{X86GeneralRegs, X86InterruptFrame, X86SegmentRegs};
 pub use tlb::*;

--- a/src/cpu/vc.rs
+++ b/src/cpu/vc.rs
@@ -5,11 +5,12 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 
 use super::idt::common::X86ExceptionContext;
+use crate::cpu::cpuid::{cpuid_table_raw, CpuidLeaf};
 use crate::cpu::extable::handle_exception_table;
 use crate::cpu::insn::{insn_fetch, Instruction};
+use crate::cpu::registers::X86GeneralRegs;
 use crate::debug::gdbstub::svsm_gdbstub::handle_db_exception;
 use crate::error::SvsmError;
-
 use core::fmt;
 
 pub const SVM_EXIT_EXCP_BASE: usize = 0x40;
@@ -58,17 +59,66 @@ pub fn stage2_handle_vc_exception(ctx: &mut X86ExceptionContext) {
         )
     });
 
-    // If the debugger is enabled then handle the DB exception
-    // by directly invoking the exception hander
-    if err == (SVM_EXIT_EXCP_BASE + X86_TRAP_DB) {
-        handle_db_exception(ctx);
-        return;
-    }
+    match err {
+        // If the debugger is enabled then handle the DB exception
+        // by directly invoking the exception handler
+        X86_TRAP_DB => {
+            handle_db_exception(ctx);
+            Ok(())
+        }
 
-    panic!(
-        "Unhandled #VC exception RIP {:#018x} error code: {:#018x}",
-        rip, err
-    );
+        SVM_EXIT_CPUID => handle_cpuid(ctx),
+        _ => Err(SvsmError::Vc(VcError::Unsupported)),
+    }
+    .unwrap_or_else(|error| {
+        panic!(
+            "Unhandled #VC exception RIP {:#018x} error code: {:#018x}: error: {:?}",
+            rip, err, error
+        )
+    });
+
+    vc_finish_insn(ctx);
+}
+
+fn handle_cpuid(ctx: &mut X86ExceptionContext) -> Result<(), SvsmError> {
+    let regs = &mut ctx.regs;
+
+    /*
+     * Section 2.3.1 GHCB MSR Protocol in SEV-ES Guest-Hypervisor Communication Block
+     * Standardization Rev. 2.02.
+     * For SEV-ES/SEV-SNP, we can use the CPUID table already defined and populated with
+     * firmware information.
+     * We choose for now not to call the hypervisor to perform CPUID, since it's no trusted.
+     * Since GHCB is not needed to handle CPUID with the firmware table, we can call the handler
+     * very soon in stage 2.
+     */
+
+    snp_cpuid(regs)
+}
+
+fn snp_cpuid(regs: &mut X86GeneralRegs) -> Result<(), SvsmError> {
+    let mut leaf = CpuidLeaf::new(regs.rax as u32, regs.rcx as u32);
+
+    let ret = match cpuid_table_raw(leaf.cpuid_fn, leaf.cpuid_subfn, 0, 0) {
+        None => Err(SvsmError::Vc(VcError::UnknownCpuidLeaf)),
+        Some(v) => Ok(v),
+    }?;
+
+    leaf.eax = ret.eax;
+    leaf.ebx = ret.ebx;
+    leaf.ecx = ret.ecx;
+    leaf.edx = ret.edx;
+
+    regs.rax = leaf.eax as usize;
+    regs.rbx = leaf.ebx as usize;
+    regs.rcx = leaf.ecx as usize;
+    regs.rdx = leaf.edx as usize;
+
+    Ok(())
+}
+
+fn vc_finish_insn(ctx: &mut X86ExceptionContext) {
+    ctx.frame.rip += ctx.insn.length;
 }
 
 fn vc_decode_insn(ctx: &mut X86ExceptionContext) -> Result<(), SvsmError> {

--- a/src/cpu/vc.rs
+++ b/src/cpu/vc.rs
@@ -4,12 +4,29 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
-use super::idt::X86ExceptionContext;
+use super::idt::common::X86ExceptionContext;
 use crate::cpu::extable::handle_exception_table;
 use crate::debug::gdbstub::svsm_gdbstub::handle_db_exception;
 
 pub const SVM_EXIT_EXCP_BASE: usize = 0x40;
 pub const X86_TRAP_DB: usize = 0x01;
+
+pub fn stage2_handle_vc_exception(ctx: &mut X86ExceptionContext) {
+    let err = ctx.error_code;
+    let rip = ctx.frame.rip;
+
+    // If the debugger is enabled then handle the DB exception
+    // by directly invoking the exception hander
+    if err == (SVM_EXIT_EXCP_BASE + X86_TRAP_DB) {
+        handle_db_exception(ctx);
+        return;
+    }
+
+    panic!(
+        "Unhandled #VC exception RIP {:#018x} error code: {:#018x}",
+        rip, err
+    );
+}
 
 pub fn handle_vc_exception(ctx: &mut X86ExceptionContext) {
     let err = ctx.error_code;

--- a/src/cpu/vc.rs
+++ b/src/cpu/vc.rs
@@ -6,14 +6,57 @@
 
 use super::idt::common::X86ExceptionContext;
 use crate::cpu::extable::handle_exception_table;
+use crate::cpu::insn::{insn_fetch, Instruction};
 use crate::debug::gdbstub::svsm_gdbstub::handle_db_exception;
+use crate::error::SvsmError;
+
+use core::fmt;
 
 pub const SVM_EXIT_EXCP_BASE: usize = 0x40;
+pub const SVM_EXIT_LAST_EXCP: usize = 0x5f;
+pub const SVM_EXIT_CPUID: usize = 0x72;
 pub const X86_TRAP_DB: usize = 0x01;
+pub const X86_TRAP: usize = SVM_EXIT_EXCP_BASE + X86_TRAP_DB;
+
+#[derive(Clone, Copy, Debug)]
+pub enum VcError {
+    Unsupported,
+    DecodeFailed,
+    UnknownCpuidLeaf,
+}
+
+impl From<VcError> for SvsmError {
+    fn from(e: VcError) -> Self {
+        Self::Vc(e)
+    }
+}
+
+impl fmt::Display for VcError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Unsupported => {
+                write!(f, "unsupported #VC exception")
+            }
+            Self::DecodeFailed => {
+                write!(f, "invalid instruction")
+            }
+            Self::UnknownCpuidLeaf => {
+                write!(f, "unknown CPUID leaf")
+            }
+        }
+    }
+}
 
 pub fn stage2_handle_vc_exception(ctx: &mut X86ExceptionContext) {
     let err = ctx.error_code;
     let rip = ctx.frame.rip;
+
+    vc_decode_insn(ctx).unwrap_or_else(|e| {
+        panic!(
+            "Unhandled #VC exception RIP {:#018x} error code: {:#018x} error {:?}",
+            rip, err, e
+        )
+    });
 
     // If the debugger is enabled then handle the DB exception
     // by directly invoking the exception hander
@@ -26,6 +69,29 @@ pub fn stage2_handle_vc_exception(ctx: &mut X86ExceptionContext) {
         "Unhandled #VC exception RIP {:#018x} error code: {:#018x}",
         rip, err
     );
+}
+
+fn vc_decode_insn(ctx: &mut X86ExceptionContext) -> Result<(), SvsmError> {
+    if !vc_decoding_needed(ctx.error_code) {
+        return Ok(());
+    }
+
+    // TODO: the instruction fetch will likely to be handled differently when
+    // #VC exception will be raised from CPL > 0.
+    // TODO: handle invalid RIPs with exception fixup
+    // SAFETY: safe if [rip;rip+MAX_INSN_SIZE] doesn't overlap with an unmapped page
+    let insn_raw = unsafe { insn_fetch(ctx.frame.rip as *const u8) };
+
+    let mut insn = Instruction::new(insn_raw);
+    insn.decode()?;
+
+    ctx.insn = insn;
+
+    Ok(())
+}
+
+fn vc_decoding_needed(error_code: usize) -> bool {
+    !(SVM_EXIT_EXCP_BASE..=SVM_EXIT_LAST_EXCP).contains(&error_code)
 }
 
 pub fn handle_vc_exception(ctx: &mut X86ExceptionContext) {

--- a/src/cpu/vmsa.rs
+++ b/src/cpu/vmsa.rs
@@ -11,7 +11,7 @@ use crate::types::{GUEST_VMPL, SVSM_CS, SVSM_CS_FLAGS, SVSM_DS, SVSM_DS_FLAGS};
 use super::control_regs::{read_cr0, read_cr3, read_cr4};
 use super::efer::read_efer;
 use super::gdt::gdt_base_limit;
-use super::idt::idt_base_limit;
+use super::idt::common::idt_base_limit;
 use super::msr::read_msr;
 
 fn svsm_code_segment() -> VMSASegment {

--- a/src/debug/gdbstub.rs
+++ b/src/debug/gdbstub.rs
@@ -15,7 +15,7 @@ pub mod svsm_gdbstub {
 
     use crate::address::{Address, VirtAddr};
     use crate::cpu::control_regs::read_cr3;
-    use crate::cpu::idt::{X86ExceptionContext, BP_VECTOR};
+    use crate::cpu::idt::common::{X86ExceptionContext, BP_VECTOR};
     use crate::cpu::percpu::{this_cpu, this_cpu_mut};
     use crate::cpu::X86GeneralRegs;
     use crate::error::SvsmError;

--- a/src/debug/stacktrace.rs
+++ b/src/debug/stacktrace.rs
@@ -6,8 +6,8 @@
 
 use crate::address::{Address, VirtAddr};
 #[cfg(feature = "enable-stacktrace")]
-use crate::cpu::idt::is_exception_handler_return_site;
-use crate::cpu::idt::X86ExceptionContext;
+use crate::cpu::idt::common::is_exception_handler_return_site;
+use crate::cpu::idt::common::X86ExceptionContext;
 use crate::cpu::percpu::this_cpu;
 #[cfg(feature = "enable-stacktrace")]
 use crate::mm::address_space::STACK_SIZE;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use crate::cpu::vc::VcError;
 use crate::fs::FsError;
 use crate::fw_cfg::FwCfgError;
 use crate::sev::ghcb::GhcbError;
@@ -36,4 +37,6 @@ pub enum SvsmError {
     FileSystem(FsError),
     // Task management errors,
     Task(TaskError),
+    // Errors from #VC handler
+    Vc(VcError),
 }

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -15,6 +15,8 @@ use core::slice;
 use svsm::address::{Address, PhysAddr, VirtAddr};
 use svsm::console::{init_console, install_console_logger, WRITER};
 use svsm::cpu::cpuid::{dump_cpuid_table, register_cpuid_table, SnpCpuidTable};
+use svsm::cpu::gdt::load_gdt;
+use svsm::cpu::idt::stage2::early_idt_init;
 use svsm::cpu::percpu::{this_cpu_mut, PerCpu};
 use svsm::elf;
 use svsm::fw_cfg::FwCfg;
@@ -81,6 +83,9 @@ static CONSOLE_SERIAL: SerialPort = SerialPort {
 };
 
 fn setup_env() {
+    load_gdt();
+    early_idt_init();
+
     install_console_logger("Stage2");
     init_kernel_mapping_info(
         VirtAddr::null(),

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -22,7 +22,7 @@ use svsm::cpu::control_regs::{cr0_init, cr4_init};
 use svsm::cpu::cpuid::{dump_cpuid_table, register_cpuid_table, SnpCpuidTable};
 use svsm::cpu::efer::efer_init;
 use svsm::cpu::gdt::load_gdt;
-use svsm::cpu::idt::{early_idt_init, idt_init};
+use svsm::cpu::idt::svsm::{early_idt_init, idt_init};
 use svsm::cpu::percpu::PerCpu;
 use svsm::cpu::percpu::{this_cpu, this_cpu_mut};
 use svsm::cpu::smp::start_secondary_cpus;


### PR DESCRIPTION
This is a draft for the implementation of #14, which is implementing a #VC handler to handle NAE events.

NAE events have to be handled early, so we also set and load the IDT in stage 2.

At this point, interrupt handling in stage 2 doesn't work. I mostly moved and debug code to try to call the VC handler from a stage 2 `cpuid`, which fails. The IDT setup in this PR still handles interrupts in the SVSM kernel, but not in stage 2. My guess goes that IDT entries should be different because stage2 is a different binary (with different GDT entries?), but I'm still debugging. That's where my lack of system programming background hits.