### PR TITLE
fs/init: use external packit crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,10 +81,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "packit"
+version = "0.1.0"
+source = "git+https://github.com/coconut-svsm/packit#fffebdc18a3f559f0a01425b17cf41b1c249fbe0"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+dependencies = [
+ "proc-macro2",
+]
 
 [[package]]
 name = "svsm"
@@ -89,4 +121,43 @@ dependencies = [
  "gdbstub",
  "gdbstub_arch",
  "log",
+ "packit",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+
+[[package]]
+name = "zerocopy"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332f188cc1bcf1fe1064b8c58d150f497e697f49774aa846f2dc949d9a25f236"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6505e6815af7de1746a08f69c69606bb45695a17149517680f3b2149713b19a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,6 @@ name = "svsm"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-[profile.dev]
-
-[profile.release]
-
 [[bin]]
 name = "stage2"
 path = "src/stage2.rs"
@@ -27,6 +22,7 @@ bitflags = "1.3.2"
 gdbstub = { version = "0.6.6", default-features = false }
 gdbstub_arch = "0.2.4"
 log = { version = "0.4.17", features = ["max_level_info", "release_max_level_info"] }
+packit = { git = "https://github.com/coconut-svsm/packit", version = "0.1.0" }
 
 [build-dependencies]
 cc = "1.0.46"

--- a/src/fs/api.rs
+++ b/src/fs/api.rs
@@ -10,6 +10,7 @@ use alloc::vec::Vec;
 
 use crate::error::SvsmError;
 use crate::string::FixedString;
+use packit::PackItError;
 
 /// Maximum supported length for a single filename
 const MAX_FILENAME_LENGTH: usize = 64;
@@ -20,6 +21,25 @@ pub enum FsError {
     Inval,
     FileExists,
     FileNotFound,
+    PackIt(PackItError),
+}
+
+impl From<FsError> for SvsmError {
+    fn from(e: FsError) -> Self {
+        Self::FileSystem(e)
+    }
+}
+
+impl From<PackItError> for FsError {
+    fn from(e: PackItError) -> Self {
+        Self::PackIt(e)
+    }
+}
+
+impl From<PackItError> for SvsmError {
+    fn from(e: PackItError) -> Self {
+        Self::from(FsError::from(e))
+    }
 }
 
 macro_rules! impl_fs_err {

--- a/src/fs/init.rs
+++ b/src/fs/init.rs
@@ -7,169 +7,12 @@
 use crate::address::{Address, PhysAddr};
 use crate::error::SvsmError;
 use crate::mm::ptguards::PerCPUPageMappingGuard;
+use packit::PackItArchiveDecoder;
 
 use super::*;
 
 extern crate alloc;
 use alloc::slice;
-
-const PACKIT_MAGIC: [u8; 4] = [0x50, 0x4b, 0x49, 0x54];
-
-#[derive(Clone, Copy, Debug)]
-struct PackItHeader {
-    /// Header Magic (PKIT)
-    magic: [u8; 4],
-    /// Header Size
-    header_size: u32,
-}
-
-impl PackItHeader {
-    const fn new() -> Self {
-        PackItHeader {
-            magic: [0; 4],
-            header_size: 8,
-        }
-    }
-
-    fn load(buf: &[u8]) -> Result<Self, SvsmError> {
-        if buf.len() < 8 {
-            log::error!("Unexpected end of archive");
-            return Err(SvsmError::FileSystem(FsError::inval()));
-        }
-
-        let mut hdr = PackItHeader::new();
-        hdr.magic.copy_from_slice(&buf[0..4]);
-
-        // array indexes are static so the try_into() never fails
-        hdr.header_size = u32::from_le_bytes(buf[4..8].try_into().unwrap());
-
-        if hdr.magic != PACKIT_MAGIC {
-            log::error!("Unexpected header in FS archive");
-            return Err(SvsmError::FileSystem(FsError::inval()));
-        }
-
-        Ok(hdr)
-    }
-
-    fn len(&self) -> usize {
-        self.header_size as usize
-    }
-}
-
-#[derive(Clone, Debug)]
-struct FsArchive<'a> {
-    _hdr: PackItHeader,
-    data: &'a [u8],
-    current: usize,
-}
-
-impl<'a> FsArchive<'a> {
-    fn load(data: &'a [u8]) -> Result<Self, SvsmError> {
-        let _hdr = PackItHeader::load(data)?;
-        let current = _hdr.len();
-        Ok(Self {
-            _hdr,
-            data,
-            current,
-        })
-    }
-}
-
-impl<'a> core::iter::Iterator for FsArchive<'a> {
-    type Item = Result<FsFile<'a>, SvsmError>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.current >= self.data.len() {
-            return None;
-        }
-
-        let hdr = match FileHeader::load(&self.data[self.current..]) {
-            Ok(hdr) => hdr,
-            Err(e) => return Some(Err(e)),
-        };
-
-        let Some(start) = self.current.checked_add(hdr.header_size()) else {
-            return Some(Err(SvsmError::FileSystem(FsError::inval())));
-        };
-        let Some(end) = start.checked_add(hdr.file_size()) else {
-            return Some(Err(SvsmError::FileSystem(FsError::inval())));
-        };
-        let Some(data) = self.data.get(start..end) else {
-            return Some(Err(SvsmError::FileSystem(FsError::inval())));
-        };
-
-        self.current += hdr.total_size();
-
-        Some(Ok(FsFile { hdr, data }))
-    }
-}
-
-struct FsFile<'a> {
-    hdr: FileHeader<'a>,
-    data: &'a [u8],
-}
-
-#[derive(Clone, Debug)]
-struct FileHeader<'a> {
-    name_len: u16,
-    file_size: u64,
-    name: &'a str,
-}
-
-impl<'a> FileHeader<'a> {
-    fn load(buf: &'a [u8]) -> Result<Self, SvsmError> {
-        if buf.len() < 12 {
-            log::error!("Unexpected end of archive");
-            return Err(SvsmError::FileSystem(FsError::inval()));
-        }
-
-        // array indexes are static so the try_into() never fails
-        let hdr_type = u16::from_le_bytes(buf[0..2].try_into().unwrap());
-        let name_len = u16::from_le_bytes(buf[2..4].try_into().unwrap());
-        let file_size = u64::from_le_bytes(buf[4..12].try_into().unwrap());
-
-        let header_len: usize = name_len as usize + 12;
-
-        if buf.len() < header_len {
-            log::error!("Unexpected end of archive");
-            return Err(SvsmError::FileSystem(FsError::inval()));
-        }
-
-        let Ok(name) = core::str::from_utf8(&buf[12..header_len]) else {
-            log::error!("Invalid filename in archive");
-            return Err(SvsmError::FileSystem(FsError::inval()));
-        };
-
-        if hdr_type != 1 || name_len == 0 {
-            log::error!("Invalid file header in archive");
-            return Err(SvsmError::FileSystem(FsError::inval()));
-        }
-
-        Ok(Self {
-            name_len,
-            file_size,
-            name,
-        })
-    }
-
-    fn file_name(&self) -> &str {
-        self.name
-    }
-
-    fn file_size(&self) -> usize {
-        let size: usize = self.file_size.try_into().unwrap();
-        size
-    }
-
-    fn header_size(&self) -> usize {
-        let len: usize = self.name_len.into();
-        12usize + len
-    }
-
-    fn total_size(&self) -> usize {
-        self.file_size() + self.header_size()
-    }
-}
 
 pub fn populate_ram_fs(kernel_fs_start: u64, kernel_fs_end: u64) -> Result<(), SvsmError> {
     assert!(kernel_fs_end >= kernel_fs_start);
@@ -188,19 +31,19 @@ pub fn populate_ram_fs(kernel_fs_start: u64, kernel_fs_end: u64) -> Result<(), S
     let vstart = guard.virt_addr() + pstart.page_offset();
 
     let data: &[u8] = unsafe { slice::from_raw_parts(vstart.as_ptr(), size) };
-    let archive = FsArchive::load(data)?;
+    let archive = PackItArchiveDecoder::load(data)?;
 
     for file in archive {
         let file = file?;
-        let handle = create_all(file.hdr.file_name())?;
+        let handle = create_all(file.name())?;
         handle.truncate(0)?;
-        let written = handle.write(file.data)?;
-        if written != file.hdr.file_size() {
-            log::error!("Incomplete data write to {}", file.hdr.file_name());
+        let written = handle.write(file.data())?;
+        if written != file.data().len() {
+            log::error!("Incomplete data write to {}", file.name());
             return Err(SvsmError::FileSystem(FsError::inval()));
         }
 
-        log::info!("  Unpacked {}", file.hdr.file_name());
+        log::info!("  Unpacked {}", file.name());
     }
 
     log::info!("Unpacking done");


### PR DESCRIPTION
Since we now have a [standalone crate](/coconut-svsm/packit) implementing the filesystem blob decoding, use that external crate. Also add the appropriate error conversions to keep using the question mark operator with the error type from the external crate.