### PR TITLE
INSTALL.md: add binutils requirement for SVSM

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -169,9 +169,10 @@ configuration from the distribution like for the host kernel.
 Building the COCONUT-SVSM
 -------------------------
 
-Building the SVSM itself requires a recent Rust-nightly compiler and
-build environment installed. Please refer to [https://rustup.rs/](https://rustup.rs/)
-on how to get this environment installed.
+Building the SVSM itself requires:
+- a recent Rust-nightly compiler and build environment installed. Please refer to
+  [https://rustup.rs/](https://rustup.rs/) on how to get this environment installed.
+- `binutils` >= 2.39
 
 Then checkout the SVSM repository and build the SVSM binary:
 


### PR DESCRIPTION
Using `binutils` < 2.39, `ld` fails in this way during the build:

```bash
  $ make
  ...
  cc -o stage1/stage1 stage1/stage1.o stage1/reset.o -nostdlib -Wl,--build-id=none -Wl,-Tstage1/stage1.lds
  /usr/bin/ld: section .init LMA [00000000fffffe00,00000000ffffffff] overlaps section .data LMA [00000000fffff000,00000001000dbd93]
  stage1/stage1.o: in function `startup_32':
  (.startup.text+0x2d): relocation truncated to fit: R_X86_64_32 against `.data'
  (.startup.text+0x3d): relocation truncated to fit: R_X86_64_32 against `.data'
  (.startup.text+0x44): relocation truncated to fit: R_X86_64_32 against `.data'
  (.startup.text+0x4b): relocation truncated to fit: R_X86_64_32 against `.data'
  (.startup.text+0x52): relocation truncated to fit: R_X86_64_32 against `.data'
  collect2: error: ld returned 1 exit status
  make: *** [Makefile:53: stage1/stage1] Error 1
```

Let's put this requirement in the documentation.