### PR TITLE
scripts/pre-commit: check if files contain the correct header

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,6 +1,25 @@
 #!/bin/bash
 #
 
+check_file_header() {
+	header_warning="Header format incorrect in $1, follow the header structure in other files"
+	IFS=$'\n'
+	arr=($(head -n 5 "$1"))
+	if  ! [[ "${arr[0]}" == "// SPDX-License-Identifier: MIT OR Apache-2.0" ]] ; then
+		echo "${header_warning}"
+		return 1
+	fi
+	if  ! [[ "${arr[2]}" =~ ^//[[:space:]]Copyright ]] ; then
+		echo "${header_warning}"
+		return 1
+	fi
+	if  ! [[ "${arr[4]}" =~ ^//[[:space:]]Author: ]] ; then
+		echo "${header_warning}"
+		return 1
+	fi
+	return 0
+}
+
 RET=0
 
 for file in `git diff --name-only --staged`; do
@@ -11,9 +30,14 @@ for file in `git diff --name-only --staged`; do
             echo "$file needs rustfmt checking"
             RET=1
         fi
+	check_file_header $file
+        if [ "$?" == "1" ]; then
+            RET=1
+        fi
     fi
 done
 
 cargo clippy --all-features -- -D warnings -A clippy::bad_bit_mask || exit 1
 
 exit $RET
+


### PR DESCRIPTION
Print warning if files don't contain proper header in the beginning of the file.