### PR TITLE
mm/alloc: strongly type page types and other cleanups

### DIFF
--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -491,8 +491,10 @@ impl MemoryRegion {
         match page {
             Page::FilePage(mut fi) => {
                 let pfn = (vaddr - self.start_virt) / PAGE_SIZE;
-                assert!(fi.ref_count > 0);
-                fi.ref_count -= 1;
+                fi.ref_count = fi
+                    .ref_count
+                    .checked_sub(1)
+                    .expect("page refcount underflow");
                 if fi.ref_count > 0 {
                     self.write_page_info(pfn, Page::FilePage(fi));
                 } else {

--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -86,8 +86,8 @@ impl PageStorageType {
         Self(self.0 | (next_page as u64) << Self::NEXT_SHIFT)
     }
 
-    fn encode_slab(slab: VirtAddr) -> Self {
-        Self(PageType::SlabPage as u64 | (slab.bits() as u64) & Self::SLAB_MASK)
+    fn encode_slab(self, slab: VirtAddr) -> Self {
+        Self(self.0 | (slab.bits() as u64) & Self::SLAB_MASK)
     }
 
     fn encode_refcount(self, refcount: u64) -> Self {
@@ -155,7 +155,7 @@ struct SlabPageInfo {
 
 impl SlabPageInfo {
     pub fn encode(&self) -> PageStorageType {
-        PageStorageType::encode_slab(self.slab)
+        PageStorageType::new(PageType::SlabPage).encode_slab(self.slab)
     }
 
     pub fn decode(mem: PageStorageType) -> Self {

--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -1308,19 +1308,6 @@ pub fn root_mem_init(pstart: PhysAddr, vstart: VirtAddr, page_count: usize) {
         .expect("Failed to initialize SLAB_PAGE_SLAB");
 }
 
-pub fn print_alloc_info() {
-    for i in 0..MAX_ORDER {
-        let nr_pages = ROOT_MEM.lock().nr_pages[i];
-        let free_pages = ROOT_MEM.lock().free_pages[i];
-        log::trace!(
-            "Order-{}: Pages: {:#04} Free Pages: {:#04}",
-            i,
-            nr_pages,
-            free_pages
-        );
-    }
-}
-
 #[cfg(test)]
 static TEST_ROOT_MEM_LOCK: SpinLock<()> = SpinLock::new(());
 

--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -15,9 +15,6 @@ use core::mem::size_of;
 use core::ptr;
 use log;
 
-#[derive(Debug)]
-struct PageStorageType(u64);
-
 // Support allocations up to order-5 (128kb)
 pub const MAX_ORDER: usize = 6;
 
@@ -37,25 +34,29 @@ pub fn get_order(size: usize) -> usize {
     order
 }
 
+#[derive(Clone, Copy, Debug)]
+#[repr(transparent)]
+struct PageStorageType(u64);
+
 impl PageStorageType {
     pub const fn new(t: u64) -> Self {
-        PageStorageType(t)
+        Self(t)
     }
 
-    fn encode_order(&self, order: usize) -> PageStorageType {
-        PageStorageType(self.0 | ((order as u64) & PAGE_ORDER_MASK) << PAGE_TYPE_SHIFT)
+    fn encode_order(self, order: usize) -> Self {
+        Self(self.0 | ((order as u64) & PAGE_ORDER_MASK) << PAGE_TYPE_SHIFT)
     }
 
-    fn encode_next(&self, next_page: usize) -> PageStorageType {
-        PageStorageType(self.0 | (next_page as u64) << PAGE_FREE_NEXT_SHIFT)
+    fn encode_next(self, next_page: usize) -> Self {
+        Self(self.0 | (next_page as u64) << PAGE_FREE_NEXT_SHIFT)
     }
 
     fn encode_slab(slab: VirtAddr) -> Self {
-        PageStorageType(PAGE_TYPE_SLABPAGE | (slab.bits() as u64) & PAGE_TYPE_SLABPAGE_MASK)
+        Self(PAGE_TYPE_SLABPAGE | (slab.bits() as u64) & PAGE_TYPE_SLABPAGE_MASK)
     }
 
-    fn encode_refcount(&self, refcount: u64) -> PageStorageType {
-        PageStorageType(self.0 | refcount << PAGE_TYPE_SHIFT)
+    fn encode_refcount(self, refcount: u64) -> Self {
+        Self(self.0 | refcount << PAGE_TYPE_SHIFT)
     }
 }
 


### PR DESCRIPTION
Strongly type the page type reported by `PageStorageType`, rework its usage around that and other minor cleanups