### PR TITLE
task/schedule: Implement scheduler and per-cpu runqueues

### DIFF
--- a/src/cpu/idt.rs
+++ b/src/cpu/idt.rs
@@ -10,7 +10,7 @@ use super::vc::handle_vc_exception;
 use super::{X86GeneralRegs, X86InterruptFrame};
 use crate::address::{Address, VirtAddr};
 use crate::cpu::extable::handle_exception_table;
-use crate::debug::gdbstub::svsm_gdbstub::handle_bp_exception;
+use crate::debug::gdbstub::svsm_gdbstub::handle_debug_exception;
 use crate::types::SVSM_CS;
 use core::arch::{asm, global_asm};
 use core::mem;
@@ -199,6 +199,7 @@ fn generic_idt_handler(ctx: &mut X86ExceptionContext) {
         let err = ctx.error_code;
 
         if !handle_exception_table(ctx) {
+            handle_debug_exception(ctx, ctx.vector);
             panic!(
                 "Unhandled Page-Fault at RIP {:#018x} CR2: {:#018x} error code: {:#018x}",
                 rip, cr2, err
@@ -207,7 +208,7 @@ fn generic_idt_handler(ctx: &mut X86ExceptionContext) {
     } else if ctx.vector == VC_VECTOR {
         handle_vc_exception(ctx);
     } else if ctx.vector == BP_VECTOR {
-        handle_bp_exception(ctx);
+        handle_debug_exception(ctx, ctx.vector);
     } else {
         let err = ctx.error_code;
         let vec = ctx.vector;

--- a/src/cpu/percpu.rs
+++ b/src/cpu/percpu.rs
@@ -193,17 +193,11 @@ pub struct PerCpu {
     pub vrange_2m: VirtualRange,
 }
 
-impl Default for PerCpu {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl PerCpu {
-    pub fn new() -> Self {
+    fn new(apic_id: u32) -> Self {
         PerCpu {
             online: AtomicBool::new(false),
-            apic_id: 0,
+            apic_id,
             pgtbl: SpinLock::<PageTableRef>::new(PageTableRef::unset()),
             ghcb: ptr::null_mut(),
             init_stack: None,
@@ -222,8 +216,7 @@ impl PerCpu {
         let vaddr = allocate_zeroed_page()?;
         unsafe {
             let percpu = vaddr.as_mut_ptr::<PerCpu>();
-            (*percpu) = PerCpu::new();
-            (*percpu).apic_id = apic_id;
+            (*percpu) = PerCpu::new(apic_id);
             PERCPU_AREAS.push(PerCpuInfo::new(apic_id, vaddr));
             Ok(percpu)
         }

--- a/src/cpu/smp.rs
+++ b/src/cpu/smp.rs
@@ -7,9 +7,10 @@
 extern crate alloc;
 
 use crate::acpi::tables::ACPICPUInfo;
-use crate::cpu::percpu::{this_cpu_mut, PerCpu};
+use crate::cpu::percpu::{this_cpu, this_cpu_mut, PerCpu};
 use crate::cpu::vmsa::init_svsm_vmsa;
 use crate::requests::request_loop;
+use crate::task::{create_task, TASK_FLAG_SHARE_PT};
 
 fn start_cpu(apic_id: u32) {
     unsafe {
@@ -66,8 +67,17 @@ fn start_ap() {
     // Set CPU online so that BSP can proceed
     this_cpu_mut().set_online();
 
-    // Loop for now
-    request_loop();
+    // Create the task making sure the task only runs on this new AP
+    create_task(
+        ap_request_loop,
+        TASK_FLAG_SHARE_PT,
+        Some(this_cpu().get_apic_id()),
+    )
+    .expect("Failed to create AP initial task");
+}
 
+#[no_mangle]
+pub extern "C" fn ap_request_loop() {
+    request_loop();
     panic!("Returned from request_loop!");
 }

--- a/src/cpu/smp.rs
+++ b/src/cpu/smp.rs
@@ -51,7 +51,7 @@ pub fn start_secondary_cpus(cpus: &[ACPICPUInfo]) {
         start_cpu(c.apic_id);
         count += 1;
     }
-    log::info!("Brough {} AP(s) online", count);
+    log::info!("Brought {} AP(s) online", count);
 }
 
 #[no_mangle]

--- a/src/debug/gdbstub.rs
+++ b/src/debug/gdbstub.rs
@@ -11,24 +11,34 @@
 //
 #[cfg(feature = "enable-gdb")]
 pub mod svsm_gdbstub {
+    extern crate alloc;
+
     use crate::address::{Address, VirtAddr};
-    use crate::cpu::percpu::this_cpu;
-    use crate::cpu::X86ExceptionContext;
+    use crate::cpu::control_regs::read_cr3;
+    use crate::cpu::idt::X86ExceptionContext;
+    use crate::cpu::percpu::{this_cpu, this_cpu_mut};
+    use crate::cpu::X86GeneralRegs;
     use crate::error::SvsmError;
+    use crate::locking::{LockGuard, SpinLock};
     use crate::mm::guestmem::{read_u8, write_u8};
     use crate::mm::PerCPUPageMappingGuard;
     use crate::serial::{SerialPort, Terminal};
     use crate::svsm_console::SVSMIOPort;
+    use crate::task::{is_current_task, TaskContext, TaskState, INITIAL_TASK_ID, TASKLIST};
     use core::arch::asm;
+    use core::fmt;
+    use core::sync::atomic::{AtomicBool, Ordering};
+    use gdbstub::common::{Signal, Tid};
     use gdbstub::conn::Connection;
     use gdbstub::stub::state_machine::GdbStubStateMachine;
-    use gdbstub::stub::{GdbStubBuilder, SingleThreadStopReason};
-    use gdbstub::target::ext::base::singlethread::{
-        SingleThreadBase, SingleThreadResume, SingleThreadResumeOps, SingleThreadSingleStep,
-        SingleThreadSingleStepOps,
+    use gdbstub::stub::{GdbStubBuilder, MultiThreadStopReason};
+    use gdbstub::target::ext::base::multithread::{
+        MultiThreadBase, MultiThreadResume, MultiThreadResumeOps, MultiThreadSingleStep,
+        MultiThreadSingleStepOps,
     };
     use gdbstub::target::ext::base::BaseOps;
     use gdbstub::target::ext::breakpoints::{Breakpoints, SwBreakpoint};
+    use gdbstub::target::ext::thread_extra_info::ThreadExtraInfo;
     use gdbstub::target::{Target, TargetError};
     use gdbstub_arch::x86::reg::X86_64CoreRegs;
     use gdbstub_arch::x86::X86_64_SSE;
@@ -45,21 +55,112 @@ pub mod svsm_gdbstub {
                 .expect("Failed to initialise GDB stub")
                 .run_state_machine(&mut target)
                 .expect("Failed to start GDB state machine");
-            GDB_STATE = Some(SvsmGdbStub { gdb, target });
+            *GDB_STATE.lock() = Some(SvsmGdbStub { gdb, target });
+            GDB_STACK_TOP = GDB_STACK.as_mut_ptr().offset(GDB_STACK.len() as isize - 1) as u64;
         }
+        GDB_INITIALISED.store(true, Ordering::Relaxed);
         Ok(())
     }
 
+    #[derive(PartialEq, Eq)]
+    enum ExceptionType {
+        Debug,
+        SwBreakpoint,
+    }
+
     pub fn handle_bp_exception(ctx: &mut X86ExceptionContext) {
-        handle_stop(ctx, true);
+        handle_exception(ctx, ExceptionType::SwBreakpoint);
     }
 
     pub fn handle_db_exception(ctx: &mut X86ExceptionContext) {
-        handle_stop(ctx, false);
+        handle_exception(ctx, ExceptionType::Debug);
+    }
+
+    fn handle_exception(ctx: &mut X86ExceptionContext, exception_type: ExceptionType) {
+        let id = this_cpu().runqueue().lock_read().current_task_id();
+        let mut task_ctx = TaskContext {
+            regs: X86GeneralRegs {
+                r15: ctx.regs.r15,
+                r14: ctx.regs.r14,
+                r13: ctx.regs.r13,
+                r12: ctx.regs.r12,
+                r11: ctx.regs.r11,
+                r10: ctx.regs.r10,
+                r9: ctx.regs.r9,
+                r8: ctx.regs.r8,
+                rbp: ctx.regs.rbp,
+                rdi: ctx.regs.rdi,
+                rsi: ctx.regs.rsi,
+                rdx: ctx.regs.rdx,
+                rcx: ctx.regs.rcx,
+                rbx: ctx.regs.rbx,
+                rax: ctx.regs.rax,
+            },
+            rsp: ctx.frame.rsp as u64,
+            flags: ctx.frame.flags as u64,
+            ret_addr: ctx.frame.rip as u64,
+        };
+
+        if let Some(task_node) = this_cpu_mut().runqueue().lock_read().get_task(id) {
+            task_node.task.lock_write().rsp = &task_ctx as *const TaskContext as u64;
+        }
+
+        // Locking the GDB state for the duration of the stop will cause any other
+        // APs that hit a breakpoint to busy-wait until the current CPU releases
+        // the GDB state. They will then resume and report the stop state
+        // to GDB.
+        // One thing to watch out for - if a breakpoint is inadvertently placed in
+        // the GDB handling code itself then this will cause a re-entrant state
+        // within the same CPU causing a deadlock.
+        loop {
+            let mut gdb_state = GDB_STATE.lock();
+            if let Some(stub) = gdb_state.as_ref() {
+                if stub.target.is_single_step != 0 && stub.target.is_single_step != id {
+                    continue;
+                }
+            }
+
+            unsafe {
+                asm!(
+                    r#"
+                        movq    %rsp, (%rax)
+                        movq    %rax, %rsp
+                        call    handle_stop
+                        popq    %rax
+                        movq    %rax, %rsp
+                    "#,
+                    in("rsi") exception_type as u64,
+                    in("rdi") &mut task_ctx,
+                    in("rdx") &mut gdb_state,
+                    in("rax") GDB_STACK_TOP,
+                    options(att_syntax));
+            }
+
+            ctx.frame.rip = task_ctx.ret_addr as usize;
+            ctx.frame.flags = task_ctx.flags as usize;
+            ctx.frame.rsp = task_ctx.rsp as usize;
+            ctx.regs.rax = task_ctx.regs.rax;
+            ctx.regs.rbx = task_ctx.regs.rbx;
+            ctx.regs.rcx = task_ctx.regs.rcx;
+            ctx.regs.rdx = task_ctx.regs.rdx;
+            ctx.regs.rsi = task_ctx.regs.rsi;
+            ctx.regs.rdi = task_ctx.regs.rdi;
+            ctx.regs.rbp = task_ctx.regs.rbp;
+            ctx.regs.r8 = task_ctx.regs.r8;
+            ctx.regs.r9 = task_ctx.regs.r9;
+            ctx.regs.r10 = task_ctx.regs.r10;
+            ctx.regs.r11 = task_ctx.regs.r11;
+            ctx.regs.r12 = task_ctx.regs.r12;
+            ctx.regs.r13 = task_ctx.regs.r13;
+            ctx.regs.r14 = task_ctx.regs.r14;
+            ctx.regs.r15 = task_ctx.regs.r15;
+
+            break;
+        }
     }
 
     pub fn debug_break() {
-        if unsafe { GDB_STATE.is_some() } {
+        if GDB_INITIALISED.load(Ordering::Acquire) {
             log::info!("***********************************");
             log::info!("* Waiting for connection from GDB *");
             log::info!("***********************************");
@@ -69,37 +170,100 @@ pub mod svsm_gdbstub {
         }
     }
 
-    static mut GDB_STATE: Option<SvsmGdbStub> = None;
+    static GDB_INITIALISED: AtomicBool = AtomicBool::new(false);
+    static GDB_STATE: SpinLock<Option<SvsmGdbStub>> = SpinLock::new(None);
     static GDB_IO: SVSMIOPort = SVSMIOPort::new();
     static mut GDB_SERIAL: SerialPort = SerialPort {
         driver: &GDB_IO,
         port: 0x2f8,
     };
     static mut PACKET_BUFFER: [u8; 4096] = [0; 4096];
+    // Allocate the GDB stack as an array of u64's to ensure 8 byte alignment of the stack.
+    static mut GDB_STACK: [u64; 8192] = [0; 8192];
+    static mut GDB_STACK_TOP: u64 = 0;
+
+    struct GdbTaskContext {
+        cr3: usize,
+    }
+
+    impl GdbTaskContext {
+        fn switch_to_task(id: u32) -> Self {
+            let cr3 = if is_current_task(id) {
+                0
+            } else {
+                let tl = TASKLIST.lock();
+                let cr3 = read_cr3();
+                let task_node = tl.get_task(id);
+                if let Some(task_node) = task_node {
+                    task_node.task.lock_write().page_table.lock().load();
+                    cr3.bits()
+                } else {
+                    0
+                }
+            };
+            Self { cr3 }
+        }
+    }
+
+    impl Drop for GdbTaskContext {
+        fn drop(&mut self) {
+            if self.cr3 != 0 {
+                unsafe {
+                    asm!("mov %rax, %cr3",
+                         in("rax") self.cr3,
+                         options(att_syntax));
+                }
+            }
+        }
+    }
 
     struct SvsmGdbStub<'a> {
         gdb: GdbStubStateMachine<'a, GdbStubTarget, GdbStubConnection>,
         target: GdbStubTarget,
     }
 
-    fn handle_stop(ctx: &mut X86ExceptionContext, bp_exception: bool) {
-        let SvsmGdbStub { gdb, mut target } = unsafe {
-            GDB_STATE.take().unwrap_or_else(|| {
-                panic!("GDB stub not initialised!");
-            })
-        };
+    impl<'a> fmt::Debug for SvsmGdbStub<'a> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "SvsmGdbStub")
+        }
+    }
+
+    #[no_mangle]
+    fn handle_stop(
+        ctx: &mut TaskContext,
+        exception_type: ExceptionType,
+        gdb_state: &mut LockGuard<'_, Option<SvsmGdbStub<'_>>>,
+    ) {
+        let SvsmGdbStub { gdb, mut target } = gdb_state.take().unwrap_or_else(|| {
+            panic!("Invalid GDB state");
+        });
 
         target.set_regs(ctx);
 
+        let hardcoded_bp = (exception_type == ExceptionType::SwBreakpoint)
+            && !target.is_breakpoint(ctx.ret_addr as usize - 1);
+
         // If the current address is on a breakpoint then we need to
         // move the IP back by one byte
-        if bp_exception && target.is_breakpoint(ctx.frame.rip - 1) {
-            ctx.frame.rip -= 1;
+        if (exception_type == ExceptionType::SwBreakpoint)
+            && target.is_breakpoint(ctx.ret_addr as usize - 1)
+        {
+            ctx.ret_addr -= 1;
         }
 
+        let tid = Tid::new(this_cpu().runqueue().lock_read().current_task_id() as usize)
+            .expect("Current task has invalid ID");
         let mut new_gdb = match gdb {
             GdbStubStateMachine::Running(gdb_inner) => {
-                match gdb_inner.report_stop(&mut target, SingleThreadStopReason::SwBreak(())) {
+                let reason = if hardcoded_bp {
+                    MultiThreadStopReason::SignalWithThread {
+                        tid,
+                        signal: Signal::SIGINT,
+                    }
+                } else {
+                    MultiThreadStopReason::SwBreak(tid)
+                };
+                match gdb_inner.report_stop(&mut target, reason) {
                     Ok(gdb) => gdb,
                     Err(_) => panic!("Failed to handle software breakpoint"),
                 }
@@ -128,22 +292,19 @@ pub mod svsm_gdbstub {
                     break;
                 }
                 _ => {
-                    log::info!("Invalid GDB state when handling breakpoint interrupt");
-                    return;
+                    panic!("Invalid GDB state when handling breakpoint interrupt");
                 }
             };
         }
-        if target.is_single_step {
-            ctx.frame.flags |= 0x100;
+        if target.is_single_step == tid.get() as u32 {
+            ctx.flags |= 0x100;
         } else {
-            ctx.frame.flags &= !0x100;
+            ctx.flags &= !0x100;
         }
-        unsafe {
-            GDB_STATE = Some(SvsmGdbStub {
-                gdb: new_gdb,
-                target,
-            })
-        };
+        **gdb_state = Some(SvsmGdbStub {
+            gdb: new_gdb,
+            target,
+        });
     }
 
     struct GdbStubConnection;
@@ -182,7 +343,7 @@ pub mod svsm_gdbstub {
     struct GdbStubTarget {
         ctx: usize,
         breakpoints: [GdbStubBreakpoint; MAX_BREAKPOINTS],
-        is_single_step: bool,
+        is_single_step: u32,
     }
 
     impl GdbStubTarget {
@@ -193,11 +354,11 @@ pub mod svsm_gdbstub {
                     addr: VirtAddr::null(),
                     inst: 0,
                 }; MAX_BREAKPOINTS],
-                is_single_step: false,
+                is_single_step: 0,
             }
         }
 
-        pub fn set_regs(&mut self, ctx: &X86ExceptionContext) {
+        pub fn set_regs(&mut self, ctx: &TaskContext) {
             self.ctx = (ctx as *const _) as usize;
         }
 
@@ -227,7 +388,7 @@ pub mod svsm_gdbstub {
         type Error = usize;
 
         fn base_ops(&mut self) -> gdbstub::target::ext::base::BaseOps<'_, Self::Arch, Self::Error> {
-            BaseOps::SingleThread(self)
+            BaseOps::MultiThread(self)
         }
 
         #[inline(always)]
@@ -238,10 +399,10 @@ pub mod svsm_gdbstub {
         }
     }
 
-    impl From<&X86ExceptionContext> for X86_64CoreRegs {
-        fn from(value: &X86ExceptionContext) -> Self {
+    impl From<&TaskContext> for X86_64CoreRegs {
+        fn from(value: &TaskContext) -> Self {
             let mut regs = X86_64CoreRegs::default();
-            regs.rip = value.frame.rip as u64;
+            regs.rip = value.ret_addr;
             regs.regs = [
                 value.regs.rax as u64,
                 value.regs.rbx as u64,
@@ -250,7 +411,7 @@ pub mod svsm_gdbstub {
                 value.regs.rsi as u64,
                 value.regs.rdi as u64,
                 value.regs.rbp as u64,
-                value.frame.rsp as u64,
+                value.rsp,
                 value.regs.r8 as u64,
                 value.regs.r9 as u64,
                 value.regs.r10 as u64,
@@ -260,34 +421,49 @@ pub mod svsm_gdbstub {
                 value.regs.r14 as u64,
                 value.regs.r15 as u64,
             ];
-            regs.eflags = value.frame.flags as u32;
-            regs.segments.cs = value.frame.cs as u32;
-            regs.segments.ss = value.frame.ss as u32;
+            regs.eflags = value.flags as u32;
             regs
         }
     }
 
-    impl SingleThreadBase for GdbStubTarget {
+    impl MultiThreadBase for GdbStubTarget {
         fn read_registers(
             &mut self,
             regs: &mut <Self::Arch as gdbstub::arch::Arch>::Registers,
+            tid: Tid,
         ) -> gdbstub::target::TargetResult<(), Self> {
-            unsafe {
-                let context = (self.ctx as *mut X86ExceptionContext).as_ref().unwrap();
-                *regs = X86_64CoreRegs::from(context);
+            if is_current_task(tid.get() as u32) {
+                unsafe {
+                    let context = (self.ctx as *const TaskContext).as_ref().unwrap();
+                    *regs = X86_64CoreRegs::from(context);
+                }
+            } else {
+                let task = TASKLIST.lock().get_task(tid.get() as u32);
+                if let Some(task_node) = task {
+                    // The registers are stored in the top of the task stack as part of the
+                    // saved context. We need to switch to the task pagetable to access them.
+                    let _task_context = GdbTaskContext::switch_to_task(tid.get() as u32);
+                    let task = task_node.task.lock_read();
+                    unsafe {
+                        *regs = X86_64CoreRegs::from(&*(task.rsp as *const TaskContext));
+                    };
+                    regs.regs[7] = task.rsp;
+                } else {
+                    *regs = <Self::Arch as gdbstub::arch::Arch>::Registers::default();
+                }
             }
-
             Ok(())
         }
 
         fn write_registers(
             &mut self,
             regs: &<Self::Arch as gdbstub::arch::Arch>::Registers,
+            _tid: Tid,
         ) -> gdbstub::target::TargetResult<(), Self> {
             unsafe {
-                let context = (self.ctx as *mut X86ExceptionContext).as_mut().unwrap();
+                let context = (self.ctx as *mut TaskContext).as_mut().unwrap();
 
-                context.frame.rip = regs.rip as usize;
+                context.ret_addr = regs.rip;
                 context.regs.rax = regs.regs[0] as usize;
                 context.regs.rbx = regs.regs[1] as usize;
                 context.regs.rcx = regs.regs[2] as usize;
@@ -295,7 +471,7 @@ pub mod svsm_gdbstub {
                 context.regs.rsi = regs.regs[4] as usize;
                 context.regs.rdi = regs.regs[5] as usize;
                 context.regs.rbp = regs.regs[6] as usize;
-                context.frame.rsp = regs.regs[7] as usize;
+                context.rsp = regs.regs[7];
                 context.regs.r8 = regs.regs[8] as usize;
                 context.regs.r9 = regs.regs[9] as usize;
                 context.regs.r10 = regs.regs[10] as usize;
@@ -304,9 +480,7 @@ pub mod svsm_gdbstub {
                 context.regs.r13 = regs.regs[13] as usize;
                 context.regs.r14 = regs.regs[14] as usize;
                 context.regs.r15 = regs.regs[15] as usize;
-                context.frame.flags = regs.eflags as usize;
-                context.frame.cs = regs.segments.cs as usize;
-                context.frame.ss = regs.segments.ss as usize;
+                context.flags = regs.eflags as u64;
             }
             Ok(())
         }
@@ -315,7 +489,11 @@ pub mod svsm_gdbstub {
             &mut self,
             start_addr: <Self::Arch as gdbstub::arch::Arch>::Usize,
             data: &mut [u8],
+            tid: Tid,
         ) -> gdbstub::target::TargetResult<(), Self> {
+            // Switch to the task pagetable if necessary. The switch back will
+            // happen automatically when the variable falls out of scope
+            let _task_context = GdbTaskContext::switch_to_task(tid.get() as u32);
             let start_addr = VirtAddr::from(start_addr);
             for (off, dst) in data.iter_mut().enumerate() {
                 let Ok(val) = read_u8(start_addr + off) else {
@@ -330,6 +508,7 @@ pub mod svsm_gdbstub {
             &mut self,
             start_addr: <Self::Arch as gdbstub::arch::Arch>::Usize,
             data: &[u8],
+            _tid: Tid,
         ) -> gdbstub::target::TargetResult<(), Self> {
             let start_addr = VirtAddr::from(start_addr);
             for (off, src) in data.iter().enumerate() {
@@ -341,26 +520,117 @@ pub mod svsm_gdbstub {
         }
 
         #[inline(always)]
-        fn support_resume(&mut self) -> Option<SingleThreadResumeOps<Self>> {
+        fn support_resume(&mut self) -> Option<MultiThreadResumeOps<Self>> {
+            Some(self)
+        }
+
+        fn list_active_threads(
+            &mut self,
+            thread_is_active: &mut dyn FnMut(gdbstub::common::Tid),
+        ) -> Result<(), Self::Error> {
+            let mut tl = TASKLIST.lock();
+
+            let mut any_scheduled = false;
+
+            if tl.list().is_empty() {
+                // Task list has not been initialised yet. Report a single thread
+                // for the current CPU
+                thread_is_active(Tid::new(INITIAL_TASK_ID as usize).unwrap());
+            } else {
+                let mut cursor = tl.list().front_mut();
+                while cursor.get().is_some() {
+                    if cursor.get().unwrap().task.lock_read().allocation.is_some() {
+                        any_scheduled = true;
+                        break;
+                    }
+                    cursor.move_next();
+                }
+                if any_scheduled {
+                    let mut cursor = tl.list().front_mut();
+                    while cursor.get().is_some() {
+                        thread_is_active(
+                            Tid::new(cursor.get().unwrap().task.lock_read().id as usize).unwrap(),
+                        );
+                        cursor.move_next();
+                    }
+                } else {
+                    thread_is_active(Tid::new(INITIAL_TASK_ID as usize).unwrap());
+                }
+            }
+            Ok(())
+        }
+
+        fn support_thread_extra_info(
+            &mut self,
+        ) -> Option<gdbstub::target::ext::thread_extra_info::ThreadExtraInfoOps<'_, Self>> {
             Some(self)
         }
     }
 
-    impl SingleThreadResume for GdbStubTarget {
-        fn resume(&mut self, _signal: Option<gdbstub::common::Signal>) -> Result<(), Self::Error> {
-            self.is_single_step = false;
+    impl ThreadExtraInfo for GdbStubTarget {
+        fn thread_extra_info(&self, tid: Tid, buf: &mut [u8]) -> Result<usize, Self::Error> {
+            // Get the current task from the stopped CPU so we can mark it as stopped
+            let tl = TASKLIST.lock();
+            let str = match tl.get_task(tid.get() as u32) {
+                Some(t) => {
+                    let t = t.task.lock_read();
+                    match t.state {
+                        TaskState::RUNNING => {
+                            if let Some(allocation) = t.allocation {
+                                if this_cpu().get_apic_id() == allocation {
+                                    "Stopped".as_bytes()
+                                } else {
+                                    "Running".as_bytes()
+                                }
+                            } else {
+                                "Stopped".as_bytes()
+                            }
+                        }
+                        TaskState::TERMINATED => "Terminated".as_bytes(),
+                    }
+                }
+                None => "Stopped".as_bytes(),
+            };
+            let mut count = 0;
+            for (dst, src) in buf.iter_mut().zip(str) {
+                *dst = *src;
+                count += 1;
+            }
+            Ok(count)
+        }
+    }
+
+    impl MultiThreadResume for GdbStubTarget {
+        fn resume(&mut self) -> Result<(), Self::Error> {
             Ok(())
         }
 
         #[inline(always)]
-        fn support_single_step(&mut self) -> Option<SingleThreadSingleStepOps<'_, Self>> {
+        fn support_single_step(&mut self) -> Option<MultiThreadSingleStepOps<'_, Self>> {
             Some(self)
+        }
+
+        fn clear_resume_actions(&mut self) -> Result<(), Self::Error> {
+            self.is_single_step = 0;
+            Ok(())
+        }
+
+        fn set_resume_action_continue(
+            &mut self,
+            _tid: Tid,
+            _signal: Option<Signal>,
+        ) -> Result<(), Self::Error> {
+            Ok(())
         }
     }
 
-    impl SingleThreadSingleStep for GdbStubTarget {
-        fn step(&mut self, _signal: Option<gdbstub::common::Signal>) -> Result<(), Self::Error> {
-            self.is_single_step = true;
+    impl MultiThreadSingleStep for GdbStubTarget {
+        fn set_resume_action_step(
+            &mut self,
+            tid: Tid,
+            _signal: Option<Signal>,
+        ) -> Result<(), Self::Error> {
+            self.is_single_step = tid.get() as u32;
             Ok(())
         }
     }
@@ -437,9 +707,9 @@ pub mod svsm_gdbstub {
         Ok(())
     }
 
-    pub fn handle_bp_exception(_regs: &mut X86ExceptionContext) {}
+    pub fn handle_bp_exception(_ctx: &mut X86ExceptionContext) {}
 
-    pub fn handle_db_exception(_regs: &mut X86ExceptionContext) {}
+    pub fn handle_db_exception(_ctx: &mut X86ExceptionContext) {}
 
     pub fn debug_break() {}
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,7 @@ use crate::fw_cfg::FwCfgError;
 use crate::sev::ghcb::GhcbError;
 use crate::sev::msr_protocol::GhcbMsrError;
 use crate::sev::SevSnpError;
+use crate::task::TaskError;
 
 // As a general rule, functions private to a given module may use the
 // leaf error types. Public functions should return an SvsmError
@@ -33,4 +34,6 @@ pub enum SvsmError {
     Acpi,
     // Errors from file systems
     FileSystem(FsError),
+    // Task management errors,
+    Task(TaskError),
 }

--- a/src/locking/rwlock.rs
+++ b/src/locking/rwlock.rs
@@ -156,4 +156,32 @@ impl<T: Debug> RWLock<T> {
             data: unsafe { &mut *self.data.get() },
         }
     }
+
+    /// Waits then locks the RWLock, returning a mutable pointer to the
+    /// protected item. The lock must be released with a call to
+    /// [`Self::unlock_write_direct()`] when access to the protected resource is
+    /// no longer exclusively required.
+    pub fn lock_write_direct(&self) -> *mut T {
+        let guard = self.lock_write();
+        core::mem::forget(guard);
+        self.data.get()
+    }
+
+    /// Unlocks the RWLock, relinquishing access to the raw pointer
+    /// that was gained by a previous call to [`Self::lock_write_direct()`].
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the raw pointer returned by a
+    /// previous call to [`Self::lock_write_direct()`] is not used after
+    /// calling this function. Although the pointer may still point
+    /// to a valid object there is no guarantee of this and use of
+    /// the pointer is undefined behaviour.
+    ///
+    /// In order to gain mutable or immutable access to the object
+    /// the caller must again restablish the RWLock.
+    pub unsafe fn unlock_write_direct(&self) {
+        // There are no readers - safe to just set lock to 0
+        self.rwlock.store(0, Ordering::Release);
+    }
 }

--- a/src/mm/address_space.rs
+++ b/src/mm/address_space.rs
@@ -83,13 +83,7 @@ pub const SIZE_LEVEL1: usize = 1usize << ((9 * 1) + 12);
 pub const SIZE_LEVEL0: usize = 1usize << ((9 * 0) + 12);
 
 // Stack definitions
-// The GDB stub requires a larger stack.
-#[cfg(feature = "enable-gdb")]
-pub const STACK_PAGES_GDB: usize = 8;
-#[cfg(not(feature = "enable-gdb"))]
-pub const STACK_PAGES_GDB: usize = 0;
-
-pub const STACK_PAGES: usize = 8 + STACK_PAGES_GDB;
+pub const STACK_PAGES: usize = 8;
 pub const STACK_SIZE: usize = PAGE_SIZE * STACK_PAGES;
 pub const STACK_GUARD_SIZE: usize = STACK_SIZE;
 pub const STACK_TOTAL_SIZE: usize = STACK_SIZE + STACK_GUARD_SIZE;

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -418,13 +418,8 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
 
 #[no_mangle]
 pub extern "C" fn svsm_main() {
-    // The GDB stub can be started earlier, just after the console is initialised
-    // in svsm_start() above. It uses a lot of stack though so if you want to move
-    // it earlier then you need to set bsp_stack to 64K in the inline assembler
-    // above:
-    //
-    //     bsp_stack:
-    //        .fill 65536, 1, 0
+    // If required, the GDB stub can be started earlier, just after the console
+    // is initialised in svsm_start() above.
     gdbstub_start().expect("Could not start GDB stub");
     // Uncomment the line below if you want to wait for
     // a remote GDB connection

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -12,7 +12,7 @@ extern crate alloc;
 use alloc::vec::Vec;
 use svsm::fw_meta::{parse_fw_meta_data, print_fw_meta, validate_fw_memory, SevFWMetaData};
 
-use core::arch::{asm, global_asm};
+use core::arch::global_asm;
 use core::panic::PanicInfo;
 use core::slice;
 use svsm::acpi::tables::load_acpi_cpu_info;
@@ -46,6 +46,7 @@ use svsm::sev::sev_status_init;
 use svsm::sev::utils::{rmp_adjust, RMPFlags};
 use svsm::svsm_console::SVSMIOPort;
 use svsm::svsm_paging::{init_page_table, invalidate_stage2};
+use svsm::task::{create_task, TASK_FLAG_SHARE_PT};
 use svsm::types::{PageSize, GUEST_VMPL, PAGE_SIZE};
 use svsm::utils::{halt, immut_after_init::ImmutAfterInitCell, zero_mem_region};
 
@@ -407,13 +408,15 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
 
     log::info!("BSP Runtime stack starts @ {:#018x}", bp);
 
-    // Enable runtime stack and jump to main function
-    unsafe {
-        asm!("movq  %rax, %rsp
-              jmp   svsm_main",
-              in("rax") bp.bits(),
-              options(att_syntax));
-    }
+    // Create the root task that runs the entry point then handles the request loop
+    create_task(
+        svsm_main,
+        TASK_FLAG_SHARE_PT,
+        Some(this_cpu().get_apic_id()),
+    )
+    .expect("Failed to create initial task");
+
+    panic!("SVSM entry point terminated unexpectedly");
 }
 
 #[no_mangle]

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -7,5 +7,7 @@
 mod schedule;
 mod tasks;
 
-pub use schedule::{create_task, RunQueue, TaskNode, TaskPointer, TASKLIST};
+pub use schedule::{
+    create_task, is_current_task, schedule, RunQueue, TaskNode, TaskPointer, TASKLIST,
+};
 pub use tasks::{Task, TaskContext, TaskError, TaskState, INITIAL_TASK_ID, TASK_FLAG_SHARE_PT};

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -7,5 +7,5 @@
 mod schedule;
 mod tasks;
 
-pub use schedule::{create_task, TaskNode, TaskPointer, TASKLIST};
+pub use schedule::{create_task, RunQueue, TaskNode, TaskPointer, TASKLIST};
 pub use tasks::{Task, TaskContext, TaskError, TaskState, INITIAL_TASK_ID, TASK_FLAG_SHARE_PT};

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -6,4 +6,4 @@
 
 mod tasks;
 
-pub use tasks::{Task, TaskContext, TaskState, INITIAL_TASK_ID, TASK_FLAG_SHARE_PT};
+pub use tasks::{Task, TaskContext, TaskError, TaskState, INITIAL_TASK_ID, TASK_FLAG_SHARE_PT};

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -4,6 +4,8 @@
 //
 // Author: Roy Hopkins <rhopkins@suse.de>
 
+mod schedule;
 mod tasks;
 
+pub use schedule::{create_task, TaskNode, TaskPointer, TASKLIST};
 pub use tasks::{Task, TaskContext, TaskError, TaskState, INITIAL_TASK_ID, TASK_FLAG_SHARE_PT};

--- a/src/task/schedule.rs
+++ b/src/task/schedule.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2022-2023 SUSE LLC
+//
+// Author: Roy Hopkins <rhopkins@suse.de>
+
+extern crate alloc;
+
+use super::Task;
+use crate::error::SvsmError;
+use crate::locking::{RWLock, SpinLock};
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use intrusive_collections::{intrusive_adapter, LinkedList, LinkedListAtomicLink};
+
+pub type TaskPointer = Arc<TaskNode>;
+
+#[derive(Debug)]
+pub struct TaskNode {
+    list_link: LinkedListAtomicLink,
+    pub task: RWLock<Box<Task>>,
+}
+
+// SAFETY: Send + Sync is required for Arc<TaskNode> to implement Send. The `task`
+// member is Send + Sync but the intrusive_collection links are only Send. The only
+// access to these is via the intrusive_adapter! generated code which does not use
+// them concurrently across threads.
+unsafe impl Sync for TaskNode {}
+
+intrusive_adapter!(pub TaskListAdapter = Arc<TaskNode>: TaskNode { list_link: LinkedListAtomicLink });
+
+/// Global task list
+/// This contains every task regardless of affinity or run state.
+#[derive(Debug)]
+pub struct TaskList {
+    list: Option<LinkedList<TaskListAdapter>>,
+}
+
+impl TaskList {
+    pub const fn new() -> Self {
+        Self { list: None }
+    }
+
+    pub fn list(&mut self) -> &mut LinkedList<TaskListAdapter> {
+        self.list
+            .get_or_insert_with(|| LinkedList::new(TaskListAdapter::new()))
+    }
+
+    pub fn get_task(&self, id: u32) -> Option<TaskPointer> {
+        let task_list = &self.list.as_ref()?;
+        let mut cursor = task_list.front();
+        while let Some(task_node) = cursor.get() {
+            if task_node.task.lock_read().id == id {
+                return cursor.clone_pointer();
+            }
+            cursor.move_next();
+        }
+        None
+    }
+}
+
+pub static TASKLIST: SpinLock<TaskList> = SpinLock::new(TaskList::new());
+
+pub fn create_task(
+    entry: extern "C" fn(),
+    flags: u16,
+    affinity: Option<u32>,
+) -> Result<TaskPointer, SvsmError> {
+    let mut task = Task::create(entry, flags)?;
+    task.set_affinity(affinity);
+    let node = Arc::new(TaskNode {
+        list_link: LinkedListAtomicLink::default(),
+        task: RWLock::new(task),
+    });
+    TASKLIST.lock().list().push_front(node.clone());
+    Ok(node)
+}

--- a/src/task/tasks.rs
+++ b/src/task/tasks.rs
@@ -33,6 +33,20 @@ pub enum TaskState {
     TERMINATED,
 }
 
+#[derive(Clone, Copy, Debug)]
+pub enum TaskError {
+    // Attempt to close a non-terminated task
+    NotTerminated,
+    // A closed task could not be removed from the task list
+    CloseFailed,
+}
+
+impl From<TaskError> for SvsmError {
+    fn from(e: TaskError) -> Self {
+        Self::Task(e)
+    }
+}
+
 pub const TASK_FLAG_SHARE_PT: u16 = 0x01;
 
 #[derive(Debug, Default)]

--- a/src/task/tasks.rs
+++ b/src/task/tasks.rs
@@ -28,7 +28,6 @@ pub const INITIAL_TASK_ID: u32 = 1;
 #[derive(PartialEq, Debug, Copy, Clone, Default)]
 pub enum TaskState {
     RUNNING,
-    SCHEDULED,
     #[default]
     TERMINATED,
 }
@@ -87,17 +86,9 @@ pub trait TaskRuntime {
     /// update the runtime calculation at this point.
     fn schedule_out(&mut self);
 
-    /// Returns whether this is the first time a task has been
-    /// considered for scheduling.
-    fn first(&self) -> bool;
-
     /// Overrides the calculated runtime value with the given value.
     /// This can be used to set or adjust the runtime of a task.
     fn set(&mut self, runtime: u64);
-
-    /// Flag the runtime as terminated so the scheduler does not
-    /// find terminated tasks before running tasks.
-    fn terminated(&mut self);
 
     /// Returns a value that represents the amount of CPU the task
     /// has been allocated
@@ -120,16 +111,8 @@ impl TaskRuntime for TscRuntime {
         self.runtime += rdtsc() - self.runtime;
     }
 
-    fn first(&self) -> bool {
-        self.runtime == 0
-    }
-
     fn set(&mut self, runtime: u64) {
         self.runtime = runtime;
-    }
-
-    fn terminated(&mut self) {
-        self.runtime = u64::MAX;
     }
 
     fn value(&self) -> u64 {
@@ -152,16 +135,8 @@ impl TaskRuntime for CountRuntime {
 
     fn schedule_out(&mut self) {}
 
-    fn first(&self) -> bool {
-        self.count == 0
-    }
-
     fn set(&mut self, runtime: u64) {
         self.count = runtime;
-    }
-
-    fn terminated(&mut self) {
-        self.count = u64::MAX;
     }
 
     fn value(&self) -> u64 {

--- a/src/task/tasks.rs
+++ b/src/task/tasks.rs
@@ -198,6 +198,10 @@ pub struct Task {
     /// u32:  The APIC ID of the CPU that the task must run on
     pub affinity: Option<u32>,
 
+    // APIC ID of the CPU that task has been assigned to. If 'None' then
+    // the task is not currently assigned to a CPU
+    pub allocation: Option<u32>,
+
     /// ID of the task
     pub id: u32,
 
@@ -239,6 +243,7 @@ impl Task {
             vm_kernel_range,
             state: TaskState::RUNNING,
             affinity: None,
+            allocation: None,
             id: TASK_ID_ALLOCATOR.next_id(),
             runtime: TaskRuntimeImpl::default(),
         });

--- a/src/task/tasks.rs
+++ b/src/task/tasks.rs
@@ -23,6 +23,8 @@ use crate::mm::pagetable::{get_init_pgtable_locked, PTEntryFlags, PageTableRef};
 use crate::mm::vm::{Mapping, VMKernelStack, VMR};
 use crate::mm::{SVSM_PERTASK_BASE, SVSM_PERTASK_END, SVSM_PERTASK_STACK_BASE};
 
+use super::schedule::{current_task_terminated, schedule};
+
 pub const INITIAL_TASK_ID: u32 = 1;
 
 #[derive(PartialEq, Debug, Copy, Clone, Default)]
@@ -293,7 +295,10 @@ impl Task {
 }
 
 extern "C" fn task_exit() {
-    panic!("Current task has exited");
+    unsafe {
+        current_task_terminated();
+    }
+    schedule();
 }
 
 #[allow(unused)]

--- a/src/task/tasks.rs
+++ b/src/task/tasks.rs
@@ -152,6 +152,7 @@ type TaskRuntimeImpl = CountRuntime;
 #[repr(C)]
 #[derive(Default, Debug)]
 pub struct TaskContext {
+    pub rsp: u64,
     pub regs: X86GeneralRegs,
     pub flags: u64,
     pub ret_addr: u64,
@@ -341,6 +342,7 @@ global_asm!(
         pushq   %r13
         pushq   %r14
         pushq   %r15
+        pushq   %rsp
         
         // Save the current stack pointer
         testq   %rsi, %rsi
@@ -356,9 +358,13 @@ global_asm!(
         // Switch to the new task stack
         movq    (%rbx), %rsp
 
+        // We've already restored rsp
+        addq        $8, %rsp
+
         mov         %rbx, %rdi
         call        on_switch
 
+        // Restore the task context
         popq        %r15
         popq        %r14
         popq        %r13


### PR DESCRIPTION
This PR builds on the merged task switching PR https://github.com/coconut-svsm/svsm/pull/61 and also the draft scheduler PR https://github.com/coconut-svsm/svsm/pull/50 to add scheduling support to coconut-SVSM.

Two different task lists have been implemented in task/schedule:

* Firstly all newly created tasks are added to a simple doubly-linked list where they remain until the task is terminated and subsequently closed. An instance of the tasklist is provided globally and can be used to determine the status of every task.

* Secondly, an RB tree based list is implemented that sorts tasks based on their calculated execution time. The shortest running task and hence the highest priority task for scheduling is leftmost on the tree. Each CPU creates an instance of the RB tree named `runqueue` which maintains all tasks in RUNNING state that should share time from the allocated CPU.

Currently, there is no load balancing for migrating tasks between each CPU, instead each time a task is created the newly created task is allocated to the currently running CPU.

The entry point for every vCPU in the VM has been converted to launch using tasks.