### PR TITLE
fs: fix clippy warning

### DIFF
--- a/src/fs/filesystem.rs
+++ b/src/fs/filesystem.rs
@@ -262,7 +262,7 @@ pub fn read(fh: &FileHandle, buf: &mut [u8]) -> Result<usize, SvsmError> {
     fh.read(buf)
 }
 
-pub fn write(fh: &FileHandle, buf: &mut [u8]) -> Result<usize, SvsmError> {
+pub fn write(fh: &FileHandle, buf: &[u8]) -> Result<usize, SvsmError> {
     fh.write(buf)
 }
 


### PR DESCRIPTION
Fix a new clippy warning that comes up with the latest nightly toolchain:

```
warning: this argument is a mutable reference, but not used mutably
   --> src/fs/filesystem.rs:265:36
    |
265 | pub fn write(fh: &FileHandle, buf: &mut [u8]) -> Result<usize, SvsmError> {
    |                                    ^^^^^^^^^ help: consider changing to: `&[u8]`
    |
    = warning: changing this function will impact semver compatibility
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_ref_mut
    = note: `#[warn(clippy::needless_pass_by_ref_mut)]` on by default
```