### PR TITLE
scripts: Build the svsm.bin from a container

### DIFF
--- a/scripts/docker/build.sh
+++ b/scripts/docker/build.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+CURDIR=$(dirname $(realpath "$0"))
+WORKDIR=$(realpath ${CURDIR}/../..)
+DOCKER_FILE=$WORKDIR/scripts/docker/opensuse-rust.docker
+
+IMAGE_NAME=opensuse-rust
+CONTAINER_NAME=coconut-build
+
+# Command line arguments
+ARG_REUSE=0
+
+####
+#### Help function
+####
+Help()
+{
+    echo "Build the SVSM within a container."
+    echo
+    echo "Syntax: $0 [-r|v|h]"
+    echo "options:"
+    echo "r    Reuse the ${CONTAINER_NAME} to build the SVSM"
+    echo "v    Verbose mode"
+    echo "h    Print this help"
+}
+
+####
+#### ParseOptions function
+####
+ParseOptions()
+{
+    while getopts "rvh" option; do
+        case $option in
+            r) # Reuse option
+                ARG_REUSE=1
+                ;;
+            v) # Verbose mode
+                set -x
+                ;;
+            h) # Display help
+                Help
+                exit
+                ;;
+            \?) # Invalid option
+                echo -e "ERR: Invalid option\n"
+                Help
+                exit
+                ;;
+        esac
+    done
+}
+
+####
+#### Reuse container to build the SVSM
+####
+BuildSvsmReuse()
+{
+    CONTAINER_ID=$(docker ps -q -f name=${CONTAINER_NAME})
+
+    # Create and start the the container if it's not running
+    if [ -z ${CONTAINER_ID} ] ; then
+
+        CONTAINER_ID=$(docker ps -q -f name=coconut-build)
+
+        if [ -z ${CONTAINER_ID} ] ; then
+            docker create \
+                -it --name=${CONTAINER_NAME} \
+                --workdir=${WORKDIR} \
+                --user ${USER} \
+                --mount type=bind,source=${WORKDIR},target=${WORKDIR} \
+                ${IMAGE_NAME} \
+                /bin/bash
+        fi
+
+        docker start ${CONTAINER_NAME}
+    fi
+
+    docker exec \
+        -it ${CONTAINER_NAME} \
+        /bin/bash -c "source $HOME/.cargo/env && make clean && make"
+}
+
+####
+#### Build the SVSM in the container, but delete the container afterwards
+####
+BuildSvsmDelete()
+{
+    docker run \
+        --rm -it \
+        --workdir=${WORKDIR} \
+        --user ${USER} \
+        --mount type=bind,source=${WORKDIR},target=${WORKDIR} \
+        ${IMAGE_NAME} \
+        /bin/bash -c "source $HOME/.cargo/env && make clean && make"
+}
+
+####
+#### Build the docker image
+####
+BuildDockerImage()
+{
+    IMAGE_ID=$(docker images -q ${IMAGE_NAME})
+
+    # Build the container image if it's the first time
+    if [ -z ${IMAGE_ID} ] ; then
+        docker build -t ${IMAGE_NAME} --build-arg USER_NAME=${USER} --build-arg USER_ID=$(id -u) -f ${DOCKER_FILE} .
+    fi
+}
+
+####
+#### Main block
+####
+
+if ! command -v docker &> /dev/null ; then
+    echo "ERR: docker not found"
+    exit
+fi
+
+ParseOptions $@
+
+BuildDockerImage
+
+if [ $ARG_REUSE -eq 1 ] ; then
+    BuildSvsmReuse
+else
+    BuildSvsmDelete
+fi

--- a/scripts/docker/opensuse-rust.docker
+++ b/scripts/docker/opensuse-rust.docker
@@ -1,0 +1,22 @@
+# Usage example:
+#
+# git clone https://github.com/coconut-svsm/svsm.git
+# cd svsm
+# ./scripts/docker/build.sh 
+
+FROM opensuse/tumbleweed:latest
+LABEL Description="OpenSUSE environment for coconut-svsm build"
+
+ARG USER_ID 1000
+ARG USER_NAME user
+
+SHELL ["/bin/bash", "-c"]
+
+RUN zypper ref && \
+    zypper install -y system-user-mail make gcc curl && \
+    useradd -u $USER_ID -m $USER_NAME
+
+USER $USER_NAME
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/rustup-init.sh && \
+    sh /tmp/rustup-init.sh --default-toolchain nightly-x86_64-unknown-linux-gnu --component rust-src -y


### PR DESCRIPTION
I have seem people asking about a script to build the SVSM from a container (Issue #65)as the build process depends on a recent binutils. 

This PR add scripts to build the project from a docker container. This can be useful for multiple situations e.g., build it for a CI, quick build the SVSM, or build it from a fresh environment for debugging. 

$ ./scripts/docker/build.sh

The script will not stop the container created since there is a chance it can be used again in a short term.