### PR TITLE
Page tables: Support heap allocation and page-table freeing

### DIFF
--- a/src/mm/pagetable.rs
+++ b/src/mm/pagetable.rs
@@ -197,6 +197,12 @@ pub struct PageTable {
     root: PTPage,
 }
 
+impl Drop for PageTable {
+    fn drop(&mut self) {
+        self.free();
+    }
+}
+
 impl PageTable {
     pub fn load(&self) {
         write_cr3(self.cr3_value());


### PR DESCRIPTION
This implements the pieces to free page-tables and support allocation/de-allocation on the heap.