### PR TITLE
Update `bitflags` crate to 2.4.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,4 +46,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-features -- -D warnings -A clippy::bad_bit_mask
+          args: --all-features -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -32,7 +38,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4e02bf1b1a624d96925c608f1b268d82a76cbc587ce9e59f7c755e9ea11c75c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "log",
  "managed",
@@ -107,7 +113,7 @@ dependencies = [
 name = "svsm"
 version = "0.1.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.0",
  "gdbstub",
  "gdbstub_arch",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ test = true
 doctest = false
 
 [dependencies]
-bitflags = "1.3.2"
+bitflags = "2.4"
 gdbstub = { version = "0.6.6", default-features = false, optional = true }
 gdbstub_arch = { version = "0.2.4", optional = true }
 log = { version = "0.4.17", features = ["max_level_info", "release_max_level_info"] }

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -37,7 +37,7 @@ for file in `git diff --name-only --staged`; do
     fi
 done
 
-cargo clippy --all-features -- -D warnings -A clippy::bad_bit_mask || exit 1
+cargo clippy --all-features -- -D warnings || exit 1
 
 exit $RET
 

--- a/src/elf/mod.rs
+++ b/src/elf/mod.rs
@@ -777,6 +777,7 @@ pub struct Elf64Phdr {
 }
 
 bitflags! {
+    #[derive(Debug)]
     pub struct Elf64PhdrFlags : Elf64Word {
         const EXECUTE = 0x01;
         const WRITE   = 0x02;
@@ -866,6 +867,7 @@ pub struct Elf64Shdr {
 }
 
 bitflags! {
+    #[derive(Debug)]
     pub struct Elf64ShdrFlags : Elf64Xword {
         const WRITE            = 0x001;
         const ALLOC            = 0x002;

--- a/src/mm/pagetable.rs
+++ b/src/mm/pagetable.rs
@@ -108,6 +108,7 @@ fn set_c_bit(paddr: PhysAddr) -> PhysAddr {
 }
 
 bitflags! {
+    #[derive(Copy, Clone)]
     pub struct PTEntryFlags: u64 {
         const PRESENT       = 1 << 0;
         const WRITABLE      = 1 << 1;

--- a/src/sev/status.rs
+++ b/src/sev/status.rs
@@ -11,6 +11,7 @@ use core::fmt::{self, Write};
 use log;
 
 bitflags! {
+    #[derive(Copy, Clone, PartialEq, Eq)]
     pub struct SEVStatusFlags: u64 {
         const SEV           = 1 << 0;
         const SEV_ES        = 1 << 1;

--- a/src/sev/utils.rs
+++ b/src/sev/utils.rs
@@ -4,9 +4,6 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
-// For bitflags definitions
-#![allow(clippy::bad_bit_mask)]
-
 use crate::address::{Address, VirtAddr};
 use crate::error::SvsmError;
 use crate::types::{GUEST_VMPL, PAGE_SIZE, PAGE_SIZE_2M};

--- a/src/sev/utils.rs
+++ b/src/sev/utils.rs
@@ -141,8 +141,8 @@ bitflags::bitflags! {
         const X_SUPER = 1u64 << 11;
         const BIT_VMSA = 1u64 << 16;
         const NONE = 0;
-        const RWX = Self::READ.bits | Self::WRITE.bits | Self::X_USER.bits | Self::X_SUPER.bits;
-        const VMSA = Self::READ.bits | Self::BIT_VMSA.bits;
+        const RWX = Self::READ.bits() | Self::WRITE.bits() | Self::X_USER.bits() | Self::X_SUPER.bits();
+        const VMSA = Self::READ.bits() | Self::BIT_VMSA.bits();
     }
 }
 


### PR DESCRIPTION
Commit a94d48d ("SVSM/sev/utils: Suppress clippy::bad_bit_mask errors") was necessary because we use an older version of bitflags. As suggested in this [1] bitflags issue, let's switch to the latest version available. In this way we can avoid to suppress clippy::bad_bit_mask.

Just minor adjustments are needed to support bitflags 2.4.0.

[1] https://github.com/bitflags/bitflags/pull/373