### PR TITLE
rust-toolchain.toml: set "x86_64-unknown-none" target

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "stable"
+targets = [ "x86_64-unknown-none" ]


### PR DESCRIPTION
By specifying the target, rustup will automatically install the necessary toolchain if it is not present when we invoke cargo.

Suggested-by: Tom Dohrmann <erbse.13@gmx.de>