### PR TITLE
scripts/docker: fix reuse option

### DIFF
--- a/scripts/docker/build.sh
+++ b/scripts/docker/build.sh
@@ -60,7 +60,7 @@ BuildSvsmReuse()
     # Create and start the the container if it's not running
     if [ -z ${CONTAINER_ID} ] ; then
 
-        CONTAINER_ID=$(docker ps -q -f name=coconut-build)
+        CONTAINER_ID=$(docker ps -q -a -f name=${CONTAINER_NAME})
 
         if [ -z ${CONTAINER_ID} ] ; then
             docker create \


### PR DESCRIPTION
Using option "-r" the script uses a pre-created container. If the container was already created but it is stopped, the script is failing whit the following error:

  the container name "coconut-build" is already in use by ...

Let's add "-a" option to "docker ps" to list all containers, not only the running ones.
Since we are editing this line, let's also use the CONTAINER_NAME variable for the container name.