### PR TITLE
SVSM/scripts: Remove unstable rustfmt parameters from pre-commit

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -25,7 +25,7 @@ RET=0
 for file in `git diff --name-only --staged`; do
     ext=${file##*.}
     if [ "$ext" == "rs" ]; then
-        rustfmt --unstable-features --check --edition 2021 --skip-children $file > /dev/null 2>&1
+        rustfmt --check --edition 2021 $file > /dev/null 2>&1
         if [ "$?" == "1" ]; then
             echo "$file needs rustfmt checking"
             RET=1


### PR DESCRIPTION
After the switch to stable rust the rustfmt checks triggered by the pre-commit script fail because rustfmt is invoked with parameters not available in stable rust. Remove these parameters to make the checks succeed again.