### PR TITLE
spinlock: remove unlock()

### DIFF
--- a/src/locking/spinlock.rs
+++ b/src/locking/spinlock.rs
@@ -88,8 +88,4 @@ impl<T: Debug> SpinLock<T> {
 
         None
     }
-
-    pub fn unlock(&mut self) {
-        self.holder.fetch_add(1, Ordering::Release);
-    }
 }


### PR DESCRIPTION
Remove Spinlock::unlock() because it bypasses the RAII lock tracking logic of LockGuard.  This function is not used anywhere anyway.

The only way to lock the SpinLock is by acquiring a LockGuard instance via lock() or try_lock().  LockGuard automatically releases the lock when dropped.  There is no need for unlock(), it just allows messing up the holder counting.