### PR TITLE
Makefile: add missing targets to clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,6 @@ svsm.bin: stage1/stage1
 
 clean:
 	cargo clean
-	rm -f stage1/stage2.bin svsm.bin stage1/meta.bin ${STAGE1_OBJS} gen_meta
+	rm -f stage1/stage2.bin svsm.bin stage1/meta.bin stage1/kernel.elf stage1/stage1 stage1/svsm-fs.bin ${STAGE1_OBJS} utils/gen_meta utils/print-meta
 
 .PHONY: stage1/stage2.bin stage1/kernel.elf svsm.bin clean stage1/svsm-fs.bin


### PR DESCRIPTION
The following targets were not being removed by `make clean`:
    $ git check-ignore -v */*
    .gitignore:3:*.elf	stage1/kernel.elf
    .gitignore:8:stage1/stage1	stage1/stage1
    .gitignore:2:*.bin	stage1/svsm-fs.bin
    .gitignore:7:gen_meta	utils/gen_meta
    .gitignore:9:print-meta	utils/print-meta