### PR TITLE
SVSM: Increase boot-stack size

### DIFF
--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -87,7 +87,7 @@ global_asm!(
 
         .align 4096
     bsp_stack:
-        .fill 8192, 1, 0
+        .fill 4*4096, 1, 0
     bsp_stack_end:
 
         .align 4096


### PR DESCRIPTION
The 8 KiB of boot stack are not enough anymore after the switch to stable rust. Especially in debug builds the stack usage is higher. The maximum value I measured so far was 9608 bytes, which leads to early boot crashes. Increase the boot stack size to 16 KiB to be on the safe side.

Fixes: Github issue #90