### PR TITLE
tests: fix doctests and run in Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ all: svsm.bin
 
 test:
 	cargo test --target=x86_64-unknown-linux-gnu
+	RUSTFLAGS="--cfg doctest" cargo test --target=x86_64-unknown-linux-gnu --doc
 
 utils/gen_meta: utils/gen_meta.c
 	cc -O3 -Wall -o $@ $<

--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -1282,7 +1282,7 @@ unsafe impl GlobalAlloc for SvsmAllocator {
     }
 }
 
-#[cfg_attr(not(test), global_allocator)]
+#[cfg_attr(not(any(test, doctest)), global_allocator)]
 pub static mut ALLOCATOR: SvsmAllocator = SvsmAllocator::new();
 
 pub fn root_mem_init(pstart: PhysAddr, vstart: VirtAddr, page_count: usize) {

--- a/src/utils/immut_after_init.rs
+++ b/src/utils/immut_after_init.rs
@@ -203,27 +203,8 @@ unsafe impl<T> Sync for ImmutAfterInitCell<T> {}
 /// }
 /// ```
 ///
-/// Also, a `ImmutAfterInitRef` can get initialized by dereferencing another,
-/// possibly temporary `ImmutAfterInitRef`, with the temporary again either
-/// dereferencing a [`ImmutAfterInitCell`]'s contents,
-/// ```
-/// # use svsm::utils::immut_after_init::{ImmutAfterInitCell, ImmutAfterInitRef};
-/// static RX : ImmutAfterInitRef::<'static, i32> = ImmutAfterInitRef::uninit();
-///
-/// fn init_rx(r : ImmutAfterInitRef<'static, i32>) {
-///     unsafe { RX.init_from_ref(r.get()) };
-/// }
-///
-/// static X : ImmutAfterInitCell<i32> = ImmutAfterInitCell::uninit();
-///
-/// fn main() {
-///     unsafe { X.init(&123) };
-///
-///     init_rx(ImmutAfterInitRef::new_from_cell(&X));
-///     assert_eq!(*RX, 123);
-/// }
-/// ```
-/// or a plain value directly:
+/// Also, an `ImmutAfterInitRef` can be initialized by obtaining a reference
+/// from another `ImmutAfterInitRef`:
 /// ```
 /// # use svsm::utils::immut_after_init::ImmutAfterInitRef;
 /// static RX : ImmutAfterInitRef::<'static, i32> = ImmutAfterInitRef::uninit();


### PR DESCRIPTION
Our custom bare-metal allocator (`SvsmAllocator`) does not work during tests, as they run as regular userspace binaries. Thus, we must not set it as the global Rust allocator. To do this, we need a compile-time directive that lets us know we are building doctests and not the regular binary (`cfg(doctests)`), but sadly it is not properly set during test compilation (see rust-lang/rust#45599, rust-lang/rust#67295 and coconut-svsm/svsm#93).

In order to bypass this, set the compile time flag ourselves via the `RUSTFLAGS` environment variable so that tests work. Also add the new invocation to the `test` target in the Makefile.

Closes #93 