### PR TITLE
Fixes+cleanups

### DIFF
--- a/src/cpu/idt.rs
+++ b/src/cpu/idt.rs
@@ -147,6 +147,18 @@ fn load_idt(idt: &Idt) {
     }
 }
 
+pub fn triple_fault() {
+    let desc: IdtDesc = IdtDesc {
+        size: 0,
+        address: VirtAddr::from(0u64),
+    };
+
+    unsafe {
+        asm!("lidt (%rax)
+              int3", in("rax") &desc, options(att_syntax));
+    }
+}
+
 pub fn early_idt_init() {
     unsafe {
         init_idt(&mut GLOBAL_IDT);

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -52,8 +52,6 @@ fn setup_stage2_allocator() {
     root_mem_init(pstart, vstart, nr_pages);
 }
 
-pub static mut PERCPU: PerCpu = PerCpu::new();
-
 fn init_percpu() {
     unsafe {
         let bsp_percpu = PerCpu::alloc(0)
@@ -69,11 +67,9 @@ fn init_percpu() {
 }
 
 fn shutdown_percpu() {
-    unsafe {
-        PERCPU
-            .shutdown()
-            .expect("Failed to shut down percpu data (including GHCB)");
-    }
+    this_cpu_mut()
+        .shutdown()
+        .expect("Failed to shut down percpu data (including GHCB)");
 }
 
 static CONSOLE_IO: SVSMIOPort = SVSMIOPort::new();

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -101,8 +101,6 @@ global_asm!(
 static CPUID_PAGE: ImmutAfterInitCell<SnpCpuidTable> = ImmutAfterInitCell::uninit();
 static LAUNCH_INFO: ImmutAfterInitCell<KernelLaunchInfo> = ImmutAfterInitCell::uninit();
 
-pub static mut PERCPU: PerCpu = PerCpu::new();
-
 fn copy_cpuid_table_to_fw(fw_addr: PhysAddr) -> Result<(), SvsmError> {
     let guard = PerCPUPageMappingGuard::create_4k(fw_addr)?;
     let start = guard.virt_addr();


### PR DESCRIPTION
A couple of small fixes and cleanup. One patch also adds a new triple_fault() helper which is unused by default. But it can be used during debugging.