### PR TITLE
types: explicitly type page size parameters

### DIFF
--- a/src/fw_meta.rs
+++ b/src/fw_meta.rs
@@ -12,7 +12,7 @@ use crate::error::SvsmError;
 use crate::mm::PerCPUPageMappingGuard;
 use crate::mm::SIZE_1G;
 use crate::sev::ghcb::PageStateChangeOp;
-use crate::sev::{pvalidate, rmp_adjust, RMPFlags};
+use crate::sev::{pvalidate, rmp_adjust, PvalidateOp, RMPFlags};
 use crate::types::{PageSize, PAGE_SIZE};
 use crate::utils::{overlap, zero_mem_region};
 use alloc::vec::Vec;
@@ -414,7 +414,7 @@ fn validate_fw_mem_region(region: SevPreValidMem) -> Result<(), SvsmError> {
         let guard = PerCPUPageMappingGuard::create_4k(paddr)?;
         let vaddr = guard.virt_addr();
 
-        pvalidate(vaddr, PageSize::Regular, true)?;
+        pvalidate(vaddr, PageSize::Regular, PvalidateOp::Valid)?;
 
         // Make page accessible to guest VMPL
         rmp_adjust(

--- a/src/protocols/core.rs
+++ b/src/protocols/core.rs
@@ -18,7 +18,7 @@ use crate::sev::utils::{
     rmp_set_guest_vmsa, RMPFlags, SevSnpError,
 };
 use crate::sev::vmsa::VMSA;
-use crate::types::{PAGE_SIZE, PAGE_SIZE_2M};
+use crate::types::{PageSize, PAGE_SIZE, PAGE_SIZE_2M};
 use crate::utils::zero_mem_region;
 
 const SVSM_REQ_CORE_REMAP_CA: u32 = 0;
@@ -198,8 +198,8 @@ fn core_configure_vtom(params: &mut RequestParams) -> Result<(), SvsmReqError> {
 
 fn core_pvalidate_one(entry: u64, flush: &mut bool) -> Result<(), SvsmReqError> {
     let (page_size_bytes, valign, huge) = match entry & 3 {
-        0 => (PAGE_SIZE, VIRT_ALIGN_4K, false),
-        1 => (PAGE_SIZE_2M, VIRT_ALIGN_2M, true),
+        0 => (PAGE_SIZE, VIRT_ALIGN_4K, PageSize::Regular),
+        1 => (PAGE_SIZE_2M, VIRT_ALIGN_2M, PageSize::Huge),
         _ => return Err(SvsmReqError::invalid_parameter()),
     };
 

--- a/src/sev/ghcb.rs
+++ b/src/sev/ghcb.rs
@@ -16,7 +16,7 @@ use crate::mm::validate::{
 use crate::mm::virt_to_phys;
 use crate::sev::sev_snp_enabled;
 use crate::sev::utils::raw_vmgexit;
-use crate::types::{PAGE_SIZE, PAGE_SIZE_2M};
+use crate::types::{PageSize, PAGE_SIZE_2M};
 use core::cell::RefCell;
 use core::{mem, ptr};
 
@@ -143,7 +143,7 @@ impl GHCB {
 
         if sev_snp_enabled() {
             // Make page invalid
-            pvalidate(vaddr, false, false)?;
+            pvalidate(vaddr, PageSize::Regular, false)?;
 
             // Let the Hypervisor take the page back
             invalidate_page_msr(paddr)?;
@@ -184,7 +184,7 @@ impl GHCB {
         validate_page_msr(paddr)?;
 
         // Make page guest-valid
-        pvalidate(vaddr, false, true)?;
+        pvalidate(vaddr, PageSize::Regular, true)?;
 
         // Needs guarding for Stage2 GHCB
         if valid_bitmap_valid_addr(paddr) {
@@ -375,12 +375,18 @@ impl GHCB {
         Ok(())
     }
 
-    pub fn psc_entry(&self, paddr: PhysAddr, op_mask: u64, current_page: u64, huge: bool) -> u64 {
-        assert!(!huge || paddr.is_aligned(PAGE_SIZE_2M));
+    pub fn psc_entry(
+        &self,
+        paddr: PhysAddr,
+        op_mask: u64,
+        current_page: u64,
+        size: PageSize,
+    ) -> u64 {
+        assert!(size == PageSize::Regular || paddr.is_aligned(PAGE_SIZE_2M));
 
         let mut entry: u64 =
             ((paddr.bits() as u64) & PSC_GFN_MASK) | op_mask | (current_page & 0xfffu64);
-        if huge {
+        if size == PageSize::Huge {
             entry |= PSC_FLAG_HUGE;
         }
 
@@ -391,7 +397,7 @@ impl GHCB {
         &mut self,
         start: PhysAddr,
         end: PhysAddr,
-        huge: bool,
+        size: PageSize,
         op: PageStateChangeOp,
     ) -> Result<(), SvsmError> {
         // Maximum entries (8 bytes each_ minus 8 bytes for header
@@ -408,12 +414,16 @@ impl GHCB {
         self.clear();
 
         while paddr < end {
-            let huge = huge && paddr.is_aligned(PAGE_SIZE_2M) && paddr + PAGE_SIZE_2M <= end;
-            let pgsize: usize = match huge {
-                true => PAGE_SIZE_2M,
-                false => PAGE_SIZE,
+            let size = if size == PageSize::Huge
+                && paddr.is_aligned(PAGE_SIZE_2M)
+                && paddr + PAGE_SIZE_2M <= end
+            {
+                PageSize::Huge
+            } else {
+                PageSize::Regular
             };
-            let entry = self.psc_entry(paddr, op_mask, 0, huge);
+            let pgsize = usize::from(size);
+            let entry = self.psc_entry(paddr, op_mask, 0, size);
             let offset: isize = (entries as isize) * 8 + 8;
             self.write_buffer(&entry, offset)?;
             entries += 1;

--- a/src/sev/ghcb.rs
+++ b/src/sev/ghcb.rs
@@ -23,7 +23,7 @@ use core::{mem, ptr};
 use super::msr_protocol::{
     invalidate_page_msr, register_ghcb_gpa_msr, request_termination_msr, validate_page_msr,
 };
-use super::pvalidate;
+use super::{pvalidate, PvalidateOp};
 
 // TODO: Fix this when Rust gets decent compile time struct offset support
 const OFF_CPL: u16 = 0xcb;
@@ -143,7 +143,7 @@ impl GHCB {
 
         if sev_snp_enabled() {
             // Make page invalid
-            pvalidate(vaddr, PageSize::Regular, false)?;
+            pvalidate(vaddr, PageSize::Regular, PvalidateOp::Invalid)?;
 
             // Let the Hypervisor take the page back
             invalidate_page_msr(paddr)?;
@@ -184,7 +184,7 @@ impl GHCB {
         validate_page_msr(paddr)?;
 
         // Make page guest-valid
-        pvalidate(vaddr, PageSize::Regular, true)?;
+        pvalidate(vaddr, PageSize::Regular, PvalidateOp::Valid)?;
 
         // Needs guarding for Stage2 GHCB
         if valid_bitmap_valid_addr(paddr) {

--- a/src/sev/mod.rs
+++ b/src/sev/mod.rs
@@ -15,5 +15,5 @@ pub mod utils;
 pub use status::sev_status_init;
 pub use status::sev_status_verify;
 pub use status::{sev_es_enabled, sev_snp_enabled};
-pub use utils::{pvalidate, pvalidate_range, SevSnpError};
+pub use utils::{pvalidate, pvalidate_range, PvalidateOp, SevSnpError};
 pub use utils::{rmp_adjust, RMPFlags};

--- a/src/sev/utils.rs
+++ b/src/sev/utils.rs
@@ -50,7 +50,7 @@ impl fmt::Display for SevSnpError {
     }
 }
 
-fn pvalidate_range_4k(start: VirtAddr, end: VirtAddr, valid: bool) -> Result<(), SvsmError> {
+fn pvalidate_range_4k(start: VirtAddr, end: VirtAddr, valid: PvalidateOp) -> Result<(), SvsmError> {
     for addr in (start.bits()..end.bits())
         .step_by(PAGE_SIZE)
         .map(VirtAddr::from)
@@ -61,7 +61,11 @@ fn pvalidate_range_4k(start: VirtAddr, end: VirtAddr, valid: bool) -> Result<(),
     Ok(())
 }
 
-pub fn pvalidate_range(start: VirtAddr, end: VirtAddr, valid: bool) -> Result<(), SvsmError> {
+pub fn pvalidate_range(
+    start: VirtAddr,
+    end: VirtAddr,
+    valid: PvalidateOp,
+) -> Result<(), SvsmError> {
     let mut addr = start;
 
     while addr < end {
@@ -84,7 +88,15 @@ pub fn pvalidate_range(start: VirtAddr, end: VirtAddr, valid: bool) -> Result<()
     Ok(())
 }
 
-pub fn pvalidate(vaddr: VirtAddr, size: PageSize, valid: bool) -> Result<(), SvsmError> {
+/// The desired state of the page passed to PVALIDATE.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u64)]
+pub enum PvalidateOp {
+    Invalid = 0,
+    Valid = 1,
+}
+
+pub fn pvalidate(vaddr: VirtAddr, size: PageSize, valid: PvalidateOp) -> Result<(), SvsmError> {
     let rax = vaddr.bits();
     let rcx: u64 = match size {
         PageSize::Regular => 0,

--- a/src/sev/utils.rs
+++ b/src/sev/utils.rs
@@ -6,7 +6,7 @@
 
 use crate::address::{Address, VirtAddr};
 use crate::error::SvsmError;
-use crate::types::{GUEST_VMPL, PAGE_SIZE, PAGE_SIZE_2M};
+use crate::types::{PageSize, GUEST_VMPL, PAGE_SIZE, PAGE_SIZE_2M};
 use core::arch::asm;
 use core::fmt;
 
@@ -55,7 +55,7 @@ fn pvalidate_range_4k(start: VirtAddr, end: VirtAddr, valid: bool) -> Result<(),
         .step_by(PAGE_SIZE)
         .map(VirtAddr::from)
     {
-        pvalidate(addr, false, valid)?;
+        pvalidate(addr, PageSize::Regular, valid)?;
     }
 
     Ok(())
@@ -68,7 +68,7 @@ pub fn pvalidate_range(start: VirtAddr, end: VirtAddr, valid: bool) -> Result<()
         if addr.is_aligned(PAGE_SIZE_2M) && addr + PAGE_SIZE_2M <= end {
             // Try to validate as a huge page.
             // If we fail, try to fall back to regular-sized pages.
-            pvalidate(addr, true, valid).or_else(|err| match err {
+            pvalidate(addr, PageSize::Huge, valid).or_else(|err| match err {
                 SvsmError::SevSnp(SevSnpError::FAIL_SIZEMISMATCH(_)) => {
                     pvalidate_range_4k(addr, addr + PAGE_SIZE_2M, valid)
                 }
@@ -76,7 +76,7 @@ pub fn pvalidate_range(start: VirtAddr, end: VirtAddr, valid: bool) -> Result<()
             })?;
             addr = addr + PAGE_SIZE_2M;
         } else {
-            pvalidate(addr, false, valid)?;
+            pvalidate(addr, PageSize::Regular, valid)?;
             addr = addr + PAGE_SIZE;
         }
     }
@@ -84,9 +84,12 @@ pub fn pvalidate_range(start: VirtAddr, end: VirtAddr, valid: bool) -> Result<()
     Ok(())
 }
 
-pub fn pvalidate(vaddr: VirtAddr, huge_page: bool, valid: bool) -> Result<(), SvsmError> {
+pub fn pvalidate(vaddr: VirtAddr, size: PageSize, valid: bool) -> Result<(), SvsmError> {
     let rax = vaddr.bits();
-    let rcx = huge_page as u64;
+    let rcx: u64 = match size {
+        PageSize::Regular => 0,
+        PageSize::Huge => 1,
+    };
     let rdx = valid as u64;
     let ret: u64;
     let cf: u64;
@@ -143,8 +146,11 @@ bitflags::bitflags! {
     }
 }
 
-pub fn rmp_adjust(addr: VirtAddr, flags: RMPFlags, huge: bool) -> Result<(), SvsmError> {
-    let rcx: usize = if huge { 1 } else { 0 };
+pub fn rmp_adjust(addr: VirtAddr, flags: RMPFlags, size: PageSize) -> Result<(), SvsmError> {
+    let rcx: u64 = match size {
+        PageSize::Regular => 0,
+        PageSize::Huge => 1,
+    };
     let rax: u64 = addr.bits() as u64;
     let rdx: u64 = flags.bits();
     let mut ret: u64;
@@ -182,24 +188,28 @@ pub fn rmp_adjust(addr: VirtAddr, flags: RMPFlags, huge: bool) -> Result<(), Svs
     }
 }
 
-pub fn rmp_revoke_guest_access(vaddr: VirtAddr, huge: bool) -> Result<(), SvsmError> {
+pub fn rmp_revoke_guest_access(vaddr: VirtAddr, size: PageSize) -> Result<(), SvsmError> {
     for vmpl in RMPFlags::GUEST_VMPL.bits()..=RMPFlags::VMPL3.bits() {
         let vmpl = RMPFlags::from_bits_truncate(vmpl);
-        rmp_adjust(vaddr, vmpl | RMPFlags::NONE, huge)?;
+        rmp_adjust(vaddr, vmpl | RMPFlags::NONE, size)?;
     }
     Ok(())
 }
 
-pub fn rmp_grant_guest_access(vaddr: VirtAddr, huge: bool) -> Result<(), SvsmError> {
-    rmp_adjust(vaddr, RMPFlags::GUEST_VMPL | RMPFlags::RWX, huge)
+pub fn rmp_grant_guest_access(vaddr: VirtAddr, size: PageSize) -> Result<(), SvsmError> {
+    rmp_adjust(vaddr, RMPFlags::GUEST_VMPL | RMPFlags::RWX, size)
 }
 
 pub fn rmp_set_guest_vmsa(vaddr: VirtAddr) -> Result<(), SvsmError> {
-    rmp_revoke_guest_access(vaddr, false)?;
-    rmp_adjust(vaddr, RMPFlags::GUEST_VMPL | RMPFlags::VMSA, false)
+    rmp_revoke_guest_access(vaddr, PageSize::Regular)?;
+    rmp_adjust(
+        vaddr,
+        RMPFlags::GUEST_VMPL | RMPFlags::VMSA,
+        PageSize::Regular,
+    )
 }
 
 pub fn rmp_clear_guest_vmsa(vaddr: VirtAddr) -> Result<(), SvsmError> {
-    rmp_revoke_guest_access(vaddr, false)?;
-    rmp_grant_guest_access(vaddr, false)
+    rmp_revoke_guest_access(vaddr, PageSize::Regular)?;
+    rmp_grant_guest_access(vaddr, PageSize::Regular)
 }

--- a/src/sev/vmsa.rs
+++ b/src/sev/vmsa.rs
@@ -8,7 +8,7 @@ use super::utils::{rmp_adjust, RMPFlags};
 use crate::address::{Address, VirtAddr};
 use crate::error::SvsmError;
 use crate::mm::alloc::{allocate_pages, free_page};
-use crate::types::{PAGE_SIZE, PAGE_SIZE_2M};
+use crate::types::{PageSize, PAGE_SIZE, PAGE_SIZE_2M};
 use crate::utils::zero_mem_region;
 
 pub const VMPL_MAX: usize = 4;
@@ -318,7 +318,7 @@ pub fn allocate_new_vmsa(vmpl: RMPFlags) -> Result<VirtAddr, SvsmError> {
 
     zero_mem_region(vmsa_page, vmsa_page + PAGE_SIZE);
 
-    if let Err(e) = rmp_adjust(vmsa_page, RMPFlags::VMSA | vmpl, false) {
+    if let Err(e) = rmp_adjust(vmsa_page, RMPFlags::VMSA | vmpl, PageSize::Regular) {
         free_page(vmsa_page);
         return Err(e);
     }
@@ -326,6 +326,7 @@ pub fn allocate_new_vmsa(vmpl: RMPFlags) -> Result<VirtAddr, SvsmError> {
 }
 
 pub fn free_vmsa(vaddr: VirtAddr) {
-    rmp_adjust(vaddr, RMPFlags::RWX | RMPFlags::VMPL0, false).expect("Failed to free VMSA page");
+    rmp_adjust(vaddr, RMPFlags::RWX | RMPFlags::VMPL0, PageSize::Regular)
+        .expect("Failed to free VMSA page");
     free_page(vaddr);
 }

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -31,7 +31,7 @@ use svsm::mm::validate::{
 use svsm::serial::{SerialPort, SERIAL_PORT};
 use svsm::sev::ghcb::PageStateChangeOp;
 use svsm::sev::msr_protocol::verify_ghcb_version;
-use svsm::sev::{pvalidate_range, sev_status_init, sev_status_verify};
+use svsm::sev::{pvalidate_range, sev_status_init, sev_status_verify, PvalidateOp};
 use svsm::svsm_console::SVSMIOPort;
 use svsm::types::{PageSize, PAGE_SIZE};
 use svsm::utils::halt;
@@ -126,7 +126,8 @@ fn map_and_validate(vaddr: VirtAddr, paddr: PhysAddr, len: usize) {
             PageStateChangeOp::PscPrivate,
         )
         .expect("GHCB::PAGE_STATE_CHANGE call failed for kernel region");
-    pvalidate_range(vaddr, vaddr + len, true).expect("PVALIDATE kernel region failed");
+    pvalidate_range(vaddr, vaddr + len, PvalidateOp::Valid)
+        .expect("PVALIDATE kernel region failed");
     valid_bitmap_set_valid_range(paddr, paddr + len);
 }
 

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -33,7 +33,7 @@ use svsm::sev::ghcb::PageStateChangeOp;
 use svsm::sev::msr_protocol::verify_ghcb_version;
 use svsm::sev::{pvalidate_range, sev_status_init, sev_status_verify};
 use svsm::svsm_console::SVSMIOPort;
-use svsm::types::PAGE_SIZE;
+use svsm::types::{PageSize, PAGE_SIZE};
 use svsm::utils::halt;
 
 extern "C" {
@@ -119,7 +119,12 @@ fn map_and_validate(vaddr: VirtAddr, paddr: PhysAddr, len: usize) {
 
     this_cpu_mut()
         .ghcb()
-        .page_state_change(paddr, paddr + len, true, PageStateChangeOp::PscPrivate)
+        .page_state_change(
+            paddr,
+            paddr + len,
+            PageSize::Huge,
+            PageStateChangeOp::PscPrivate,
+        )
         .expect("GHCB::PAGE_STATE_CHANGE call failed for kernel region");
     pvalidate_range(vaddr, vaddr + len, true).expect("PVALIDATE kernel region failed");
     valid_bitmap_set_valid_range(paddr, paddr + len);

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -46,7 +46,7 @@ use svsm::sev::sev_status_init;
 use svsm::sev::utils::{rmp_adjust, RMPFlags};
 use svsm::svsm_console::SVSMIOPort;
 use svsm::svsm_paging::{init_page_table, invalidate_stage2};
-use svsm::types::{GUEST_VMPL, PAGE_SIZE};
+use svsm::types::{PageSize, GUEST_VMPL, PAGE_SIZE};
 use svsm::utils::{halt, immut_after_init::ImmutAfterInitCell, zero_mem_region};
 
 use svsm::mm::validate::{init_valid_bitmap_ptr, migrate_valid_bitmap};
@@ -267,7 +267,11 @@ fn validate_flash() -> Result<(), SvsmError> {
         {
             let guard = PerCPUPageMappingGuard::create_4k(paddr)?;
             let vaddr = guard.virt_addr();
-            if let Err(e) = rmp_adjust(vaddr, RMPFlags::GUEST_VMPL | RMPFlags::RWX, false) {
+            if let Err(e) = rmp_adjust(
+                vaddr,
+                RMPFlags::GUEST_VMPL | RMPFlags::RWX,
+                PageSize::Regular,
+            ) {
                 log::info!("rmpadjust failed for addr {:#018x}", vaddr);
                 return Err(e);
             }

--- a/src/svsm_paging.rs
+++ b/src/svsm_paging.rs
@@ -14,7 +14,7 @@ use crate::mm::pagetable::{set_init_pgtable, PageTable, PageTableRef};
 use crate::mm::PerCPUPageMappingGuard;
 use crate::sev::ghcb::PageStateChangeOp;
 use crate::sev::pvalidate;
-use crate::types::PAGE_SIZE;
+use crate::types::{PageSize, PAGE_SIZE};
 
 pub fn init_page_table(launch_info: &KernelLaunchInfo, kernel_elf: &elf::Elf64File) {
     let vaddr = mm::alloc::allocate_zeroed_page().expect("Failed to allocate root page-table");
@@ -71,14 +71,14 @@ pub fn invalidate_stage2() -> Result<(), SvsmError> {
         let guard = PerCPUPageMappingGuard::create_4k(paddr)?;
         let vaddr = guard.virt_addr();
 
-        pvalidate(vaddr, false, false)?;
+        pvalidate(vaddr, PageSize::Regular, false)?;
 
         paddr = paddr + PAGE_SIZE;
     }
 
     this_cpu_mut()
         .ghcb()
-        .page_state_change(paddr, pend, false, PageStateChangeOp::PscShared)
+        .page_state_change(paddr, pend, PageSize::Regular, PageStateChangeOp::PscShared)
         .expect("Failed to invalidate Stage2 memory");
 
     Ok(())

--- a/src/svsm_paging.rs
+++ b/src/svsm_paging.rs
@@ -13,7 +13,7 @@ use crate::mm;
 use crate::mm::pagetable::{set_init_pgtable, PageTable, PageTableRef};
 use crate::mm::PerCPUPageMappingGuard;
 use crate::sev::ghcb::PageStateChangeOp;
-use crate::sev::pvalidate;
+use crate::sev::{pvalidate, PvalidateOp};
 use crate::types::{PageSize, PAGE_SIZE};
 
 pub fn init_page_table(launch_info: &KernelLaunchInfo, kernel_elf: &elf::Elf64File) {
@@ -71,7 +71,7 @@ pub fn invalidate_stage2() -> Result<(), SvsmError> {
         let guard = PerCPUPageMappingGuard::create_4k(paddr)?;
         let vaddr = guard.virt_addr();
 
-        pvalidate(vaddr, PageSize::Regular, false)?;
+        pvalidate(vaddr, PageSize::Regular, PvalidateOp::Invalid)?;
 
         paddr = paddr + PAGE_SIZE;
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,6 +11,21 @@ pub const PAGE_SHIFT_2M: usize = 21;
 pub const PAGE_SIZE: usize = 1 << PAGE_SHIFT;
 pub const PAGE_SIZE_2M: usize = PAGE_SIZE * 512;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PageSize {
+    Regular,
+    Huge,
+}
+
+impl From<PageSize> for usize {
+    fn from(psize: PageSize) -> Self {
+        match psize {
+            PageSize::Regular => PAGE_SIZE,
+            PageSize::Huge => PAGE_SIZE_2M,
+        }
+    }
+}
+
 #[allow(clippy::identity_op)]
 pub const SVSM_CS: u16 = 1 * 8;
 pub const SVSM_DS: u16 = 2 * 8;


### PR DESCRIPTION
* Explicitly type the page size parameters for `pvalidate()`, `GHCB::page_state_change()` and related functions.

* Explicitly type the state parameter for `pvalidate()`.

This way, the following:

```rust
pvalidate(vaddr, false, true)?;
```

Turns into:

```rust
pvalidate(vaddr, PageSize::Regular, PvalidateOp::Valid)?;
```

And this:

```rust
    this_cpu_mut()
        .ghcb()
        .page_state_change(pstart, pend, false, PageStateChangeOp::PscPrivate)
```

turns into:

```rust
    this_cpu_mut()
        .ghcb()
        .page_state_change(
            pstart,
            pend,
            PageSize::Regular,
            PageStateChangeOp::PscPrivate,
        )
```