### PR TITLE
sev/ghcb: Allow for page state change range smaller than max entries

### DIFF
--- a/src/sev/ghcb.rs
+++ b/src/sev/ghcb.rs
@@ -419,7 +419,7 @@ impl GHCB {
             entries += 1;
             paddr = paddr + pgsize;
 
-            if entries == max_entries {
+            if entries == max_entries || paddr >= end {
                 let header = PageStateChangeHeader {
                     cur_entry: 0,
                     end_entry: entries - 1,


### PR DESCRIPTION
If the range supplied to the the page_state_change() function is less than the maximum number of entries that the GHCB can hold, the VMGEXIT to perform the change is not issued. This has not caused an issue, yet, because when marking a range as private, the subsequent PVALIDATE will generate a #NPF and KVM will automatically change the state of the page. While likely, a hypervisor is not required to implement that behavior, which could cause the guest to spin in a #NPF loop.

This can be seen in stage 2, where the target SVSM destination was:
  vaddr=0xffffff8000000000, paddr=0x8000000000, len=0x6c000
and the VMGEXIT is not issued when the page_state_change() function is invoked.

Modify the check for when to issue the VMGEXIT to include a check for reaching the end of the address range.

Fixes: 8d6fa30342fe ("SVSM: Implement GHCB::page_state_change() and use it in Stage2")