### PR TITLE
sev/ghcb: explicitly type size parameter in `GHCB::page_state_change()`

### DIFF
--- a/src/fw_meta.rs
+++ b/src/fw_meta.rs
@@ -11,7 +11,7 @@ use crate::cpu::percpu::this_cpu_mut;
 use crate::error::SvsmError;
 use crate::mm::PerCPUPageMappingGuard;
 use crate::mm::SIZE_1G;
-use crate::sev::ghcb::PageStateChangeOp;
+use crate::sev::ghcb::{PageStateChangeOp, PageStateChangeSize};
 use crate::sev::{pvalidate, rmp_adjust, RMPFlags};
 use crate::types::PAGE_SIZE;
 use crate::utils::{overlap, zero_mem_region};
@@ -399,7 +399,12 @@ fn validate_fw_mem_region(region: SevPreValidMem) -> Result<(), SvsmError> {
 
     this_cpu_mut()
         .ghcb()
-        .page_state_change(pstart, pend, false, PageStateChangeOp::PscPrivate)
+        .page_state_change(
+            pstart,
+            pend,
+            PageStateChangeSize::RegularPage,
+            PageStateChangeOp::PscPrivate,
+        )
         .expect("GHCB PSC call failed to validate firmware memory");
 
     for paddr in (pstart.bits()..pend.bits())

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -29,7 +29,7 @@ use svsm::mm::validate::{
     init_valid_bitmap_alloc, valid_bitmap_addr, valid_bitmap_set_valid_range,
 };
 use svsm::serial::{SerialPort, SERIAL_PORT};
-use svsm::sev::ghcb::PageStateChangeOp;
+use svsm::sev::ghcb::{PageStateChangeOp, PageStateChangeSize};
 use svsm::sev::msr_protocol::verify_ghcb_version;
 use svsm::sev::{pvalidate_range, sev_status_init, sev_status_verify};
 use svsm::svsm_console::SVSMIOPort;
@@ -119,7 +119,12 @@ fn map_and_validate(vaddr: VirtAddr, paddr: PhysAddr, len: usize) {
 
     this_cpu_mut()
         .ghcb()
-        .page_state_change(paddr, paddr + len, true, PageStateChangeOp::PscPrivate)
+        .page_state_change(
+            paddr,
+            paddr + len,
+            PageStateChangeSize::HugePage,
+            PageStateChangeOp::PscPrivate,
+        )
         .expect("GHCB::PAGE_STATE_CHANGE call failed for kernel region");
     pvalidate_range(vaddr, vaddr + len, true).expect("PVALIDATE kernel region failed");
     valid_bitmap_set_valid_range(paddr, paddr + len);

--- a/src/svsm_paging.rs
+++ b/src/svsm_paging.rs
@@ -12,7 +12,7 @@ use crate::kernel_launch::KernelLaunchInfo;
 use crate::mm;
 use crate::mm::pagetable::{set_init_pgtable, PageTable, PageTableRef};
 use crate::mm::PerCPUPageMappingGuard;
-use crate::sev::ghcb::PageStateChangeOp;
+use crate::sev::ghcb::{PageStateChangeOp, PageStateChangeSize};
 use crate::sev::pvalidate;
 use crate::types::PAGE_SIZE;
 
@@ -78,7 +78,12 @@ pub fn invalidate_stage2() -> Result<(), SvsmError> {
 
     this_cpu_mut()
         .ghcb()
-        .page_state_change(paddr, pend, false, PageStateChangeOp::PscShared)
+        .page_state_change(
+            paddr,
+            pend,
+            PageStateChangeSize::RegularPage,
+            PageStateChangeOp::PscShared,
+        )
         .expect("Failed to invalidate Stage2 memory");
 
     Ok(())


### PR DESCRIPTION
Use an enum instead of a boolean to make the page size parameter explicit. This improves readability.

this:

```rust
    this_cpu_mut()
        .ghcb()
        .page_state_change(pstart, pend, false, PageStateChangeOp::PscPrivate)
```

turns into:

```rust
    this_cpu_mut()
        .ghcb()
        .page_state_change(
            pstart,
            pend,
            PageStateChangeSize::RegularPage,
            PageStateChangeOp::PscPrivate,
        )
```