### PR TITLE
run clippy on tests on the CI and fix several warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,3 +48,9 @@ jobs:
         with:
           command: clippy
           args: --all-features -- -D warnings
+
+      - name: Clippy on tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-features --tests --target=x86_64-unknown-linux-gnu -- -D warnings

--- a/src/fs/filesystem.rs
+++ b/src/fs/filesystem.rs
@@ -408,15 +408,15 @@ mod tests {
 
         assert!(fh.size() == 0);
 
-        let mut buf: [u8; 512] = [0xff; 512];
-        let result = write(&fh, &mut buf).unwrap();
+        let buf: [u8; 512] = [0xff; 512];
+        let result = write(&fh, &buf).unwrap();
         assert_eq!(result, 512);
 
         assert_eq!(fh.size(), 512);
 
         fh.seek(256);
-        let mut buf2: [u8; 512] = [0xcc; 512];
-        let result = write(&fh, &mut buf2).unwrap();
+        let buf2: [u8; 512] = [0xcc; 512];
+        let result = write(&fh, &buf2).unwrap();
         assert_eq!(result, 512);
 
         assert_eq!(fh.size(), 768);
@@ -426,7 +426,7 @@ mod tests {
         let result = read(&fh, &mut buf3).unwrap();
         assert_eq!(result, 768);
 
-        for i in 0..buf3.len() {
+        for (i, elem) in buf3.iter().enumerate() {
             let expected: u8 = if i < 256 {
                 0xff
             } else if i < 768 {
@@ -434,7 +434,7 @@ mod tests {
             } else {
                 0x0
             };
-            assert!(buf3[i] == expected);
+            assert!(*elem == expected);
         }
 
         drop(fh);
@@ -463,8 +463,8 @@ mod tests {
         let result = fh2.read(&mut buf2).unwrap();
         assert_eq!(result, 4096);
 
-        for i in 0..buf2.len() {
-            assert_eq!(buf2[i], 0xff);
+        for elem in &buf2 {
+            assert_eq!(*elem, 0xff);
         }
 
         fh1.truncate(2048).unwrap();

--- a/src/fs/ramfs.rs
+++ b/src/fs/ramfs.rs
@@ -296,12 +296,12 @@ mod tests {
         let mut buf1 = [0xffu8; 512];
 
         // Write first buffer at offset 0
-        file.write(&mut buf1, 0).expect("Failed to write file data");
+        file.write(&buf1, 0).expect("Failed to write file data");
         assert!(file.size() == 512);
 
         // Write second buffer at offset 4096 - 256 - cross-page write
         let mut buf2 = [0xaau8; 512];
-        file.write(&mut buf2, PAGE_SIZE - 256)
+        file.write(&buf2, PAGE_SIZE - 256)
             .expect("Failed to write file cross-page");
         assert!(file.size() == PAGE_SIZE + 256);
 
@@ -336,7 +336,7 @@ mod tests {
         let size = file.read(&mut buf3, 0).expect("Failed to read whole file");
         assert!(size == PAGE_SIZE + 256);
 
-        for i in 0..buf3.len() {
+        for (i, elem) in buf3.iter().enumerate() {
             let expected: u8 = if i < 512 {
                 0xff
             } else if i < PAGE_SIZE - 256 {
@@ -346,7 +346,7 @@ mod tests {
             } else {
                 0xcc
             };
-            assert!(buf3[i] == expected);
+            assert!(*elem == expected);
         }
 
         assert_eq!(file.truncate(1024).unwrap(), 1024);
@@ -359,9 +359,9 @@ mod tests {
         let size = file.read(&mut buf3, 0).expect("Failed to read whole file");
         assert!(size == 1024);
 
-        for i in 0..1024 {
+        for (i, elem) in buf3.iter().enumerate().take(1024) {
             let expected: u8 = if i < 512 { 0xff } else { 0 };
-            assert!(buf3[i] == expected);
+            assert!(*elem == expected);
         }
 
         // file needs to be dropped before memory allocator is destroyed


### PR DESCRIPTION
Running `cargo clippy --tests --target=x86_64-unknown-linux-gnu --all-features` highlighted several things that we can improve in our tests code.

Only tests are affected, so no change to code behavior.

We need to add a second call to clippy for tests in the CI because we need to use a different target (i.e. x86_64-unknown-linux-gnu) to avoid build failure.

I squashed all the tests changes in a single commit since they are tests, but if you prefer I can split them in several commits.