### PR TITLE
locking: Add unit tests

### DIFF
--- a/src/locking/rwlock.rs
+++ b/src/locking/rwlock.rs
@@ -155,3 +155,46 @@ impl<T: Debug> RWLock<T> {
         }
     }
 }
+
+mod tests {
+
+    #[test]
+    fn test_lock_rw() {
+        use crate::locking::*;
+        let rwlock = RWLock::new(42);
+
+        // Acquire a read lock and check the initial value
+        let read_guard = rwlock.lock_read();
+        assert_eq!(*read_guard, 42);
+
+        drop(read_guard);
+
+        let read_guard2 = rwlock.lock_read();
+        assert_eq!(*read_guard2, 42);
+
+        // Create another RWLock instance for modification
+        let rwlock_modify = RWLock::new(0);
+
+        let mut write_guard = rwlock_modify.lock_write();
+        *write_guard = 99;
+        assert_eq!(*write_guard, 99);
+
+        drop(write_guard);
+
+        let read_guard = rwlock.lock_read();
+        assert_eq!(*read_guard, 42);
+
+        // Let's test two concurrent readers on a new RWLock instance
+        let rwlock_concurrent = RWLock::new(123);
+
+        let read_guard1 = rwlock_concurrent.lock_read();
+        let read_guard2 = rwlock_concurrent.lock_read();
+
+        // Assert that both readers can access the same value (123)
+        assert_eq!(*read_guard1, 123);
+        assert_eq!(*read_guard2, 123);
+
+        drop(read_guard1);
+        drop(read_guard2);
+    }
+}

--- a/src/locking/spinlock.rs
+++ b/src/locking/spinlock.rs
@@ -89,3 +89,23 @@ impl<T: Debug> SpinLock<T> {
         None
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_spin_lock() {
+        let spin_lock = SpinLock::new(0);
+
+        let mut guard = spin_lock.lock();
+        *guard += 1;
+
+        // Ensure the locked data is updated.
+        assert_eq!(*guard, 1);
+
+        // Try to lock again; it should fail and return None.
+        let try_lock_result = spin_lock.try_lock();
+        assert!(try_lock_result.is_none());
+    }
+}


### PR DESCRIPTION
Add unit tests to test correct behavior of both spinlock and rwlock.