### PR TITLE
locking/rwlock: fix undefined behavior via `RWLock::lock_read()`

### DIFF
--- a/src/locking/rwlock.rs
+++ b/src/locking/rwlock.rs
@@ -12,7 +12,7 @@ use core::sync::atomic::{AtomicU64, Ordering};
 #[derive(Debug)]
 pub struct ReadLockGuard<'a, T: Debug> {
     rwlock: &'a AtomicU64,
-    data: &'a mut T,
+    data: &'a T,
 }
 
 impl<'a, T: Debug> Drop for ReadLockGuard<'a, T> {
@@ -124,7 +124,7 @@ impl<T: Debug> RWLock<T> {
 
         ReadLockGuard {
             rwlock: &self.rwlock,
-            data: unsafe { &mut *self.data.get() },
+            data: unsafe { &*self.data.get() },
         }
     }
 


### PR DESCRIPTION
Fix an undefined behavior that could be triggered when acquiring a read guard on a RWLock. This happened because a ReadLockGuard would keep a mutable reference to the underlying shared data. Since one might acquire multiple ReadLockGuards to the same data, this would lead to undefined behavior under Rust's borrowing rules.

This was found by @Freax13 while running @Zildj1an's tests in #105 under the [Miri](/rust-lang/miri) interpreter.

Fixes: b29acca1 ("SVSM/locking: Add RWLock implementation")
Reported-by: Tom Dohrmann <erbse.13@gmx.de>