### PR TITLE
mm/alloc: acquire `Slab` spinlock when freeing a pointer

### DIFF
--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -1257,13 +1257,10 @@ unsafe impl GlobalAlloc for SvsmAllocator {
     unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
         let virt_addr = VirtAddr::from(ptr);
 
-        let result = ROOT_MEM.lock().get_page_info(virt_addr);
-
-        if result.is_err() {
-            panic!("Freeing unknown memory");
-        }
-
-        let info = result.unwrap();
+        let info = ROOT_MEM
+            .lock()
+            .get_page_info(virt_addr)
+            .expect("Freeing unknown memory");
 
         match info {
             Page::Allocated(_ai) => {

--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -62,8 +62,6 @@ impl PageStorageType {
     const NEXT_SHIFT: u64 = 12;
     const NEXT_MASK: u64 = !((1u64 << Self::NEXT_SHIFT) - 1);
     const ORDER_MASK: u64 = (1u64 << (Self::NEXT_SHIFT - Self::TYPE_SHIFT)) - 1;
-    // SLAB pages are always order-0
-    const SLAB_MASK: u64 = !Self::TYPE_MASK;
 
     const fn new(t: PageType) -> Self {
         Self(t as u64)
@@ -77,10 +75,6 @@ impl PageStorageType {
         Self(self.0 | (next_page as u64) << Self::NEXT_SHIFT)
     }
 
-    fn encode_slab(self, slab: VirtAddr) -> Self {
-        Self(self.0 | (slab.bits() as u64) & Self::SLAB_MASK)
-    }
-
     fn encode_refcount(self, refcount: u64) -> Self {
         Self(self.0 | refcount << Self::TYPE_SHIFT)
     }
@@ -91,10 +85,6 @@ impl PageStorageType {
 
     fn decode_next(&self) -> usize {
         ((self.0 & Self::NEXT_MASK) >> Self::NEXT_SHIFT) as usize
-    }
-
-    fn decode_slab(&self) -> VirtAddr {
-        VirtAddr::from(self.0 & Self::SLAB_MASK)
     }
 
     fn decode_refcount(&self) -> u64 {
@@ -140,18 +130,15 @@ impl AllocatedInfo {
     }
 }
 
-struct SlabPageInfo {
-    slab: VirtAddr,
-}
+struct SlabPageInfo;
 
 impl SlabPageInfo {
     fn encode(&self) -> PageStorageType {
-        PageStorageType::new(PageType::SlabPage).encode_slab(self.slab)
+        PageStorageType::new(PageType::SlabPage)
     }
 
-    fn decode(mem: PageStorageType) -> Self {
-        let slab = mem.decode_slab();
-        Self { slab }
+    fn decode(_mem: PageStorageType) -> Self {
+        Self
     }
 }
 
@@ -442,13 +429,11 @@ impl MemoryRegion {
         Ok(vaddr)
     }
 
-    fn allocate_slab_page(&mut self, slab: Option<VirtAddr>) -> Result<VirtAddr, SvsmError> {
+    fn allocate_slab_page(&mut self) -> Result<VirtAddr, SvsmError> {
         self.refill_page_list(0)?;
 
-        let slab_vaddr = slab.unwrap_or(VirtAddr::null());
         let pfn = self.get_next_page(0)?;
-        assert_eq!(slab_vaddr.bits() & (PageStorageType::TYPE_MASK as usize), 0);
-        let pg = Page::SlabPage(SlabPageInfo { slab: slab_vaddr });
+        let pg = Page::SlabPage(SlabPageInfo);
         self.write_page_info(pfn, pg);
         Ok(self.start_virt + (pfn * PAGE_SIZE))
     }
@@ -773,8 +758,8 @@ pub fn allocate_pages(order: usize) -> Result<VirtAddr, SvsmError> {
     ROOT_MEM.lock().allocate_pages(order)
 }
 
-pub fn allocate_slab_page(slab: Option<VirtAddr>) -> Result<VirtAddr, SvsmError> {
-    ROOT_MEM.lock().allocate_slab_page(slab)
+pub fn allocate_slab_page() -> Result<VirtAddr, SvsmError> {
+    ROOT_MEM.lock().allocate_slab_page()
 }
 
 pub fn allocate_zeroed_page() -> Result<VirtAddr, SvsmError> {
@@ -832,7 +817,7 @@ impl SlabPage {
         }
     }
 
-    fn init(&mut self, slab_vaddr: Option<VirtAddr>, mut item_size: u16) -> Result<(), SvsmError> {
+    fn init(&mut self, mut item_size: u16) -> Result<(), SvsmError> {
         if self.item_size != 0 {
             return Ok(());
         }
@@ -844,7 +829,7 @@ impl SlabPage {
             item_size = 32;
         }
 
-        let vaddr = allocate_slab_page(slab_vaddr)?;
+        let vaddr = allocate_slab_page()?;
         self.vaddr = vaddr;
         self.item_size = item_size;
         self.capacity = (PAGE_SIZE as u16) / item_size;
@@ -941,8 +926,8 @@ impl SlabCommon {
         }
     }
 
-    fn init(&mut self, slab_vaddr: Option<VirtAddr>) -> Result<(), SvsmError> {
-        self.page.init(slab_vaddr, self.item_size)?;
+    fn init(&mut self) -> Result<(), SvsmError> {
+        self.page.init(self.item_size)?;
 
         self.capacity = self.page.get_capacity() as u32;
         self.free = self.capacity;
@@ -1040,7 +1025,7 @@ impl SlabPageSlab {
     }
 
     fn init(&mut self) -> Result<(), SvsmError> {
-        self.common.init(None)
+        self.common.init()
     }
 
     fn grow_slab(&mut self) -> Result<(), SvsmError> {
@@ -1059,7 +1044,7 @@ impl SlabPageSlab {
         let slab_page = unsafe { &mut *page_vaddr.as_mut_ptr::<SlabPage>() };
 
         *slab_page = SlabPage::new();
-        if let Err(e) = slab_page.init(None, self.common.item_size) {
+        if let Err(e) = slab_page.init(self.common.item_size) {
             self.common.deallocate_slot(page_vaddr);
             return Err(e);
         }
@@ -1123,8 +1108,7 @@ impl Slab {
     }
 
     fn init(&mut self) -> Result<(), SvsmError> {
-        let slab_vaddr = VirtAddr::from(self as *mut Slab);
-        self.common.init(Some(slab_vaddr))
+        self.common.init()
     }
 
     fn grow_slab(&mut self) -> Result<(), SvsmError> {
@@ -1140,9 +1124,8 @@ impl Slab {
             .lock()
             .allocate()
             .map(|ptr| unsafe { &mut *ptr })?;
-        let slab_vaddr = VirtAddr::from(self as *mut Slab);
         *slab_page = SlabPage::new();
-        if let Err(e) = slab_page.init(Some(slab_vaddr), self.common.item_size) {
+        if let Err(e) = slab_page.init(self.common.item_size) {
             SLAB_PAGE_SLAB.lock().deallocate(slab_page);
             return Err(e);
         }

--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -1197,7 +1197,7 @@ impl Slab {
 static SLAB_PAGE_SLAB: SpinLock<SlabPageSlab> = SpinLock::new(SlabPageSlab::new());
 
 #[derive(Debug)]
-pub struct SvsmAllocator {
+struct SvsmAllocator {
     slab_size_32: SpinLock<Slab>,
     slab_size_64: SpinLock<Slab>,
     slab_size_128: SpinLock<Slab>,
@@ -1208,7 +1208,7 @@ pub struct SvsmAllocator {
 }
 
 impl SvsmAllocator {
-    pub const fn new() -> Self {
+    const fn new() -> Self {
         SvsmAllocator {
             slab_size_32: SpinLock::new(Slab::new(32)),
             slab_size_64: SpinLock::new(Slab::new(64)),
@@ -1284,7 +1284,8 @@ unsafe impl GlobalAlloc for SvsmAllocator {
 }
 
 #[cfg_attr(not(any(test, doctest)), global_allocator)]
-pub static mut ALLOCATOR: SvsmAllocator = SvsmAllocator::new();
+#[cfg_attr(any(test, doctest), allow(dead_code))]
+static mut ALLOCATOR: SvsmAllocator = SvsmAllocator::new();
 
 pub fn root_mem_init(pstart: PhysAddr, vstart: VirtAddr, page_count: usize) {
     {


### PR DESCRIPTION
Fix the undefined behavior detailed in #107 by acquiring a lock to the corresponding `Slab` before freeing an allocation from it. Before, this could lead to undefined behavior, as freeing an address would access the Slab mutably, regardless of any concurrent users.

The appropriate `Slab` can be found by using the `layout` parameter to `SvsmAllocator::dealloc()`.

The PR also includes small refactors and cleanups to make the change simpler.

This does not completely solve #107 because by avoiding this UB, further UB warnings are revealed.