### PR TITLE
locking, mm/ptguards: add `#[must_use]` to data guards

### DIFF
--- a/src/locking/rwlock.rs
+++ b/src/locking/rwlock.rs
@@ -10,6 +10,7 @@ use core::ops::{Deref, DerefMut};
 use core::sync::atomic::{AtomicU64, Ordering};
 
 #[derive(Debug)]
+#[must_use = "if unused the RWLock will immediately unlock"]
 pub struct ReadLockGuard<'a, T: Debug> {
     rwlock: &'a AtomicU64,
     data: &'a T,
@@ -29,6 +30,7 @@ impl<'a, T: Debug> Deref for ReadLockGuard<'a, T> {
 }
 
 #[derive(Debug)]
+#[must_use = "if unused the RWLock will immediately unlock"]
 pub struct WriteLockGuard<'a, T: Debug> {
     rwlock: &'a AtomicU64,
     data: &'a mut T,

--- a/src/locking/spinlock.rs
+++ b/src/locking/spinlock.rs
@@ -10,6 +10,7 @@ use core::ops::{Deref, DerefMut};
 use core::sync::atomic::{AtomicU64, Ordering};
 
 #[derive(Debug)]
+#[must_use = "if unused the SpinLock will immediately unlock"]
 pub struct LockGuard<'a, T: Debug> {
     holder: &'a AtomicU64,
     data: &'a mut T,

--- a/src/mm/ptguards.rs
+++ b/src/mm/ptguards.rs
@@ -25,6 +25,7 @@ impl RawPTMappingGuard {
     }
 }
 
+#[must_use = "if unused the mapping will immediately be unmapped"]
 pub struct PerCPUPageMappingGuard {
     mapping: Option<RawPTMappingGuard>,
     huge: bool,


### PR DESCRIPTION
Add `#[must_use]` attribute to several guard-like types to avoid potential use mistakes.