### PR TITLE
test:  Use target OS to determine use of bare-metal allocator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ test = false
 
 [lib]
 test = true
-doctest = false
+doctest = true
 
 [dependencies]
 bitflags = "2.4"

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ all: svsm.bin
 
 test:
 	cargo test --target=x86_64-unknown-linux-gnu
-	RUSTFLAGS="--cfg doctest" cargo test --target=x86_64-unknown-linux-gnu --doc
 
 utils/gen_meta: utils/gen_meta.c
 	cc -O3 -Wall -o $@ $<

--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -1266,8 +1266,8 @@ unsafe impl GlobalAlloc for SvsmAllocator {
     }
 }
 
-#[cfg_attr(not(any(test, doctest)), global_allocator)]
-#[cfg_attr(any(test, doctest), allow(dead_code))]
+#[cfg_attr(any(target_os = "none"), global_allocator)]
+#[cfg_attr(not(target_os = "none"), allow(dead_code))]
 static mut ALLOCATOR: SvsmAllocator = SvsmAllocator::new();
 
 pub fn root_mem_init(pstart: PhysAddr, vstart: VirtAddr, page_count: usize) {


### PR DESCRIPTION
Our custom bare-metal allocator (`SvsmAllocator`) cannot be used in regular userspace binaries so needs to be disabled for unit and doc testing. The previous fix for documentation tests used the `doctest` cfg to conditionally use the allocator, passing the configuration option via RUSTFLAGS. Unfortunately, this caused compilation issues with dependencies that make use of #[cfg(doctest)] such as memoffset which is used by intrusive-collections.

Instead, this change makes use of the fact that the tests run on an OS platform whereas the SVSM is built for a target OS of 'none'. The custom allocator is enabled only when `target_os` = "none". This means the specific docs test invocation can be removed from the test Makefile target as the doc tests will be run alongside the unit tests.