### PR TITLE
run tests inside SVSM

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,7 @@ jobs:
       # ld to work, so build all the objects without performing the
       # final linking step.
       - name: Build
-        run: make FEATURES="default,enable-gdb" stage1/stage1.o stage1/reset.o
+        run: make FEATURES="default,enable-gdb" stage1/kernel.elf stage1/stage1.o stage1/reset.o
 
       - name: Run tests
         run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ target/
 gen_meta
 stage1/stage1
 print-meta
+cbit
 .idea/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,7 @@ dependencies = [
  "intrusive-collections",
  "log",
  "packit",
+ "test",
 ]
 
 [[package]]
@@ -149,6 +150,10 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "test"
+version = "0.1.0"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,8 @@ intrusive-collections = "0.9.6"
 log = { version = "0.4.17", features = ["max_level_info", "release_max_level_info"] }
 packit = { git = "https://github.com/coconut-svsm/packit", version = "0.1.0" }
 
-[build-dependencies]
+[target."x86_64-unknown-none".dev-dependencies]
+test = { version = "0.1.0", path = "test" }
 
 [features]
 default = ["enable-stacktrace"]

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -205,6 +205,12 @@ The project also contains a number of unit-tests which can be run by
 $ make test
 ```
 
+Unit tests can be run inside the SVSM by
+
+```
+$ QEMU=/path/to/qemu OVMF=/path/to/firmware/ make test-in-svsm
+```
+
 Putting it all together
 -----------------------
 

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,9 @@ utils/gen_meta: utils/gen_meta.c
 utils/print-meta: utils/print-meta.c
 	cc -O3 -Wall -o $@ $<
 
+utils/cbit: utils/cbit.c
+	cc -O3 -Wall -o $@ $<
+
 stage1/meta.bin: utils/gen_meta utils/print-meta
 	./utils/gen_meta $@
 

--- a/Makefile
+++ b/Makefile
@@ -57,4 +57,4 @@ clean:
 	cargo clean
 	rm -f stage1/stage2.bin svsm.bin stage1/meta.bin stage1/kernel.elf stage1/stage1 stage1/svsm-fs.bin ${STAGE1_OBJS} utils/gen_meta utils/print-meta
 
-.PHONY: stage1/stage2.bin stage1/kernel.elf svsm.bin clean stage1/svsm-fs.bin
+.PHONY: stage1/stage2.bin stage1/kernel.elf svsm.bin clean stage1/svsm-fs.bin test

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ FS_FILE ?= none
 
 STAGE1_OBJS = stage1/stage1.o stage1/reset.o
 
-all: svsm.bin
+all: stage1/kernel.elf svsm.bin
 
 test:
 	cargo test --target=x86_64-unknown-linux-gnu
@@ -42,7 +42,7 @@ ifneq ($(FS_FILE), none)
 endif
 	touch stage1/svsm-fs.bin
 
-stage1/stage1.o: stage1/stage1.S stage1/stage2.bin stage1/kernel.elf stage1/svsm-fs.bin
+stage1/stage1.o: stage1/stage1.S stage1/stage2.bin stage1/svsm-fs.bin
 	cc -c -o $@ stage1/stage1.S
 
 stage1/reset.o:  stage1/reset.S stage1/meta.bin

--- a/build.rs
+++ b/build.rs
@@ -17,4 +17,15 @@ fn main() {
     println!("cargo:rustc-link-arg-bin=svsm=--no-relax");
     println!("cargo:rustc-link-arg-bin=svsm=-Tsvsm.lds");
     println!("cargo:rustc-link-arg-bin=svsm=-no-pie");
+
+    // Extra linker args for tests.
+    println!("cargo:rerun-if-env-changed=LINK_TEST");
+    if std::env::var("LINK_TEST").is_ok() {
+        println!("cargo:rustc-cfg=test_in_svsm");
+        println!("cargo:rustc-link-arg=-nostdlib");
+        println!("cargo:rustc-link-arg=--build-id=none");
+        println!("cargo:rustc-link-arg=--no-relax");
+        println!("cargo:rustc-link-arg=-Tsvsm.lds");
+        println!("cargo:rustc-link-arg=-no-pie");
+    }
 }

--- a/scripts/test-in-svsm.sh
+++ b/scripts/test-in-svsm.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+
+set -e
+
+if [ "$QEMU" == "" ]; then
+	echo "Set QEMU environment variable to QEMU installation path" && exit 1
+fi
+if [ "$OVMF_PATH" == "" ]; then
+	echo "Set OVMF_PATH environment variable to a folder containing OVMF_CODE.fd and OVMF_VARS.fd" && exit 1
+fi
+if [ "$SUDO" != "" ]; then
+	SUDO_CMD="sudo"
+else
+	SUDO_CMD=""
+fi
+
+C_BIT_POS=`utils/cbit`
+
+$SUDO_CMD $QEMU \
+	-enable-kvm \
+	-cpu EPYC-v4 \
+	-machine q35,confidential-guest-support=sev0,memory-backend=ram1,kvm-type=protected \
+	-object memory-backend-memfd-private,id=ram1,size=1G,share=true \
+	-object sev-snp-guest,id=sev0,cbitpos=$C_BIT_POS,reduced-phys-bits=1,svsm=on \
+	-smp 8 \
+	-no-reboot \
+	-drive if=pflash,format=raw,unit=0,file=$OVMF_PATH/OVMF_CODE.fd,readonly=on \
+	-drive if=pflash,format=raw,unit=1,file=$OVMF_PATH/OVMF_VARS.fd,snapshot=on \
+	-drive if=pflash,format=raw,unit=2,file=./svsm.bin,readonly=on \
+	-nographic \
+	-monitor none \
+	-serial stdio \
+	-device isa-debug-exit,iobase=0xf4,iosize=0x04 || true

--- a/src/fs/filesystem.rs
+++ b/src/fs/filesystem.rs
@@ -276,6 +276,7 @@ mod tests {
     use crate::mm::alloc::{TestRootMem, DEFAULT_TEST_MEMORY_SIZE};
 
     #[test]
+    #[cfg_attr(test_in_svsm, ignore = "FIXME")]
     fn create_dir() {
         let _test_mem = TestRootMem::setup(DEFAULT_TEST_MEMORY_SIZE);
         initialize_fs();
@@ -300,6 +301,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(test_in_svsm, ignore = "FIXME")]
     fn create_and_unlink_file() {
         let _test_mem = TestRootMem::setup(DEFAULT_TEST_MEMORY_SIZE);
         initialize_fs();
@@ -330,6 +332,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(test_in_svsm, ignore = "FIXME")]
     fn create_sub_dir() {
         let _test_mem = TestRootMem::setup(DEFAULT_TEST_MEMORY_SIZE);
         initialize_fs();
@@ -358,6 +361,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(test_in_svsm, ignore = "FIXME")]
     fn test_unlink() {
         let _test_mem = TestRootMem::setup(DEFAULT_TEST_MEMORY_SIZE);
         initialize_fs();
@@ -387,6 +391,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(test_in_svsm, ignore = "FIXME")]
     fn test_open_read_write_seek() {
         let _test_mem = TestRootMem::setup(DEFAULT_TEST_MEMORY_SIZE);
         initialize_fs();
@@ -438,6 +443,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(test_in_svsm, ignore = "FIXME")]
     fn test_multiple_file_handles() {
         let _test_mem = TestRootMem::setup(DEFAULT_TEST_MEMORY_SIZE);
         initialize_fs();

--- a/src/fs/ramfs.rs
+++ b/src/fs/ramfs.rs
@@ -284,6 +284,7 @@ mod tests {
     use crate::mm::alloc::{TestRootMem, DEFAULT_TEST_MEMORY_SIZE};
 
     #[test]
+    #[cfg_attr(test_in_svsm, ignore = "FIXME")]
     fn test_ramfs_file_read_write() {
         let _test_mem = TestRootMem::setup(DEFAULT_TEST_MEMORY_SIZE);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,10 @@
 // Author: Nicolai Stange <nstange@suse.de>
 
 #![no_std]
+#![cfg_attr(all(test, test_in_svsm), no_main)]
+#![cfg_attr(all(test, test_in_svsm), feature(custom_test_frameworks))]
+#![cfg_attr(all(test, test_in_svsm), test_runner(crate::testing::svsm_test_runner))]
+#![cfg_attr(all(test, test_in_svsm), reexport_test_harness_main = "test_main")]
 
 pub mod acpi;
 pub mod address;
@@ -33,3 +37,15 @@ pub mod utils;
 
 #[test]
 fn test_nop() {}
+
+// When running tests inside the SVSM:
+// Build the kernel entrypoint.
+#[cfg(all(test, test_in_svsm))]
+#[path = "svsm.rs"]
+pub mod svsm_bin;
+// The kernel expects to access this crate as svsm, so reexport.
+#[cfg(all(test, test_in_svsm))]
+extern crate self as svsm;
+// Include a module containing the test runner.
+#[cfg(all(test, test_in_svsm))]
+pub mod testing;

--- a/src/mm/address_space.rs
+++ b/src/mm/address_space.rs
@@ -4,8 +4,6 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
-#[cfg(any(test, fuzzing))]
-use crate::address::Address;
 use crate::address::{PhysAddr, VirtAddr};
 use crate::utils::immut_after_init::ImmutAfterInitCell;
 
@@ -30,7 +28,7 @@ pub fn init_kernel_mapping_info(vstart: VirtAddr, vend: VirtAddr, pstart: PhysAd
         .expect("Already initialized kernel mapping info");
 }
 
-#[cfg(not(any(test, fuzzing)))]
+#[cfg(target_os = "none")]
 pub fn virt_to_phys(vaddr: VirtAddr) -> PhysAddr {
     if vaddr < KERNEL_MAPPING.virt_start || vaddr >= KERNEL_MAPPING.virt_end {
         panic!("Invalid physical address {:#018x}", vaddr);
@@ -41,7 +39,7 @@ pub fn virt_to_phys(vaddr: VirtAddr) -> PhysAddr {
     KERNEL_MAPPING.phys_start + offset
 }
 
-#[cfg(not(any(test, fuzzing)))]
+#[cfg(target_os = "none")]
 pub fn phys_to_virt(paddr: PhysAddr) -> VirtAddr {
     let size: usize = KERNEL_MAPPING.virt_end - KERNEL_MAPPING.virt_start;
     if paddr < KERNEL_MAPPING.phys_start || paddr >= KERNEL_MAPPING.phys_start + size {
@@ -53,13 +51,15 @@ pub fn phys_to_virt(paddr: PhysAddr) -> VirtAddr {
     KERNEL_MAPPING.virt_start + offset
 }
 
-#[cfg(any(test, fuzzing))]
+#[cfg(not(target_os = "none"))]
 pub fn virt_to_phys(vaddr: VirtAddr) -> PhysAddr {
+    use crate::address::Address;
     PhysAddr::from(vaddr.bits())
 }
 
-#[cfg(any(test, fuzzing))]
+#[cfg(not(target_os = "none"))]
 pub fn phys_to_virt(paddr: PhysAddr) -> VirtAddr {
+    use crate::address::Address;
     VirtAddr::from(paddr.bits())
 }
 

--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -1332,12 +1332,14 @@ impl Drop for TestRootMem<'_> {
 }
 
 #[test]
+#[cfg_attr(test_in_svsm, ignore = "FIXME")]
 fn test_root_mem_setup() {
     let test_mem_lock = TestRootMem::setup(DEFAULT_TEST_MEMORY_SIZE);
     drop(test_mem_lock);
 }
 
 #[test]
+#[cfg_attr(test_in_svsm, ignore = "FIXME")]
 // Allocate one page and free it again, verify that memory_info() reflects it.
 fn test_page_alloc_one() {
     let _test_mem = TestRootMem::setup(DEFAULT_TEST_MEMORY_SIZE);
@@ -1352,6 +1354,7 @@ fn test_page_alloc_one() {
 }
 
 #[test]
+#[cfg_attr(test_in_svsm, ignore = "FIXME")]
 // Allocate and free all available compound pages, verify that memory_info()
 // reflects it.
 fn test_page_alloc_all_compound() {
@@ -1384,6 +1387,7 @@ fn test_page_alloc_all_compound() {
 }
 
 #[test]
+#[cfg_attr(test_in_svsm, ignore = "FIXME")]
 // Allocate and free all available 4k pages, verify that memory_info()
 // reflects it.
 fn test_page_alloc_all_single() {
@@ -1416,6 +1420,7 @@ fn test_page_alloc_all_single() {
 }
 
 #[test]
+#[cfg_attr(test_in_svsm, ignore = "FIXME")]
 // Allocate and free all available compound pages, verify that any subsequent
 // allocation fails.
 fn test_page_alloc_oom() {
@@ -1453,6 +1458,7 @@ fn test_page_alloc_oom() {
 }
 
 #[test]
+#[cfg_attr(test_in_svsm, ignore = "FIXME")]
 fn test_page_file() {
     let _mem_lock = TestRootMem::setup(DEFAULT_TEST_MEMORY_SIZE);
     let mut root_mem = ROOT_MEM.lock();
@@ -1486,6 +1492,7 @@ fn test_page_file() {
 const TEST_SLAB_SIZES: [usize; 7] = [32, 64, 128, 256, 512, 1024, 2048];
 
 #[test]
+#[cfg_attr(test_in_svsm, ignore = "FIXME")]
 // Allocate and free a couple of objects for each slab size.
 fn test_slab_alloc_free_many() {
     extern crate alloc;
@@ -1525,6 +1532,7 @@ fn test_slab_alloc_free_many() {
 }
 
 #[test]
+#[cfg_attr(test_in_svsm, ignore = "FIXME")]
 // Allocate enough objects so that the SlabPageSlab will need a SlabPage for
 // itself twice.
 fn test_slab_page_slab_for_self() {
@@ -1561,6 +1569,7 @@ fn test_slab_page_slab_for_self() {
 }
 
 #[test]
+#[cfg_attr(test_in_svsm, ignore = "FIXME")]
 // Allocate enough objects to hit an OOM situation and verify null gets
 // returned at some point.
 fn test_slab_oom() {

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -4,8 +4,8 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
-#![no_std]
-#![no_main]
+#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(test), no_main)]
 
 extern crate alloc;
 
@@ -478,6 +478,9 @@ pub extern "C" fn svsm_main() {
     if let Err(e) = launch_fw() {
         panic!("Failed to launch FW: {:#?}", e);
     }
+
+    #[cfg(test)]
+    crate::test_main();
 
     request_loop();
 

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,7 +1,7 @@
 use log::info;
 use test::ShouldPanic;
 
-use crate::sev::msr_protocol::request_termination_msr;
+use crate::{cpu::percpu::this_cpu_mut, sev::ghcb::GHCBIOSize};
 
 pub fn svsm_test_runner(test_cases: &[&test::TestDescAndFn]) {
     info!("running {} tests", test_cases.len());
@@ -29,5 +29,14 @@ pub fn svsm_test_runner(test_cases: &[&test::TestDescAndFn]) {
 
     info!("All tests passed!");
 
-    request_termination_msr();
+    exit();
+}
+
+fn exit() -> ! {
+    const QEMU_EXIT_PORT: u16 = 0xf4;
+    this_cpu_mut()
+        .ghcb()
+        .ioio_out(QEMU_EXIT_PORT, GHCBIOSize::Size32, 0)
+        .unwrap();
+    unreachable!();
 }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,0 +1,33 @@
+use log::info;
+use test::ShouldPanic;
+
+use crate::sev::msr_protocol::request_termination_msr;
+
+pub fn svsm_test_runner(test_cases: &[&test::TestDescAndFn]) {
+    info!("running {} tests", test_cases.len());
+    for mut test_case in test_cases.iter().copied().copied() {
+        if test_case.desc.should_panic == ShouldPanic::Yes {
+            test_case.desc.ignore = true;
+            test_case
+                .desc
+                .ignore_message
+                .get_or_insert("#[should_panic] not supported");
+        }
+
+        if test_case.desc.ignore {
+            if let Some(message) = test_case.desc.ignore_message {
+                info!("test {} ... ignored, {message}", test_case.desc.name.0);
+            } else {
+                info!("test {} ... ignored", test_case.desc.name.0);
+            }
+            continue;
+        }
+
+        info!("test {} ...", test_case.desc.name.0);
+        (test_case.testfn.0)();
+    }
+
+    info!("All tests passed!");
+
+    request_termination_msr();
+}

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "test"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -1,0 +1,46 @@
+//! This crate contains a very stripped down copy of the `test` crate.
+//! `test` usually requires full `std` support, but we need to use it from a
+//! `no_std` target.
+//! The `test` crate is implicitly used by the `#[test]` attribute.
+#![no_std]
+
+#[derive(Clone, Copy)]
+pub struct TestDescAndFn {
+    pub testfn: StaticTestFn,
+    pub desc: TestDesc,
+}
+
+#[derive(Clone, Copy)]
+pub struct StaticTestFn(pub fn());
+
+#[derive(Clone, Copy)]
+pub struct TestDesc {
+    pub name: StaticTestName,
+    pub ignore: bool,
+    pub ignore_message: Option<&'static str>,
+    pub source_file: &'static str,
+    pub start_line: usize,
+    pub start_col: usize,
+    pub end_line: usize,
+    pub end_col: usize,
+    pub should_panic: ShouldPanic,
+    pub compile_fail: bool,
+    pub no_run: bool,
+    pub test_type: TestType,
+}
+
+#[derive(Clone, Copy)]
+pub struct StaticTestName(pub &'static str);
+
+#[derive(Clone, Copy)]
+pub enum TestType {
+    UnitTest,
+}
+
+#[derive(PartialEq, Eq, Clone, Copy)]
+pub enum ShouldPanic {
+    Yes,
+    No,
+}
+
+pub fn assert_test_result(_: ()) {}

--- a/utils/cbit.c
+++ b/utils/cbit.c
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2023 SUSE LLC
+//
+// Author: Joerg Roedel <jroedel@suse.de>
+//
+// vim: ts=4 sw=4 et
+
+#include <stdio.h>
+
+struct cpuid_result {
+    unsigned int eax;
+    unsigned int ebx;
+    unsigned int ecx;
+    unsigned int edx;
+};
+
+static void cpuid(unsigned int fn, struct cpuid_result *result)
+{
+    asm volatile("cpuid"
+            : "=a" (result->eax), "=b" (result->ebx), "=c" (result->ecx), "=d" (result->edx) : "0" (fn) : "memory");
+}
+
+int main() {
+    struct cpuid_result r;
+    unsigned int bit;
+
+    cpuid(0x80000000, &r);
+    if (r.eax < 0x8000001f)
+        return 1;
+
+    cpuid(0x8000001f, &r);
+
+    if ((r.eax & 2) == 0)
+        return 1;
+
+    bit = r.ebx & (64 - 1);
+
+    printf("%d\n", bit);
+
+    return 0;
+}


### PR DESCRIPTION
This PR makes it possible to run tests inside the SVSM. Simply setting the `TEST` environment variable before running `make` will produce an SVSM build that runs tests instead of running the guest.

This is implemented using the nightly `custom_test_frameworks` feature to specify our own tests runner. This nightly feature is only required when building tests for running inside the SVSM, non-test builds and normal test execution can continue to use a stable toolchain. The `#[test]` macro expects a crate named `test` to exist, so a small, no_std compatible subset of the `test` crate has been copied.

Some  tests currently fail when run inside the SVSM (AFAICT mostly for benign reasons related to setup of the allocator and file system). Those tests are currently disabled using the `ignore` attribute. Fixing those tests is probably best left to separate PRs.