### PR TITLE
docs: Add Makefile generation target and CI testing 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,3 +68,8 @@ jobs:
           args: --all-features --target=x86_64-unknown-linux-gnu --manifest-path fuzz/Cargo.toml -- -D warnings
         env:
           RUSTFLAGS: --cfg fuzzing
+
+      - name: Check documentation
+        run: make doc
+        env:
+          RUSTDOCFLAGS: -D warnings  

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ test:
 test-in-svsm: utils/cbit stage1/test-kernel.elf svsm.bin
 	./scripts/test-in-svsm.sh
 
+doc:
+	cargo doc --open --all-features --document-private-items
+
 utils/gen_meta: utils/gen_meta.c
 	cc -O3 -Wall -o $@ $<
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ any way:
   replacement for the FW when launching QEMU
 * Live migration
 
+Documentation
+-------------
+
+Coconut-SVSM components are documented using rustdoc, a tool that produces
+a user-friendly, browsable website explaining the code's contents. To
+generate and open the documentation, simply execute the following command:
+
+```
+$ make doc
+```
+
 Acknowledgments
 ---------------
 


### PR DESCRIPTION
Add Makefile target to generate cargo documentation and update README accordingly.