### PR TITLE
mm/stack: remove use of `ffs()`

### DIFF
--- a/src/mm/stack.rs
+++ b/src/mm/stack.rs
@@ -15,7 +15,6 @@ use crate::mm::{
     STACK_PAGES, STACK_SIZE, STACK_TOTAL_SIZE, SVSM_SHARED_STACK_BASE, SVSM_SHARED_STACK_END,
 };
 use crate::types::PAGE_SIZE;
-use crate::utils::ffs;
 
 // Limit maximum number of stacks for now, address range support 2**16 8k stacks
 const MAX_STACKS: usize = 1024;
@@ -40,7 +39,7 @@ impl StackRange {
     pub fn alloc(&mut self) -> Result<VirtAddr, SvsmError> {
         for i in 0..BMP_QWORDS {
             let val = !self.alloc_bitmap[i];
-            let idx = ffs(val);
+            let idx = val.trailing_zeros() as usize;
 
             if idx >= 64 {
                 continue;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -8,4 +8,4 @@ pub mod bitmap_allocator;
 pub mod immut_after_init;
 pub mod util;
 
-pub use util::{align_up, ffs, halt, overlap, page_align_up, page_offset, zero_mem_region};
+pub use util::{align_up, halt, overlap, page_align_up, page_offset, zero_mem_region};

--- a/src/utils/util.rs
+++ b/src/utils/util.rs
@@ -12,23 +12,6 @@ pub fn align_up(addr: usize, align: usize) -> usize {
     (addr + (align - 1)) & !(align - 1)
 }
 
-#[inline(always)]
-pub fn ffs(val: u64) -> usize {
-    let mut ret: usize;
-
-    unsafe {
-        asm!("bsf   %rax, %rsi
-              jz    1f
-              jmp   2f
-        1:    xorq  %rsi, %rsi
-              not   %rsi
-        2:", in("rax") val, out("rsi") ret,
-        options(att_syntax));
-    }
-
-    ret
-}
-
 pub fn halt() {
     unsafe {
         asm!("hlt", options(att_syntax));


### PR DESCRIPTION
Remove the use the `ffs()` function in favor of `u64::trailing_zeros()`. Both functions work identically except when the value is zero, where `ffs()` returns `u64::MAX` and `u64::trailing_zeros()` simply returns `u64::BITS` (64), which is fine for our use case.

The function has no other users, so it can be removed. This also removes an unsafe block, and allows running Miri on the upcoming stack tests (#126), since Miri does not work on inline assembly. Additionally, the new code runs twice as fast in my own (naive) benchmarks.