### PR TITLE
mm/alloc: bounds-check page order before indexing

### DIFF
--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -394,12 +394,12 @@ impl MemoryRegion {
     }
 
     fn refill_page_list(&mut self, order: usize) -> Result<(), SvsmError> {
-        if self.next_page[order] != 0 {
-            return Ok(());
+        if order >= MAX_ORDER {
+            return Err(SvsmError::Mem);
         }
 
-        if order >= MAX_ORDER - 1 {
-            return Err(SvsmError::Mem);
+        if self.next_page[order] != 0 {
+            return Ok(());
         }
 
         self.refill_page_list(order + 1)?;


### PR DESCRIPTION
Bounds check the order parameter to `MemoryRegion::refill_page_list()` before indexing, as an invalid order could cause an out of bounds access, resulting in a panic. The previous bounds check was too late, and also had an off-by-one bug.

This function is reachable from other modules via `allocate_pages()`, which naively forwards the order parameter.

Fixes: bee9fe779bf0 ("SVSM: Implement higher-order allocations")