### PR TITLE
fw_meta: do not trust firmware metadata memory regions

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -55,7 +55,7 @@ pub trait Address:
         self.is_aligned(PAGE_SIZE)
     }
 
-    fn checked_offset(&self, off: InnerAddr) -> Option<Self> {
+    fn checked_add(&self, off: InnerAddr) -> Option<Self> {
         self.bits().checked_add(off).map(|addr| addr.into())
     }
 
@@ -262,7 +262,7 @@ impl ops::Add<InnerAddr> for VirtAddr {
 }
 
 impl Address for VirtAddr {
-    fn checked_offset(&self, off: InnerAddr) -> Option<Self> {
+    fn checked_add(&self, off: InnerAddr) -> Option<Self> {
         self.bits()
             .checked_add(off)
             .map(|addr| sign_extend(addr).into())

--- a/src/address.rs
+++ b/src/address.rs
@@ -63,6 +63,10 @@ pub trait Address:
         self.bits().checked_sub(off).map(|addr| addr.into())
     }
 
+    fn saturating_add(&self, off: InnerAddr) -> Self {
+        Self::from(self.bits().saturating_add(off))
+    }
+
     fn page_offset(&self) -> usize {
         self.bits() & (PAGE_SIZE - 1)
     }

--- a/src/debug/stacktrace.rs
+++ b/src/debug/stacktrace.rs
@@ -26,7 +26,7 @@ struct StackBounds {
 #[cfg(feature = "enable-stacktrace")]
 impl StackBounds {
     fn range_is_on_stack(&self, begin: VirtAddr, len: usize) -> bool {
-        match begin.checked_offset(len) {
+        match begin.checked_add(len) {
             Some(end) => begin >= self.bottom && end <= self.top,
             None => false,
         }

--- a/src/fw_cfg.rs
+++ b/src/fw_cfg.rs
@@ -6,6 +6,7 @@
 
 extern crate alloc;
 
+use crate::address::{Address, PhysAddr};
 use crate::error::SvsmError;
 use crate::mm::pagetable::max_phys_addr;
 
@@ -154,14 +155,17 @@ impl<'a> FwCfg<'a> {
     }
 
     fn read_memory_region(&self) -> MemoryRegion {
-        let start: u64 = self.read_le();
-        let size: u64 = self.read_le();
-        let end = start.saturating_add(size);
+        let start = PhysAddr::from(self.read_le::<u64>());
+        let size = self.read_le::<u64>();
+        let end = start.saturating_add(size as usize);
 
         assert!(start <= max_phys_addr(), "{start:#018x} is out of range");
         assert!(end <= max_phys_addr(), "{end:#018x} is out of range");
 
-        MemoryRegion { start, end }
+        MemoryRegion {
+            start: start.into(),
+            end: end.into(),
+        }
     }
 
     pub fn get_memory_regions(&self) -> Result<Vec<MemoryRegion>, SvsmError> {

--- a/src/fw_cfg.rs
+++ b/src/fw_cfg.rs
@@ -9,6 +9,7 @@ extern crate alloc;
 use crate::address::{Address, PhysAddr};
 use crate::error::SvsmError;
 use crate::mm::pagetable::max_phys_addr;
+use crate::utils::MemoryRegion;
 
 use super::io::IOPort;
 use super::string::FixedString;
@@ -61,20 +62,6 @@ impl FwCfgFile {
     }
     pub fn selector(&self) -> u16 {
         self.selector
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-pub struct MemoryRegion {
-    pub start: u64,
-    pub end: u64,
-}
-
-impl MemoryRegion {
-    /// Returns `true` if the region overlaps with another region with given
-    /// start and end.
-    pub fn overlaps(&self, start: u64, end: u64) -> bool {
-        self.start < end && start < self.end
     }
 }
 
@@ -143,7 +130,7 @@ impl<'a> FwCfg<'a> {
         Err(SvsmError::FwCfg(FwCfgError::FileNotFound))
     }
 
-    fn find_svsm_region(&self) -> Result<MemoryRegion, SvsmError> {
+    fn find_svsm_region(&self) -> Result<MemoryRegion<PhysAddr>, SvsmError> {
         let file = self.file_selector("etc/sev/svsm")?;
 
         if file.size != 16 {
@@ -154,7 +141,7 @@ impl<'a> FwCfg<'a> {
         Ok(self.read_memory_region())
     }
 
-    fn read_memory_region(&self) -> MemoryRegion {
+    fn read_memory_region(&self) -> MemoryRegion<PhysAddr> {
         let start = PhysAddr::from(self.read_le::<u64>());
         let size = self.read_le::<u64>();
         let end = start.saturating_add(size as usize);
@@ -162,14 +149,11 @@ impl<'a> FwCfg<'a> {
         assert!(start <= max_phys_addr(), "{start:#018x} is out of range");
         assert!(end <= max_phys_addr(), "{end:#018x} is out of range");
 
-        MemoryRegion {
-            start: start.into(),
-            end: end.into(),
-        }
+        MemoryRegion::from_addresses(start, end)
     }
 
-    pub fn get_memory_regions(&self) -> Result<Vec<MemoryRegion>, SvsmError> {
-        let mut regions: Vec<MemoryRegion> = Vec::new();
+    pub fn get_memory_regions(&self) -> Result<Vec<MemoryRegion<PhysAddr>>, SvsmError> {
+        let mut regions = Vec::new();
         let file = self.file_selector("etc/e820")?;
         let entries = file.size / 20;
 
@@ -187,33 +171,35 @@ impl<'a> FwCfg<'a> {
         Ok(regions)
     }
 
-    fn find_kernel_region_e820(&self) -> Result<MemoryRegion, SvsmError> {
+    fn find_kernel_region_e820(&self) -> Result<MemoryRegion<PhysAddr>, SvsmError> {
         let regions = self.get_memory_regions()?;
-        let mut kernel_region = regions
+        let kernel_region = regions
             .iter()
-            .max_by_key(|region| region.start)
-            .copied()
+            .max_by_key(|region| region.start())
             .ok_or(SvsmError::FwCfg(FwCfgError::KernelRegion))?;
 
-        let start =
-            (kernel_region.end.saturating_sub(KERNEL_REGION_SIZE)) & KERNEL_REGION_SIZE_MASK;
+        let start = PhysAddr::from(
+            kernel_region
+                .end()
+                .bits()
+                .saturating_sub(KERNEL_REGION_SIZE as usize)
+                & KERNEL_REGION_SIZE_MASK as usize,
+        );
 
-        if start < kernel_region.start {
+        if start < kernel_region.start() {
             return Err(SvsmError::FwCfg(FwCfgError::KernelRegion));
         }
 
-        kernel_region.start = start;
-
-        Ok(kernel_region)
+        Ok(MemoryRegion::new(start, kernel_region.len()))
     }
 
-    pub fn find_kernel_region(&self) -> Result<MemoryRegion, SvsmError> {
+    pub fn find_kernel_region(&self) -> Result<MemoryRegion<PhysAddr>, SvsmError> {
         let kernel_region = self
             .find_svsm_region()
             .or_else(|_| self.find_kernel_region_e820())?;
 
         // Make sure that the kernel region doesn't overlap with the loader.
-        if kernel_region.start < 640 * 1024 {
+        if kernel_region.start() < PhysAddr::from(640 * 1024u64) {
             return Err(SvsmError::FwCfg(FwCfgError::KernelRegion));
         }
 
@@ -223,7 +209,7 @@ impl<'a> FwCfg<'a> {
     // This needs to be &mut self to prevent iterator invalidation, where the caller
     // could do fw_cfg.select() while iterating. Having a mutable reference prevents
     // other references.
-    pub fn iter_flash_regions(&mut self) -> impl Iterator<Item = MemoryRegion> + '_ {
+    pub fn iter_flash_regions(&mut self) -> impl Iterator<Item = MemoryRegion<PhysAddr>> + '_ {
         let num = match self.file_selector("etc/flash") {
             Ok(file) => {
                 self.select(file.selector);

--- a/src/kernel_launch.rs
+++ b/src/kernel_launch.rs
@@ -4,6 +4,9 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
+use crate::address::PhysAddr;
+use crate::utils::MemoryRegion;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct KernelLaunchInfo {
@@ -29,5 +32,11 @@ impl KernelLaunchInfo {
 
     pub fn heap_area_virt_end(&self) -> u64 {
         self.heap_area_virt_start + self.heap_area_size()
+    }
+
+    pub fn kernel_region(&self) -> MemoryRegion<PhysAddr> {
+        let start = PhysAddr::from(self.kernel_region_phys_start);
+        let end = PhysAddr::from(self.kernel_region_phys_end);
+        MemoryRegion::from_addresses(start, end)
     }
 }

--- a/src/mm/pagetable.rs
+++ b/src/mm/pagetable.rs
@@ -85,8 +85,8 @@ fn encrypt_mask() -> usize {
 }
 
 /// Returns the exclusive end of the physical address space.
-pub fn max_phys_addr() -> u64 {
-    *MAX_PHYS_ADDR
+pub fn max_phys_addr() -> PhysAddr {
+    PhysAddr::from(*MAX_PHYS_ADDR)
 }
 
 fn supported_flags(flags: PTEntryFlags) -> PTEntryFlags {

--- a/src/mm/ptguards.rs
+++ b/src/mm/ptguards.rs
@@ -13,21 +13,11 @@ use crate::mm::virtualrange::{
     virt_alloc_range_2m, virt_alloc_range_4k, virt_free_range_2m, virt_free_range_4k,
 };
 use crate::types::{PAGE_SIZE, PAGE_SIZE_2M};
-
-struct RawPTMappingGuard {
-    start: VirtAddr,
-    end: VirtAddr,
-}
-
-impl RawPTMappingGuard {
-    pub const fn new(start: VirtAddr, end: VirtAddr) -> Self {
-        RawPTMappingGuard { start, end }
-    }
-}
+use crate::utils::MemoryRegion;
 
 #[must_use = "if unused the mapping will immediately be unmapped"]
 pub struct PerCPUPageMappingGuard {
-    mapping: Option<RawPTMappingGuard>,
+    mapping: Option<MemoryRegion<VirtAddr>>,
     huge: bool,
 }
 
@@ -70,7 +60,7 @@ impl PerCPUPageMappingGuard {
             vaddr
         };
 
-        let raw_mapping = RawPTMappingGuard::new(vaddr, vaddr + size);
+        let raw_mapping = MemoryRegion::new(vaddr, size);
 
         Ok(PerCPUPageMappingGuard {
             mapping: Some(raw_mapping),
@@ -83,22 +73,26 @@ impl PerCPUPageMappingGuard {
     }
 
     pub fn virt_addr(&self) -> VirtAddr {
-        self.mapping.as_ref().unwrap().start
+        self.mapping.as_ref().unwrap().start()
     }
 }
 
 impl Drop for PerCPUPageMappingGuard {
     fn drop(&mut self) {
         if let Some(m) = &self.mapping {
-            let size = m.end - m.start;
+            let size = m.len();
             if self.huge {
-                this_cpu_mut().get_pgtable().unmap_region_2m(m.start, m.end);
-                virt_free_range_2m(m.start, size);
+                this_cpu_mut()
+                    .get_pgtable()
+                    .unmap_region_2m(m.start(), m.end());
+                virt_free_range_2m(m.start(), size);
             } else {
-                this_cpu_mut().get_pgtable().unmap_region_4k(m.start, m.end);
-                virt_free_range_4k(m.start, size);
+                this_cpu_mut()
+                    .get_pgtable()
+                    .unmap_region_4k(m.start(), m.end());
+                virt_free_range_4k(m.start(), size);
             }
-            flush_address_sync(m.start);
+            flush_address_sync(m.start());
         }
     }
 }

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -159,8 +159,7 @@ pub extern "C" fn stage2_main(launch_info: &Stage1LaunchInfo) {
 
     let kernel_region_phys_start = r.start();
     let kernel_region_phys_end = r.end();
-    init_valid_bitmap_alloc(kernel_region_phys_start, kernel_region_phys_end)
-        .expect("Failed to allocate valid-bitmap");
+    init_valid_bitmap_alloc(r).expect("Failed to allocate valid-bitmap");
 
     // Read the SVSM kernel's ELF file metadata.
     let kernel_elf_len = kernel_elf_end - kernel_elf_start;

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -157,8 +157,8 @@ pub extern "C" fn stage2_main(launch_info: &Stage1LaunchInfo) {
 
     log::info!("COCONUT Secure Virtual Machine Service Module (SVSM) Stage 2 Loader");
 
-    let kernel_region_phys_start = PhysAddr::from(r.start);
-    let kernel_region_phys_end = PhysAddr::from(r.end);
+    let kernel_region_phys_start = r.start();
+    let kernel_region_phys_end = r.end();
     init_valid_bitmap_alloc(kernel_region_phys_start, kernel_region_phys_end)
         .expect("Failed to allocate valid-bitmap");
 

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -442,7 +442,7 @@ pub extern "C" fn svsm_main() {
 
     print_fw_meta(&fw_meta);
 
-    if let Err(e) = validate_fw_memory(&fw_meta) {
+    if let Err(e) = validate_fw_memory(&fw_meta, &LAUNCH_INFO) {
         panic!("Failed to validate firmware memory: {:#?}", e);
     }
 

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -47,7 +47,7 @@ use svsm::sev::utils::{rmp_adjust, RMPFlags};
 use svsm::svsm_console::SVSMIOPort;
 use svsm::svsm_paging::{init_page_table, invalidate_stage2};
 use svsm::types::{PageSize, GUEST_VMPL, PAGE_SIZE};
-use svsm::utils::{halt, immut_after_init::ImmutAfterInitCell, zero_mem_region};
+use svsm::utils::{halt, immut_after_init::ImmutAfterInitCell, zero_mem_region, MemoryRegion};
 
 use svsm::mm::validate::{init_valid_bitmap_ptr, migrate_valid_bitmap};
 
@@ -221,26 +221,29 @@ fn validate_flash() -> Result<(), SvsmError> {
     let mut fw_cfg = FwCfg::new(&CONSOLE_IO);
 
     let flash_regions = fw_cfg.iter_flash_regions().collect::<Vec<_>>();
+    let kernel_region = LAUNCH_INFO.kernel_region();
+    let flash_range = {
+        let one_gib = 1024 * 1024 * 1024usize;
+        let start = PhysAddr::from(3 * one_gib);
+        MemoryRegion::new(start, one_gib)
+    };
 
     // Sanity-check flash regions.
     for region in flash_regions.iter() {
         // Make sure that the regions are between 3GiB and 4GiB.
-        if !region.overlaps(3 * 1024 * 1024 * 1024, 4 * 1024 * 1024 * 1024) {
+        if !region.overlap(&flash_range) {
             panic!("flash region in unexpected region");
         }
 
         // Make sure that no regions overlap with the kernel.
-        if region.overlaps(
-            LAUNCH_INFO.kernel_region_phys_start,
-            LAUNCH_INFO.kernel_region_phys_end,
-        ) {
+        if region.overlap(&kernel_region) {
             panic!("flash region overlaps with kernel");
         }
     }
     // Make sure that regions don't overlap.
     for (i, outer) in flash_regions.iter().enumerate() {
         for inner in flash_regions[..i].iter() {
-            if outer.overlaps(inner.start, inner.end) {
+            if outer.overlap(inner) {
                 panic!("flash regions overlap");
             }
         }
@@ -248,23 +251,18 @@ fn validate_flash() -> Result<(), SvsmError> {
     // Make sure that one regions ends at 4GiB.
     let one_region_ends_at_4gib = flash_regions
         .iter()
-        .any(|region| region.end == 4 * 1024 * 1024 * 1024);
+        .any(|region| region.end() == flash_range.end());
     assert!(one_region_ends_at_4gib);
 
     for (i, region) in flash_regions.into_iter().enumerate() {
-        let pstart = PhysAddr::from(region.start);
-        let pend = PhysAddr::from(region.end);
         log::info!(
             "Flash region {} at {:#018x} size {:018x}",
             i,
-            pstart,
-            pend - pstart
+            region.start(),
+            region.len(),
         );
 
-        for paddr in (pstart.bits()..pend.bits())
-            .step_by(PAGE_SIZE)
-            .map(PhysAddr::from)
-        {
+        for paddr in region.iter_pages(PageSize::Regular) {
             let guard = PerCPUPageMappingGuard::create_4k(paddr)?;
             let vaddr = guard.virt_addr();
             if let Err(e) = rmp_adjust(

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -315,11 +315,7 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
 
     mapping_info_init(&launch_info);
 
-    init_valid_bitmap_ptr(
-        launch_info.kernel_region_phys_start.try_into().unwrap(),
-        launch_info.kernel_region_phys_end.try_into().unwrap(),
-        vb_ptr,
-    );
+    init_valid_bitmap_ptr(launch_info.kernel_region(), vb_ptr);
 
     load_gdt();
     early_idt_init();

--- a/src/utils/memory_region.rs
+++ b/src/utils/memory_region.rs
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2022-2023 SUSE LLC
+//
+// Author: Carlos López <carlos.lopez@suse.com>
+
+use crate::address::Address;
+use crate::types::PageSize;
+
+/// An abstraction over a memory region, expressed in terms of physical
+/// ([`PhysAddr`](crate::address::PhysAddr)) or virtual
+/// ([`VirtAddr`](crate::address::VirtAddr)) addresses.
+#[derive(Clone, Copy, Debug)]
+pub struct MemoryRegion<A> {
+    start: A,
+    end: A,
+}
+
+impl<A> MemoryRegion<A>
+where
+    A: Address,
+{
+    /// Create a new memory region starting at address `start`, spanning `len`
+    /// bytes.
+    pub fn new(start: A, len: usize) -> Self {
+        let end = A::from(start.bits() + len);
+        Self { start, end }
+    }
+
+    /// Create a new memory region with overflow checks.
+    ///
+    /// ```rust
+    /// # use svsm::address::VirtAddr;
+    /// # use svsm::types::PAGE_SIZE;
+    /// # use svsm::utils::MemoryRegion;
+    /// let start = VirtAddr::from(u64::MAX);
+    /// let region = MemoryRegion::checked_new(start, PAGE_SIZE);
+    /// assert!(region.is_none());
+    /// ```
+    pub fn checked_new(start: A, len: usize) -> Option<Self> {
+        let end = start.checked_offset(len)?;
+        Some(Self { start, end })
+    }
+
+    /// Create a memory region from two raw addresses.
+    pub const fn from_addresses(start: A, end: A) -> Self {
+        Self { start, end }
+    }
+
+    /// The base address of the memory region, originally set in
+    /// [`MemoryRegion::new()`].
+    #[inline]
+    pub const fn start(&self) -> A {
+        self.start
+    }
+
+    /// The length of the memory region in bytes, originally set in
+    /// [`MemoryRegion::new()`].
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.end.bits().saturating_sub(self.start.bits())
+    }
+
+    /// Returns whether the region spans any actual memory.
+    ///
+    /// ```rust
+    /// # use svsm::address::VirtAddr;
+    /// # use svsm::utils::MemoryRegion;
+    /// let r = MemoryRegion::new(VirtAddr::from(0xffffff0000u64), 0);
+    /// assert!(r.is_empty());
+    /// ```
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// The end address of the memory region.
+    ///
+    /// ```rust
+    /// # use svsm::address::VirtAddr;
+    /// # use svsm::types::PAGE_SIZE;
+    /// # use svsm::utils::MemoryRegion;
+    /// let base = VirtAddr::from(0xffffff0000u64);
+    /// let region = MemoryRegion::new(base, PAGE_SIZE);
+    /// assert_eq!(region.end(), VirtAddr::from(0xffffff1000u64));
+    /// ```
+    #[inline]
+    pub const fn end(&self) -> A {
+        self.end
+    }
+
+    /// Checks whether two regions overlap. This does *not* include contiguous
+    /// regions, use [`MemoryRegion::contiguous()`] for that purpose.
+    ///
+    /// ```rust
+    /// # use svsm::address::VirtAddr;
+    /// # use svsm::types::PAGE_SIZE;
+    /// # use svsm::utils::MemoryRegion;
+    /// let r1 = MemoryRegion::new(VirtAddr::from(0xffffff0000u64), PAGE_SIZE);
+    /// let r2 = MemoryRegion::new(VirtAddr::from(0xffffff2000u64), PAGE_SIZE);
+    /// assert!(!r1.overlap(&r2));
+    /// ```
+    ///
+    /// ```rust
+    /// # use svsm::address::VirtAddr;
+    /// # use svsm::types::PAGE_SIZE;
+    /// # use svsm::utils::MemoryRegion;
+    /// let r1 = MemoryRegion::new(VirtAddr::from(0xffffff0000u64), PAGE_SIZE * 2);
+    /// let r2 = MemoryRegion::new(VirtAddr::from(0xffffff1000u64), PAGE_SIZE);
+    /// assert!(r1.overlap(&r2));
+    /// ```
+    ///
+    /// ```rust
+    /// # use svsm::address::VirtAddr;
+    /// # use svsm::types::PAGE_SIZE;
+    /// # use svsm::utils::MemoryRegion;
+    /// // Contiguous regions do not overlap
+    /// let r1 = MemoryRegion::new(VirtAddr::from(0xffffff0000u64), PAGE_SIZE);
+    /// let r2 = MemoryRegion::new(VirtAddr::from(0xffffff1000u64), PAGE_SIZE);
+    /// assert!(!r1.overlap(&r2));
+    /// ```
+    pub fn overlap(&self, other: &Self) -> bool {
+        self.start() < other.end() && self.end() > other.start()
+    }
+
+    /// Checks whether two regions are contiguous or overlapping. This is a
+    /// less strict check than [`MemoryRegion::overlap()`].
+    ///
+    /// ```rust
+    /// # use svsm::address::VirtAddr;
+    /// # use svsm::types::PAGE_SIZE;
+    /// # use svsm::utils::MemoryRegion;
+    /// let r1 = MemoryRegion::new(VirtAddr::from(0xffffff0000u64), PAGE_SIZE);
+    /// let r2 = MemoryRegion::new(VirtAddr::from(0xffffff1000u64), PAGE_SIZE);
+    /// assert!(r1.contiguous(&r2));
+    /// ```
+    ///
+    /// ```rust
+    /// # use svsm::address::VirtAddr;
+    /// # use svsm::types::PAGE_SIZE;
+    /// # use svsm::utils::MemoryRegion;
+    /// let r1 = MemoryRegion::new(VirtAddr::from(0xffffff0000u64), PAGE_SIZE);
+    /// let r2 = MemoryRegion::new(VirtAddr::from(0xffffff2000u64), PAGE_SIZE);
+    /// assert!(!r1.contiguous(&r2));
+    /// ```
+    pub fn contiguous(&self, other: &Self) -> bool {
+        self.start() <= other.end() && self.end() >= other.start()
+    }
+
+    /// Merge two regions. It does not check whether the two regions are
+    /// contiguous in the first place, so the resulting region will cover
+    /// any non-overlapping memory between both.
+    ///
+    /// ```rust
+    /// # use svsm::address::VirtAddr;
+    /// # use svsm::types::PAGE_SIZE;
+    /// # use svsm::utils::MemoryRegion;
+    /// let r1 = MemoryRegion::new(VirtAddr::from(0xffffff0000u64), PAGE_SIZE);
+    /// let r2 = MemoryRegion::new(VirtAddr::from(0xffffff1000u64), PAGE_SIZE);
+    /// let r3  = r1.merge(&r2);
+    /// assert_eq!(r3.start(), r1.start());
+    /// assert_eq!(r3.len(), r1.len() + r2.len());
+    /// assert_eq!(r3.end(), r2.end());
+    /// ```
+    pub fn merge(&self, other: &Self) -> Self {
+        let start = self.start.min(other.start);
+        let end = self.end().max(other.end());
+        Self { start, end }
+    }
+
+    /// Iterate over the addresses covering the memory region in jumps of the
+    /// specified page size. Note that if the base address of the region is not
+    /// page aligned, returned addresses will not be aligned either.
+    ///
+    /// ```rust
+    /// # use svsm::address::VirtAddr;
+    /// # use svsm::types::{PAGE_SIZE, PageSize};
+    /// # use svsm::utils::MemoryRegion;
+    /// let region = MemoryRegion::new(VirtAddr::from(0xffffff0000u64), PAGE_SIZE * 2);
+    /// let mut iter = region.iter_pages(PageSize::Regular);
+    /// assert_eq!(iter.next(), Some(VirtAddr::from(0xffffff0000u64)));
+    /// assert_eq!(iter.next(), Some(VirtAddr::from(0xffffff1000u64)));
+    /// assert_eq!(iter.next(), None);
+    /// ```
+    pub fn iter_pages(&self, size: PageSize) -> impl Iterator<Item = A> {
+        let size = usize::from(size);
+        (self.start().bits()..self.end().bits())
+            .step_by(size)
+            .map(A::from)
+    }
+}

--- a/src/utils/memory_region.rs
+++ b/src/utils/memory_region.rs
@@ -38,7 +38,7 @@ where
     /// assert!(region.is_none());
     /// ```
     pub fn checked_new(start: A, len: usize) -> Option<Self> {
-        let end = start.checked_offset(len)?;
+        let end = start.checked_add(len)?;
         Some(Self { start, end })
     }
 

--- a/src/utils/memory_region.rs
+++ b/src/utils/memory_region.rs
@@ -188,4 +188,19 @@ where
             .step_by(size)
             .map(A::from)
     }
+
+    /// Check whether an address is within this region.
+    ///
+    /// ```rust
+    /// # use svsm::address::VirtAddr;
+    /// # use svsm::types::{PAGE_SIZE, PageSize};
+    /// # use svsm::utils::MemoryRegion;
+    /// let region = MemoryRegion::new(VirtAddr::from(0xffffff0000u64), PAGE_SIZE);
+    /// assert!(region.contains(VirtAddr::from(0xffffff0000u64)));
+    /// assert!(region.contains(VirtAddr::from(0xffffff0fffu64)));
+    /// assert!(!region.contains(VirtAddr::from(0xffffff1000u64)));
+    /// ```
+    pub fn contains(&self, addr: A) -> bool {
+        self.start() <= addr && addr < self.end()
+    }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -6,6 +6,8 @@
 
 pub mod bitmap_allocator;
 pub mod immut_after_init;
+pub mod memory_region;
 pub mod util;
 
+pub use memory_region::MemoryRegion;
 pub use util::{align_down, align_up, halt, overlap, page_align_up, page_offset, zero_mem_region};


### PR DESCRIPTION
As described in #114, the SVSM `PVALIDATE`s and uses hypervisor-provided memory regions without any checks, which could lead to the SVSM kernel doubly validating its own memory.

In order to fix this, introduce a new type, `MemoryRegion`, to serve as a common type to perform these kinds of checks. While we are at it, use this new type everywhere possible instead of having per-module types with essentially the same functionality.

While we are at it, cleanup code around the use of memory regions.

Fixes #114.