### PR TITLE
github/workflows: Add CI test for documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,16 @@
+name: Docs
+
+on: [pull_request]
+
+jobs:
+  check:
+    name: Check commits
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Generate Documentation
+        run: make doc


### PR DESCRIPTION
Check documentation didn't break on pull requests, as discussed in pull request #124 (this test depends on merging first `make doc`).