### PR TITLE
Add support for vTPM and its runtime protocol

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,6 +28,9 @@ jobs:
             override: true
             components: rustfmt, rust-src, clippy
 
+      - name: Install Microsoft TPM build dependencies
+        run: sudo apt install -y autoconf autoconf-archive pkg-config build-essential automake libssl-dev
+
       # ubuntu-latest does not have binutils 2.39, which we need for
       # ld to work, so build all the objects without performing the
       # final linking step.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -94,6 +94,13 @@ jobs:
             override: true
             components: rustfmt
 
+      # The bindings.rs is auto-generated during make, but we are not
+      # building the code with nightly. So we initialize bindings.rs here
+      # for cargo-fmt in the next workflow, otherwise it will fail reporting
+      # that bindings.rs does not exist.
+      - name: Touch libmstpm bindings
+        run: echo "" > libmstpm/src/bindings.rs
+
       - name: Format doctests
         uses: actions-rs/cargo@v1
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "libmstpm/deps/openssl"]
 	path = libmstpm/deps/openssl
 	url = https://github.com/openssl/openssl.git
+[submodule "libmstpm/deps/ms-tpm-20-ref"]
+	path = libmstpm/deps/ms-tpm-20-ref
+	url = https://github.com/microsoft/ms-tpm-20-ref.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libmstpm/deps/openssl"]
+	path = libmstpm/deps/openssl
+	url = https://github.com/openssl/openssl.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,6 +426,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "libmstpm"
+version = "0.1.0"
+
+[[package]]
 name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,6 +578,7 @@ dependencies = [
  "gdbstub_arch",
  "igvm_defs",
  "intrusive-collections",
+ "libmstpm",
  "log",
  "memoffset",
  "packit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ members = [
     "fuzz",
     # ELF loader
     "elf",
+    # Microsoft TPM library
+    "libmstpm",
 ]
 
 
@@ -20,6 +22,7 @@ cpuarch = { path = "cpuarch" }
 test = { path = "test" }
 svsm = { path = "kernel" }
 elf = { path = "elf" }
+libmstpm = { path = "libmstpm" }
 
 # crates.io
 aes-gcm = { version = "0.10.3", default-features = false }

--- a/Documentation/INSTALL.md
+++ b/Documentation/INSTALL.md
@@ -139,15 +139,16 @@ openSUSE you can do this by:
 $ sudo zypper si -d qemu-ovmf-x86_64
 ```
 
-Then go back to the EDK2 source directory and follow these steps to
-build the firmware:
+Then go back to the EDK2 source directory and follow the steps below to
+build the firmware. `-DTPM2_ENABLE` is required only if you want to use
+the SVSM vTPM.
 
 ```
 $ export PYTHON3_ENABLE=TRUE
 $ export PYTHON_COMMAND=python3
 $ make -j16 -C BaseTools/
-$ source ./edksetup.sh
-$ build -a X64 -b DEBUG -t GCC5 -D DEBUG_ON_SERIAL_PORT -D DEBUG_VERBOSE -p OvmfPkg/OvmfPkgX64.dsc
+$ source ./edksetup.sh --reconfig
+$ build -a X64 -b DEBUG -t GCC5 -D DEBUG_ON_SERIAL_PORT -D DEBUG_VERBOSE -DTPM2_ENABLE -p OvmfPkg/OvmfPkgX64.dsc
 ```
 
 This will build the OVMF binary that will be packaged into the IGVM file to use
@@ -180,6 +181,9 @@ the guest kernel configuration you can follow the same steps as for the
 host kernel. Best results are achieved by re-using the kernel
 configuration from the distribution like for the host kernel.
 
+The `CONFIG_TCG_PLATFORM` is required in the guest kernel if you want to
+use the SVSM vTPM.
+
 Building the COCONUT-SVSM
 -------------------------
 
@@ -189,11 +193,22 @@ Building the SVSM itself requires:
 - `x86_64-unknown-none` target toolchain installed (`rustup target add x86_64-unknown-none`)
 - `binutils` >= 2.39
 
+You may also need to install the Microsoft TPM build dependencies. On OpenSUSE
+you can do this by:
+
+```
+$ sudo zypper in system-user-mail make gcc curl patterns-devel-base-devel_basis \
+      glibc-devel-static git libclang13 autoconf autoconf-archive pkg-config \
+      automake libopenssl-devel perl
+```
+
 Then checkout the SVSM repository and build the SVSM binary:
 
 ```
 $ git clone https://github.com/coconut-svsm/svsm
 $ cd svsm
+$ git submodule update --init
+$ cargo install bindgen-cli
 ```
 
 That checks out the SVSM which can be built by

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 FEATURES ?= "default"
 SVSM_ARGS = --features ${FEATURES}
 
+FEATURES_TEST ?= "default-test"
+SVSM_ARGS_TEST = --no-default-features --features ${FEATURES_TEST}
+
 ifdef RELEASE
 TARGET_PATH=release
 CARGO_ARGS += --release
@@ -73,7 +76,7 @@ bin/coconut-test-qemu.igvm: $(IGVMBUILDER)  $(IGVMMEASURE) bin/test-kernel.elf b
 	$(IGVMMEASURE) $@
 
 test:
-	cargo test ${CARGO_ARGS} --workspace --target=x86_64-unknown-linux-gnu
+	cargo test ${CARGO_ARGS} ${SVSM_ARGS_TEST} --workspace --target=x86_64-unknown-linux-gnu
 
 test-in-svsm: utils/cbit bin/coconut-test-qemu.igvm
 	./scripts/test-in-svsm.sh

--- a/Makefile
+++ b/Makefile
@@ -144,4 +144,7 @@ clean:
 	rm -f ${STAGE1_OBJS} utils/gen_meta utils/print-meta
 	rm -rf bin
 
-.PHONY: test clean clippy bin/stage2.bin bin/svsm-kernel.elf bin/test-kernel.elf
+distclean: clean
+	$(MAKE) -C libmstpm $@
+
+.PHONY: test clean clippy bin/stage2.bin bin/svsm-kernel.elf bin/test-kernel.elf distclean

--- a/Makefile
+++ b/Makefile
@@ -145,4 +145,3 @@ clean:
 	rm -rf bin
 
 .PHONY: test clean clippy bin/stage2.bin bin/svsm-kernel.elf bin/test-kernel.elf
-

--- a/fuzz/fuzz_targets/page_alloc.rs
+++ b/fuzz/fuzz_targets/page_alloc.rs
@@ -93,7 +93,7 @@ fuzz_target!(|inp: FuzzInput| {
                 }
             }
             Action::AllocateSlab => {
-                if let Ok(page) = allocate_slab_page() {
+                if let Ok(page) = allocate_slab_page(None) {
                     pages.push(page);
                 }
             }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -37,6 +37,7 @@ test.workspace = true
 
 [features]
 default = ["mstpm"]
+default-test = []
 enable-gdb = ["dep:gdbstub", "dep:gdbstub_arch"]
 mstpm = ["dep:libmstpm"]
 

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -30,14 +30,15 @@ igvm_defs = { workspace = true, features = ["unstable"] }
 intrusive-collections.workspace = true
 log = { workspace = true, features = ["max_level_info", "release_max_level_info"] }
 packit.workspace = true
-
+libmstpm = { workspace = true, optional = true }
 
 [target."x86_64-unknown-none".dev-dependencies]
 test.workspace = true
 
 [features]
-default = []
+default = ["mstpm"]
 enable-gdb = ["dep:gdbstub", "dep:gdbstub_arch"]
+mstpm = ["dep:libmstpm"]
 
 [dev-dependencies]
 memoffset.workspace = true

--- a/kernel/build.rs
+++ b/kernel/build.rs
@@ -17,6 +17,10 @@ fn main() {
     println!("cargo:rustc-link-arg-bin=svsm=--no-relax");
     println!("cargo:rustc-link-arg-bin=svsm=-Tkernel/src/svsm.lds");
     println!("cargo:rustc-link-arg-bin=svsm=-no-pie");
+    if std::env::var("CARGO_FEATURE_MSTPM").is_ok() {
+        println!("cargo:rustc-link-arg-bin=svsm=-Llibmstpm");
+        println!("cargo:rustc-link-arg-bin=svsm=-lmstpm");
+    }
 
     // Extra linker args for tests.
     println!("cargo:rerun-if-env-changed=LINK_TEST");

--- a/kernel/build.rs
+++ b/kernel/build.rs
@@ -17,7 +17,9 @@ fn main() {
     println!("cargo:rustc-link-arg-bin=svsm=--no-relax");
     println!("cargo:rustc-link-arg-bin=svsm=-Tkernel/src/svsm.lds");
     println!("cargo:rustc-link-arg-bin=svsm=-no-pie");
-    if std::env::var("CARGO_FEATURE_MSTPM").is_ok() {
+    if std::env::var("CARGO_FEATURE_MSTPM").is_ok()
+        && std::env::var("CARGO_FEATURE_DEFAULT_TEST").is_err()
+    {
         println!("cargo:rustc-link-arg-bin=svsm=-Llibmstpm");
         println!("cargo:rustc-link-arg-bin=svsm=-lmstpm");
     }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -37,6 +37,8 @@ pub mod svsm_paging;
 pub mod task;
 pub mod types;
 pub mod utils;
+#[cfg(feature = "mstpm")]
+pub mod vtpm;
 
 #[test]
 fn test_nop() {}

--- a/kernel/src/mm/alloc.rs
+++ b/kernel/src/mm/alloc.rs
@@ -98,6 +98,8 @@ impl PageStorageType {
     const NEXT_SHIFT: u64 = 12;
     const NEXT_MASK: u64 = !((1u64 << Self::NEXT_SHIFT) - 1);
     const ORDER_MASK: u64 = (1u64 << (Self::NEXT_SHIFT - Self::TYPE_SHIFT)) - 1;
+    // SLAB pages are always order-0
+    const SLAB_MASK: u64 = !Self::TYPE_MASK;
 
     /// Creates a new [`PageStorageType`] with the specified page type.
     ///
@@ -138,6 +140,19 @@ impl PageStorageType {
         Self(self.0 | (next_page as u64) << Self::NEXT_SHIFT)
     }
 
+    /// Encodes the virtual address of the slab
+    ///
+    /// # Arguments
+    ///
+    /// * `slab` - slab virtual address
+    ///
+    /// # Returns
+    ///
+    /// The updated [`PageStorageType`]
+    fn encode_slab(self, slab: VirtAddr) -> Self {
+        Self(self.0 | (slab.bits() as u64) & Self::SLAB_MASK)
+    }
+
     /// Encodes the reference count.
     ///
     /// # Arguments
@@ -159,6 +174,11 @@ impl PageStorageType {
     /// Decodes the index of the next page.
     fn decode_next(&self) -> usize {
         ((self.0 & Self::NEXT_MASK) >> Self::NEXT_SHIFT) as usize
+    }
+
+    /// Decodes the slab
+    fn decode_slab(&self) -> VirtAddr {
+        VirtAddr::from(self.0 & Self::SLAB_MASK)
     }
 
     /// Decodes the reference count.
@@ -218,17 +238,20 @@ impl AllocatedInfo {
 
 /// Struct representing information about a slab memory page.
 #[derive(Clone, Copy, Debug)]
-struct SlabPageInfo;
+struct SlabPageInfo {
+    slab: VirtAddr,
+}
 
 impl SlabPageInfo {
     /// Encodes the [`SlabPageInfo`] into a [`PageStorageType`].
     fn encode(&self) -> PageStorageType {
-        PageStorageType::new(PageType::SlabPage)
+        PageStorageType::new(PageType::SlabPage).encode_slab(self.slab)
     }
 
     /// Decodes a [`PageStorageType`] into a [`SlabPageInfo`].
-    fn decode(_mem: PageStorageType) -> Self {
-        Self
+    fn decode(mem: PageStorageType) -> Self {
+        let slab = mem.decode_slab();
+        Self { slab }
     }
 }
 
@@ -557,9 +580,15 @@ impl MemoryRegion {
     }
 
     /// Allocates a slab page.
-    fn allocate_slab_page(&mut self) -> Result<VirtAddr, AllocError> {
-        let pg = PageInfo::Slab(SlabPageInfo);
-        self.allocate_pages_info(0, pg)
+    fn allocate_slab_page(&mut self, slab: Option<VirtAddr>) -> Result<VirtAddr, AllocError> {
+        self.refill_page_list(0)?;
+
+        let slab_vaddr = slab.unwrap_or(VirtAddr::null());
+        let pfn = self.get_next_page(0)?;
+        assert_eq!(slab_vaddr.bits() & (PageStorageType::TYPE_MASK as usize), 0);
+        let pg = PageInfo::Slab(SlabPageInfo { slab: slab_vaddr });
+        self.write_page_info(pfn, pg);
+        Ok(self.start_virt + (pfn * PAGE_SIZE))
     }
 
     /// Allocates a file page with initial reference count.
@@ -984,12 +1013,16 @@ pub fn allocate_pages(order: usize) -> Result<VirtAddr, SvsmError> {
 
 /// Allocate a slab page.
 ///
+/// # Arguments
+///
+/// `slab` - slab virtual address
+///
 /// # Returns
 ///
 /// Result containing the virtual address of the allocated slab page or an
 /// `SvsmError` if allocation fails.
-pub fn allocate_slab_page() -> Result<VirtAddr, SvsmError> {
-    Ok(ROOT_MEM.lock().allocate_slab_page()?)
+pub fn allocate_slab_page(slab: Option<VirtAddr>) -> Result<VirtAddr, SvsmError> {
+    Ok(ROOT_MEM.lock().allocate_slab_page(slab)?)
 }
 
 /// Allocate a zeroed page.
@@ -1070,8 +1103,8 @@ impl SlabPage {
         }
     }
 
-    /// Initialize the [`SlabPage`] with a given item size
-    fn init(&mut self, mut item_size: u16) -> Result<(), AllocError> {
+    /// Initialize the [`SlabPage`] with a given item size and slab address
+    fn init(&mut self, slab_vaddr: Option<VirtAddr>, mut item_size: u16) -> Result<(), AllocError> {
         if self.item_size != 0 {
             return Ok(());
         }
@@ -1083,7 +1116,7 @@ impl SlabPage {
             item_size = 32;
         }
 
-        let vaddr = ROOT_MEM.lock().allocate_slab_page()?;
+        let vaddr = ROOT_MEM.lock().allocate_slab_page(slab_vaddr)?;
         self.vaddr = vaddr;
         self.item_size = item_size;
         self.capacity = (PAGE_SIZE as u16) / item_size;
@@ -1190,8 +1223,8 @@ impl SlabCommon {
     }
 
     /// Initialize the [`SlabCommon`] with default values
-    fn init(&mut self) -> Result<(), AllocError> {
-        self.page.init(self.item_size)?;
+    fn init(&mut self, slab_vaddr: Option<VirtAddr>) -> Result<(), AllocError> {
+        self.page.init(slab_vaddr, self.item_size)?;
 
         self.capacity = self.page.get_capacity() as u32;
         self.free = self.capacity;
@@ -1318,7 +1351,7 @@ impl SlabPageSlab {
 
     /// Initializes the [`SlabPageSlab`], allocating the first slab page if necessary.
     fn init(&mut self) -> Result<(), AllocError> {
-        self.common.init()
+        self.common.init(None)
     }
 
     /// Grows the slab by allocating a new slab page.
@@ -1338,7 +1371,7 @@ impl SlabPageSlab {
         let slab_page = unsafe { &mut *page_vaddr.as_mut_ptr::<SlabPage>() };
 
         *slab_page = SlabPage::new();
-        if let Err(e) = slab_page.init(self.common.item_size) {
+        if let Err(e) = slab_page.init(None, self.common.item_size) {
             self.common.deallocate_slot(page_vaddr);
             return Err(e);
         }
@@ -1398,7 +1431,8 @@ impl Slab {
 
     /// Initialize the [`Slab`] instance
     fn init(&mut self) -> Result<(), AllocError> {
-        self.common.init()
+        let slab_vaddr = VirtAddr::from(self as *mut Slab);
+        self.common.init(Some(slab_vaddr))
     }
 
     fn grow_slab(&mut self) -> Result<(), AllocError> {
@@ -1414,8 +1448,9 @@ impl Slab {
             .lock()
             .allocate()
             .map(|ptr| unsafe { &mut *ptr })?;
+        let slab_vaddr = VirtAddr::from(self as *mut Slab);
         *slab_page = SlabPage::new();
-        if let Err(e) = slab_page.init(self.common.item_size) {
+        if let Err(e) = slab_page.init(Some(slab_vaddr), self.common.item_size) {
             SLAB_PAGE_SLAB.lock().deallocate(slab_page);
             return Err(e);
         }

--- a/kernel/src/protocols/mod.rs
+++ b/kernel/src/protocols/mod.rs
@@ -9,6 +9,9 @@ pub mod errors;
 
 use cpuarch::vmsa::{GuestVMExit, VMSA};
 
+// SVSM protocols
+pub const SVSM_CORE_PROTOCOL: u32 = 0;
+
 #[derive(Debug, Default, Clone, Copy)]
 pub struct RequestParams {
     pub guest_exit_code: GuestVMExit,

--- a/kernel/src/protocols/mod.rs
+++ b/kernel/src/protocols/mod.rs
@@ -6,11 +6,14 @@
 
 pub mod core;
 pub mod errors;
+#[cfg(feature = "mstpm")]
+pub mod vtpm;
 
 use cpuarch::vmsa::{GuestVMExit, VMSA};
 
 // SVSM protocols
 pub const SVSM_CORE_PROTOCOL: u32 = 0;
+pub const SVSM_VTPM_PROTOCOL: u32 = 2;
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct RequestParams {

--- a/kernel/src/protocols/vtpm.rs
+++ b/kernel/src/protocols/vtpm.rs
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (C) 2023 IBM Corp
+//
+// Author: Claudio Carvalho <cclaudio@linux.ibm.com>
+
+//! vTPM protocol implementation (SVSM spec, chapter 8).
+
+extern crate alloc;
+
+use core::{mem::size_of, slice::from_raw_parts_mut};
+
+use alloc::vec::Vec;
+
+use crate::{
+    address::{Address, PhysAddr},
+    mm::{valid_phys_address, GuestPtr, PerCPUPageMappingGuard},
+    protocols::{errors::SvsmReqError, RequestParams},
+    types::PAGE_SIZE,
+    vtpm::{vtpm_get_locked, MsTpmSimulatorInterface, VtpmProtocolInterface},
+};
+
+/// vTPM platform commands (SVSM spec, section 8.1 - SVSM_VTPM_QUERY)
+///
+/// The platform commmand values follow the values used by the
+/// Official TPM 2.0 Reference Implementation by Microsoft.
+///
+/// `ms-tpm-20-ref/TPMCmd/Simulator/include/TpmTcpProtocol.h`
+#[repr(u32)]
+#[derive(PartialEq, Copy, Clone, Debug)]
+pub enum TpmPlatformCommand {
+    SendCommand = 8,
+}
+
+impl TryFrom<u32> for TpmPlatformCommand {
+    type Error = SvsmReqError;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        let cmd = match value {
+            x if x == TpmPlatformCommand::SendCommand as u32 => TpmPlatformCommand::SendCommand,
+            other => {
+                log::warn!("Failed to convert {} to a TPM platform command", other);
+                return Err(SvsmReqError::invalid_parameter());
+            }
+        };
+
+        Ok(cmd)
+    }
+}
+
+fn vtpm_platform_commands_supported_bitmap() -> u64 {
+    let mut bitmap: u64 = 0;
+    let vtpm = vtpm_get_locked();
+
+    for cmd in vtpm.get_supported_commands() {
+        bitmap |= 1u64 << *cmd as u32;
+    }
+
+    bitmap
+}
+
+fn is_vtpm_platform_command_supported(cmd: TpmPlatformCommand) -> bool {
+    let vtpm = vtpm_get_locked();
+    vtpm.get_supported_commands().iter().any(|x| *x == cmd)
+}
+
+const SEND_COMMAND_REQ_INBUF_SIZE: usize = PAGE_SIZE - 9;
+
+// vTPM protocol services (SVSM spec, table 14)
+const SVSM_VTPM_QUERY: u32 = 0;
+const SVSM_VTPM_COMMAND: u32 = 1;
+
+/// TPM_SEND_COMMAND request structure (SVSM spec, table 16)
+#[derive(Clone, Copy, Debug)]
+#[repr(C, packed)]
+struct TpmSendCommandRequest {
+    /// MSSIM platform command ID
+    command: u32,
+    /// Locality usage for the vTPM is not defined yet (must be zero)
+    locality: u8,
+    /// Size of the input buffer
+    inbuf_size: u32,
+    /// Input buffer that contains the TPM command
+    inbuf: [u8; SEND_COMMAND_REQ_INBUF_SIZE],
+}
+
+impl TpmSendCommandRequest {
+    // Take as slice and return a reference for Self
+    pub fn try_from_as_ref(buffer: &[u8]) -> Result<&Self, SvsmReqError> {
+        let buffer = buffer
+            .get(..size_of::<Self>())
+            .ok_or_else(SvsmReqError::invalid_parameter)?;
+
+        // SAFETY: SnpReportRequest has no invalid representations, as it is
+        // comprised entirely of integer types. It is repr(packed), so its
+        // required alignment is simply 1. We have checked the size, so this
+        // is entirely safe.
+        let request = unsafe { &*buffer.as_ptr().cast::<Self>() };
+
+        Ok(request)
+    }
+
+    pub fn send(&self) -> Result<Vec<u8>, SvsmReqError> {
+        // TODO: Before implementing locality, we need to agree what it means
+        // to the platform
+        if self.locality != 0 {
+            return Err(SvsmReqError::invalid_parameter());
+        }
+
+        let mut length = self.inbuf_size as usize;
+
+        let tpm_cmd = self
+            .inbuf
+            .get(..length)
+            .ok_or_else(SvsmReqError::invalid_parameter)?;
+        let mut buffer: Vec<u8> = Vec::with_capacity(SEND_COMMAND_RESP_OUTBUF_SIZE);
+        buffer.extend_from_slice(tpm_cmd);
+
+        // The buffer slice must be large enough to hold the TPM command response
+        buffer.resize(SEND_COMMAND_RESP_OUTBUF_SIZE, 0);
+
+        let vtpm = vtpm_get_locked();
+        vtpm.send_tpm_command(buffer.as_mut_slice(), &mut length, self.locality)?;
+
+        if length > buffer.len() {
+            return Err(SvsmReqError::invalid_request());
+        }
+        buffer.truncate(length);
+
+        Ok(buffer)
+    }
+}
+
+const SEND_COMMAND_RESP_OUTBUF_SIZE: usize = PAGE_SIZE - 4;
+
+/// TPM_SEND_COMMAND response structure (SVSM spec, table 17)
+#[derive(Clone, Copy, Debug)]
+#[repr(C, packed)]
+struct TpmSendCommandResponse {
+    /// Size of the output buffer
+    outbuf_size: u32,
+    /// Output buffer that will hold the command response
+    outbuf: [u8; SEND_COMMAND_RESP_OUTBUF_SIZE],
+}
+
+impl TpmSendCommandResponse {
+    // Take as slice and return a &mut Self
+    pub fn try_from_as_mut_ref(buffer: &mut [u8]) -> Result<&mut Self, SvsmReqError> {
+        let buffer = buffer
+            .get_mut(..size_of::<Self>())
+            .ok_or_else(SvsmReqError::invalid_parameter)?;
+
+        // SAFETY: SnpReportRequest has no invalid representations, as it is
+        // comprised entirely of integer types. It is repr(packed), so its
+        // required alignment is simply 1. We have checked the size, so this
+        // is entirely safe.
+        let response = unsafe { &mut *buffer.as_mut_ptr().cast::<Self>() };
+
+        Ok(response)
+    }
+
+    /// Write the response to the outbuf
+    ///
+    /// # Arguments
+    ///
+    /// * `response`: TPM_SEND_COMMAND response slice
+    pub fn set_outbuf(&mut self, response: &[u8]) -> Result<(), SvsmReqError> {
+        self.outbuf
+            .get_mut(..response.len())
+            .ok_or_else(SvsmReqError::invalid_request)?
+            .copy_from_slice(response);
+        self.outbuf_size = response.len() as u32;
+
+        Ok(())
+    }
+}
+
+fn vtpm_query_request(params: &mut RequestParams) -> Result<(), SvsmReqError> {
+    // Bitmap of the supported vTPM commands
+    params.rcx = vtpm_platform_commands_supported_bitmap();
+    // Supported vTPM features. Must-be-zero
+    params.rdx = 0;
+
+    Ok(())
+}
+
+/// Send a TpmSendCommandRequest to the vTPM
+///
+/// # Arguments
+///
+/// * `buffer`: Contains the TpmSendCommandRequest. It will also be
+///             used to store the TpmSendCommandResponse as a byte slice
+///
+/// # Returns
+///
+/// * `u32`: Number of bytes written back to `buffer` as part of
+///          the TpmSendCommandResponse
+fn tpm_send_command_request(buffer: &mut [u8]) -> Result<u32, SvsmReqError> {
+    let outbuf: Vec<u8> = {
+        let request = TpmSendCommandRequest::try_from_as_ref(buffer)?;
+        request.send()?
+    };
+    let response = TpmSendCommandResponse::try_from_as_mut_ref(buffer)?;
+    let _ = response.set_outbuf(outbuf.as_slice());
+
+    Ok(outbuf.len() as u32)
+}
+
+fn vtpm_command_request(params: &RequestParams) -> Result<(), SvsmReqError> {
+    let paddr = PhysAddr::from(params.rcx);
+
+    if paddr.is_null() {
+        return Err(SvsmReqError::invalid_parameter());
+    }
+    if !valid_phys_address(paddr) {
+        return Err(SvsmReqError::invalid_address());
+    }
+
+    // The vTPM buffer size is one page, but it not required to be page aligned.
+    let start = paddr.page_align();
+    let offset = paddr.page_offset();
+    let end = (paddr + PAGE_SIZE).page_align_up();
+
+    let guard = PerCPUPageMappingGuard::create(start, end, 0)?;
+    let vaddr = guard.virt_addr() + offset;
+
+    // vTPM common request/response structure (SVSM spec, table 15)
+    //
+    // First 4 bytes are used as input and output.
+    //     IN: platform command
+    //    OUT: platform command response size
+
+    let command = GuestPtr::<u32>::new(vaddr).read()?;
+    let cmd = TpmPlatformCommand::try_from(command)?;
+
+    if !is_vtpm_platform_command_supported(cmd) {
+        return Err(SvsmReqError::unsupported_call());
+    }
+
+    let buffer = unsafe { from_raw_parts_mut(vaddr.as_mut_ptr::<u8>(), PAGE_SIZE) };
+
+    let response_size = match cmd {
+        TpmPlatformCommand::SendCommand => tpm_send_command_request(buffer)?,
+    };
+
+    GuestPtr::<u32>::new(vaddr).write(response_size)?;
+
+    Ok(())
+}
+
+pub fn vtpm_protocol_request(request: u32, params: &mut RequestParams) -> Result<(), SvsmReqError> {
+    match request {
+        SVSM_VTPM_QUERY => vtpm_query_request(params),
+        SVSM_VTPM_COMMAND => vtpm_command_request(params),
+        _ => Err(SvsmReqError::unsupported_call()),
+    }
+}

--- a/kernel/src/requests.rs
+++ b/kernel/src/requests.rs
@@ -12,6 +12,8 @@ use crate::mm::GuestPtr;
 use crate::protocols::core::core_protocol_request;
 use crate::protocols::errors::{SvsmReqError, SvsmResultCode};
 
+#[cfg(feature = "mstpm")]
+use crate::protocols::{vtpm::vtpm_protocol_request, SVSM_VTPM_PROTOCOL};
 use crate::protocols::{RequestParams, SVSM_CORE_PROTOCOL};
 use crate::types::GUEST_VMPL;
 use crate::utils::halt;
@@ -93,6 +95,8 @@ fn request_loop_once(
 
     match protocol {
         SVSM_CORE_PROTOCOL => core_protocol_request(request, params).map(|_| true),
+        #[cfg(feature = "mstpm")]
+        SVSM_VTPM_PROTOCOL => vtpm_protocol_request(request, params).map(|_| true),
         _ => Err(SvsmReqError::unsupported_protocol()),
     }
 }

--- a/kernel/src/requests.rs
+++ b/kernel/src/requests.rs
@@ -11,7 +11,8 @@ use crate::error::SvsmError;
 use crate::mm::GuestPtr;
 use crate::protocols::core::core_protocol_request;
 use crate::protocols::errors::{SvsmReqError, SvsmResultCode};
-use crate::protocols::RequestParams;
+
+use crate::protocols::{RequestParams, SVSM_CORE_PROTOCOL};
 use crate::types::GUEST_VMPL;
 use crate::utils::halt;
 use cpuarch::vmsa::GuestVMExit;
@@ -91,7 +92,7 @@ fn request_loop_once(
     }
 
     match protocol {
-        0 => core_protocol_request(request, params).map(|_| true),
+        SVSM_CORE_PROTOCOL => core_protocol_request(request, params).map(|_| true),
         _ => Err(SvsmReqError::unsupported_protocol()),
     }
 }

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -50,6 +50,8 @@ use svsm::svsm_paging::{init_page_table, invalidate_early_boot_memory};
 use svsm::task::{create_kernel_task, schedule_init, TASK_FLAG_SHARE_PT};
 use svsm::types::{PageSize, GUEST_VMPL, PAGE_SIZE};
 use svsm::utils::{halt, immut_after_init::ImmutAfterInitCell, zero_mem_region};
+#[cfg(feature = "mstpm")]
+use svsm::vtpm::vtpm_init;
 
 use svsm::mm::validate::{init_valid_bitmap_ptr, migrate_valid_bitmap};
 
@@ -427,6 +429,9 @@ pub extern "C" fn svsm_main() {
     if let Some(ref fw_meta) = fw_metadata {
         prepare_fw_launch(fw_meta).expect("Failed to setup guest VMSA/CAA");
     }
+
+    #[cfg(feature = "mstpm")]
+    vtpm_init().expect("vTPM failed to initialize");
 
     virt_log_usage();
 

--- a/kernel/src/vtpm/mod.rs
+++ b/kernel/src/vtpm/mod.rs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (C) 2023 IBM
+//
+// Authors: Claudio Carvalho <cclaudio@linux.ibm.com>
+
+//! This crate defines the Virtual TPM interfaces and shows what
+//! TPM backends are supported
+
+/// TPM 2.0 Reference Implementation by Microsoft
+pub mod mstpm;

--- a/kernel/src/vtpm/mod.rs
+++ b/kernel/src/vtpm/mod.rs
@@ -9,3 +9,60 @@
 
 /// TPM 2.0 Reference Implementation by Microsoft
 pub mod mstpm;
+
+use crate::protocols::vtpm::TpmPlatformCommand;
+use crate::protocols::errors::SvsmReqError;
+
+/// Basic services required to perform the VTPM Protocol
+pub trait VtpmProtocolInterface {
+    /// Get the list of Platform Commands supported by the TPM implementation.
+    fn get_supported_commands(&self) -> &[TpmPlatformCommand];
+}
+
+/// This implements one handler for each [`TpmPlatformCommand`] supported by the
+/// VTPM Protocol. These handlers are based on the TPM Simulator
+/// interface (by Microsoft), but with a few changes to make it more Rust
+/// idiomatic.
+///
+/// `ms-tpm-20-ref/TPMCmd/Simulator/include/prototypes/Simulator_fp.h`
+pub trait MsTpmSimulatorInterface: VtpmProtocolInterface {
+    /// Send a command for the TPM to run in a given locality
+    ///
+    /// # Arguments
+    ///
+    /// * `buffer`: Buffer with the command to be sent to the TPM. It has to be large enough
+    ///             to hold the response received from the TPM.
+    /// * `length`: The length of the command stored in `buffer`. It will be updated with the
+    ///             size of the TPM response received from the TPM.
+    /// * `locality`: TPM locality the TPM command will be executed
+    fn send_tpm_command(
+        &self,
+        buffer: &mut [u8],
+        length: &mut usize,
+        locality: u8,
+    ) -> Result<(), SvsmReqError>;
+
+    /// Power-on the TPM, which also triggers a reset
+    ///
+    /// # Arguments
+    ///
+    /// *`only_reset``: If enabled, it will only reset the vTPM;
+    ///                 however, the vtPM has to be powered on previously.
+    ///                 Otherwise, it will fail.
+    fn signal_poweron(&mut self, only_reset: bool) -> Result<(), SvsmReqError>;
+
+    /// In a system where the NV memory used by the TPM is not within the TPM,
+    /// the NV may not always be available. This function indicates that NV
+    /// is available.
+    fn signal_nvon(&self) -> Result<(), SvsmReqError>;
+}
+
+/// Basic TPM driver services
+pub trait VtpmInterface: MsTpmSimulatorInterface {
+    /// Check if the TPM is powered on.
+    fn is_powered_on(&self) -> bool;
+
+    /// Prepare the TPM to be used for the first time. At this stage,
+    /// the TPM is manufactured.
+    fn init(&mut self) -> Result<(), SvsmReqError>;
+}

--- a/kernel/src/vtpm/mod.rs
+++ b/kernel/src/vtpm/mod.rs
@@ -10,8 +10,8 @@
 /// TPM 2.0 Reference Implementation by Microsoft
 pub mod mstpm;
 
-use crate::protocols::vtpm::TpmPlatformCommand;
 use crate::vtpm::mstpm::MsTpm as Vtpm;
+use crate::{locking::LockGuard, protocols::vtpm::TpmPlatformCommand};
 use crate::{locking::SpinLock, protocols::errors::SvsmReqError};
 
 /// Basic services required to perform the VTPM Protocol
@@ -79,4 +79,8 @@ pub fn vtpm_init() -> Result<(), SvsmReqError> {
     }
     vtpm.init()?;
     Ok(())
+}
+
+pub fn vtpm_get_locked<'a>() -> LockGuard<'a, Vtpm> {
+    VTPM.lock()
 }

--- a/kernel/src/vtpm/mstpm/mod.rs
+++ b/kernel/src/vtpm/mstpm/mod.rs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (C) 2023 IBM
+//
+// Authors: Claudio Carvalho <cclaudio@linux.ibm.com>
+
+//! This crate implements the virtual TPM interfaces for the TPM 2.0
+//! Reference Implementation (by Microsoft)
+
+/// Functions required to build the Microsoft TPM libraries
+mod wrapper;

--- a/kernel/src/vtpm/mstpm/mod.rs
+++ b/kernel/src/vtpm/mstpm/mod.rs
@@ -8,6 +8,7 @@
 //! Reference Implementation (by Microsoft)
 
 /// Functions required to build the Microsoft TPM libraries
+#[cfg(not(feature = "default-test"))]
 mod wrapper;
 
 extern crate alloc;

--- a/kernel/src/vtpm/mstpm/mod.rs
+++ b/kernel/src/vtpm/mstpm/mod.rs
@@ -9,3 +9,182 @@
 
 /// Functions required to build the Microsoft TPM libraries
 mod wrapper;
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+use core::{ffi::c_void, ptr::addr_of_mut};
+use libmstpm::bindings::{
+    TPM_Manufacture, TPM_TearDown, _plat__LocalitySet, _plat__NVDisable, _plat__NVEnable,
+    _plat__RunCommand, _plat__SetNvAvail, _plat__Signal_PowerOn, _plat__Signal_Reset,
+};
+
+use crate::{
+    address::VirtAddr,
+    protocols::{errors::SvsmReqError, vtpm::TpmPlatformCommand},
+    types::PAGE_SIZE,
+    vtpm::{MsTpmSimulatorInterface, VtpmInterface, VtpmProtocolInterface},
+};
+
+#[derive(Debug, Copy, Clone)]
+pub struct MsTpm {
+    is_powered_on: bool,
+}
+
+impl MsTpm {
+    pub const fn new() -> MsTpm {
+        MsTpm {
+            is_powered_on: false,
+        }
+    }
+
+    fn teardown(&self) -> Result<(), SvsmReqError> {
+        let result = unsafe { TPM_TearDown() };
+        match result {
+            0 => Ok(()),
+            rc => {
+                log::error!("TPM_Teardown failed rc={}", rc);
+                Err(SvsmReqError::incomplete())
+            }
+        }
+    }
+
+    fn manufacture(&self, first_time: i32) -> Result<i32, SvsmReqError> {
+        let result = unsafe { TPM_Manufacture(first_time) };
+        match result {
+            // TPM manufactured successfully
+            0 => Ok(0),
+            // TPM already manufactured
+            1 => Ok(1),
+            // TPM failed to manufacture
+            rc => {
+                log::error!("TPM_Manufacture failed rc={}", rc);
+                Err(SvsmReqError::incomplete())
+            }
+        }
+    }
+}
+
+const TPM_CMDS_SUPPORTED: &[TpmPlatformCommand] = &[TpmPlatformCommand::SendCommand];
+
+impl VtpmProtocolInterface for MsTpm {
+    fn get_supported_commands(&self) -> &[TpmPlatformCommand] {
+        TPM_CMDS_SUPPORTED
+    }
+}
+
+pub const TPM_BUFFER_MAX_SIZE: usize = PAGE_SIZE;
+
+impl MsTpmSimulatorInterface for MsTpm {
+    fn send_tpm_command(
+        &self,
+        buffer: &mut [u8],
+        length: &mut usize,
+        locality: u8,
+    ) -> Result<(), SvsmReqError> {
+        if !self.is_powered_on {
+            return Err(SvsmReqError::invalid_request());
+        }
+        if *length > TPM_BUFFER_MAX_SIZE || *length > buffer.len() {
+            return Err(SvsmReqError::invalid_parameter());
+        }
+
+        let mut request_ffi = buffer[..*length].to_vec();
+
+        let mut response_ffi = Vec::<u8>::with_capacity(TPM_BUFFER_MAX_SIZE);
+        let mut response_ffi_p = response_ffi.as_mut_ptr();
+        let mut response_ffi_size = TPM_BUFFER_MAX_SIZE as u32;
+
+        unsafe {
+            _plat__LocalitySet(locality);
+            _plat__RunCommand(
+                request_ffi.len() as u32,
+                request_ffi.as_mut_ptr().cast::<u8>(),
+                addr_of_mut!(response_ffi_size),
+                addr_of_mut!(response_ffi_p),
+            );
+            if response_ffi_size == 0 || response_ffi_size as usize > response_ffi.capacity() {
+                return Err(SvsmReqError::invalid_request());
+            }
+            response_ffi.set_len(response_ffi_size as usize);
+        }
+
+        buffer.fill(0);
+        buffer
+            .get_mut(..response_ffi.len())
+            .ok_or_else(SvsmReqError::invalid_request)?
+            .copy_from_slice(response_ffi.as_slice());
+        *length = response_ffi.len();
+
+        Ok(())
+    }
+
+    fn signal_poweron(&mut self, only_reset: bool) -> Result<(), SvsmReqError> {
+        if self.is_powered_on && !only_reset {
+            return Ok(());
+        }
+        if only_reset && !self.is_powered_on {
+            return Err(SvsmReqError::invalid_request());
+        }
+        if !only_reset {
+            unsafe { _plat__Signal_PowerOn() };
+        }
+        // It calls TPM_init() within to indicate that a TPM2_Startup is required.
+        unsafe { _plat__Signal_Reset() };
+        self.is_powered_on = true;
+
+        Ok(())
+    }
+
+    fn signal_nvon(&self) -> Result<(), SvsmReqError> {
+        if !self.is_powered_on {
+            return Err(SvsmReqError::invalid_request());
+        }
+        unsafe { _plat__SetNvAvail() };
+
+        Ok(())
+    }
+}
+
+impl VtpmInterface for MsTpm {
+    fn is_powered_on(&self) -> bool {
+        self.is_powered_on
+    }
+
+    fn init(&mut self) -> Result<(), SvsmReqError> {
+        // Initialize the MS TPM following the same steps done in the Simulator:
+        //
+        // 1. Manufacture it for the first time
+        // 2. Make sure it does not fail if it is re-manufactured
+        // 3. Teardown to indicate it needs to be manufactured
+        // 4. Manufacture it for the first time
+        // 5. Power it on indicating it requires startup. By default, OVMF will start
+        //    and selftest it.
+
+        unsafe { _plat__NVEnable(VirtAddr::null().as_mut_ptr::<c_void>()) };
+
+        let mut rc = self.manufacture(1)?;
+        if rc != 0 {
+            unsafe { _plat__NVDisable(1) };
+            return Err(SvsmReqError::incomplete());
+        }
+
+        rc = self.manufacture(0)?;
+        if rc != 1 {
+            return Err(SvsmReqError::incomplete());
+        }
+
+        self.teardown()?;
+        rc = self.manufacture(1)?;
+        if rc != 0 {
+            return Err(SvsmReqError::incomplete());
+        }
+
+        self.signal_poweron(false)?;
+        self.signal_nvon()?;
+
+        log::info!("VTPM: Microsoft TPM 2.0 initialized");
+
+        Ok(())
+    }
+}

--- a/kernel/src/vtpm/mstpm/wrapper.rs
+++ b/kernel/src/vtpm/mstpm/wrapper.rs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (C) 2023 IBM
+//
+// Authors: Claudio Carvalho <cclaudio@linux.ibm.com>
+
+//! Implement functions required to build the Microsoft TPM libraries.
+//! All these functionalities are owned by the SVSM Rust code,
+//! so we just need to create wrappers for them.
+
+use crate::{
+    console::_print,
+    mm::alloc::{layout_from_ptr, layout_from_size, mem_allocate, mem_deallocate, mem_reallocate},
+    sev::msr_protocol::request_termination_msr,
+};
+
+use core::{
+    alloc::Layout,
+    ffi::{c_char, c_int, c_ulong, c_void},
+    ptr,
+    slice::from_raw_parts,
+    str::from_utf8,
+};
+
+#[no_mangle]
+pub extern "C" fn malloc(size: c_ulong) -> *mut c_void {
+    let layout: Layout = layout_from_size(size as usize);
+    mem_allocate(layout) as *mut c_void
+}
+
+#[no_mangle]
+pub extern "C" fn calloc(items: c_ulong, size: c_ulong) -> *mut c_void {
+    if let Some(new_size) = items.checked_mul(size) {
+        return malloc(new_size);
+    }
+    ptr::null_mut()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn realloc(p: *mut c_void, size: c_ulong) -> *mut c_void {
+    let ptr = p as *mut u8;
+    let new_size = size as usize;
+    if let Some(layout) = layout_from_ptr(ptr) {
+        return unsafe { mem_reallocate(ptr, layout, new_size) as *mut c_void };
+    }
+    ptr::null_mut()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn free(p: *mut c_void) {
+    if p.is_null() {
+        return;
+    }
+    let ptr = p as *mut u8;
+    if let Some(layout) = layout_from_ptr(ptr) {
+        unsafe { mem_deallocate(ptr, layout) }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn serial_out(s: *const c_char, size: c_int) {
+    let str_slice: &[u8] = unsafe { from_raw_parts(s as *const u8, size as usize) };
+    if let Ok(rust_str) = from_utf8(str_slice) {
+        _print(format_args!("[SVSM] {}", rust_str));
+    } else {
+        log::error!("ERR: BUG: serial_out arg1 is not a valid utf8 string");
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn abort() -> ! {
+    request_termination_msr();
+}

--- a/libmstpm/.gitignore
+++ b/libmstpm/.gitignore
@@ -1,1 +1,2 @@
 libmstpm.a
+src/bindings.rs

--- a/libmstpm/.gitignore
+++ b/libmstpm/.gitignore
@@ -1,0 +1,1 @@
+libmstpm.a

--- a/libmstpm/Cargo.toml
+++ b/libmstpm/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "libmstpm"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/libmstpm/Makefile
+++ b/libmstpm/Makefile
@@ -1,0 +1,25 @@
+DEPS_DIR = $(CURDIR)/deps
+
+LIBCRT_DIR = $(DEPS_DIR)/libcrt
+
+LIBCRT = $(LIBCRT_DIR)/libcrt.a
+
+LIBS = $(LIBCRT)
+
+all: libmstpm.a
+
+libmstpm.a: $(LIBS)
+	rm -f $@
+	ar rcsTPD $@ $^
+
+# libcrt
+$(LIBCRT):
+	$(MAKE) -C $(LIBCRT_DIR)
+
+clean:
+	make -C $(LIBCRT_DIR) clean
+	rm -f libmstpm.a
+
+distclean: clean
+
+.PHONY: all clean distclean

--- a/libmstpm/Makefile
+++ b/libmstpm/Makefile
@@ -91,7 +91,7 @@ $(OPENSSL_MAKEFILE):
 			no-sse2 \
 			no-ui-console \
 			no-asm \
-			--with-rand-seed=none \
+			--with-rand-seed=getrandom \
 			$(OPENSSL_CONFIG_TYPE) \
 			-I$(LIBCRT_DIR)/include \
 			-Wl,rpath=$(LIBCRT_DIR) -lcrt)
@@ -104,7 +104,7 @@ $(LIBPLATFORM): $(MSTPM_MAKEFILE) $(LIBCRYPTO)
 	$(MAKE) -C $(MSTPM_DIR) $(LIBPLATFORM_A)
 
 MSTPM_CFLAGS += -static -nostdinc -fno-stack-protector -fPIE -mno-sse
-MSTPM_CFLAGS += -DSIMULATION=NO -DFILE_BACKED_NV=NO -DSELF_TEST=NO
+MSTPM_CFLAGS += -DSIMULATION=NO -DFILE_BACKED_NV=NO
 MSTPM_CFLAGS += -I$(LIBCRT_DIR)/include
 MSTPM_CFLAGS += -I$(OPENSSL_DIR)/include
 

--- a/libmstpm/Makefile
+++ b/libmstpm/Makefile
@@ -1,20 +1,30 @@
 ifdef RELEASE
 OPENSSL_CONFIG_TYPE = --release
+MSTPM_CFLAGS = -O3 -DDEBUG=NO
 else
 OPENSSL_CONFIG_TYPE = --debug
+MSTPM_CFLAGS = -g -O0 -DDEBUG=YES
 endif
 
 DEPS_DIR = $(CURDIR)/deps
 
 LIBCRT_DIR = $(DEPS_DIR)/libcrt
 OPENSSL_DIR = $(DEPS_DIR)/openssl
+MSTPM_DIR = $(DEPS_DIR)/ms-tpm-20-ref/TPMCmd
 
 LIBCRT = $(LIBCRT_DIR)/libcrt.a
 LIBCRYPTO = $(OPENSSL_DIR)/libcrypto.a
 
-OPENSSL_MAKEFILE = $(OPENSSL_DIR)/Makefile
+LIBTPM_A = tpm/src/libtpm.a
+LIBTPM = $(MSTPM_DIR)/$(LIBTPM_A)
 
-LIBS = $(LIBCRT) $(LIBCRYPTO)
+LIBPLATFORM_A = Platform/src/libplatform.a
+LIBPLATFORM = $(MSTPM_DIR)/$(LIBPLATFORM_A)
+
+OPENSSL_MAKEFILE = $(OPENSSL_DIR)/Makefile
+MSTPM_MAKEFILE = $(MSTPM_DIR)/Makefile
+
+LIBS = $(LIBCRT) $(LIBCRYPTO) $(LIBTPM) $(LIBPLATFORM)
 
 all: libmstpm.a
 
@@ -86,12 +96,38 @@ $(OPENSSL_MAKEFILE):
 			-I$(LIBCRT_DIR)/include \
 			-Wl,rpath=$(LIBCRT_DIR) -lcrt)
 
-clean: $(OPENSSL_MAKEFILE)
+# ms-tpm
+$(LIBTPM): $(MSTPM_MAKEFILE) $(LIBCRYPTO)
+	$(MAKE) -C $(MSTPM_DIR) $(LIBTPM_A)
+
+$(LIBPLATFORM): $(MSTPM_MAKEFILE) $(LIBCRYPTO)
+	$(MAKE) -C $(MSTPM_DIR) $(LIBPLATFORM_A)
+
+MSTPM_CFLAGS += -static -nostdinc -fno-stack-protector -fPIE -mno-sse
+MSTPM_CFLAGS += -DSIMULATION=NO -DFILE_BACKED_NV=NO -DSELF_TEST=NO
+MSTPM_CFLAGS += -I$(LIBCRT_DIR)/include
+MSTPM_CFLAGS += -I$(OPENSSL_DIR)/include
+
+# Configure the Microsoft TPM and remove the pthread requirement.
+# In fact, pthread is required only in the TPM simulator, but we
+# are not building the simulator.
+$(MSTPM_MAKEFILE):
+	(cd $(MSTPM_DIR) && \
+		sed -i '/^AX_PTHREAD/d' configure.ac && \
+		./bootstrap && \
+		./configure \
+			CFLAGS="${MSTPM_CFLAGS}" \
+			LIBCRYPTO_LIBS="${$(LIBCRT) $(LIBCRYPTO)}")
+
+clean: $(OPENSSL_MAKEFILE) $(MSTPM_MAKEFILE)
 	make -C $(LIBCRT_DIR) clean
 	make -C $(OPENSSL_DIR) clean
+	sed -i '/^AX_PTHREAD/d' $(MSTPM_DIR)/configure.ac
+	make -C $(MSTPM_DIR) clean
 	rm -f libmstpm.a
 
 distclean: clean
 	rm -f $(OPENSSL_MAKEFILE)
+	rm -f $(MSTPM_MAKEFILE)
 
 .PHONY: all clean distclean

--- a/libmstpm/Makefile
+++ b/libmstpm/Makefile
@@ -26,7 +26,7 @@ MSTPM_MAKEFILE = $(MSTPM_DIR)/Makefile
 
 LIBS = $(LIBCRT) $(LIBCRYPTO) $(LIBTPM) $(LIBPLATFORM)
 
-all: libmstpm.a
+all: libmstpm.a src/bindings.rs
 
 libmstpm.a: $(LIBS)
 	rm -f $@
@@ -119,12 +119,25 @@ $(MSTPM_MAKEFILE):
 			CFLAGS="${MSTPM_CFLAGS}" \
 			LIBCRYPTO_LIBS="${$(LIBCRT) $(LIBCRYPTO)}")
 
+# bindings.rs
+BINDGEN_FLAGS = --use-core
+CLANG_FLAGS = -Wno-incompatible-library-redeclaration
+
+src/bindings.rs: deps/libmstpm.h $(LIBTPM)
+	echo "#![allow(non_upper_case_globals)]" > $@
+	echo "#![allow(non_camel_case_types)]" >> $@
+	echo "#![allow(non_snake_case)]" >> $@
+	echo "#![allow(unused)]" >> $@
+	echo "#![allow(improper_ctypes)]" >> $@
+	bindgen $(BINDGEN_FLAGS) deps/libmstpm.h -- $(CLANG_FLAGS) >> $@
+
 clean: $(OPENSSL_MAKEFILE) $(MSTPM_MAKEFILE)
 	make -C $(LIBCRT_DIR) clean
 	make -C $(OPENSSL_DIR) clean
 	sed -i '/^AX_PTHREAD/d' $(MSTPM_DIR)/configure.ac
 	make -C $(MSTPM_DIR) clean
 	rm -f libmstpm.a
+	rm -f src/bindings.rs
 
 distclean: clean
 	rm -f $(OPENSSL_MAKEFILE)

--- a/libmstpm/Makefile
+++ b/libmstpm/Makefile
@@ -1,10 +1,20 @@
+ifdef RELEASE
+OPENSSL_CONFIG_TYPE = --release
+else
+OPENSSL_CONFIG_TYPE = --debug
+endif
+
 DEPS_DIR = $(CURDIR)/deps
 
 LIBCRT_DIR = $(DEPS_DIR)/libcrt
+OPENSSL_DIR = $(DEPS_DIR)/openssl
 
 LIBCRT = $(LIBCRT_DIR)/libcrt.a
+LIBCRYPTO = $(OPENSSL_DIR)/libcrypto.a
 
-LIBS = $(LIBCRT)
+OPENSSL_MAKEFILE = $(OPENSSL_DIR)/Makefile
+
+LIBS = $(LIBCRT) $(LIBCRYPTO)
 
 all: libmstpm.a
 
@@ -16,10 +26,72 @@ libmstpm.a: $(LIBS)
 $(LIBCRT):
 	$(MAKE) -C $(LIBCRT_DIR)
 
-clean:
+# openssl
+$(LIBCRYPTO): $(OPENSSL_MAKEFILE) $(LIBCRT)
+	$(MAKE) -C $(OPENSSL_DIR) -j$$(nproc)
+
+$(OPENSSL_MAKEFILE):
+	(cd $(OPENSSL_DIR) && \
+		./Configure \
+			--config=$(DEPS_DIR)/openssl_svsm.conf \
+			SVSM \
+			no-afalgeng \
+			no-async \
+			no-autoerrinit \
+			no-autoload-config \
+			no-bf \
+			no-blake2 \
+			no-capieng \
+			no-cast \
+			no-chacha \
+			no-cms \
+			no-ct \
+			no-deprecated \
+			no-des \
+			no-dgram \
+			no-dsa \
+			no-dynamic-engine \
+			no-ec2m \
+			no-engine \
+			no-err \
+			no-filenames \
+			no-gost \
+			no-hw \
+			no-idea \
+			no-md4 \
+			no-mdc2 \
+			no-pic \
+			no-ocb \
+			no-poly1305 \
+			no-posix-io \
+			no-rc2 \
+			no-rc4 \
+			no-rfc3779 \
+			no-rmd160 \
+			no-scrypt \
+			no-seed \
+			no-sock \
+			no-srp \
+			no-ssl \
+			no-stdio \
+			no-threads \
+			no-ts \
+			no-whirlpool \
+			no-shared \
+			no-sse2 \
+			no-ui-console \
+			no-asm \
+			--with-rand-seed=none \
+			$(OPENSSL_CONFIG_TYPE) \
+			-I$(LIBCRT_DIR)/include \
+			-Wl,rpath=$(LIBCRT_DIR) -lcrt)
+
+clean: $(OPENSSL_MAKEFILE)
 	make -C $(LIBCRT_DIR) clean
+	make -C $(OPENSSL_DIR) clean
 	rm -f libmstpm.a
 
 distclean: clean
+	rm -f $(OPENSSL_MAKEFILE)
 
 .PHONY: all clean distclean

--- a/libmstpm/build.rs
+++ b/libmstpm/build.rs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (C) 2024 IBM
+//
+// Authors: Claudio Carvalho <cclaudio@linux.ibm.com>
+
+use std::process::Command;
+use std::process::Stdio;
+
+fn main() {
+    let output = Command::new("make")
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .output()
+        .unwrap();
+
+    if !output.status.success() {
+        panic!();
+    }
+}

--- a/libmstpm/deps/libcrt/.gitignore
+++ b/libmstpm/deps/libcrt/.gitignore
@@ -1,0 +1,1 @@
+libcrt.a

--- a/libmstpm/deps/libcrt/Makefile
+++ b/libmstpm/deps/libcrt/Makefile
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: MIT
+
+ifdef RELEASE
+CFLAGS = -O3
+else
+CFLAGS = -g -O0
+endif
+
+CFLAGS += -I./include -nostdinc -nostdlib
+CFLAGS += -m64 -march=x86-64 -mno-sse2 -fPIE
+CFLAGS += -fno-stack-protector
+CFLAGS += -ffreestanding
+
+CC = gcc
+
+# Functions we stub out
+OBJS = src/stub.o
+
+# ctype
+OBJS += $(addprefix src/ctype/, \
+				isdigit.o \
+				islower.o \
+				isspace.o \
+				isupper.o \
+				tolower.o \
+				toupper.o \
+				)
+# exit
+OBJS += src/exit/assert.o
+
+# prng
+OBJS += src/prng/rand.o
+
+# setjmp
+OBJS += $(addprefix src/setjmp/x86_64/, \
+				longjmp.o \
+				setjmp.o \
+				)
+# stdio
+OBJS += $(addprefix src/stdio/, \
+				asprintf.o \
+				fprintf.o \
+				printf.o \
+				printf_wrapper.o \
+				snprintf.o \
+				sprintf.o \
+				vasprintf.o \
+				vsnprintf.o \
+				vsprintf.o \
+				)
+# stdlib
+OBJS += $(addprefix src/stdlib/, \
+				atoi.o \
+				qsort.o \
+				qsort_nr.o \
+				)
+# string
+OBJS += $(addprefix src/string/, \
+				memchr.o \
+				memcmp.o \
+				memcpy.o \
+				memmove.o \
+				memrchr.o \
+				memset.o \
+				stpcpy.o \
+				stpncpy.o \
+				strcasecmp.o \
+				strcat.o \
+				strchr.o \
+				strchrnul.o \
+				strcmp.o \
+				strcspn.o \
+				strcpy.o \
+				strdup.o \
+				strlen.o \
+				strncasecmp.o \
+				strncat.o \
+				strncmp.o \
+				strncpy.o \
+				strrchr.o \
+				strspn.o \
+				strstr.o \
+				)
+# time
+OBJS += $(addprefix src/time/, \
+				__secs_to_tm.o \
+				gmtime_r.o \
+				time.o \
+				)
+
+all: libcrt.a
+
+libcrt.a: $(OBJS)
+	ar rcs $@ $(OBJS)
+
+%.o : %.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+%.o : %.s
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+clean:
+	rm -f libcrt.a
+	rm -f $(OBJS)

--- a/libmstpm/deps/libcrt/include/assert.h
+++ b/libmstpm/deps/libcrt/include/assert.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/libmstpm/deps/libcrt/include/atomic.h
+++ b/libmstpm/deps/libcrt/include/atomic.h
@@ -1,0 +1,335 @@
+/* SPDX-License-Identifier: MIT */
+
+#ifndef _ATOMIC_H
+#define _ATOMIC_H
+
+#include <stdint.h>
+
+#include <bits/atomic_arch.h>
+
+#ifdef a_ll
+
+#ifndef a_pre_llsc
+#define a_pre_llsc()
+#endif
+
+#ifndef a_post_llsc
+#define a_post_llsc()
+#endif
+
+#ifndef a_cas
+#define a_cas a_cas
+static inline int a_cas(volatile int *p, int t, int s)
+{
+	int old;
+	a_pre_llsc();
+	do old = a_ll(p);
+	while (old==t && !a_sc(p, s));
+	a_post_llsc();
+	return old;
+}
+#endif
+
+#ifndef a_swap
+#define a_swap a_swap
+static inline int a_swap(volatile int *p, int v)
+{
+	int old;
+	a_pre_llsc();
+	do old = a_ll(p);
+	while (!a_sc(p, v));
+	a_post_llsc();
+	return old;
+}
+#endif
+
+#ifndef a_fetch_add
+#define a_fetch_add a_fetch_add
+static inline int a_fetch_add(volatile int *p, int v)
+{
+	int old;
+	a_pre_llsc();
+	do old = a_ll(p);
+	while (!a_sc(p, (unsigned)old + v));
+	a_post_llsc();
+	return old;
+}
+#endif
+
+#ifndef a_fetch_and
+#define a_fetch_and a_fetch_and
+static inline int a_fetch_and(volatile int *p, int v)
+{
+	int old;
+	a_pre_llsc();
+	do old = a_ll(p);
+	while (!a_sc(p, old & v));
+	a_post_llsc();
+	return old;
+}
+#endif
+
+#ifndef a_fetch_or
+#define a_fetch_or a_fetch_or
+static inline int a_fetch_or(volatile int *p, int v)
+{
+	int old;
+	a_pre_llsc();
+	do old = a_ll(p);
+	while (!a_sc(p, old | v));
+	a_post_llsc();
+	return old;
+}
+#endif
+
+#endif
+
+#ifdef a_ll_p
+
+#ifndef a_cas_p
+#define a_cas_p a_cas_p
+static inline void *a_cas_p(volatile void *p, void *t, void *s)
+{
+	void *old;
+	a_pre_llsc();
+	do old = a_ll_p(p);
+	while (old==t && !a_sc_p(p, s));
+	a_post_llsc();
+	return old;
+}
+#endif
+
+#endif
+
+#ifndef a_cas
+#error missing definition of a_cas
+#endif
+
+#ifndef a_swap
+#define a_swap a_swap
+static inline int a_swap(volatile int *p, int v)
+{
+	int old;
+	do old = *p;
+	while (a_cas(p, old, v) != old);
+	return old;
+}
+#endif
+
+#ifndef a_fetch_add
+#define a_fetch_add a_fetch_add
+static inline int a_fetch_add(volatile int *p, int v)
+{
+	int old;
+	do old = *p;
+	while (a_cas(p, old, (unsigned)old+v) != old);
+	return old;
+}
+#endif
+
+#ifndef a_fetch_and
+#define a_fetch_and a_fetch_and
+static inline int a_fetch_and(volatile int *p, int v)
+{
+	int old;
+	do old = *p;
+	while (a_cas(p, old, old&v) != old);
+	return old;
+}
+#endif
+#ifndef a_fetch_or
+#define a_fetch_or a_fetch_or
+static inline int a_fetch_or(volatile int *p, int v)
+{
+	int old;
+	do old = *p;
+	while (a_cas(p, old, old|v) != old);
+	return old;
+}
+#endif
+
+#ifndef a_and
+#define a_and a_and
+static inline void a_and(volatile int *p, int v)
+{
+	a_fetch_and(p, v);
+}
+#endif
+
+#ifndef a_or
+#define a_or a_or
+static inline void a_or(volatile int *p, int v)
+{
+	a_fetch_or(p, v);
+}
+#endif
+
+#ifndef a_inc
+#define a_inc a_inc
+static inline void a_inc(volatile int *p)
+{
+	a_fetch_add(p, 1);
+}
+#endif
+
+#ifndef a_dec
+#define a_dec a_dec
+static inline void a_dec(volatile int *p)
+{
+	a_fetch_add(p, -1);
+}
+#endif
+
+#ifndef a_store
+#define a_store a_store
+static inline void a_store(volatile int *p, int v)
+{
+#ifdef a_barrier
+	a_barrier();
+	*p = v;
+	a_barrier();
+#else
+	a_swap(p, v);
+#endif
+}
+#endif
+
+#ifndef a_barrier
+#define a_barrier a_barrier
+static void a_barrier()
+{
+	volatile int tmp = 0;
+	a_cas(&tmp, 0, 0);
+}
+#endif
+
+#ifndef a_spin
+#define a_spin a_barrier
+#endif
+
+#ifndef a_and_64
+#define a_and_64 a_and_64
+static inline void a_and_64(volatile uint64_t *p, uint64_t v)
+{
+	union { uint64_t v; uint32_t r[2]; } u = { v };
+	if (u.r[0]+1) a_and((int *)p, u.r[0]);
+	if (u.r[1]+1) a_and((int *)p+1, u.r[1]);
+}
+#endif
+
+#ifndef a_or_64
+#define a_or_64 a_or_64
+static inline void a_or_64(volatile uint64_t *p, uint64_t v)
+{
+	union { uint64_t v; uint32_t r[2]; } u = { v };
+	if (u.r[0]) a_or((int *)p, u.r[0]);
+	if (u.r[1]) a_or((int *)p+1, u.r[1]);
+}
+#endif
+
+#ifndef a_cas_p
+typedef char a_cas_p_undefined_but_pointer_not_32bit[-sizeof(char) == 0xffffffff ? 1 : -1];
+#define a_cas_p a_cas_p
+static inline void *a_cas_p(volatile void *p, void *t, void *s)
+{
+	return (void *)a_cas((volatile int *)p, (int)t, (int)s);
+}
+#endif
+
+#ifndef a_or_l
+#define a_or_l a_or_l
+static inline void a_or_l(volatile void *p, long v)
+{
+	if (sizeof(long) == sizeof(int)) a_or(p, v);
+	else a_or_64(p, v);
+}
+#endif
+
+#ifndef a_crash
+#define a_crash a_crash
+static inline void a_crash()
+{
+	*(volatile char *)0=0;
+}
+#endif
+
+#ifndef a_ctz_32
+#define a_ctz_32 a_ctz_32
+static inline int a_ctz_32(uint32_t x)
+{
+#ifdef a_clz_32
+	return 31-a_clz_32(x&-x);
+#else
+	static const char debruijn32[32] = {
+		0, 1, 23, 2, 29, 24, 19, 3, 30, 27, 25, 11, 20, 8, 4, 13,
+		31, 22, 28, 18, 26, 10, 7, 12, 21, 17, 9, 6, 16, 5, 15, 14
+	};
+	return debruijn32[(x&-x)*0x076be629 >> 27];
+#endif
+}
+#endif
+
+#ifndef a_ctz_64
+#define a_ctz_64 a_ctz_64
+static inline int a_ctz_64(uint64_t x)
+{
+	static const char debruijn64[64] = {
+		0, 1, 2, 53, 3, 7, 54, 27, 4, 38, 41, 8, 34, 55, 48, 28,
+		62, 5, 39, 46, 44, 42, 22, 9, 24, 35, 59, 56, 49, 18, 29, 11,
+		63, 52, 6, 26, 37, 40, 33, 47, 61, 45, 43, 21, 23, 58, 17, 10,
+		51, 25, 36, 32, 60, 20, 57, 16, 50, 31, 19, 15, 30, 14, 13, 12
+	};
+	if (sizeof(long) < 8) {
+		uint32_t y = x;
+		if (!y) {
+			y = x>>32;
+			return 32 + a_ctz_32(y);
+		}
+		return a_ctz_32(y);
+	}
+	return debruijn64[(x&-x)*0x022fdd63cc95386dull >> 58];
+}
+#endif
+
+static inline int a_ctz_l(unsigned long x)
+{
+	return (sizeof(long) < 8) ? a_ctz_32(x) : a_ctz_64(x);
+}
+
+#ifndef a_clz_64
+#define a_clz_64 a_clz_64
+static inline int a_clz_64(uint64_t x)
+{
+#ifdef a_clz_32
+	if (x>>32)
+		return a_clz_32(x>>32);
+	return a_clz_32(x) + 32;
+#else
+	uint32_t y;
+	int r;
+	if (x>>32) y=x>>32, r=0; else y=x, r=32;
+	if (y>>16) y>>=16; else r |= 16;
+	if (y>>8) y>>=8; else r |= 8;
+	if (y>>4) y>>=4; else r |= 4;
+	if (y>>2) y>>=2; else r |= 2;
+	return r | !(y>>1);
+#endif
+}
+#endif
+
+#ifndef a_clz_32
+#define a_clz_32 a_clz_32
+static inline int a_clz_32(uint32_t x)
+{
+	x >>= 1;
+	x |= x >> 1;
+	x |= x >> 2;
+	x |= x >> 4;
+	x |= x >> 8;
+	x |= x >> 16;
+	x++;
+	return 31-a_ctz_32(x);
+}
+#endif
+
+#endif

--- a/libmstpm/deps/libcrt/include/bits/alltypes.h
+++ b/libmstpm/deps/libcrt/include/bits/alltypes.h
@@ -1,0 +1,417 @@
+/* SPDX-License-Identifier: MIT */
+
+#define _Addr long
+#define _Int64 long
+#define _Reg long
+
+#define __BYTE_ORDER 1234
+#define __LONG_MAX 0x7fffffffffffffffL
+
+#ifndef __cplusplus
+#if defined(__NEED_wchar_t) && !defined(__DEFINED_wchar_t)
+typedef int wchar_t;
+#define __DEFINED_wchar_t
+#endif
+
+#endif
+
+#if defined(__FLT_EVAL_METHOD__) && __FLT_EVAL_METHOD__ == 2
+#if defined(__NEED_float_t) && !defined(__DEFINED_float_t)
+typedef long double float_t;
+#define __DEFINED_float_t
+#endif
+
+#if defined(__NEED_double_t) && !defined(__DEFINED_double_t)
+typedef long double double_t;
+#define __DEFINED_double_t
+#endif
+
+#else
+#if defined(__NEED_float_t) && !defined(__DEFINED_float_t)
+typedef float float_t;
+#define __DEFINED_float_t
+#endif
+
+#if defined(__NEED_double_t) && !defined(__DEFINED_double_t)
+typedef double double_t;
+#define __DEFINED_double_t
+#endif
+
+#endif
+
+#if defined(__NEED_max_align_t) && !defined(__DEFINED_max_align_t)
+typedef struct { long long __ll; long double __ld; } max_align_t;
+#define __DEFINED_max_align_t
+#endif
+
+#define __LITTLE_ENDIAN 1234
+#define __BIG_ENDIAN 4321
+#define __USE_TIME_BITS64 1
+
+#if defined(__NEED_size_t) && !defined(__DEFINED_size_t)
+typedef unsigned _Addr size_t;
+#define __DEFINED_size_t
+#endif
+
+#if defined(__NEED_uintptr_t) && !defined(__DEFINED_uintptr_t)
+typedef unsigned _Addr uintptr_t;
+#define __DEFINED_uintptr_t
+#endif
+
+#if defined(__NEED_ptrdiff_t) && !defined(__DEFINED_ptrdiff_t)
+typedef _Addr ptrdiff_t;
+#define __DEFINED_ptrdiff_t
+#endif
+
+#if defined(__NEED_ssize_t) && !defined(__DEFINED_ssize_t)
+typedef _Addr ssize_t;
+#define __DEFINED_ssize_t
+#endif
+
+#if defined(__NEED_intptr_t) && !defined(__DEFINED_intptr_t)
+typedef _Addr intptr_t;
+#define __DEFINED_intptr_t
+#endif
+
+#if defined(__NEED_regoff_t) && !defined(__DEFINED_regoff_t)
+typedef _Addr regoff_t;
+#define __DEFINED_regoff_t
+#endif
+
+#if defined(__NEED_register_t) && !defined(__DEFINED_register_t)
+typedef _Reg register_t;
+#define __DEFINED_register_t
+#endif
+
+#if defined(__NEED_time_t) && !defined(__DEFINED_time_t)
+typedef _Int64 time_t;
+#define __DEFINED_time_t
+#endif
+
+#if defined(__NEED_suseconds_t) && !defined(__DEFINED_suseconds_t)
+typedef _Int64 suseconds_t;
+#define __DEFINED_suseconds_t
+#endif
+
+
+#if defined(__NEED_int8_t) && !defined(__DEFINED_int8_t)
+typedef signed char     int8_t;
+#define __DEFINED_int8_t
+#endif
+
+#if defined(__NEED_int16_t) && !defined(__DEFINED_int16_t)
+typedef signed short    int16_t;
+#define __DEFINED_int16_t
+#endif
+
+#if defined(__NEED_int32_t) && !defined(__DEFINED_int32_t)
+typedef signed int      int32_t;
+#define __DEFINED_int32_t
+#endif
+
+#if defined(__NEED_int64_t) && !defined(__DEFINED_int64_t)
+typedef signed _Int64   int64_t;
+#define __DEFINED_int64_t
+#endif
+
+#if defined(__NEED_intmax_t) && !defined(__DEFINED_intmax_t)
+typedef signed _Int64   intmax_t;
+#define __DEFINED_intmax_t
+#endif
+
+#if defined(__NEED_uint8_t) && !defined(__DEFINED_uint8_t)
+typedef unsigned char   uint8_t;
+#define __DEFINED_uint8_t
+#endif
+
+#if defined(__NEED_uint16_t) && !defined(__DEFINED_uint16_t)
+typedef unsigned short  uint16_t;
+#define __DEFINED_uint16_t
+#endif
+
+#if defined(__NEED_uint32_t) && !defined(__DEFINED_uint32_t)
+typedef unsigned int    uint32_t;
+#define __DEFINED_uint32_t
+#endif
+
+#if defined(__NEED_uint64_t) && !defined(__DEFINED_uint64_t)
+typedef unsigned _Int64 uint64_t;
+#define __DEFINED_uint64_t
+#endif
+
+#if defined(__NEED_u_int64_t) && !defined(__DEFINED_u_int64_t)
+typedef unsigned _Int64 u_int64_t;
+#define __DEFINED_u_int64_t
+#endif
+
+#if defined(__NEED_uintmax_t) && !defined(__DEFINED_uintmax_t)
+typedef unsigned _Int64 uintmax_t;
+#define __DEFINED_uintmax_t
+#endif
+
+
+#if defined(__NEED_mode_t) && !defined(__DEFINED_mode_t)
+typedef unsigned mode_t;
+#define __DEFINED_mode_t
+#endif
+
+#if defined(__NEED_nlink_t) && !defined(__DEFINED_nlink_t)
+typedef unsigned _Reg nlink_t;
+#define __DEFINED_nlink_t
+#endif
+
+#if defined(__NEED_off_t) && !defined(__DEFINED_off_t)
+typedef _Int64 off_t;
+#define __DEFINED_off_t
+#endif
+
+#if defined(__NEED_ino_t) && !defined(__DEFINED_ino_t)
+typedef unsigned _Int64 ino_t;
+#define __DEFINED_ino_t
+#endif
+
+#if defined(__NEED_dev_t) && !defined(__DEFINED_dev_t)
+typedef unsigned _Int64 dev_t;
+#define __DEFINED_dev_t
+#endif
+
+#if defined(__NEED_blksize_t) && !defined(__DEFINED_blksize_t)
+typedef long blksize_t;
+#define __DEFINED_blksize_t
+#endif
+
+#if defined(__NEED_blkcnt_t) && !defined(__DEFINED_blkcnt_t)
+typedef _Int64 blkcnt_t;
+#define __DEFINED_blkcnt_t
+#endif
+
+#if defined(__NEED_fsblkcnt_t) && !defined(__DEFINED_fsblkcnt_t)
+typedef unsigned _Int64 fsblkcnt_t;
+#define __DEFINED_fsblkcnt_t
+#endif
+
+#if defined(__NEED_fsfilcnt_t) && !defined(__DEFINED_fsfilcnt_t)
+typedef unsigned _Int64 fsfilcnt_t;
+#define __DEFINED_fsfilcnt_t
+#endif
+
+
+#if defined(__NEED_wint_t) && !defined(__DEFINED_wint_t)
+typedef unsigned wint_t;
+#define __DEFINED_wint_t
+#endif
+
+#if defined(__NEED_wctype_t) && !defined(__DEFINED_wctype_t)
+typedef unsigned long wctype_t;
+#define __DEFINED_wctype_t
+#endif
+
+
+#if defined(__NEED_timer_t) && !defined(__DEFINED_timer_t)
+typedef void * timer_t;
+#define __DEFINED_timer_t
+#endif
+
+#if defined(__NEED_clockid_t) && !defined(__DEFINED_clockid_t)
+typedef int clockid_t;
+#define __DEFINED_clockid_t
+#endif
+
+#if defined(__NEED_clock_t) && !defined(__DEFINED_clock_t)
+typedef long clock_t;
+#define __DEFINED_clock_t
+#endif
+
+#if defined(__NEED_struct_timeval) && !defined(__DEFINED_struct_timeval)
+struct timeval { time_t tv_sec; suseconds_t tv_usec; };
+#define __DEFINED_struct_timeval
+#endif
+
+#if defined(__NEED_struct_timespec) && !defined(__DEFINED_struct_timespec)
+struct timespec { time_t tv_sec; int :8*(sizeof(time_t)-sizeof(long))*(__BYTE_ORDER==4321); long tv_nsec; int :8*(sizeof(time_t)-sizeof(long))*(__BYTE_ORDER!=4321); };
+#define __DEFINED_struct_timespec
+#endif
+
+
+#if defined(__NEED_pid_t) && !defined(__DEFINED_pid_t)
+typedef int pid_t;
+#define __DEFINED_pid_t
+#endif
+
+#if defined(__NEED_id_t) && !defined(__DEFINED_id_t)
+typedef unsigned id_t;
+#define __DEFINED_id_t
+#endif
+
+#if defined(__NEED_uid_t) && !defined(__DEFINED_uid_t)
+typedef unsigned uid_t;
+#define __DEFINED_uid_t
+#endif
+
+#if defined(__NEED_gid_t) && !defined(__DEFINED_gid_t)
+typedef unsigned gid_t;
+#define __DEFINED_gid_t
+#endif
+
+#if defined(__NEED_key_t) && !defined(__DEFINED_key_t)
+typedef int key_t;
+#define __DEFINED_key_t
+#endif
+
+#if defined(__NEED_useconds_t) && !defined(__DEFINED_useconds_t)
+typedef unsigned useconds_t;
+#define __DEFINED_useconds_t
+#endif
+
+
+#ifdef __cplusplus
+#if defined(__NEED_pthread_t) && !defined(__DEFINED_pthread_t)
+typedef unsigned long pthread_t;
+#define __DEFINED_pthread_t
+#endif
+
+#else
+#if defined(__NEED_pthread_t) && !defined(__DEFINED_pthread_t)
+typedef struct __pthread * pthread_t;
+#define __DEFINED_pthread_t
+#endif
+
+#endif
+#if defined(__NEED_pthread_once_t) && !defined(__DEFINED_pthread_once_t)
+typedef int pthread_once_t;
+#define __DEFINED_pthread_once_t
+#endif
+
+#if defined(__NEED_pthread_key_t) && !defined(__DEFINED_pthread_key_t)
+typedef unsigned pthread_key_t;
+#define __DEFINED_pthread_key_t
+#endif
+
+#if defined(__NEED_pthread_spinlock_t) && !defined(__DEFINED_pthread_spinlock_t)
+typedef int pthread_spinlock_t;
+#define __DEFINED_pthread_spinlock_t
+#endif
+
+#if defined(__NEED_pthread_mutexattr_t) && !defined(__DEFINED_pthread_mutexattr_t)
+typedef struct { unsigned __attr; } pthread_mutexattr_t;
+#define __DEFINED_pthread_mutexattr_t
+#endif
+
+#if defined(__NEED_pthread_condattr_t) && !defined(__DEFINED_pthread_condattr_t)
+typedef struct { unsigned __attr; } pthread_condattr_t;
+#define __DEFINED_pthread_condattr_t
+#endif
+
+#if defined(__NEED_pthread_barrierattr_t) && !defined(__DEFINED_pthread_barrierattr_t)
+typedef struct { unsigned __attr; } pthread_barrierattr_t;
+#define __DEFINED_pthread_barrierattr_t
+#endif
+
+#if defined(__NEED_pthread_rwlockattr_t) && !defined(__DEFINED_pthread_rwlockattr_t)
+typedef struct { unsigned __attr[2]; } pthread_rwlockattr_t;
+#define __DEFINED_pthread_rwlockattr_t
+#endif
+
+
+#if defined(__NEED_struct__IO_FILE) && !defined(__DEFINED_struct__IO_FILE)
+struct _IO_FILE { char __x; };
+#define __DEFINED_struct__IO_FILE
+#endif
+
+#if defined(__NEED_FILE) && !defined(__DEFINED_FILE)
+typedef struct _IO_FILE FILE;
+#define __DEFINED_FILE
+#endif
+
+
+#if defined(__NEED_va_list) && !defined(__DEFINED_va_list)
+typedef __builtin_va_list va_list;
+#define __DEFINED_va_list
+#endif
+
+#if defined(__NEED___isoc_va_list) && !defined(__DEFINED___isoc_va_list)
+typedef __builtin_va_list __isoc_va_list;
+#define __DEFINED___isoc_va_list
+#endif
+
+
+#if defined(__NEED_mbstate_t) && !defined(__DEFINED_mbstate_t)
+typedef struct __mbstate_t { unsigned __opaque1, __opaque2; } mbstate_t;
+#define __DEFINED_mbstate_t
+#endif
+
+
+#if defined(__NEED_locale_t) && !defined(__DEFINED_locale_t)
+typedef struct __locale_struct * locale_t;
+#define __DEFINED_locale_t
+#endif
+
+
+#if defined(__NEED_sigset_t) && !defined(__DEFINED_sigset_t)
+typedef struct __sigset_t { unsigned long __bits[128/sizeof(long)]; } sigset_t;
+#define __DEFINED_sigset_t
+#endif
+
+
+#if defined(__NEED_struct_iovec) && !defined(__DEFINED_struct_iovec)
+struct iovec { void *iov_base; size_t iov_len; };
+#define __DEFINED_struct_iovec
+#endif
+
+
+#if defined(__NEED_struct_winsize) && !defined(__DEFINED_struct_winsize)
+struct winsize { unsigned short ws_row, ws_col, ws_xpixel, ws_ypixel; };
+#define __DEFINED_struct_winsize
+#endif
+
+
+#if defined(__NEED_socklen_t) && !defined(__DEFINED_socklen_t)
+typedef unsigned socklen_t;
+#define __DEFINED_socklen_t
+#endif
+
+#if defined(__NEED_sa_family_t) && !defined(__DEFINED_sa_family_t)
+typedef unsigned short sa_family_t;
+#define __DEFINED_sa_family_t
+#endif
+
+
+#if defined(__NEED_pthread_attr_t) && !defined(__DEFINED_pthread_attr_t)
+typedef struct { union { int __i[sizeof(long)==8?14:9]; volatile int __vi[sizeof(long)==8?14:9]; unsigned long __s[sizeof(long)==8?7:9]; } __u; } pthread_attr_t;
+#define __DEFINED_pthread_attr_t
+#endif
+
+#if defined(__NEED_pthread_mutex_t) && !defined(__DEFINED_pthread_mutex_t)
+typedef struct { union { int __i[sizeof(long)==8?10:6]; volatile int __vi[sizeof(long)==8?10:6]; volatile void *volatile __p[sizeof(long)==8?5:6]; } __u; } pthread_mutex_t;
+#define __DEFINED_pthread_mutex_t
+#endif
+
+#if defined(__NEED_mtx_t) && !defined(__DEFINED_mtx_t)
+typedef struct { union { int __i[sizeof(long)==8?10:6]; volatile int __vi[sizeof(long)==8?10:6]; volatile void *volatile __p[sizeof(long)==8?5:6]; } __u; } mtx_t;
+#define __DEFINED_mtx_t
+#endif
+
+#if defined(__NEED_pthread_cond_t) && !defined(__DEFINED_pthread_cond_t)
+typedef struct { union { int __i[12]; volatile int __vi[12]; void *__p[12*sizeof(int)/sizeof(void*)]; } __u; } pthread_cond_t;
+#define __DEFINED_pthread_cond_t
+#endif
+
+#if defined(__NEED_cnd_t) && !defined(__DEFINED_cnd_t)
+typedef struct { union { int __i[12]; volatile int __vi[12]; void *__p[12*sizeof(int)/sizeof(void*)]; } __u; } cnd_t;
+#define __DEFINED_cnd_t
+#endif
+
+#if defined(__NEED_pthread_rwlock_t) && !defined(__DEFINED_pthread_rwlock_t)
+typedef struct { union { int __i[sizeof(long)==8?14:8]; volatile int __vi[sizeof(long)==8?14:8]; void *__p[sizeof(long)==8?7:8]; } __u; } pthread_rwlock_t;
+#define __DEFINED_pthread_rwlock_t
+#endif
+
+#if defined(__NEED_pthread_barrier_t) && !defined(__DEFINED_pthread_barrier_t)
+typedef struct { union { int __i[sizeof(long)==8?8:5]; volatile int __vi[sizeof(long)==8?8:5]; void *__p[sizeof(long)==8?4:5]; } __u; } pthread_barrier_t;
+#define __DEFINED_pthread_barrier_t
+#endif
+
+
+#undef _Addr
+#undef _Int64
+#undef _Reg

--- a/libmstpm/deps/libcrt/include/bits/atomic_arch.h
+++ b/libmstpm/deps/libcrt/include/bits/atomic_arch.h
@@ -1,0 +1,125 @@
+/* SPDX-License-Identifier: MIT */
+
+#define a_cas a_cas
+static inline int a_cas(volatile int *p, int t, int s)
+{
+	__asm__ __volatile__ (
+		"lock ; cmpxchg %3, %1"
+		: "=a"(t), "=m"(*p) : "a"(t), "r"(s) : "memory" );
+	return t;
+}
+
+#define a_cas_p a_cas_p
+static inline void *a_cas_p(volatile void *p, void *t, void *s)
+{
+	__asm__( "lock ; cmpxchg %3, %1"
+		: "=a"(t), "=m"(*(void *volatile *)p)
+		: "a"(t), "r"(s) : "memory" );
+	return t;
+}
+
+#define a_swap a_swap
+static inline int a_swap(volatile int *p, int v)
+{
+	__asm__ __volatile__(
+		"xchg %0, %1"
+		: "=r"(v), "=m"(*p) : "0"(v) : "memory" );
+	return v;
+}
+
+#define a_fetch_add a_fetch_add
+static inline int a_fetch_add(volatile int *p, int v)
+{
+	__asm__ __volatile__(
+		"lock ; xadd %0, %1"
+		: "=r"(v), "=m"(*p) : "0"(v) : "memory" );
+	return v;
+}
+
+#define a_and a_and
+static inline void a_and(volatile int *p, int v)
+{
+	__asm__ __volatile__(
+		"lock ; and %1, %0"
+		: "=m"(*p) : "r"(v) : "memory" );
+}
+
+#define a_or a_or
+static inline void a_or(volatile int *p, int v)
+{
+	__asm__ __volatile__(
+		"lock ; or %1, %0"
+		: "=m"(*p) : "r"(v) : "memory" );
+}
+
+#define a_and_64 a_and_64
+static inline void a_and_64(volatile uint64_t *p, uint64_t v)
+{
+	__asm__ __volatile(
+		"lock ; and %1, %0"
+		 : "=m"(*p) : "r"(v) : "memory" );
+}
+
+#define a_or_64 a_or_64
+static inline void a_or_64(volatile uint64_t *p, uint64_t v)
+{
+	__asm__ __volatile__(
+		"lock ; or %1, %0"
+		 : "=m"(*p) : "r"(v) : "memory" );
+}
+
+#define a_inc a_inc
+static inline void a_inc(volatile int *p)
+{
+	__asm__ __volatile__(
+		"lock ; incl %0"
+		: "=m"(*p) : "m"(*p) : "memory" );
+}
+
+#define a_dec a_dec
+static inline void a_dec(volatile int *p)
+{
+	__asm__ __volatile__(
+		"lock ; decl %0"
+		: "=m"(*p) : "m"(*p) : "memory" );
+}
+
+#define a_store a_store
+static inline void a_store(volatile int *p, int x)
+{
+	__asm__ __volatile__(
+		"mov %1, %0 ; lock ; orl $0,(%%rsp)"
+		: "=m"(*p) : "r"(x) : "memory" );
+}
+
+#define a_barrier a_barrier
+static inline void a_barrier()
+{
+	__asm__ __volatile__( "" : : : "memory" );
+}
+
+#define a_spin a_spin
+static inline void a_spin()
+{
+	__asm__ __volatile__( "pause" : : : "memory" );
+}
+
+#define a_crash a_crash
+static inline void a_crash()
+{
+	__asm__ __volatile__( "hlt" : : : "memory" );
+}
+
+#define a_ctz_64 a_ctz_64
+static inline int a_ctz_64(uint64_t x)
+{
+	__asm__( "bsf %1,%0" : "=r"(x) : "r"(x) );
+	return x;
+}
+
+#define a_clz_64 a_clz_64
+static inline int a_clz_64(uint64_t x)
+{
+	__asm__( "bsr %1,%0 ; xor $63,%0" : "=r"(x) : "r"(x) );
+	return x;
+}

--- a/libmstpm/deps/libcrt/include/ctype.h
+++ b/libmstpm/deps/libcrt/include/ctype.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/libmstpm/deps/libcrt/include/dirent.h
+++ b/libmstpm/deps/libcrt/include/dirent.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/libmstpm/deps/libcrt/include/endian.h
+++ b/libmstpm/deps/libcrt/include/endian.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/libmstpm/deps/libcrt/include/errno.h
+++ b/libmstpm/deps/libcrt/include/errno.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/libmstpm/deps/libcrt/include/fcntl.h
+++ b/libmstpm/deps/libcrt/include/fcntl.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/libmstpm/deps/libcrt/include/inttypes.h
+++ b/libmstpm/deps/libcrt/include/inttypes.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/libmstpm/deps/libcrt/include/libcrt.h
+++ b/libmstpm/deps/libcrt/include/libcrt.h
@@ -20,7 +20,6 @@
 
 #define _Noreturn __attribute__((__noreturn__))
 
-#define weak __attribute__((__weak__))
 #define hidden __attribute__((__visibility__("hidden")))
 #define weak_alias(old, new) \
         extern __typeof(old) new __attribute__((__weak__, __alias__(#old)))
@@ -73,8 +72,10 @@
 // errno.h
 
 extern int errno;
+#define EINTR         4
 #define ENOMEM        12
 #define EINVAL        22
+#define ENOSYS        38
 #define EAFNOSUPPORT  47
 #define EOVERFLOW     75
 
@@ -146,6 +147,10 @@ uid_t geteuid(void);
 gid_t getgid(void);
 gid_t getegid(void);
 int issetugid(void);
+
+int getentropy(void *buffer, size_t length);
+long syscall(long number, ...);
+int usleep(unsigned usec);
 
 // stdio.h
 
@@ -361,6 +366,9 @@ size_t fread(void *, size_t, size_t, FILE *);
 size_t fwrite(const void *buffer, size_t size, size_t count, FILE *stream);
 int fprintf(FILE *, const char *, ...);
 int fputc(int c, FILE *f);
+
+int ferror(FILE *stream);
+int clearerr(FILE *stream);
 
 int vasprintf(char **s, const char *fmt, va_list ap);
 int asprintf(char **s, const char *fmt, ...);

--- a/libmstpm/deps/libcrt/include/libcrt.h
+++ b/libmstpm/deps/libcrt/include/libcrt.h
@@ -1,0 +1,388 @@
+/* SPDX-License-Identifier: MIT */
+
+#ifndef __LIBCRT_H__
+#define __LIBCRT_H__
+
+// The SVSM guids are expected to be the last bytes of the svsm.bin file. When
+// we set the external dependencies symbols to be hidden, we prevent them from
+// being preempted. Otherwise, the SVSM guids will not be the last bytes of the
+// svsm.bin.
+#if defined(__pie__)
+#pragma GCC visibility push (hidden)
+#endif
+
+// Openssl big number operation (bn_op). Ensure it is defined for all SVSM
+// external dependency that requires openssl crypto functions.
+//#define SIXTY_FOUR_BIT_LONG
+#define SIXTY_FOUR_BIT
+
+// features.h
+
+#define _Noreturn __attribute__((__noreturn__))
+
+#define weak __attribute__((__weak__))
+#define hidden __attribute__((__visibility__("hidden")))
+#define weak_alias(old, new) \
+        extern __typeof(old) new __attribute__((__weak__, __alias__(#old)))
+
+// All types required
+
+#define __NEED_va_list
+
+#define __NEED_int8_t
+#define __NEED_int16_t
+#define __NEED_int32_t
+#define __NEED_int64_t
+
+#define __NEED_uint8_t
+#define __NEED_uint16_t
+#define __NEED_uint32_t
+#define __NEED_uint64_t
+
+#define __NEED_intptr_t
+#define __NEED_uintptr_t
+#define __NEED_size_t
+#define __NEED_ssize_t
+#define __NEED_ptrdiff_t
+#define __NEED_wchar_t
+
+#define __NEED_intmax_t
+#define __NEED_uintmax_t
+
+#define __NEED_time_t
+#define __NEED_clock_t
+#define __NEED_clockid_t
+#define __NEED_struct_timespec
+
+#define __NEED_pid_t
+#define __NEED_FILE
+#define __NEED_struct__IO_FILE
+
+#define __NEED_dev_t
+#define __NEED_ino_t
+#define __NEED_mode_t
+#define __NEED_nlink_t
+#define __NEED_uid_t
+#define __NEED_gid_t
+#define __NEED_off_t
+#define __NEED_blksize_t
+#define __NEED_blkcnt_t
+
+#include <bits/alltypes.h>
+
+// errno.h
+
+extern int errno;
+#define ENOMEM        12
+#define EINVAL        22
+#define EAFNOSUPPORT  47
+#define EOVERFLOW     75
+
+// stddef.h
+
+#ifndef NULL
+#define NULL  ((void *) 0)
+#endif
+
+#define offsetof(type, member) __builtin_offsetof(type, member)
+
+// stdbool.h
+
+#define true 1
+#define false 0
+#define bool _Bool
+
+// stdint.h
+
+#define INT8_MIN   (-1-0x7f)
+#define INT16_MIN  (-1-0x7fff)
+#define INT32_MIN  (-1-0x7fffffff)
+#define INT64_MIN  (-1-0x7fffffffffffffff)
+
+#define INT8_MAX   (0x7f)
+#define INT16_MAX  (0x7fff)
+#define INT32_MAX  (0x7fffffff)
+#define INT64_MAX  (0x7fffffffffffffff)
+
+#define UINT8_MAX  (0xff)
+#define UINT16_MAX (0xffff)
+#define UINT32_MAX (0xffffffffu)
+#define UINT64_MAX (0xffffffffffffffffu)
+
+// limits.h
+
+#define UCHAR_MAX  255
+#define SSIZE_MAX  0xFFFFFFFFFFFFFFFFU
+#define INT_MIN  (-1-0x7fffffff)
+#define INT_MAX  0x7fffffff
+#define LONG_MIN (-LONG_MAX-1)
+#define LONG_MAX __LONG_MAX
+#define UINT_MAX 0xffffffffU
+#define ULONG_MAX (2UL*LONG_MAX+1)
+#define CHAR_BIT 8
+
+// atomic.h
+
+// Check the atomic.h file for the atomic definitions. It is a busy file with
+// lots of inline functions and it also includes architecture dependent code.
+
+// stdarg.h
+
+#define va_start(v,l)   __builtin_va_start(v,l)
+#define va_end(v)       __builtin_va_end(v)
+#define va_arg(v,l)     __builtin_va_arg(v,l)
+#define va_copy(d,s)    __builtin_va_copy(d,s)
+
+// unistd.h
+
+#define STDERR_FILENO 2
+#define SEEK_SET 0
+#define SEEK_CUR 1
+#define SEEK_END 2
+
+pid_t getpid(void);
+uid_t getuid(void);
+uid_t geteuid(void);
+gid_t getgid(void);
+gid_t getegid(void);
+int issetugid(void);
+
+// stdio.h
+
+#define EOF (-1)
+#define BUFSIZ  8192
+void setbuf(FILE *stream, char *buf);
+int printf(const char *restrict fmt, ...);
+int dprintf(int fd, const char *__restrict fmt, ...);
+int vdprintf(int fd, const char *restrict fmt, va_list ap);
+int puts(const char *s);
+int fprintf(FILE *restrict f, const char *restrict fmt, ...);
+int asprintf(char **s, const char *fmt, ...);
+int snprintf(char *restrict s, size_t n, const char *restrict fmt, ...);
+int sprintf(char *restrict s, const char *restrict fmt, ...);
+int vasprintf(char **s, const char *fmt, va_list ap);
+int vsnprintf(char *restrict s, size_t n, const char *restrict fmt, va_list ap);
+int vsprintf(char *restrict s, const char *restrict fmt, va_list ap);
+
+int vprints(const char *format, va_list ap);
+int vsnprints(char *str, size_t size, const char *format, va_list ap);
+
+// Functions exported by the SVSM
+extern void serial_out(const char *s, int len);
+
+// stdlib.h
+
+// Functions exported by the SVSM
+extern void *malloc(size_t size);
+extern void *realloc(void *ptr, size_t size);
+extern void *calloc(size_t nmemb, size_t size);
+extern void free(void *ptr);
+extern _Noreturn void abort(void);
+
+int atoi(const char *s);
+int atexit(void (*func)(void));
+
+void qsort(void *, size_t, size_t,  int (*)(const void *, const void *));
+void qsort_r(void *, size_t, size_t, int (*)(const void *, const void *, void *), void *);
+void __qsort_r(void *, size_t, size_t, int (*)(const void *, const void *, void *), void *);
+
+char *getenv(const char *);
+
+int rand(void);
+void srand(unsigned s);
+
+// time.h
+
+#define CLOCK_MONOTONIC          1
+
+struct tm {
+  int tm_sec;     /* seconds after the minute [0-60] */
+  int tm_min;     /* minutes after the hour [0-59] */
+  int tm_hour;    /* hours since midnight [0-23] */
+  int tm_mday;    /* day of the month [1-31] */
+  int tm_mon;     /* months since January [0-11] */
+  int tm_year;    /* years since 1900 */
+  int tm_wday;    /* days since Sunday [0-6] */
+  int tm_yday;    /* days since January 1 [0-365] */
+  int tm_isdst;   /* Daylight Savings Time flag */
+  long tm_gmtoff; /* offset from CUT in seconds */
+  char *tm_zone;  /* timezone abbreviation */
+};
+
+struct timeval {
+  long tv_sec;  /* time value, in seconds */
+  long tv_usec; /* time value, in microseconds */
+};
+
+char *ctime(const time_t *t);
+time_t time(time_t *);
+struct tm *gmtime(const time_t *);
+struct tm *gmtime_r(const time_t *restrict t, struct tm *restrict tm);
+clock_t clock(void);
+int clock_gettime(clockid_t clk_id, struct timespec *tp);
+int gettimeofday(struct timeval *restrict tv, void *restrict tz);
+int __secs_to_tm(long long t, struct tm *tm);
+
+#define DECLARE_ARGS(val, low, high)	unsigned long low, high
+#define EAX_EDX_VAL(val, low, high)	((low) | (high) << 32)
+#define EAX_EDX_RET(val, low, high)	"=a" (low), "=d" (high)
+
+static inline unsigned long long rdtsc(void)
+{
+	DECLARE_ARGS(val, low, high);
+	asm volatile("rdtsc" : EAX_EDX_RET(val, low, high));
+	return EAX_EDX_VAL(val, low, high);
+}
+
+// inttypes.h
+
+#if UINTPTR_MAX == UINT64_MAX
+#define __PRI64  "l"
+#define __PRIPTR "l"
+#else
+#define __PRI64  "ll"
+#define __PRIPTR ""
+#endif
+
+#define PRIu8  "u"
+#define PRIu16 "u"
+#define PRIu32 "u"
+#define PRIu64 __PRI64 "u"
+
+// dirent.h
+
+typedef struct __dirstream DIR;
+
+struct dirent {
+    ino_t d_ino;
+    off_t d_off;
+    unsigned short d_reclen;
+    unsigned char d_type;
+    char d_name[256];
+};
+
+DIR *opendir(const char *name);
+int closedir(DIR *name);
+struct dirent *readdir(DIR *name);
+
+typedef unsigned long __jmp_buf[8];
+
+typedef struct __jmp_buf_tag {
+	__jmp_buf __jb;
+	unsigned long __fl;
+	unsigned long __ss[128/sizeof(long)];
+} jmp_buf[1];
+
+#define __setjmp_attr __attribute__((__returns_twice__))
+
+// sys/stat.h
+
+#define S_IFDIR 0040000
+#define S_IFMT  0170000
+
+#define S_ISDIR(mode)  (((mode) & S_IFMT) == S_IFDIR)
+
+/* copied from kernel definition, but with padding replaced
+ * by the corresponding correctly-sized userspace types. */
+struct stat {
+    dev_t st_dev;
+    ino_t st_ino;
+    nlink_t st_nlink;
+
+    mode_t st_mode;
+    uid_t st_uid;
+    gid_t st_gid;
+    unsigned int    __pad0;
+    dev_t st_rdev;
+    off_t st_size;
+    blksize_t st_blksize;
+    blkcnt_t st_blocks;
+
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    long __unused[3];
+};
+
+int stat(const char *__restrict path, struct stat *restrict buf);
+
+// string.h
+
+void *memset(void *, int, size_t);
+int memcmp(const void *, const void *, size_t);
+void *memcpy(void *restrict dest, const void *restrict src, size_t n);
+void *memchr(const void *src, int c, size_t n);
+void *memmove(void *dest, const void *src, size_t n);
+void *memrchr(const void *m, int c, size_t n);
+void *__memrchr(const void *m, int c, size_t n);
+
+int strcmp(const char *, const char *);
+int strncasecmp(const char *, const char *, size_t);
+char *strchr(const char *, int);
+char *strrchr(const char *, int);
+unsigned long strtoul(const char *, char **, int);
+long strtol(const char *, char **, int);
+char *strerror(int);
+size_t strspn(const char *, const char *);
+size_t strcspn(const char *, const char *);
+
+char *strcpy(char *strDest, const char  *strSource);
+size_t strlen(const char *s);
+char *__strchrnul(const char *s, int c);
+char *__stpcpy(char *restrict d, const char *restrict s);
+char *__stpncpy(char *restrict d, const char *restrict s, size_t n);
+char *strstr(const char *h, const char *n);
+char *strdup(const char *s);
+char *strncpy(char *restrict d, const char *restrict s, size_t n);
+int strncmp(const char *_l, const char *_r, size_t n);
+int strcasecmp(const char *_l, const char *_r);
+char *strcat(char *restrict dest, const char *restrict src);
+char *strncat (char *__restrict, const char *__restrict, size_t);
+
+// ctype.h
+
+int isdigit(int c);
+int isspace(int c);
+int isupper(int c);
+int isascii(int c);
+int islower(int c);
+
+int tolower(int c);
+int toupper(int c);
+
+// stdio.h
+
+int printf(const char *, ...);
+int sscanf(const char *, const char *, ...);
+
+FILE *fopen(const char *, const char *);
+int fclose(FILE *);
+size_t fread(void *, size_t, size_t, FILE *);
+size_t fwrite(const void *buffer, size_t size, size_t count, FILE *stream);
+int fprintf(FILE *, const char *, ...);
+int fputc(int c, FILE *f);
+
+int vasprintf(char **s, const char *fmt, va_list ap);
+int asprintf(char **s, const char *fmt, ...);
+int vsnprintf(char *restrict s, size_t n, const char *restrict fmt, va_list ap);
+int vsprintf(char *restrict s, const char *restrict fmt, va_list ap);
+int snprintf(char *restrict s, size_t n, const char *restrict fmt, ...);
+int sprintf(char *restrict s, const char *restrict fmt, ...);
+int dprintf(int fd, const char *__restrict fmt, ...);
+int vdprintf(int fd, const char *restrict fmt, va_list ap);
+
+// inet.h
+
+int inet_pton(int, const char *, void *);
+
+// setjmp.h
+
+int setjmp (jmp_buf) __setjmp_attr;
+_Noreturn void longjmp (jmp_buf, int);
+
+// assert.h
+
+#define assert(x) ((void)((x) || (__assert_fail(#x, __FILE__, __LINE__, __func__),0)))
+_Noreturn void __assert_fail (const char *, const char *, int, const char *);
+
+#endif

--- a/libmstpm/deps/libcrt/include/limits.h
+++ b/libmstpm/deps/libcrt/include/limits.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/libmstpm/deps/libcrt/include/memory.h
+++ b/libmstpm/deps/libcrt/include/memory.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/libmstpm/deps/libcrt/include/setjmp.h
+++ b/libmstpm/deps/libcrt/include/setjmp.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/libmstpm/deps/libcrt/include/stdarg.h
+++ b/libmstpm/deps/libcrt/include/stdarg.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/libmstpm/deps/libcrt/include/stdatomic.h
+++ b/libmstpm/deps/libcrt/include/stdatomic.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/libmstpm/deps/libcrt/include/stdbool.h
+++ b/libmstpm/deps/libcrt/include/stdbool.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/libmstpm/deps/libcrt/include/stddef.h
+++ b/libmstpm/deps/libcrt/include/stddef.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/libmstpm/deps/libcrt/include/stdint.h
+++ b/libmstpm/deps/libcrt/include/stdint.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/libmstpm/deps/libcrt/include/stdio.h
+++ b/libmstpm/deps/libcrt/include/stdio.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/libmstpm/deps/libcrt/include/stdlib.h
+++ b/libmstpm/deps/libcrt/include/stdlib.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/libmstpm/deps/libcrt/include/string.h
+++ b/libmstpm/deps/libcrt/include/string.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/libmstpm/deps/libcrt/include/strings.h
+++ b/libmstpm/deps/libcrt/include/strings.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/libmstpm/deps/libcrt/include/sys/shm.h
+++ b/libmstpm/deps/libcrt/include/sys/shm.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/libmstpm/deps/libcrt/include/sys/stat.h
+++ b/libmstpm/deps/libcrt/include/sys/stat.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/libmstpm/deps/libcrt/include/sys/syscall.h
+++ b/libmstpm/deps/libcrt/include/sys/syscall.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/libmstpm/deps/libcrt/include/sys/time.h
+++ b/libmstpm/deps/libcrt/include/sys/time.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/libmstpm/deps/libcrt/include/sys/types.h
+++ b/libmstpm/deps/libcrt/include/sys/types.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/libmstpm/deps/libcrt/include/sys/utsname.h
+++ b/libmstpm/deps/libcrt/include/sys/utsname.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/libmstpm/deps/libcrt/include/time.h
+++ b/libmstpm/deps/libcrt/include/time.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/libmstpm/deps/libcrt/include/unistd.h
+++ b/libmstpm/deps/libcrt/include/unistd.h
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>

--- a/libmstpm/deps/libcrt/src/ctype/isascii.c
+++ b/libmstpm/deps/libcrt/src/ctype/isascii.c
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <ctype.h>
+
+int isascii(int c)
+{
+	return !(c&~0x7f);
+}

--- a/libmstpm/deps/libcrt/src/ctype/isdigit.c
+++ b/libmstpm/deps/libcrt/src/ctype/isdigit.c
@@ -1,0 +1,6 @@
+#include <ctype.h>
+
+int isdigit(int c)
+{
+	return (unsigned)c-'0' < 10;
+}

--- a/libmstpm/deps/libcrt/src/ctype/islower.c
+++ b/libmstpm/deps/libcrt/src/ctype/islower.c
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <ctype.h>
+
+int islower(int c)
+{
+	return (unsigned)c-'a' < 26;
+}

--- a/libmstpm/deps/libcrt/src/ctype/isspace.c
+++ b/libmstpm/deps/libcrt/src/ctype/isspace.c
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <ctype.h>
+
+int isspace(int c)
+{
+	return c == ' ' || (unsigned)c-'\t' < 5;
+}

--- a/libmstpm/deps/libcrt/src/ctype/isupper.c
+++ b/libmstpm/deps/libcrt/src/ctype/isupper.c
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <ctype.h>
+
+int isupper(int c)
+{
+	return (unsigned)c-'A' < 26;
+}

--- a/libmstpm/deps/libcrt/src/ctype/tolower.c
+++ b/libmstpm/deps/libcrt/src/ctype/tolower.c
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <ctype.h>
+
+int tolower(int c)
+{
+	if (isupper(c)) return c | 32;
+	return c;
+}

--- a/libmstpm/deps/libcrt/src/ctype/toupper.c
+++ b/libmstpm/deps/libcrt/src/ctype/toupper.c
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <ctype.h>
+
+int toupper(int c)
+{
+	if (islower(c)) return c & 0x5f;
+	return c;
+}

--- a/libmstpm/deps/libcrt/src/exit/assert.c
+++ b/libmstpm/deps/libcrt/src/exit/assert.c
@@ -1,0 +1,10 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+void __assert_fail(const char *expr, const char *file, int line, const char *func)
+{
+	printf("Assertion failed: %s (%s: %s: %d)\n", expr, file, func, line);
+    abort();
+}

--- a/libmstpm/deps/libcrt/src/prng/rand.c
+++ b/libmstpm/deps/libcrt/src/prng/rand.c
@@ -1,0 +1,75 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <assert.h>
+
+/*
+ * In the AMD64 Programmer's Manual Volume 3, the RDRAND and RDRAND
+ * instructions suggests that software should implement a retry limit
+ * to ensure forward progress of code.
+ */
+const uint32_t RDSEED_RETRIES = 1024;
+const uint32_t RDRAND_RETRIES = 1024;
+
+static uint64_t seed;
+
+void srand(unsigned s)
+{
+	seed = s - 1;
+}
+
+static inline int rdrand32(uint32_t *rnd)
+{
+    unsigned char ok;
+
+    __asm__ volatile("rdrand %0; setc %1":"=r"(*rnd), "=qm"(ok));
+    if (!ok) {
+        uint32_t retry = 0;
+	while (retry < RDRAND_RETRIES) {
+            __asm__ volatile("rdrand %0; setc %1":"=r"(*rnd), "=qm"(ok));
+            if (ok)
+		goto rc_success;
+            retry++;
+        }
+        printf("%s: failed %d times\n", __func__, retry);
+        return -1;
+    }
+
+rc_success:
+    return 0;
+}
+
+static inline int rdseed32(uint32_t *rnd)
+{
+    unsigned char ok;
+
+    __asm__ volatile("rdseed %0; setc %1":"=r"(*rnd), "=qm"(ok));
+    if (!ok) {
+        uint32_t retry = 0;
+	while (retry < RDSEED_RETRIES) {
+            __asm__ volatile("rdseed %0; setc %1":"=r"(*rnd), "=qm"(ok));
+            if (ok)
+		goto rc_success;
+            retry++;
+        }
+        printf("%s: failed %d times\n", __func__, retry);
+        return -1;
+    }
+
+rc_success:
+    return 0;
+}
+
+int rand(void)
+{
+  uint32_t r = 0;
+  if (rdrand32(&r)) {
+     if (rdseed32(&r)) {
+         printf("ERROR: %s: RDRAND and RDSEED failed reaching the retry count\n", __func__);
+         abort();
+     }
+  }
+  return r;
+}

--- a/libmstpm/deps/libcrt/src/setjmp/x86_64/longjmp.s
+++ b/libmstpm/deps/libcrt/src/setjmp/x86_64/longjmp.s
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: MIT */
+/* Copyright 2011-2012 Nicholas J. Kain, licensed under standard MIT license */
+
+.global _longjmp
+.global longjmp
+.type _longjmp,@function
+.type longjmp,@function
+_longjmp:
+longjmp:
+	xor %eax,%eax
+	cmp $1,%esi             /* CF = val ? 0 : 1 */
+	adc %esi,%eax           /* eax = val + !val */
+	mov (%rdi),%rbx         /* rdi is the jmp_buf, restore regs from it */
+	mov 8(%rdi),%rbp
+	mov 16(%rdi),%r12
+	mov 24(%rdi),%r13
+	mov 32(%rdi),%r14
+	mov 40(%rdi),%r15
+	mov 48(%rdi),%rsp
+	jmp *56(%rdi)           /* goto saved address without altering rsp */

--- a/libmstpm/deps/libcrt/src/setjmp/x86_64/setjmp.s
+++ b/libmstpm/deps/libcrt/src/setjmp/x86_64/setjmp.s
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: MIT */
+/* Copyright 2011-2012 Nicholas J. Kain, licensed under standard MIT license */
+
+.global __setjmp
+.global _setjmp
+.global setjmp
+.type __setjmp,@function
+.type _setjmp,@function
+.type setjmp,@function
+__setjmp:
+_setjmp:
+setjmp:
+	mov %rbx,(%rdi)         /* rdi is jmp_buf, move registers onto it */
+	mov %rbp,8(%rdi)
+	mov %r12,16(%rdi)
+	mov %r13,24(%rdi)
+	mov %r14,32(%rdi)
+	mov %r15,40(%rdi)
+	lea 8(%rsp),%rdx        /* this is our rsp WITHOUT current ret addr */
+	mov %rdx,48(%rdi)
+	mov (%rsp),%rdx         /* save return addr ptr for new rip */
+	mov %rdx,56(%rdi)
+	xor %eax,%eax           /* always return 0 */
+	ret

--- a/libmstpm/deps/libcrt/src/stdio/asprintf.c
+++ b/libmstpm/deps/libcrt/src/stdio/asprintf.c
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <stdio.h>
+#include <stdarg.h>
+
+int asprintf(char **s, const char *fmt, ...)
+{
+	int ret;
+	va_list ap;
+	va_start(ap, fmt);
+	ret = vasprintf(s, fmt, ap);
+	va_end(ap);
+	return ret;
+}

--- a/libmstpm/deps/libcrt/src/stdio/fprintf.c
+++ b/libmstpm/deps/libcrt/src/stdio/fprintf.c
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <stdio.h>
+#include <stdarg.h>
+
+int fprintf(FILE *restrict f, const char *restrict fmt, ...)
+{
+	int ret;
+	va_list ap;
+	va_start(ap, fmt);
+	ret = vprints(fmt, ap);
+	va_end(ap);
+	return ret;
+}

--- a/libmstpm/deps/libcrt/src/stdio/printf.c
+++ b/libmstpm/deps/libcrt/src/stdio/printf.c
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <stdio.h>
+#include <stdarg.h>
+
+int printf(const char *restrict fmt, ...)
+{
+	int ret;
+	va_list ap;
+	va_start(ap, fmt);
+	ret = vprints(fmt, ap);
+	va_end(ap);
+	return ret;
+}
+
+int dprintf(int fd, const char *__restrict fmt, ...)
+{
+	int ret;
+	va_list ap;
+	va_start(ap, fmt);
+	ret = vprints(fmt, ap);
+	va_end(ap);
+	return ret;
+}
+
+int vdprintf(int fd, const char *restrict fmt, va_list ap)
+{
+  return vprints(fmt, ap);
+}
+
+int puts(const char *s)
+{
+        return printf("%s\n", s);
+}

--- a/libmstpm/deps/libcrt/src/stdio/printf_wrapper.c
+++ b/libmstpm/deps/libcrt/src/stdio/printf_wrapper.c
@@ -1,0 +1,269 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <stdio.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+enum {
+	LEN_MOD_INVALID		= 0,
+	LEN_MOD_HALF_HALF,
+	LEN_MOD_HALF,
+	LEN_MOD_INT,
+	LEN_MOD_LONG,
+	LEN_MOD_LONG_LONG,
+	LEN_MOD_MAX
+};
+
+static char *format_string(char *cur, char *end, va_list ap)
+{
+	char *tmp = va_arg(ap, char *);
+
+	while (*tmp) {
+		if (cur < end)
+			*cur = *tmp;
+		cur++;
+		tmp++;
+	}
+
+	return cur;
+}
+
+static char *format_base16(char *cur, char *end, int width, va_list ap)
+{
+	unsigned long long num;
+	char *tmp, buffer[32];
+	unsigned int size;
+	char *map;
+
+	map = "0123456789abcdef";
+
+	if (cur < end)
+		*cur++ = '0';
+	if (cur < end)
+		*cur++ = 'x';
+
+	if (width == LEN_MOD_HALF_HALF) {
+		unsigned char n = (unsigned char) va_arg(ap, int);
+		num = (unsigned long long)n;
+		size = 1;
+	} else if (width == LEN_MOD_HALF) {
+		unsigned short n = (unsigned short) va_arg(ap, int);
+		num = (unsigned long long)n;
+		size = 2;
+	} else if (width == LEN_MOD_INT) {
+		unsigned int n = (unsigned int) va_arg(ap, int);
+		num = (unsigned long long)n;
+		size = 4;
+	} else if (width == LEN_MOD_LONG) {
+		unsigned long n = (unsigned long) va_arg(ap, long);
+		num = (unsigned long long)n;
+		size = 8;
+	} else {
+		unsigned long long n = (unsigned long long) va_arg(ap, long long);
+		num = (unsigned long long)n;
+		size = 8;
+	}
+
+	tmp = buffer + sizeof(buffer);
+
+	tmp--;
+	*tmp = '\0';
+	while (size--) {
+		tmp--;
+		*tmp = map[num & 0xf];
+		num >>= 4;
+
+		tmp--;
+		*tmp = map[num & 0xf];
+		num >>= 4;
+	}
+
+	while (*tmp) {
+		if (cur < end)
+			*cur = *tmp;
+		cur++;
+		tmp++;
+	}
+
+	return cur;
+}
+
+static char *format_base10(char *cur, char *end, int width, bool signed_format, va_list ap)
+{
+	unsigned long long num;
+	char *tmp, buffer[32];
+
+	if (width == LEN_MOD_HALF_HALF) {
+		unsigned char n = (unsigned char) va_arg(ap, int);
+		if (signed_format && (char)n < 0) {
+			if (cur < end)
+				*cur++ = '-';
+			n = -(char)n;
+		}
+		num = (unsigned long long)n;
+	} else if (width == LEN_MOD_HALF) {
+		unsigned short n = (unsigned short) va_arg(ap, int);
+		if (signed_format && (short)n < 0) {
+			if (cur < end)
+				*cur++ = '-';
+			n = -(short)n;
+		}
+		num = (unsigned long long)n;
+	} else if (width == LEN_MOD_INT) {
+		unsigned int n = (unsigned int) va_arg(ap, int);
+		if (signed_format && (int)n < 0) {
+			if (cur < end)
+				*cur++ = '-';
+			n = -(int)n;
+		}
+		num = (unsigned long long)n;
+	} else if (width == LEN_MOD_LONG) {
+		unsigned long n = (unsigned long) va_arg(ap, long);
+		if (signed_format && (long)n < 0) {
+			if (cur < end)
+				*cur++ = '-';
+			n = -(long)n;
+		}
+		num = (unsigned long long)n;
+	} else {
+		unsigned long long n = (unsigned long long) va_arg(ap, long long);
+		if (signed_format && (long long)n < 0) {
+			if (cur < end)
+				*cur++ = '-';
+			n = -(long long)n;
+		}
+		num = (unsigned long long)n;
+	}
+
+	tmp = buffer + sizeof(buffer);
+
+	tmp--;
+	*tmp = '\0';
+	do {
+		tmp--;
+		*tmp = (char)('0' + num % 10);
+
+		num /= 10;
+	} while (num);
+
+	while (*tmp) {
+		if (cur < end)
+			*cur = *tmp;
+
+		cur++;
+		tmp++;
+	}
+
+	return cur;
+}
+
+int vsnprints(char *str, size_t size, const char *format, va_list ap)
+{
+	unsigned int width;
+	char *cur, *end;
+	bool convert;
+
+	cur = str;
+	end = cur + size;
+	if (end < cur) {
+		end = (void *)-1;
+		size = end - cur;
+	}
+
+	convert = false;
+	while (*format) {
+		if (!convert) {
+			if (*format != '%') {
+				if (cur < end)
+					*cur = *format;
+
+				cur++;
+				format++;
+				continue;
+			}
+
+			format++;
+			if (*format == '%') {
+				if (cur < end)
+					*cur = '%';
+
+				cur++;
+				format++;
+				continue;
+			}
+
+			convert = true;
+			width = LEN_MOD_INT;
+		} else {
+			bool signed_format = false;
+
+			switch (*format) {
+			case 'h':
+				width--;
+				if (width == LEN_MOD_INVALID)
+					convert = false;
+				break;
+			case 'l':
+				width++;
+				if (width == LEN_MOD_MAX)
+					convert = false;
+				break;
+			case 'd':
+				signed_format = true;
+			case 'z':
+				// handle %zu
+				if (*(format+1) && *(format+1) == 'u' )
+					format++;
+			case 'u':
+				cur = format_base10(cur, end, width, signed_format, ap);
+				convert = false;
+				break;
+			case 'p':
+				width = LEN_MOD_LONG;
+			case 'x':
+				cur = format_base16(cur, end, width, ap);
+				convert = false;
+				break;
+			case 's': {
+				cur = format_string(cur, end, ap);
+				convert = false;
+				break;
+			}
+			default:
+				convert = false;
+			}
+
+			format++;
+		}
+	}
+
+	if (size) {
+		if (cur < end)
+			*cur = '\0';
+		else
+			*(end - 1) = '\0';
+	}
+
+	return cur - str;
+}
+
+// A format string is converted to the actual string, which is then
+// truncated to PRINT_STR_MAX before printing.
+#define PRINT_STR_MAX    256
+
+int vprints(const char *format, va_list ap)
+{
+	char buffer[PRINT_STR_MAX];
+	int ret;
+
+	ret = vsnprints(buffer, sizeof(buffer), format, ap);
+
+	if (ret >= sizeof(buffer)) {
+        	ret = PRINT_STR_MAX;
+		buffer[PRINT_STR_MAX - 1] = '\0';
+	}
+
+	serial_out(buffer, ret);
+
+	return ret;
+}

--- a/libmstpm/deps/libcrt/src/stdio/snprintf.c
+++ b/libmstpm/deps/libcrt/src/stdio/snprintf.c
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <stdio.h>
+#include <stdarg.h>
+
+int snprintf(char *restrict s, size_t n, const char *restrict fmt, ...)
+{
+	int ret;
+	va_list ap;
+	va_start(ap, fmt);
+	ret = vsnprintf(s, n, fmt, ap);
+	va_end(ap);
+	return ret;
+}
+

--- a/libmstpm/deps/libcrt/src/stdio/sprintf.c
+++ b/libmstpm/deps/libcrt/src/stdio/sprintf.c
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <stdio.h>
+#include <stdarg.h>
+
+int sprintf(char *restrict s, const char *restrict fmt, ...)
+{
+	int ret;
+	va_list ap;
+	va_start(ap, fmt);
+	ret = vsprintf(s, fmt, ap);
+	va_end(ap);
+	return ret;
+}

--- a/libmstpm/deps/libcrt/src/stdio/vasprintf.c
+++ b/libmstpm/deps/libcrt/src/stdio/vasprintf.c
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdlib.h>
+
+int vasprintf(char **s, const char *fmt, va_list ap)
+{
+	va_list ap2;
+	va_copy(ap2, ap);
+	int l = vsnprintf(0, 0, fmt, ap2);
+	va_end(ap2);
+
+	if (l<0 || !(*s=malloc(l+1U))) return -1;
+	return vsnprintf(*s, l+1U, fmt, ap);
+}

--- a/libmstpm/deps/libcrt/src/stdio/vsnprintf.c
+++ b/libmstpm/deps/libcrt/src/stdio/vsnprintf.c
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+#include <stdarg.h>
+
+int vsnprintf(char *restrict s, size_t n, const char *restrict fmt, va_list ap)
+{
+	return vsnprints(s, n, fmt, ap);
+}

--- a/libmstpm/deps/libcrt/src/stdio/vsprintf.c
+++ b/libmstpm/deps/libcrt/src/stdio/vsprintf.c
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <stdio.h>
+#include <limits.h>
+
+int vsprintf(char *restrict s, const char *restrict fmt, va_list ap)
+{
+	return vsnprintf(s, INT_MAX, fmt, ap);
+}

--- a/libmstpm/deps/libcrt/src/stdlib/atoi.c
+++ b/libmstpm/deps/libcrt/src/stdlib/atoi.c
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <stdlib.h>
+#include <ctype.h>
+
+int atoi(const char *s)
+{
+	int n=0, neg=0;
+	while (isspace(*s)) s++;
+	switch (*s) {
+	case '-': neg=1;
+	case '+': s++;
+	}
+	/* Compute n as a negative number to avoid overflow on INT_MIN */
+	while (isdigit(*s))
+		n = 10*n - (*s++ - '0');
+	return neg ? n : -n;
+}

--- a/libmstpm/deps/libcrt/src/stdlib/qsort.c
+++ b/libmstpm/deps/libcrt/src/stdlib/qsort.c
@@ -1,0 +1,221 @@
+/* Copyright (C) 2011 by Valentin Ochs
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+/* Minor changes by Rich Felker for integration in musl, 2011-04-27. */
+
+/* Smoothsort, an adaptive variant of Heapsort.  Memory usage: O(1).
+   Run time: Worst case O(n log n), close to O(n) in the mostly-sorted case. */
+
+#define _BSD_SOURCE
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "atomic.h"
+#define ntz(x) a_ctz_l((x))
+
+typedef int (*cmpfun)(const void *, const void *, void *);
+
+static inline int pntz(size_t p[2]) {
+	int r = ntz(p[0] - 1);
+	if(r != 0 || (r = 8*sizeof(size_t) + ntz(p[1])) != 8*sizeof(size_t)) {
+		return r;
+	}
+	return 0;
+}
+
+static void cycle(size_t width, unsigned char* ar[], int n)
+{
+	unsigned char tmp[256];
+	size_t l;
+	int i;
+
+	if(n < 2) {
+		return;
+	}
+
+	ar[n] = tmp;
+	while(width) {
+		l = sizeof(tmp) < width ? sizeof(tmp) : width;
+		memcpy(ar[n], ar[0], l);
+		for(i = 0; i < n; i++) {
+			memcpy(ar[i], ar[i + 1], l);
+			ar[i] += l;
+		}
+		width -= l;
+	}
+}
+
+/* shl() and shr() need n > 0 */
+static inline void shl(size_t p[2], int n)
+{
+	if(n >= 8 * sizeof(size_t)) {
+		n -= 8 * sizeof(size_t);
+		p[1] = p[0];
+		p[0] = 0;
+	}
+	p[1] <<= n;
+	p[1] |= p[0] >> (sizeof(size_t) * 8 - n);
+	p[0] <<= n;
+}
+
+static inline void shr(size_t p[2], int n)
+{
+	if(n >= 8 * sizeof(size_t)) {
+		n -= 8 * sizeof(size_t);
+		p[0] = p[1];
+		p[1] = 0;
+	}
+	p[0] >>= n;
+	p[0] |= p[1] << (sizeof(size_t) * 8 - n);
+	p[1] >>= n;
+}
+
+static void sift(unsigned char *head, size_t width, cmpfun cmp, void *arg, int pshift, size_t lp[])
+{
+	unsigned char *rt, *lf;
+	unsigned char *ar[14 * sizeof(size_t) + 1];
+	int i = 1;
+
+	ar[0] = head;
+	while(pshift > 1) {
+		rt = head - width;
+		lf = head - width - lp[pshift - 2];
+
+		if(cmp(ar[0], lf, arg) >= 0 && cmp(ar[0], rt, arg) >= 0) {
+			break;
+		}
+		if(cmp(lf, rt, arg) >= 0) {
+			ar[i++] = lf;
+			head = lf;
+			pshift -= 1;
+		} else {
+			ar[i++] = rt;
+			head = rt;
+			pshift -= 2;
+		}
+	}
+	cycle(width, ar, i);
+}
+
+static void trinkle(unsigned char *head, size_t width, cmpfun cmp, void *arg, size_t pp[2], int pshift, int trusty, size_t lp[])
+{
+	unsigned char *stepson,
+	              *rt, *lf;
+	size_t p[2];
+	unsigned char *ar[14 * sizeof(size_t) + 1];
+	int i = 1;
+	int trail;
+
+	p[0] = pp[0];
+	p[1] = pp[1];
+
+	ar[0] = head;
+	while(p[0] != 1 || p[1] != 0) {
+		stepson = head - lp[pshift];
+		if(cmp(stepson, ar[0], arg) <= 0) {
+			break;
+		}
+		if(!trusty && pshift > 1) {
+			rt = head - width;
+			lf = head - width - lp[pshift - 2];
+			if(cmp(rt, stepson, arg) >= 0 || cmp(lf, stepson, arg) >= 0) {
+				break;
+			}
+		}
+
+		ar[i++] = stepson;
+		head = stepson;
+		trail = pntz(p);
+		shr(p, trail);
+		pshift += trail;
+		trusty = 0;
+	}
+	if(!trusty) {
+		cycle(width, ar, i);
+		sift(head, width, cmp, arg, pshift, lp);
+	}
+}
+
+void __qsort_r(void *base, size_t nel, size_t width, cmpfun cmp, void *arg)
+{
+	size_t lp[12*sizeof(size_t)];
+	size_t i, size = width * nel;
+	unsigned char *head, *high;
+	size_t p[2] = {1, 0};
+	int pshift = 1;
+	int trail;
+
+	if (!size) return;
+
+	head = base;
+	high = head + size - width;
+
+	/* Precompute Leonardo numbers, scaled by element width */
+	for(lp[0]=lp[1]=width, i=2; (lp[i]=lp[i-2]+lp[i-1]+width) < size; i++);
+
+	while(head < high) {
+		if((p[0] & 3) == 3) {
+			sift(head, width, cmp, arg, pshift, lp);
+			shr(p, 2);
+			pshift += 2;
+		} else {
+			if(lp[pshift - 1] >= high - head) {
+				trinkle(head, width, cmp, arg, p, pshift, 0, lp);
+			} else {
+				sift(head, width, cmp, arg, pshift, lp);
+			}
+
+			if(pshift == 1) {
+				shl(p, 1);
+				pshift = 0;
+			} else {
+				shl(p, pshift - 1);
+				pshift = 1;
+			}
+		}
+
+		p[0] |= 1;
+		head += width;
+	}
+
+	trinkle(head, width, cmp, arg, p, pshift, 0, lp);
+
+	while(pshift != 1 || p[0] != 1 || p[1] != 0) {
+		if(pshift <= 1) {
+			trail = pntz(p);
+			shr(p, trail);
+			pshift += trail;
+		} else {
+			shl(p, 2);
+			pshift -= 2;
+			p[0] ^= 7;
+			shr(p, 1);
+			trinkle(head - lp[pshift] - width, width, cmp, arg, p, pshift + 1, 1, lp);
+			shl(p, 1);
+			p[0] |= 1;
+			trinkle(head - width, width, cmp, arg, p, pshift, 1, lp);
+		}
+		head -= width;
+	}
+}
+
+weak_alias(__qsort_r, qsort_r);

--- a/libmstpm/deps/libcrt/src/stdlib/qsort_nr.c
+++ b/libmstpm/deps/libcrt/src/stdlib/qsort_nr.c
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: MIT */
+
+#define _BSD_SOURCE
+#include <stdlib.h>
+
+typedef int (*cmpfun)(const void *, const void *);
+
+static int wrapper_cmp(const void *v1, const void *v2, void *cmp)
+{
+	return ((cmpfun)cmp)(v1, v2);
+}
+
+void qsort(void *base, size_t nel, size_t width, cmpfun cmp)
+{
+	__qsort_r(base, nel, width, wrapper_cmp, (void *)cmp);
+}

--- a/libmstpm/deps/libcrt/src/string/memchr.c
+++ b/libmstpm/deps/libcrt/src/string/memchr.c
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+#include <stdint.h>
+#include <limits.h>
+
+#define SS (sizeof(size_t))
+#define ALIGN (sizeof(size_t)-1)
+#define ONES ((size_t)-1/UCHAR_MAX)
+#define HIGHS (ONES * (UCHAR_MAX/2+1))
+#define HASZERO(x) ((x)-ONES & ~(x) & HIGHS)
+
+void *memchr(const void *src, int c, size_t n)
+{
+	const unsigned char *s = src;
+	c = (unsigned char)c;
+#ifdef __GNUC__
+	for (; ((uintptr_t)s & ALIGN) && n && *s != c; s++, n--);
+	if (n && *s != c) {
+		typedef size_t __attribute__((__may_alias__)) word;
+		const word *w;
+		size_t k = ONES * c;
+		for (w = (const void *)s; n>=SS && !HASZERO(*w^k); w++, n-=SS);
+		s = (const void *)w;
+	}
+#endif
+	for (; n && *s != c; s++, n--);
+	return n ? (void *)s : 0;
+}

--- a/libmstpm/deps/libcrt/src/string/memcmp.c
+++ b/libmstpm/deps/libcrt/src/string/memcmp.c
@@ -1,0 +1,10 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+
+int memcmp(const void *vl, const void *vr, size_t n)
+{
+	const unsigned char *l=vl, *r=vr;
+	for (; n && *l == *r; n--, l++, r++);
+	return n ? *l-*r : 0;
+}

--- a/libmstpm/deps/libcrt/src/string/memcpy.c
+++ b/libmstpm/deps/libcrt/src/string/memcpy.c
@@ -1,0 +1,126 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+#include <stdint.h>
+#include <endian.h>
+
+void *memcpy(void *restrict dest, const void *restrict src, size_t n)
+{
+	unsigned char *d = dest;
+	const unsigned char *s = src;
+
+#ifdef __GNUC__
+
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+#define LS >>
+#define RS <<
+#else
+#define LS <<
+#define RS >>
+#endif
+
+	typedef uint32_t __attribute__((__may_alias__)) u32;
+	uint32_t w, x;
+
+	for (; (uintptr_t)s % 4 && n; n--) *d++ = *s++;
+
+	if ((uintptr_t)d % 4 == 0) {
+		for (; n>=16; s+=16, d+=16, n-=16) {
+			*(u32 *)(d+0) = *(u32 *)(s+0);
+			*(u32 *)(d+4) = *(u32 *)(s+4);
+			*(u32 *)(d+8) = *(u32 *)(s+8);
+			*(u32 *)(d+12) = *(u32 *)(s+12);
+		}
+		if (n&8) {
+			*(u32 *)(d+0) = *(u32 *)(s+0);
+			*(u32 *)(d+4) = *(u32 *)(s+4);
+			d += 8; s += 8;
+		}
+		if (n&4) {
+			*(u32 *)(d+0) = *(u32 *)(s+0);
+			d += 4; s += 4;
+		}
+		if (n&2) {
+			*d++ = *s++; *d++ = *s++;
+		}
+		if (n&1) {
+			*d = *s;
+		}
+		return dest;
+	}
+
+	if (n >= 32) switch ((uintptr_t)d % 4) {
+	case 1:
+		w = *(u32 *)s;
+		*d++ = *s++;
+		*d++ = *s++;
+		*d++ = *s++;
+		n -= 3;
+		for (; n>=17; s+=16, d+=16, n-=16) {
+			x = *(u32 *)(s+1);
+			*(u32 *)(d+0) = (w LS 24) | (x RS 8);
+			w = *(u32 *)(s+5);
+			*(u32 *)(d+4) = (x LS 24) | (w RS 8);
+			x = *(u32 *)(s+9);
+			*(u32 *)(d+8) = (w LS 24) | (x RS 8);
+			w = *(u32 *)(s+13);
+			*(u32 *)(d+12) = (x LS 24) | (w RS 8);
+		}
+		break;
+	case 2:
+		w = *(u32 *)s;
+		*d++ = *s++;
+		*d++ = *s++;
+		n -= 2;
+		for (; n>=18; s+=16, d+=16, n-=16) {
+			x = *(u32 *)(s+2);
+			*(u32 *)(d+0) = (w LS 16) | (x RS 16);
+			w = *(u32 *)(s+6);
+			*(u32 *)(d+4) = (x LS 16) | (w RS 16);
+			x = *(u32 *)(s+10);
+			*(u32 *)(d+8) = (w LS 16) | (x RS 16);
+			w = *(u32 *)(s+14);
+			*(u32 *)(d+12) = (x LS 16) | (w RS 16);
+		}
+		break;
+	case 3:
+		w = *(u32 *)s;
+		*d++ = *s++;
+		n -= 1;
+		for (; n>=19; s+=16, d+=16, n-=16) {
+			x = *(u32 *)(s+3);
+			*(u32 *)(d+0) = (w LS 8) | (x RS 24);
+			w = *(u32 *)(s+7);
+			*(u32 *)(d+4) = (x LS 8) | (w RS 24);
+			x = *(u32 *)(s+11);
+			*(u32 *)(d+8) = (w LS 8) | (x RS 24);
+			w = *(u32 *)(s+15);
+			*(u32 *)(d+12) = (x LS 8) | (w RS 24);
+		}
+		break;
+	}
+	if (n&16) {
+		*d++ = *s++; *d++ = *s++; *d++ = *s++; *d++ = *s++;
+		*d++ = *s++; *d++ = *s++; *d++ = *s++; *d++ = *s++;
+		*d++ = *s++; *d++ = *s++; *d++ = *s++; *d++ = *s++;
+		*d++ = *s++; *d++ = *s++; *d++ = *s++; *d++ = *s++;
+	}
+	if (n&8) {
+		*d++ = *s++; *d++ = *s++; *d++ = *s++; *d++ = *s++;
+		*d++ = *s++; *d++ = *s++; *d++ = *s++; *d++ = *s++;
+	}
+	if (n&4) {
+		*d++ = *s++; *d++ = *s++; *d++ = *s++; *d++ = *s++;
+	}
+	if (n&2) {
+		*d++ = *s++; *d++ = *s++;
+	}
+	if (n&1) {
+		*d = *s;
+	}
+	return dest;
+#endif
+
+	for (; n; n--) *d++ = *s++;
+	return dest;
+}

--- a/libmstpm/deps/libcrt/src/string/memmove.c
+++ b/libmstpm/deps/libcrt/src/string/memmove.c
@@ -1,0 +1,44 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+#include <stdint.h>
+
+#ifdef __GNUC__
+typedef __attribute__((__may_alias__)) size_t WT;
+#define WS (sizeof(WT))
+#endif
+
+void *memmove(void *dest, const void *src, size_t n)
+{
+	char *d = dest;
+	const char *s = src;
+
+	if (d==s) return d;
+	if ((uintptr_t)s-(uintptr_t)d-n <= -2*n) return memcpy(d, s, n);
+
+	if (d<s) {
+#ifdef __GNUC__
+		if ((uintptr_t)s % WS == (uintptr_t)d % WS) {
+			while ((uintptr_t)d % WS) {
+				if (!n--) return dest;
+				*d++ = *s++;
+			}
+			for (; n>=WS; n-=WS, d+=WS, s+=WS) *(WT *)d = *(WT *)s;
+		}
+#endif
+		for (; n; n--) *d++ = *s++;
+	} else {
+#ifdef __GNUC__
+		if ((uintptr_t)s % WS == (uintptr_t)d % WS) {
+			while ((uintptr_t)(d+n) % WS) {
+				if (!n--) return dest;
+				d[n] = s[n];
+			}
+			while (n>=WS) n-=WS, *(WT *)(d+n) = *(WT *)(s+n);
+		}
+#endif
+		while (n) n--, d[n] = s[n];
+	}
+
+	return dest;
+}

--- a/libmstpm/deps/libcrt/src/string/memrchr.c
+++ b/libmstpm/deps/libcrt/src/string/memrchr.c
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+
+void *__memrchr(const void *m, int c, size_t n)
+{
+	const unsigned char *s = m;
+	c = (unsigned char)c;
+	while (n--) if (s[n]==c) return (void *)(s+n);
+	return 0;
+}
+
+weak_alias(__memrchr, memrchr);

--- a/libmstpm/deps/libcrt/src/string/memset.c
+++ b/libmstpm/deps/libcrt/src/string/memset.c
@@ -1,0 +1,92 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+#include <stdint.h>
+
+void *memset(void *dest, int c, size_t n)
+{
+	unsigned char *s = dest;
+	size_t k;
+
+	/* Fill head and tail with minimal branching. Each
+	 * conditional ensures that all the subsequently used
+	 * offsets are well-defined and in the dest region. */
+
+	if (!n) return dest;
+	s[0] = c;
+	s[n-1] = c;
+	if (n <= 2) return dest;
+	s[1] = c;
+	s[2] = c;
+	s[n-2] = c;
+	s[n-3] = c;
+	if (n <= 6) return dest;
+	s[3] = c;
+	s[n-4] = c;
+	if (n <= 8) return dest;
+
+	/* Advance pointer to align it at a 4-byte boundary,
+	 * and truncate n to a multiple of 4. The previous code
+	 * already took care of any head/tail that get cut off
+	 * by the alignment. */
+
+	k = -(uintptr_t)s & 3;
+	s += k;
+	n -= k;
+	n &= -4;
+
+#ifdef __GNUC__
+	typedef uint32_t __attribute__((__may_alias__)) u32;
+	typedef uint64_t __attribute__((__may_alias__)) u64;
+
+	u32 c32 = ((u32)-1)/255 * (unsigned char)c;
+
+	/* In preparation to copy 32 bytes at a time, aligned on
+	 * an 8-byte bounary, fill head/tail up to 28 bytes each.
+	 * As in the initial byte-based head/tail fill, each
+	 * conditional below ensures that the subsequent offsets
+	 * are valid (e.g. !(n<=24) implies n>=28). */
+
+	*(u32 *)(s+0) = c32;
+	*(u32 *)(s+n-4) = c32;
+	if (n <= 8) return dest;
+	*(u32 *)(s+4) = c32;
+	*(u32 *)(s+8) = c32;
+	*(u32 *)(s+n-12) = c32;
+	*(u32 *)(s+n-8) = c32;
+	if (n <= 24) return dest;
+	*(u32 *)(s+12) = c32;
+	*(u32 *)(s+16) = c32;
+	*(u32 *)(s+20) = c32;
+	*(u32 *)(s+24) = c32;
+	*(u32 *)(s+n-28) = c32;
+	*(u32 *)(s+n-24) = c32;
+	*(u32 *)(s+n-20) = c32;
+	*(u32 *)(s+n-16) = c32;
+
+	/* Align to a multiple of 8 so we can fill 64 bits at a time,
+	 * and avoid writing the same bytes twice as much as is
+	 * practical without introducing additional branching. */
+
+	k = 24 + ((uintptr_t)s & 4);
+	s += k;
+	n -= k;
+
+	/* If this loop is reached, 28 tail bytes have already been
+	 * filled, so any remainder when n drops below 32 can be
+	 * safely ignored. */
+
+	u64 c64 = c32 | ((u64)c32 << 32);
+	for (; n >= 32; n-=32, s+=32) {
+		*(u64 *)(s+0) = c64;
+		*(u64 *)(s+8) = c64;
+		*(u64 *)(s+16) = c64;
+		*(u64 *)(s+24) = c64;
+	}
+#else
+	/* Pure C fallback with no aliasing violations. */
+	for (; n; n--, s++) *s = c;
+#endif
+
+	return dest;
+}

--- a/libmstpm/deps/libcrt/src/string/stpcpy.c
+++ b/libmstpm/deps/libcrt/src/string/stpcpy.c
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+#include <stdint.h>
+#include <limits.h>
+
+#define ALIGN (sizeof(size_t))
+#define ONES ((size_t)-1/UCHAR_MAX)
+#define HIGHS (ONES * (UCHAR_MAX/2+1))
+#define HASZERO(x) ((x)-ONES & ~(x) & HIGHS)
+
+char *__stpcpy(char *restrict d, const char *restrict s)
+{
+#ifdef __GNUC__
+	typedef size_t __attribute__((__may_alias__)) word;
+	word *wd;
+	const word *ws;
+	if ((uintptr_t)s % ALIGN == (uintptr_t)d % ALIGN) {
+		for (; (uintptr_t)s % ALIGN; s++, d++)
+			if (!(*d=*s)) return d;
+		wd=(void *)d; ws=(const void *)s;
+		for (; !HASZERO(*ws); *wd++ = *ws++);
+		d=(void *)wd; s=(const void *)ws;
+	}
+#endif
+	for (; (*d=*s); s++, d++);
+
+	return d;
+}
+
+weak_alias(__stpcpy, stpcpy);

--- a/libmstpm/deps/libcrt/src/string/stpncpy.c
+++ b/libmstpm/deps/libcrt/src/string/stpncpy.c
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+#include <stdint.h>
+#include <limits.h>
+
+#define ALIGN (sizeof(size_t)-1)
+#define ONES ((size_t)-1/UCHAR_MAX)
+#define HIGHS (ONES * (UCHAR_MAX/2+1))
+#define HASZERO(x) ((x)-ONES & ~(x) & HIGHS)
+
+char *__stpncpy(char *restrict d, const char *restrict s, size_t n)
+{
+#ifdef __GNUC__
+	typedef size_t __attribute__((__may_alias__)) word;
+	word *wd;
+	const word *ws;
+	if (((uintptr_t)s & ALIGN) == ((uintptr_t)d & ALIGN)) {
+		for (; ((uintptr_t)s & ALIGN) && n && (*d=*s); n--, s++, d++);
+		if (!n || !*s) goto tail;
+		wd=(void *)d; ws=(const void *)s;
+		for (; n>=sizeof(size_t) && !HASZERO(*ws);
+		       n-=sizeof(size_t), ws++, wd++) *wd = *ws;
+		d=(void *)wd; s=(const void *)ws;
+	}
+#endif
+	for (; n && (*d=*s); n--, s++, d++);
+tail:
+	memset(d, 0, n);
+	return d;
+}
+
+weak_alias(__stpncpy, stpncpy);
+

--- a/libmstpm/deps/libcrt/src/string/strcasecmp.c
+++ b/libmstpm/deps/libcrt/src/string/strcasecmp.c
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <strings.h>
+#include <ctype.h>
+
+int strcasecmp(const char *_l, const char *_r)
+{
+	const unsigned char *l=(void *)_l, *r=(void *)_r;
+	for (; *l && *r && (*l == *r || tolower(*l) == tolower(*r)); l++, r++);
+	return tolower(*l) - tolower(*r);
+}
+
+#if 0
+int __strcasecmp_l(const char *l, const char *r, locale_t loc)
+{
+	return strcasecmp(l, r);
+}
+
+weak_alias(__strcasecmp_l, strcasecmp_l);
+#endif

--- a/libmstpm/deps/libcrt/src/string/strcat.c
+++ b/libmstpm/deps/libcrt/src/string/strcat.c
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+
+char *strcat(char *restrict dest, const char *restrict src)
+{
+	strcpy(dest + strlen(dest), src);
+	return dest;
+}

--- a/libmstpm/deps/libcrt/src/string/strchr.c
+++ b/libmstpm/deps/libcrt/src/string/strchr.c
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+
+char *strchr(const char *s, int c)
+{
+	char *r = __strchrnul(s, c);
+	return *(unsigned char *)r == (unsigned char)c ? r : 0;
+}

--- a/libmstpm/deps/libcrt/src/string/strchrnul.c
+++ b/libmstpm/deps/libcrt/src/string/strchrnul.c
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+#include <stdint.h>
+#include <limits.h>
+
+#define ALIGN (sizeof(size_t))
+#define ONES ((size_t)-1/UCHAR_MAX)
+#define HIGHS (ONES * (UCHAR_MAX/2+1))
+#define HASZERO(x) ((x)-ONES & ~(x) & HIGHS)
+
+char *__strchrnul(const char *s, int c)
+{
+	c = (unsigned char)c;
+	if (!c) return (char *)s + strlen(s);
+
+#ifdef __GNUC__
+	typedef size_t __attribute__((__may_alias__)) word;
+	const word *w;
+	for (; (uintptr_t)s % ALIGN; s++)
+		if (!*s || *(unsigned char *)s == c) return (char *)s;
+	size_t k = ONES * c;
+	for (w = (void *)s; !HASZERO(*w) && !HASZERO(*w^k); w++);
+	s = (void *)w;
+#endif
+	for (; *s && *(unsigned char *)s != c; s++);
+	return (char *)s;
+}
+
+weak_alias(__strchrnul, strchrnul);

--- a/libmstpm/deps/libcrt/src/string/strcmp.c
+++ b/libmstpm/deps/libcrt/src/string/strcmp.c
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+
+int strcmp(const char *l, const char *r)
+{
+	for (; *l==*r && *l; l++, r++);
+	return *(unsigned char *)l - *(unsigned char *)r;
+}

--- a/libmstpm/deps/libcrt/src/string/strcpy.c
+++ b/libmstpm/deps/libcrt/src/string/strcpy.c
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+
+char *strcpy(char *restrict dest, const char *restrict src)
+{
+	__stpcpy(dest, src);
+	return dest;
+}

--- a/libmstpm/deps/libcrt/src/string/strcspn.c
+++ b/libmstpm/deps/libcrt/src/string/strcspn.c
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+
+#define BITOP(a,b,op) \
+ ((a)[(size_t)(b)/(8*sizeof *(a))] op (size_t)1<<((size_t)(b)%(8*sizeof *(a))))
+
+size_t strcspn(const char *s, const char *c)
+{
+	const char *a = s;
+	size_t byteset[32/sizeof(size_t)];
+
+	if (!c[0] || !c[1]) return __strchrnul(s, *c)-a;
+
+	memset(byteset, 0, sizeof byteset);
+	for (; *c && BITOP(byteset, *(unsigned char *)c, |=); c++);
+	for (; *s && !BITOP(byteset, *(unsigned char *)s, &); s++);
+	return s-a;
+}

--- a/libmstpm/deps/libcrt/src/string/strdup.c
+++ b/libmstpm/deps/libcrt/src/string/strdup.c
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stddef.h>
+
+char *strdup(const char *s)
+{
+	size_t l = strlen(s);
+	char *d = malloc(l+1);
+	if (!d) return NULL;
+	return memcpy(d, s, l+1);
+}

--- a/libmstpm/deps/libcrt/src/string/strlen.c
+++ b/libmstpm/deps/libcrt/src/string/strlen.c
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+#include <stdint.h>
+#include <limits.h>
+
+#define ALIGN (sizeof(size_t))
+#define ONES ((size_t)-1/UCHAR_MAX)
+#define HIGHS (ONES * (UCHAR_MAX/2+1))
+#define HASZERO(x) ((x)-ONES & ~(x) & HIGHS)
+
+size_t strlen(const char *s)
+{
+	const char *a = s;
+#ifdef __GNUC__
+	typedef size_t __attribute__((__may_alias__)) word;
+	const word *w;
+	for (; (uintptr_t)s % ALIGN; s++) if (!*s) return s-a;
+	for (w = (const void *)s; !HASZERO(*w); w++);
+	s = (const void *)w;
+#endif
+	for (; *s; s++);
+	return s-a;
+}

--- a/libmstpm/deps/libcrt/src/string/strncasecmp.c
+++ b/libmstpm/deps/libcrt/src/string/strncasecmp.c
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <strings.h>
+#include <ctype.h>
+
+int strncasecmp(const char *_l, const char *_r, size_t n)
+{
+	const unsigned char *l=(void *)_l, *r=(void *)_r;
+	if (!n--) return 0;
+	for (; *l && *r && n && (*l == *r || tolower(*l) == tolower(*r)); l++, r++, n--);
+	return tolower(*l) - tolower(*r);
+}

--- a/libmstpm/deps/libcrt/src/string/strncat.c
+++ b/libmstpm/deps/libcrt/src/string/strncat.c
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+
+char *strncat(char *restrict d, const char *restrict s, size_t n)
+{
+	char *a = d;
+	d += strlen(d);
+	while (n && *s) n--, *d++ = *s++;
+	*d++ = 0;
+	return a;
+}

--- a/libmstpm/deps/libcrt/src/string/strncmp.c
+++ b/libmstpm/deps/libcrt/src/string/strncmp.c
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+
+int strncmp(const char *_l, const char *_r, size_t n)
+{
+	const unsigned char *l=(void *)_l, *r=(void *)_r;
+	if (!n--) return 0;
+	for (; *l && *r && n && *l == *r ; l++, r++, n--);
+	return *l - *r;
+}

--- a/libmstpm/deps/libcrt/src/string/strncpy.c
+++ b/libmstpm/deps/libcrt/src/string/strncpy.c
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+
+char *strncpy(char *restrict d, const char *restrict s, size_t n)
+{
+	__stpncpy(d, s, n);
+	return d;
+}

--- a/libmstpm/deps/libcrt/src/string/strrchr.c
+++ b/libmstpm/deps/libcrt/src/string/strrchr.c
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+
+char *strrchr(const char *s, int c)
+{
+	return __memrchr(s, c, strlen(s) + 1);
+}

--- a/libmstpm/deps/libcrt/src/string/strspn.c
+++ b/libmstpm/deps/libcrt/src/string/strspn.c
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+
+#define BITOP(a,b,op) \
+ ((a)[(size_t)(b)/(8*sizeof *(a))] op (size_t)1<<((size_t)(b)%(8*sizeof *(a))))
+
+size_t strspn(const char *s, const char *c)
+{
+	const char *a = s;
+	size_t byteset[32/sizeof(size_t)] = { 0 };
+
+	if (!c[0]) return 0;
+	if (!c[1]) {
+		for (; *s == *c; s++);
+		return s-a;
+	}
+
+	for (; *c && BITOP(byteset, *(unsigned char *)c, |=); c++);
+	for (; *s && BITOP(byteset, *(unsigned char *)s, &); s++);
+	return s-a;
+}

--- a/libmstpm/deps/libcrt/src/string/strstr.c
+++ b/libmstpm/deps/libcrt/src/string/strstr.c
@@ -1,0 +1,156 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <string.h>
+#include <stdint.h>
+
+static char *twobyte_strstr(const unsigned char *h, const unsigned char *n)
+{
+	uint16_t nw = n[0]<<8 | n[1], hw = h[0]<<8 | h[1];
+	for (h++; *h && hw != nw; hw = hw<<8 | *++h);
+	return *h ? (char *)h-1 : 0;
+}
+
+static char *threebyte_strstr(const unsigned char *h, const unsigned char *n)
+{
+	uint32_t nw = (uint32_t)n[0]<<24 | n[1]<<16 | n[2]<<8;
+	uint32_t hw = (uint32_t)h[0]<<24 | h[1]<<16 | h[2]<<8;
+	for (h+=2; *h && hw != nw; hw = (hw|*++h)<<8);
+	return *h ? (char *)h-2 : 0;
+}
+
+static char *fourbyte_strstr(const unsigned char *h, const unsigned char *n)
+{
+	uint32_t nw = (uint32_t)n[0]<<24 | n[1]<<16 | n[2]<<8 | n[3];
+	uint32_t hw = (uint32_t)h[0]<<24 | h[1]<<16 | h[2]<<8 | h[3];
+	for (h+=3; *h && hw != nw; hw = hw<<8 | *++h);
+	return *h ? (char *)h-3 : 0;
+}
+
+#define MAX(a,b) ((a)>(b)?(a):(b))
+#define MIN(a,b) ((a)<(b)?(a):(b))
+
+#define BITOP(a,b,op) \
+ ((a)[(size_t)(b)/(8*sizeof *(a))] op (size_t)1<<((size_t)(b)%(8*sizeof *(a))))
+
+static char *twoway_strstr(const unsigned char *h, const unsigned char *n)
+{
+	const unsigned char *z;
+	size_t l, ip, jp, k, p, ms, p0, mem, mem0;
+	size_t byteset[32 / sizeof(size_t)] = { 0 };
+	size_t shift[256];
+
+	/* Computing length of needle and fill shift table */
+	for (l=0; n[l] && h[l]; l++)
+		BITOP(byteset, n[l], |=), shift[n[l]] = l+1;
+	if (n[l]) return 0; /* hit the end of h */
+
+	/* Compute maximal suffix */
+	ip = -1; jp = 0; k = p = 1;
+	while (jp+k<l) {
+		if (n[ip+k] == n[jp+k]) {
+			if (k == p) {
+				jp += p;
+				k = 1;
+			} else k++;
+		} else if (n[ip+k] > n[jp+k]) {
+			jp += k;
+			k = 1;
+			p = jp - ip;
+		} else {
+			ip = jp++;
+			k = p = 1;
+		}
+	}
+	ms = ip;
+	p0 = p;
+
+	/* And with the opposite comparison */
+	ip = -1; jp = 0; k = p = 1;
+	while (jp+k<l) {
+		if (n[ip+k] == n[jp+k]) {
+			if (k == p) {
+				jp += p;
+				k = 1;
+			} else k++;
+		} else if (n[ip+k] < n[jp+k]) {
+			jp += k;
+			k = 1;
+			p = jp - ip;
+		} else {
+			ip = jp++;
+			k = p = 1;
+		}
+	}
+	if (ip+1 > ms+1) ms = ip;
+	else p = p0;
+
+	/* Periodic needle? */
+	if (memcmp(n, n+p, ms+1)) {
+		mem0 = 0;
+		p = MAX(ms, l-ms-1) + 1;
+	} else mem0 = l-p;
+	mem = 0;
+
+	/* Initialize incremental end-of-haystack pointer */
+	z = h;
+
+	/* Search loop */
+	for (;;) {
+		/* Update incremental end-of-haystack pointer */
+		if (z-h < l) {
+			/* Fast estimate for MAX(l,63) */
+			size_t grow = l | 63;
+			const unsigned char *z2 = memchr(z, 0, grow);
+			if (z2) {
+				z = z2;
+				if (z-h < l) return 0;
+			} else z += grow;
+		}
+
+		/* Check last byte first; advance by shift on mismatch */
+		if (BITOP(byteset, h[l-1], &)) {
+			k = l-shift[h[l-1]];
+			if (k) {
+				if (k < mem) k = mem;
+				h += k;
+				mem = 0;
+				continue;
+			}
+		} else {
+			h += l;
+			mem = 0;
+			continue;
+		}
+
+		/* Compare right half */
+		for (k=MAX(ms+1,mem); n[k] && n[k] == h[k]; k++);
+		if (n[k]) {
+			h += k-ms;
+			mem = 0;
+			continue;
+		}
+		/* Compare left half */
+		for (k=ms+1; k>mem && n[k-1] == h[k-1]; k--);
+		if (k <= mem) return (char *)h;
+		h += p;
+		mem = mem0;
+	}
+}
+
+char *strstr(const char *h, const char *n)
+{
+	/* Return immediately on empty needle */
+	if (!n[0]) return (char *)h;
+
+	/* Use faster algorithms for short needles */
+	h = strchr(h, *n);
+	if (!h || !n[1]) return (char *)h;
+	if (!h[1]) return 0;
+	if (!n[2]) return twobyte_strstr((void *)h, (void *)n);
+	if (!h[2]) return 0;
+	if (!n[3]) return threebyte_strstr((void *)h, (void *)n);
+	if (!h[3]) return 0;
+	if (!n[4]) return fourbyte_strstr((void *)h, (void *)n);
+
+	return twoway_strstr((void *)h, (void *)n);
+}

--- a/libmstpm/deps/libcrt/src/stub.c
+++ b/libmstpm/deps/libcrt/src/stub.c
@@ -1,0 +1,155 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <libcrt.h>
+
+#define NOT_IMPLEMENTED printf("WARNING: %s not implemented\n", __func__)
+
+// errno.h
+
+int  errno = 0;
+FILE  *stderr = NULL;
+FILE  *stdin  = NULL;
+FILE  *stdout = NULL;
+
+char *strerror(int errnum)
+{
+    NOT_IMPLEMENTED;
+    return NULL;
+}
+
+// stdio.h
+
+int sscanf(const char  *buffer, const char  *format, ...)
+{
+    NOT_IMPLEMENTED;
+    return 0;
+}
+
+size_t fwrite(const void *buffer, size_t size, size_t count, FILE *stream)
+{
+    NOT_IMPLEMENTED;
+    return 0;
+}
+
+size_t fread(void *b, size_t c, size_t i, FILE *f)
+{
+    NOT_IMPLEMENTED;
+    return 0;
+}
+
+int fclose(FILE *f)
+{
+    NOT_IMPLEMENTED;
+    return EOF;
+}
+
+FILE *fopen(const char *c, const char *m)
+{
+    NOT_IMPLEMENTED;
+    return NULL;
+}
+
+int fputc(int c, FILE *f) 
+{
+    NOT_IMPLEMENTED;
+    return 0;
+}
+
+
+void setbuf(FILE *stream, char *buf)
+{
+    NOT_IMPLEMENTED;
+}
+
+// stdlib.h
+
+long strtol(const char *nptr, char **endptr, int base)
+{
+    NOT_IMPLEMENTED;
+    return LONG_MIN;
+}
+
+unsigned long strtoul(const char *nptr, char **endptr, int base)
+{
+    NOT_IMPLEMENTED;
+    return ULONG_MAX;
+}
+
+char *getenv(const char *varname)
+{
+    NOT_IMPLEMENTED;
+    return NULL;
+}
+
+int atexit(void (*func)(void))
+{
+    NOT_IMPLEMENTED;
+    return 0;
+}
+
+// unistd.h
+
+pid_t getpid(void)
+{
+    // TODO: return the actual PID when CPL3 is supported
+    return 0;
+}
+
+uid_t getuid(void)
+{
+    NOT_IMPLEMENTED;
+    return 0;
+}
+
+uid_t geteuid(void)
+{
+    NOT_IMPLEMENTED;
+    return 0;
+}
+
+gid_t getgid(void)
+{
+    NOT_IMPLEMENTED;
+    return 0;
+}
+
+gid_t getegid(void)
+{
+    NOT_IMPLEMENTED;
+    return 0;
+}
+
+// dirent.h
+
+DIR *opendir(const char *name)
+{
+    NOT_IMPLEMENTED;
+    return NULL;
+}
+
+int closedir(DIR *name)
+{
+    NOT_IMPLEMENTED;
+    return -1;
+}
+
+struct dirent *readdir(DIR *name)
+{
+    NOT_IMPLEMENTED;
+    return NULL;
+}
+
+// sys/stat.h
+
+int stat(const char *__restrict path, struct stat *restrict buf)
+{
+    NOT_IMPLEMENTED;
+    return -1;
+}
+
+// time.h
+
+char *ctime(const time_t *t) {
+	NOT_IMPLEMENTED;
+	return NULL;
+}

--- a/libmstpm/deps/libcrt/src/stub.c
+++ b/libmstpm/deps/libcrt/src/stub.c
@@ -61,6 +61,16 @@ void setbuf(FILE *stream, char *buf)
     NOT_IMPLEMENTED;
 }
 
+int ferror(FILE *stream) {
+	NOT_IMPLEMENTED;
+	return -1;
+}
+
+int clearerr(FILE *stream) {
+	NOT_IMPLEMENTED;
+	return -1;
+}
+
 // stdlib.h
 
 long strtol(const char *nptr, char **endptr, int base)
@@ -117,6 +127,19 @@ gid_t getegid(void)
 {
     NOT_IMPLEMENTED;
     return 0;
+}
+
+long syscall(long number, ...)
+{
+    NOT_IMPLEMENTED;
+    errno = ENOSYS;
+    return -1;
+}
+
+int usleep(unsigned usec)
+{
+    NOT_IMPLEMENTED;
+    return -1;
 }
 
 // dirent.h

--- a/libmstpm/deps/libcrt/src/time/__secs_to_tm.c
+++ b/libmstpm/deps/libcrt/src/time/__secs_to_tm.c
@@ -1,0 +1,84 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <limits.h>
+#include <time.h>
+
+/* 2000-03-01 (mod 400 year, immediately after feb29 */
+#define LEAPOCH (946684800LL + 86400*(31+29))
+
+#define DAYS_PER_400Y (365*400 + 97)
+#define DAYS_PER_100Y (365*100 + 24)
+#define DAYS_PER_4Y   (365*4   + 1)
+
+int __secs_to_tm(long long t, struct tm *tm)
+{
+	long long days, secs, years;
+	int remdays, remsecs, remyears;
+	int qc_cycles, c_cycles, q_cycles;
+	int months;
+	int wday, yday, leap;
+	static const char days_in_month[] = {31,30,31,30,31,31,30,31,30,31,31,29};
+
+	/* Reject time_t values whose year would overflow int */
+	if (t < INT_MIN * 31622400LL || t > INT_MAX * 31622400LL)
+		return -1;
+
+	secs = t - LEAPOCH;
+	days = secs / 86400;
+	remsecs = secs % 86400;
+	if (remsecs < 0) {
+		remsecs += 86400;
+		days--;
+	}
+
+	wday = (3+days)%7;
+	if (wday < 0) wday += 7;
+
+	qc_cycles = days / DAYS_PER_400Y;
+	remdays = days % DAYS_PER_400Y;
+	if (remdays < 0) {
+		remdays += DAYS_PER_400Y;
+		qc_cycles--;
+	}
+
+	c_cycles = remdays / DAYS_PER_100Y;
+	if (c_cycles == 4) c_cycles--;
+	remdays -= c_cycles * DAYS_PER_100Y;
+
+	q_cycles = remdays / DAYS_PER_4Y;
+	if (q_cycles == 25) q_cycles--;
+	remdays -= q_cycles * DAYS_PER_4Y;
+
+	remyears = remdays / 365;
+	if (remyears == 4) remyears--;
+	remdays -= remyears * 365;
+
+	leap = !remyears && (q_cycles || !c_cycles);
+	yday = remdays + 31 + 28 + leap;
+	if (yday >= 365+leap) yday -= 365+leap;
+
+	years = remyears + 4*q_cycles + 100*c_cycles + 400LL*qc_cycles;
+
+	for (months=0; days_in_month[months] <= remdays; months++)
+		remdays -= days_in_month[months];
+
+	if (months >= 10) {
+		months -= 12;
+		years++;
+	}
+
+	if (years+100 > INT_MAX || years+100 < INT_MIN)
+		return -1;
+
+	tm->tm_year = years + 100;
+	tm->tm_mon = months + 2;
+	tm->tm_mday = remdays + 1;
+	tm->tm_wday = wday;
+	tm->tm_yday = yday;
+
+	tm->tm_hour = remsecs / 3600;
+	tm->tm_min = remsecs / 60 % 60;
+	tm->tm_sec = remsecs % 60;
+
+	return 0;
+}

--- a/libmstpm/deps/libcrt/src/time/gmtime_r.c
+++ b/libmstpm/deps/libcrt/src/time/gmtime_r.c
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <time.h>
+#include <errno.h>
+
+char *__utc = "UTC";
+
+struct tm *gmtime_r(const time_t *restrict t, struct tm *restrict tm)
+{
+	if (__secs_to_tm(*t, tm) < 0) {
+		errno = EOVERFLOW;
+		return 0;
+	}
+	tm->tm_isdst = 0;
+	tm->tm_gmtoff = 0;
+	tm->tm_zone = __utc;
+	return tm;
+}
+
+
+struct tm *gmtime(const time_t *t)
+{
+	static struct tm tm;
+	return gmtime_r(t, &tm);
+}

--- a/libmstpm/deps/libcrt/src/time/time.c
+++ b/libmstpm/deps/libcrt/src/time/time.c
@@ -1,0 +1,37 @@
+/* SPDX-License-Identifier: MIT */
+
+#include <time.h>
+#include <stdio.h>
+#include <sys/types.h>
+
+// Calls the rdtsc instruction to read the current value of the processor's
+// time-stamp counter (a 64-bit MSR)
+clock_t clock(void) {
+	return rdtsc();
+}
+
+uint64_t secs;
+
+int clock_gettime(clockid_t clk_id, struct timespec *tp) {
+	(void) clk_id;
+	if (tp) {
+		tp->tv_nsec = rdtsc();
+		tp->tv_sec = secs++;
+	}
+	return 0;
+}
+
+//  time() returns the time as the number of seconds since the Epoch
+time_t time(time_t *tloc) {
+	(void)tloc;
+	time_t t = rdtsc();
+	return t;
+}
+
+int gettimeofday(struct timeval *restrict tv, void *restrict tz)
+{
+        if (!tv) return 0;
+        tv->tv_sec = clock();
+        tv->tv_usec = 0;
+        return 0;
+}

--- a/libmstpm/deps/libmstpm.h
+++ b/libmstpm/deps/libmstpm.h
@@ -1,0 +1,11 @@
+#pragma once
+
+void _plat__LocalitySet(unsigned char locality);
+void _plat__SetNvAvail(void);
+int  _plat__Signal_PowerOn(void);
+int  _plat__Signal_Reset(void);
+void _plat__NVDisable(int delete);
+int  _plat__NVEnable(void *platParameter);
+
+int  TPM_Manufacture(int firstTime);
+int  TPM_TearDown(void);

--- a/libmstpm/deps/libmstpm.h
+++ b/libmstpm/deps/libmstpm.h
@@ -1,5 +1,13 @@
 #pragma once
 
+typedef unsigned int uint32_t;
+void _plat__RunCommand(
+    uint32_t         requestSize,   // IN: command buffer size
+    unsigned char   *request,       // IN: command buffer
+    uint32_t        *responseSize,  // IN/OUT: response buffer size
+    unsigned char   **response      // IN/OUT: response buffer
+);
+
 void _plat__LocalitySet(unsigned char locality);
 void _plat__SetNvAvail(void);
 int  _plat__Signal_PowerOn(void);

--- a/libmstpm/deps/openssl_svsm.conf
+++ b/libmstpm/deps/openssl_svsm.conf
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright (C) 2023 IBM Corporation
+#
+# Authors: Claudio Carvalho <cclaudio@linux.ibm.com>
+
+my %targets = (
+    "SVSM" => {
+        inherit_from    => [ "BASE_unix" ],
+        perlasm_scheme  => "elf",
+        CC              => "gcc",
+        CFLAGS          => add(combine(picker(default => "-Wall",
+                                          debug => "-g -O0",
+                                          release => "-O3"),
+                                   "-fPIE -m64 -nostdinc -nostdlib -static -fno-stack-protector")),
+        bn_ops          => "SIXTY_FOUR_BIT_LONG",
+        lib_cppflags    => add("-DL_ENDIAN -DNO_SYSLOG -DOPENSSL_SMALL_FOOTPRINT -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE"),
+        sys_id          => "SVSM"
+    },
+);

--- a/libmstpm/src/lib.rs
+++ b/libmstpm/src/lib.rs
@@ -8,3 +8,6 @@
 //! for the vTPM.
 
 #![no_std]
+
+/// C bindings
+pub mod bindings;

--- a/libmstpm/src/lib.rs
+++ b/libmstpm/src/lib.rs
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2024 IBM Corporation
+//
+// Author: Claudio Carvalho <cclaudio@linux.ibm.com>
+
+//! This crate provides the libmstpm definitions used by the COCONUT-SVSM
+//! for the vTPM.
+
+#![no_std]

--- a/scripts/container/build.sh
+++ b/scripts/container/build.sh
@@ -96,7 +96,7 @@ BuildSvsmReuse()
 
     "${DOCKER_CMD}" exec \
         -it ${CONTAINER_NAME} \
-        /bin/bash -c "source $HOME/.cargo/env && make clean && make"
+        /bin/bash -c "make clean && make"
 }
 
 ####
@@ -111,7 +111,7 @@ BuildSvsmDelete()
           --mount type=bind,source="${WORKDIR}",target="${WORKDIR}"${MOUNT_OPTS} \
           $EXTRA_DOCKER_OPTS \
           ${IMAGE_NAME} \
-          /bin/bash -c "source $HOME/.cargo/env && make clean && make"
+          /bin/bash -c "make clean && make"
 }
 
 ####

--- a/scripts/container/opensuse-rust.docker
+++ b/scripts/container/opensuse-rust.docker
@@ -19,7 +19,9 @@ ARG USER_NAME user
 SHELL ["/bin/bash", "-c"]
 
 RUN zypper ref && \
-    zypper install -y system-user-mail make gcc curl && \
+    zypper install -y system-user-mail make gcc curl \
+        patterns-devel-base-devel_basis glibc-devel-static git libclang13 \
+        autoconf autoconf-archive pkg-config automake libopenssl-devel perl && \
     useradd -u $USER_ID -m $USER_NAME
 
 USER $USER_NAME

--- a/scripts/container/opensuse-rust.docker
+++ b/scripts/container/opensuse-rust.docker
@@ -8,6 +8,7 @@
 #
 # git clone https://github.com/coconut-svsm/svsm.git
 # cd svsm
+# git submodule update --init --depth=1
 # ./scripts/docker/build.sh 
 
 FROM opensuse/tumbleweed:latest

--- a/scripts/container/opensuse-rust.docker
+++ b/scripts/container/opensuse-rust.docker
@@ -16,15 +16,21 @@ LABEL Description="OpenSUSE environment for coconut-svsm build"
 ARG USER_ID 1000
 ARG USER_NAME user
 
+ENV CARGO_HOME=/opt/cargo
+ENV RUSTUP_HOME=/opt/rustup
+
 SHELL ["/bin/bash", "-c"]
 
 RUN zypper ref && \
     zypper install -y system-user-mail make gcc curl \
         patterns-devel-base-devel_basis glibc-devel-static git libclang13 \
         autoconf autoconf-archive pkg-config automake libopenssl-devel perl && \
-    useradd -u $USER_ID -m $USER_NAME
+    useradd -u $USER_ID -m $USER_NAME && \
+       mkdir -p "${CARGO_HOME}" "${RUSTUP_HOME}" && \
+       chown "${USER_NAME}" "${CARGO_HOME}" "${RUSTUP_HOME}"
 
 USER $USER_NAME
+ENV PATH="${PATH}:${CARGO_HOME}/bin"
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/rustup-init.sh && \
     sh /tmp/rustup-init.sh -y \

--- a/scripts/container/opensuse-rust.docker
+++ b/scripts/container/opensuse-rust.docker
@@ -35,4 +35,5 @@ ENV PATH="${PATH}:${CARGO_HOME}/bin"
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/rustup-init.sh && \
     sh /tmp/rustup-init.sh -y \
         --default-toolchain stable-x86_64-unknown-linux-gnu \
-        --target x86_64-unknown-none
+        --target x86_64-unknown-none && \
+    cargo install bindgen-cli


### PR DESCRIPTION
This is a sketch of how the vTPM and the vTPM protocol would work in the SVSM, for now running in CPL0. 

The vTPM is initialized (manufactured) on every boot. If OVMF and the Linux guest kernel have proper tpm drivers, they should be able to communicate with the SVSM vTPM. See the section Dependencies below.

Once this is merged I can post a PR for the attestation protocol.

## Dependencies

OVMF
```
$ git clone https://github.com/coconut-svsm/edk2.git
$ cd edk2/
$ git fetch origin pull/2/head:edk2-pr2
$ git checkout edk2-pr2
$ git submodule init
$ git submodule update

$ export PYTHON3_ENABLE=TRUE
$ export PYTHON_COMMAND=python3
$ make -j16 -C BaseTools/
$ source ./edksetup.sh --reconfig
$ build -a X64 -b DEBUG -t GCC5 -D DEBUG_ON_SERIAL_PORT -D DEBUG_VERBOSE -DTPM2_ENABLE -p OvmfPkg/OvmfPkgX64.dsc
```

Guest kernel:

The linux branch below is based on the [PR#2](https://github.com/coconut-svsm/linux/pull/2) posted against the coconut-svsm/linux repository with additional two patches for the TPM platform driver.

`CONFIG_TCG_PLATFORM` should be enabled in the guest. The same kernel also needs to be installed on the host.

```
$ git clone https://github.com/cclaudio/linux.git
$ cd linux
$ git checkout svsm-host-guest-vtpm
```

QEMU:

Follow the instructions described in [INSTALL.md](https://github.com/coconut-svsm/svsm/blob/main/Documentation/INSTALL.md#building-qemu) to build the QEMU branch below.

```
$ git clone https://github.com/coconut-svsm/qemu.git
$ cd qemu
$ git fetch origin pull/2/head:qemu-pr2
$ git co qemu-pr2
```

## How to test it

Follow the [INSTALL.md](https://github.com/coconut-svsm/svsm/blob/main/Documentation/INSTALL.md#building-the-coconut-svsm) to build this PR and run a QEMU guest.

During the boot you should be able to see messages from OVMF and the linux kernel like these:

```
Loading PEIM at 0x0007F7FC000 EntryPoint=0x0007F7FD906 Tcg2ConfigPei.efi
Found SVSM TPM
Tcg2ConfigPeimEntryPoint
Tcg2ConfigPeimEntryPoint: TPM2 detected

[...]

ReadPcr - HashAlg = 0x0004, Pcr[00], digest = 51 C3 23 DE 0C 0C 69 4F 46 01 CD D0 2B EB 58 FF 13 62 9F 74 
ReadPcr - HashAlg = 0x000B, Pcr[00], digest = FC EC B5 6A CC 30 38 62 B3 0E B3 42 C4 99 0B EB 50 B5 E0 AB 89 72 24 49 C2 D9 A7 3F 37 B0 19 FE 
ReadPcr - HashAlg = 0x000C, Pcr[00], digest = 61 93 87 2D C7 23 D5 33 E3 BB 45 FB 0A EE C1 35 48 AD DE 71 11 DF 93 A4 D7 0C B1 B5 77 CE 31 10 4A C9 DF BC B8 76 BD 07 F7 7D 2C E4 B3 F7 33 DF

[...]

[    0.907842] SEV: SNP guest platform device initialized.
[    0.910991] SEV: SNP SVSM VTPM platform device initialized
[    0.993792] tpm tpm: TPM 2.0 platform device

```

From guest userspace you can also install the `tpm2-tools` package and use it to communicate with the SVSM-vTPM (e.g. `tpm2_pcrread` without arguments)