### PR TITLE
task, percpu: Use VMR to manage the task pagetable and VMKernelStack to allocate the task kernel stack

### DIFF
--- a/src/cpu/percpu.rs
+++ b/src/cpu/percpu.rs
@@ -16,7 +16,7 @@ use crate::locking::{LockGuard, RWLock, SpinLock};
 use crate::mm::alloc::{allocate_page, allocate_zeroed_page};
 use crate::mm::pagetable::{get_init_pgtable_locked, PTEntryFlags, PageTable, PageTableRef};
 use crate::mm::virtualrange::VirtualRange;
-use crate::mm::vm::{Mapping, VMKernelStack, VMPhysMem, VMReserved, VMR};
+use crate::mm::vm::{Mapping, VMKernelStack, VMPhysMem, VMRMapping, VMReserved, VMR};
 use crate::mm::{
     virt_to_phys, SVSM_PERCPU_BASE, SVSM_PERCPU_CAA_BASE, SVSM_PERCPU_END,
     SVSM_PERCPU_TEMP_BASE_2M, SVSM_PERCPU_TEMP_BASE_4K, SVSM_PERCPU_TEMP_END_2M,
@@ -536,6 +536,22 @@ impl PerCpu {
         assert!(page_count <= VirtualRange::CAPACITY);
         self.vrange_2m
             .init(SVSM_PERCPU_TEMP_BASE_2M, page_count, PAGE_SHIFT_2M);
+    }
+
+    /// Create a new virtual memory mapping in the PerCpu VMR
+    ///
+    /// # Arguments
+    ///
+    /// * `mapping` - The mapping to insert into the PerCpu VMR
+    ///
+    /// # Returns
+    ///
+    /// On success, a new ['VMRMapping'} that provides a virtual memory address for
+    /// the mapping which remains valid until the ['VRMapping'] is dropped.
+    ///
+    /// On error, an ['SvsmError'].
+    pub fn new_mapping(&mut self, mapping: Arc<Mapping>) -> Result<VMRMapping, SvsmError> {
+        VMRMapping::new(&mut self.vm_range, mapping)
     }
 }
 

--- a/src/cpu/percpu.rs
+++ b/src/cpu/percpu.rs
@@ -553,6 +553,15 @@ impl PerCpu {
     pub fn new_mapping(&mut self, mapping: Arc<Mapping>) -> Result<VMRMapping, SvsmError> {
         VMRMapping::new(&mut self.vm_range, mapping)
     }
+
+    /// Add the PerCpu virtual range into the provided pagetable
+    ///
+    /// # Arguments
+    ///
+    /// * `pt` - The page table to populate the the PerCpu range into
+    pub fn populate_page_table(&self, pt: &mut PageTableRef) {
+        self.vm_range.populate(pt);
+    }
 }
 
 unsafe impl Sync for PerCpu {}

--- a/src/mm/address_space.rs
+++ b/src/mm/address_space.rs
@@ -148,23 +148,14 @@ pub const SVSM_PERCPU_TEMP_END_4K: VirtAddr = SVSM_PERCPU_TEMP_BASE_4K.const_add
 pub const SVSM_PERCPU_TEMP_BASE_2M: VirtAddr = SVSM_PERCPU_TEMP_BASE.const_add(SIZE_LEVEL1);
 pub const SVSM_PERCPU_TEMP_END_2M: VirtAddr = SVSM_PERCPU_TEMP_BASE.const_add(SIZE_LEVEL2);
 
-/// Per-task memory map
-/// Use the region from 0xfffffe0000000000 - 0xffffff0000000000 for tasks
+/// Task mappings level 3 index
 pub const PGTABLE_LVL3_IDX_PERTASK: usize = 508;
-/// Layout of the per-task memory space is:
-///
-/// +------------------+------------------+-------------------------------------+
-/// | Start            | End              | Size | Description                  |
-/// +------------------+------------------+------+------------------------------+
-/// | fffffeffffff0000 | ffffff0000000000 | 64K  | Task stack                   |
-/// +------------------+------------------+------+------------------------------+
-/// | fffffe0000000000 | fffffe0004000000 | 64M  | Dynamic memory allocation    |
-/// +------------------+------------------+------+------------------------------+
+
+/// Base address of task memory region
 pub const SVSM_PERTASK_BASE: VirtAddr = virt_from_idx(PGTABLE_LVL3_IDX_PERTASK);
 
-/// Virtual addresses for dynamic memory allocation
-pub const SVSM_PERTASK_DYNAMIC_MEMORY: VirtAddr = SVSM_PERTASK_BASE;
+/// End address of task memory region
+pub const SVSM_PERTASK_END: VirtAddr = SVSM_PERTASK_BASE.const_add(SIZE_LEVEL3);
 
-/// Task stack
-pub const SVSM_PERTASK_STACK_BASE: VirtAddr = SVSM_PERTASK_BASE.const_add(0xffffff0000);
-pub const SVSM_PERTASK_STACK_TOP: VirtAddr = SVSM_PERTASK_STACK_BASE.const_add(0x10000);
+/// Kernel stack for a task
+pub const SVSM_PERTASK_STACK_BASE: VirtAddr = SVSM_PERTASK_BASE;

--- a/src/mm/vm/mod.rs
+++ b/src/mm/vm/mod.rs
@@ -11,4 +11,4 @@ pub use mapping::{
     Mapping, RawAllocMapping, VMKernelStack, VMMAdapter, VMPhysMem, VMReserved, VMalloc,
     VirtualMapping, VMM,
 };
-pub use range::{VMR, VMR_GRANULE};
+pub use range::{VMRMapping, VMR, VMR_GRANULE};

--- a/src/mm/vm/range.rs
+++ b/src/mm/vm/range.rs
@@ -374,3 +374,28 @@ impl VMR {
         }
     }
 }
+
+#[derive(Debug)]
+pub struct VMRMapping<'a> {
+    vmr: &'a mut VMR,
+    va: VirtAddr,
+}
+
+impl<'a> VMRMapping<'a> {
+    pub fn new(vmr: &'a mut VMR, mapping: Arc<Mapping>) -> Result<Self, SvsmError> {
+        let va = vmr.insert(mapping)?;
+        Ok(Self { vmr, va })
+    }
+
+    pub fn virt_addr(&self) -> VirtAddr {
+        self.va
+    }
+}
+
+impl<'a> Drop for VMRMapping<'a> {
+    fn drop(&mut self) {
+        self.vmr
+            .remove(self.va)
+            .expect("Error removing VRMapping virtual memory range");
+    }
+}


### PR DESCRIPTION
Now that virtual memory ranges and page table entries can be managed using the new `VMR` and associated structs, update the Task structure implementation to manage the task pagetable using these new capabilities.

The task structure now includes a `VMR` instance that defines the virtual address range for the task. The kernel stack for the task is created using `VMKernelStack` and added to the task VMR. This is applied to the task pagetable during creation.

`PerCpu` already includes a per cpu VMR. This needs to be applied to the task when it is context switched onto the CPU. Currently this is done directly by copying the PerCpu level 3 index. This patch adss the function `populate_page_table()` to PerCpu which applies the PerCpu VMR to the pagetable instead.