### PR TITLE
SVSM/mm/pagetable: avoid mutable reference in RawPageTablePart::free*()

### DIFF
--- a/src/mm/pagetable.rs
+++ b/src/mm/pagetable.rs
@@ -773,7 +773,7 @@ impl RawPageTablePart {
         Some(unsafe { &mut *address.as_mut_ptr::<PTPage>() })
     }
 
-    fn free_lvl1(page: &mut PTPage) {
+    fn free_lvl1(page: &PTPage) {
         for idx in 0..ENTRY_COUNT {
             let entry = page[idx];
 
@@ -783,7 +783,7 @@ impl RawPageTablePart {
         }
     }
 
-    fn free_lvl2(page: &mut PTPage) {
+    fn free_lvl2(page: &PTPage) {
         for idx in 0..ENTRY_COUNT {
             let entry = page[idx];
 
@@ -794,8 +794,8 @@ impl RawPageTablePart {
         }
     }
 
-    fn free(&mut self) {
-        RawPageTablePart::free_lvl2(&mut self.page);
+    fn free(&self) {
+        RawPageTablePart::free_lvl2(&self.page);
     }
 
     fn address(&self) -> PhysAddr {


### PR DESCRIPTION
The `page` argument was a mutable reference, but not used mutably, so let's make it immutable.