### PR TITLE
docs/mm: fix broken link in `RawAllocMapping` description

### DIFF
--- a/src/mm/vm/mapping/rawalloc.rs
+++ b/src/mm/vm/mapping/rawalloc.rs
@@ -13,8 +13,8 @@ use crate::utils::align_up;
 extern crate alloc;
 use alloc::vec::Vec;
 
-/// Contains base functionality for all [`VirtualMapping`] types which use
-/// self-allocated PageFile pages.
+/// Contains base functionality for all [`VirtualMapping`](super::api::VirtualMapping)
+/// types which use self-allocated PageFile pages.
 #[derive(Default, Debug)]
 pub struct RawAllocMapping {
     /// A vec containing references to PageFile allocations


### PR DESCRIPTION
Fix a broken link in the generated documentation for `RawAllocMapping`, which will cause a CI break with the upcoming changes in #124.