### PR TITLE
acpi/tables, fwcfg: limit hypervisor-controlled allocation sizes

### DIFF
--- a/src/acpi/tables.rs
+++ b/src/acpi/tables.rs
@@ -258,6 +258,8 @@ impl ACPITableMeta {
     }
 }
 
+const MAX_ACPI_TABLES_SIZE: usize = 128 * 1024;
+
 /// ACPI Table Buffer
 /// A buffer containing ACPI tables. Responsible for loading the tables
 /// from a firmware configuration
@@ -285,6 +287,9 @@ impl ACPITableBuffer {
         let size = file.size() as usize;
 
         let mut buf = Vec::<u8>::new();
+        if size > MAX_ACPI_TABLES_SIZE {
+            return Err(SvsmError::Mem);
+        }
         buf.try_reserve(size).map_err(|_| SvsmError::Mem)?;
         let ptr = buf.as_mut_ptr();
 


### PR DESCRIPTION
Limit hypervisor-controlled allocation sizes to prevent potential OOM issues. This is done in places where big allocation sizes (for example a huge number of firmware files or very big ACPI tables) would make no sense in a reasonable implementation.

This will also be useful for fuzzing performance once #113 is merged.