### PR TITLE
docs/mm: fix broken link in `RawAllocMapping` field

### DIFF
--- a/src/mm/vm/mapping/rawalloc.rs
+++ b/src/mm/vm/mapping/rawalloc.rs
@@ -20,7 +20,7 @@ pub struct RawAllocMapping {
     /// A vec containing references to PageFile allocations
     pages: Vec<PageRef>,
 
-    /// Number of pages required in [`pages`]
+    /// Number of pages required in `pages`
     count: usize,
 }
 


### PR DESCRIPTION
Fix a broken link in the generated documentation for `RawAllocMapping`, which will cause a CI break with the upcoming changes in #124.