### PR TITLE
fs: Add VMFileMapping to map ramfs file contents to virtual memory

### DIFF
--- a/src/cpu/idt.rs
+++ b/src/cpu/idt.rs
@@ -5,6 +5,7 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 
 use super::control_regs::read_cr2;
+use super::percpu::this_cpu;
 use super::tss::IST_DF;
 use super::vc::handle_vc_exception;
 use super::{X86GeneralRegs, X86InterruptFrame};
@@ -38,6 +39,8 @@ pub const _CP_VECTOR: usize = 21;
 pub const _HV_VECTOR: usize = 28;
 pub const VC_VECTOR: usize = 29;
 pub const _SX_VECTOR: usize = 30;
+
+pub const PF_ERROR_WRITE: usize = 2;
 
 #[repr(C, packed)]
 #[derive(Default, Debug)]
@@ -198,7 +201,11 @@ fn generic_idt_handler(ctx: &mut X86ExceptionContext) {
         let rip = ctx.frame.rip;
         let err = ctx.error_code;
 
-        if !handle_exception_table(ctx) {
+        if this_cpu()
+            .handle_pf(VirtAddr::from(cr2), (err & PF_ERROR_WRITE) != 0)
+            .is_err()
+            && !handle_exception_table(ctx)
+        {
             panic!(
                 "Unhandled Page-Fault at RIP {:#018x} CR2: {:#018x} error code: {:#018x}",
                 rip, cr2, err

--- a/src/cpu/percpu.rs
+++ b/src/cpu/percpu.rs
@@ -562,6 +562,10 @@ impl PerCpu {
     pub fn populate_page_table(&self, pt: &mut PageTableRef) {
         self.vm_range.populate(pt);
     }
+
+    pub fn handle_pf(&self, vaddr: VirtAddr, write: bool) -> Result<(), SvsmError> {
+        self.vm_range.handle_page_fault(vaddr, write)
+    }
 }
 
 unsafe impl Sync for PerCpu {}

--- a/src/fs/api.rs
+++ b/src/fs/api.rs
@@ -11,6 +11,7 @@ use alloc::vec::Vec;
 use core::fmt::Debug;
 
 use crate::error::SvsmError;
+use crate::mm::PageRef;
 use crate::string::FixedString;
 use packit::PackItError;
 
@@ -64,6 +65,7 @@ pub trait File: Debug + Send + Sync {
     fn write(&self, buf: &[u8], offset: usize) -> Result<usize, SvsmError>;
     fn truncate(&self, size: usize) -> Result<usize, SvsmError>;
     fn size(&self) -> usize;
+    fn mapping(&self, offset: usize) -> Option<PageRef>;
 }
 
 pub trait Directory: Debug + Send + Sync {

--- a/src/fs/filesystem.rs
+++ b/src/fs/filesystem.rs
@@ -9,6 +9,7 @@ use super::*;
 
 use crate::error::SvsmError;
 use crate::locking::SpinLock;
+use crate::mm::PageRef;
 
 use core::cmp::min;
 
@@ -57,6 +58,10 @@ impl RawFileHandle {
     fn size(&self) -> usize {
         self.file.size()
     }
+
+    fn mapping(&self, offset: usize) -> Option<PageRef> {
+        self.file.mapping(offset)
+    }
 }
 
 #[derive(Debug)]
@@ -96,6 +101,10 @@ impl FileHandle {
 
     pub fn position(&self) -> usize {
         self.handle.lock().current
+    }
+
+    pub fn mapping(&self, offset: usize) -> Option<PageRef> {
+        self.handle.lock().mapping(offset)
     }
 }
 

--- a/src/fs/ramfs.rs
+++ b/src/fs/ramfs.rs
@@ -9,7 +9,7 @@ use super::*;
 use crate::error::SvsmError;
 use crate::locking::RWLock;
 use crate::mm::{allocate_file_page_ref, PageRef};
-use crate::types::PAGE_SIZE;
+use crate::types::{PAGE_SHIFT, PAGE_SIZE};
 use crate::utils::{page_align_up, page_offset, zero_mem_region};
 
 extern crate alloc;
@@ -164,6 +164,13 @@ impl RawRamFile {
     fn size(&self) -> usize {
         self.size
     }
+
+    fn mapping(&self, offset: usize) -> Option<PageRef> {
+        if offset > self.size() {
+            return None;
+        }
+        self.pages.get(offset >> PAGE_SHIFT).cloned()
+    }
 }
 
 #[derive(Debug)]
@@ -195,6 +202,10 @@ impl File for RamFile {
 
     fn size(&self) -> usize {
         self.rawfile.lock_read().size()
+    }
+
+    fn mapping(&self, offset: usize) -> Option<PageRef> {
+        self.rawfile.lock_read().mapping(offset)
     }
 }
 

--- a/src/mm/vm/mapping/api.rs
+++ b/src/mm/vm/mapping/api.rs
@@ -48,14 +48,23 @@ pub trait VirtualMapping: core::fmt::Debug {
         // Provide default in case there is nothing to do
     }
 
-    /// Request the PTEntryFlags used for this virtual memory mapping. This is
-    /// a combination of
+    /// Request the PTEntryFlags used for this virtual memory mapping.
     ///
+    /// # Arguments
+    ///
+    /// * 'offset' -> The offset in bytes into the `VirtualMapping`. The flags
+    ///               returned from this function relate to the page at the
+    ///               given offset
+    ///
+    /// # Returns
+    ///
+    /// A combination of:
+
     /// * PTEntryFlags::WRITABLE
     /// * PTEntryFlags::NX,
     /// * PTEntryFlags::ACCESSED
     /// * PTEntryFlags::DIRTY
-    fn pt_flags(&self) -> PTEntryFlags;
+    fn pt_flags(&self, offset: usize) -> PTEntryFlags;
 
     /// Request the page size used for mappings
     ///

--- a/src/mm/vm/mapping/api.rs
+++ b/src/mm/vm/mapping/api.rs
@@ -5,8 +5,10 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 
 use crate::address::{PhysAddr, VirtAddr};
+use crate::error::SvsmError;
 use crate::locking::{RWLock, ReadLockGuard, WriteLockGuard};
 use crate::mm::pagetable::PTEntryFlags;
+use crate::mm::vm::VMR;
 use crate::types::{PAGE_SHIFT, PAGE_SIZE};
 
 use intrusive_collections::rbtree::Link;
@@ -17,6 +19,16 @@ use core::ops::Range;
 extern crate alloc;
 use alloc::boxed::Box;
 use alloc::sync::Arc;
+
+/// Information required to resolve a page fault within a virtual mapping
+pub struct VMPageFaultResolution {
+    /// The physical address of a page that must be mapped to the page fault
+    /// virtual address to resolve the page fault.
+    pub paddr: PhysAddr,
+
+    /// The flags to use to map the virtual memory page.
+    pub flags: PTEntryFlags,
+}
 
 pub trait VirtualMapping: core::fmt::Debug {
     /// Request the size of the virtual memory mapping
@@ -86,6 +98,30 @@ pub trait VirtualMapping: core::fmt::Debug {
     fn shared(&self) -> bool {
         // Shared with the HV - defaults not No
         false
+    }
+
+    /// Handle a page fault that occurred on a virtual memory address within
+    /// this mapping.
+    ///
+    /// # Arguments
+    ///
+    /// * 'vmr' - Virtual memory range that contains the mapping. This
+    ///           [`VirtualMapping`] can use this to insert/remove regions
+    ///           as necessary to handle the page fault.
+    ///
+    /// * `offset` - Offset into the virtual mapping that was the subject of
+    ///              the page fault.
+    ///
+    /// * 'write' - `true` if the fault was due to a write to the memory
+    ///              location, or 'false' if the fault was due to a read.
+    ///
+    fn handle_page_fault(
+        &mut self,
+        _vmr: &VMR,
+        _offset: usize,
+        _write: bool,
+    ) -> Result<VMPageFaultResolution, SvsmError> {
+        Err(SvsmError::Mem)
     }
 }
 
@@ -194,5 +230,9 @@ impl VMM {
 
     pub fn get_mapping_mut(&self) -> WriteLockGuard<Box<dyn VirtualMapping>> {
         self.mapping.get_mut()
+    }
+
+    pub fn get_mapping_clone(&self) -> Arc<Mapping> {
+        self.mapping.clone()
     }
 }

--- a/src/mm/vm/mapping/file_mapping.rs
+++ b/src/mm/vm/mapping/file_mapping.rs
@@ -6,11 +6,16 @@
 
 extern crate alloc;
 
+use core::slice::from_raw_parts_mut;
+
+use alloc::sync::Arc;
 use alloc::vec::Vec;
 
-use super::{RawAllocMapping, VirtualMapping};
+use super::{Mapping, RawAllocMapping, VMPageFaultResolution, VMPhysMem, VirtualMapping};
+use crate::address::Address;
 use crate::error::SvsmError;
 use crate::fs::FileHandle;
+use crate::mm::vm::VMR;
 use crate::mm::PageRef;
 use crate::mm::{pagetable::PageTable, PAGE_SIZE};
 use crate::types::PAGE_SHIFT;
@@ -18,6 +23,16 @@ use crate::utils::align_up;
 
 #[derive(Debug)]
 struct VMWriteFileMapping(RawAllocMapping);
+
+impl VMWriteFileMapping {
+    pub fn get_alloc(&self) -> &RawAllocMapping {
+        &self.0
+    }
+
+    pub fn get_alloc_mut(&mut self) -> &mut RawAllocMapping {
+        &mut self.0
+    }
+}
 
 impl VirtualMapping for VMWriteFileMapping {
     fn mapping_size(&self) -> usize {
@@ -57,6 +72,9 @@ pub struct VMFileMapping {
 
     /// A vec containing references to mapped pages within the file
     pages: Vec<Option<PageRef>>,
+
+    /// A copy of the file pages for mappings with Write permission
+    write_copy: Option<VMWriteFileMapping>,
 }
 
 impl VMFileMapping {
@@ -98,12 +116,22 @@ impl VMFileMapping {
         for page_index in 0..count {
             pages.push(file.mapping(offset + page_index * PAGE_SIZE));
         }
+        // For ranges with write access we need to take a copy of the ram pages
+        // to allow them to be written to without modifying the contents of the
+        // file itself and also to prevent pointer aliasing with any other
+        // FileHandles that may be open on the same file.
+        let write_copy = if permission == VMFileMappingPermission::Write {
+            Some(VMWriteFileMapping(RawAllocMapping::new(size)))
+        } else {
+            None
+        };
 
         Ok(Self {
             file,
             size: page_size,
             permission,
             pages,
+            write_copy,
         })
     }
 }
@@ -118,14 +146,67 @@ impl VirtualMapping for VMFileMapping {
         if page_index >= self.pages.len() {
             return None;
         }
+        if let Some(write_copy) = &self.write_copy {
+            let write_addr = write_copy.map(offset);
+            if write_addr.is_some() {
+                return write_addr;
+            }
+        }
         self.pages[page_index].as_ref().map(|p| p.phys_addr())
     }
 
-    fn pt_flags(&self, _offset: usize) -> crate::mm::pagetable::PTEntryFlags {
+    fn pt_flags(&self, offset: usize) -> crate::mm::pagetable::PTEntryFlags {
         match self.permission {
             VMFileMappingPermission::Read => PageTable::task_data_ro_flags(),
-            VMFileMappingPermission::Write => PageTable::task_data_flags(),
+            VMFileMappingPermission::Write => {
+                if let Some(write_copy) = &self.write_copy {
+                    if write_copy.get_alloc().present(offset) {
+                        PageTable::task_data_flags()
+                    } else {
+                        PageTable::task_data_ro_flags()
+                    }
+                } else {
+                    PageTable::task_data_ro_flags()
+                }
+            }
             VMFileMappingPermission::Execute => PageTable::task_exec_flags(),
         }
+    }
+
+    fn handle_page_fault(
+        &mut self,
+        vmr: &VMR,
+        offset: usize,
+        write: bool,
+    ) -> Result<VMPageFaultResolution, SvsmError> {
+        let page_size = self.page_size();
+        if write {
+            if let Some(write_copy) = self.write_copy.as_mut() {
+                // This is a writeable region with copy-on-write access. The
+                // page fault will have occurred because the page has not yet
+                // been allocated. Allocate a page and copy the readonly source
+                // page into the new writeable page.
+                let offset_aligned = offset & !(page_size - 1);
+                if write_copy
+                    .get_alloc_mut()
+                    .alloc_page(offset_aligned)
+                    .is_ok()
+                {
+                    let paddr_new_page = write_copy.map(offset_aligned).ok_or(SvsmError::Mem)?;
+                    let temp_map = VMPhysMem::new(paddr_new_page, page_size, true);
+                    let vaddr_new_page = vmr.insert(Arc::new(Mapping::new(temp_map)))?;
+                    let slice =
+                        unsafe { from_raw_parts_mut(vaddr_new_page.bits() as *mut u8, page_size) };
+                    self.file.seek(offset_aligned);
+                    self.file.read(slice)?;
+                    vmr.remove(vaddr_new_page)?;
+                    return Ok(VMPageFaultResolution {
+                        paddr: paddr_new_page,
+                        flags: PageTable::task_data_flags(),
+                    });
+                }
+            }
+        }
+        Err(SvsmError::Mem)
     }
 }

--- a/src/mm/vm/mapping/file_mapping.rs
+++ b/src/mm/vm/mapping/file_mapping.rs
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2023 SUSE LLC
+//
+// Author: Roy Hopkins <rhopkins@suse.de>
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+use super::{RawAllocMapping, VirtualMapping};
+use crate::error::SvsmError;
+use crate::fs::FileHandle;
+use crate::mm::PageRef;
+use crate::mm::{pagetable::PageTable, PAGE_SIZE};
+use crate::types::PAGE_SHIFT;
+use crate::utils::align_up;
+
+#[derive(Debug)]
+struct VMWriteFileMapping(RawAllocMapping);
+
+impl VirtualMapping for VMWriteFileMapping {
+    fn mapping_size(&self) -> usize {
+        self.0.mapping_size()
+    }
+
+    fn map(&self, offset: usize) -> Option<crate::address::PhysAddr> {
+        self.0.map(offset)
+    }
+
+    fn pt_flags(&self) -> crate::mm::pagetable::PTEntryFlags {
+        PageTable::task_data_flags()
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum VMFileMappingPermission {
+    /// Read-only access to the file
+    Read,
+    // Read/Write access to a copy of the files pages
+    Write,
+    // Read-only access that allows execution
+    Execute,
+}
+
+/// Map view of a ramfs file into virtual memory
+#[derive(Debug)]
+pub struct VMFileMapping {
+    /// The file that this mapping relates to
+    file: FileHandle,
+
+    /// The size of the mapping in bytes
+    size: usize,
+
+    /// The permission to apply to the virtual mapping
+    permission: VMFileMappingPermission,
+
+    /// A vec containing references to mapped pages within the file
+    pages: Vec<Option<PageRef>>,
+}
+
+impl VMFileMapping {
+    /// Create a new ['VMFileMapping'] for a file. The file provides the backing
+    /// pages for the file contents.
+    ///
+    /// # Arguments
+    ///
+    /// * 'file' - The file to create the mapping for. This instance keeps a
+    ///            reference to the file until it is dropped.
+    ///
+    /// * 'offset' - The offset from the start of the file to map. This must be
+    ///   align to PAGE_SIZE.
+    ///
+    /// * 'size' - The number of bytes to map starting from the offset. This
+    ///   must be a multiple of PAGE_SIZE.
+    ///
+    /// # Returns
+    ///
+    /// Initialized mapping on success, Err(SvsmError::Mem) on error
+    pub fn new(
+        file: FileHandle,
+        offset: usize,
+        size: usize,
+        permission: VMFileMappingPermission,
+    ) -> Result<Self, SvsmError> {
+        let page_size = align_up(size, PAGE_SIZE);
+        let file_size = align_up(file.size(), PAGE_SIZE);
+        if (offset & (PAGE_SIZE - 1)) != 0 {
+            return Err(SvsmError::Mem);
+        }
+        if (page_size + offset) > file_size {
+            return Err(SvsmError::Mem);
+        }
+
+        // Take references to the file pages
+        let count = page_size >> PAGE_SHIFT;
+        let mut pages = Vec::<Option<PageRef>>::new();
+        for page_index in 0..count {
+            pages.push(file.mapping(offset + page_index * PAGE_SIZE));
+        }
+
+        Ok(Self {
+            file,
+            size: page_size,
+            permission,
+            pages,
+        })
+    }
+}
+
+impl VirtualMapping for VMFileMapping {
+    fn mapping_size(&self) -> usize {
+        self.size
+    }
+
+    fn map(&self, offset: usize) -> Option<crate::address::PhysAddr> {
+        let page_index = offset / PAGE_SIZE;
+        if page_index >= self.pages.len() {
+            return None;
+        }
+        self.pages[page_index].as_ref().map(|p| p.phys_addr())
+    }
+
+    fn pt_flags(&self) -> crate::mm::pagetable::PTEntryFlags {
+        match self.permission {
+            VMFileMappingPermission::Read => PageTable::task_data_ro_flags(),
+            VMFileMappingPermission::Write => PageTable::task_data_flags(),
+            VMFileMappingPermission::Execute => PageTable::task_exec_flags(),
+        }
+    }
+}

--- a/src/mm/vm/mapping/file_mapping.rs
+++ b/src/mm/vm/mapping/file_mapping.rs
@@ -28,7 +28,7 @@ impl VirtualMapping for VMWriteFileMapping {
         self.0.map(offset)
     }
 
-    fn pt_flags(&self) -> crate::mm::pagetable::PTEntryFlags {
+    fn pt_flags(&self, _offset: usize) -> crate::mm::pagetable::PTEntryFlags {
         PageTable::task_data_flags()
     }
 }
@@ -121,7 +121,7 @@ impl VirtualMapping for VMFileMapping {
         self.pages[page_index].as_ref().map(|p| p.phys_addr())
     }
 
-    fn pt_flags(&self) -> crate::mm::pagetable::PTEntryFlags {
+    fn pt_flags(&self, _offset: usize) -> crate::mm::pagetable::PTEntryFlags {
         match self.permission {
             VMFileMappingPermission::Read => PageTable::task_data_ro_flags(),
             VMFileMappingPermission::Write => PageTable::task_data_flags(),

--- a/src/mm/vm/mapping/kernel_stack.rs
+++ b/src/mm/vm/mapping/kernel_stack.rs
@@ -116,7 +116,7 @@ impl VirtualMapping for VMKernelStack {
         }
     }
 
-    fn pt_flags(&self) -> PTEntryFlags {
+    fn pt_flags(&self, _offset: usize) -> PTEntryFlags {
         PTEntryFlags::WRITABLE | PTEntryFlags::NX | PTEntryFlags::ACCESSED | PTEntryFlags::DIRTY
     }
 }

--- a/src/mm/vm/mapping/mod.rs
+++ b/src/mm/vm/mapping/mod.rs
@@ -5,6 +5,7 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 
 pub mod api;
+pub mod file_mapping;
 pub mod kernel_stack;
 pub mod phys_mem;
 pub mod rawalloc;
@@ -12,6 +13,7 @@ pub mod reserved;
 pub mod vmalloc;
 
 pub use api::{Mapping, VMMAdapter, VirtualMapping, VMM};
+pub use file_mapping::{VMFileMapping, VMFileMappingPermission};
 pub use kernel_stack::VMKernelStack;
 pub use phys_mem::VMPhysMem;
 pub use rawalloc::RawAllocMapping;

--- a/src/mm/vm/mapping/mod.rs
+++ b/src/mm/vm/mapping/mod.rs
@@ -12,7 +12,7 @@ pub mod rawalloc;
 pub mod reserved;
 pub mod vmalloc;
 
-pub use api::{Mapping, VMMAdapter, VirtualMapping, VMM};
+pub use api::{Mapping, VMMAdapter, VMPageFaultResolution, VirtualMapping, VMM};
 pub use file_mapping::{VMFileMapping, VMFileMappingPermission};
 pub use kernel_stack::VMKernelStack;
 pub use phys_mem::VMPhysMem;

--- a/src/mm/vm/mapping/phys_mem.rs
+++ b/src/mm/vm/mapping/phys_mem.rs
@@ -69,7 +69,7 @@ impl VirtualMapping for VMPhysMem {
         }
     }
 
-    fn pt_flags(&self) -> PTEntryFlags {
+    fn pt_flags(&self, _offset: usize) -> PTEntryFlags {
         PTEntryFlags::NX
             | PTEntryFlags::ACCESSED
             | if self.writable {

--- a/src/mm/vm/mapping/rawalloc.rs
+++ b/src/mm/vm/mapping/rawalloc.rs
@@ -4,6 +4,8 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
+use core::iter;
+
 use crate::address::PhysAddr;
 use crate::error::SvsmError;
 use crate::mm::alloc::{allocate_file_page_ref, PageRef};
@@ -18,7 +20,7 @@ use alloc::vec::Vec;
 #[derive(Default, Debug)]
 pub struct RawAllocMapping {
     /// A vec containing references to PageFile allocations
-    pages: Vec<PageRef>,
+    pages: Vec<Option<PageRef>>,
 
     /// Number of pages required in [`pages`]
     count: usize,
@@ -36,22 +38,38 @@ impl RawAllocMapping {
     /// New instance of RawAllocMapping. Still needs to call `alloc_pages()` on it before it can be used.
     pub fn new(size: usize) -> Self {
         let count = align_up(size, PAGE_SIZE) >> PAGE_SHIFT;
-        RawAllocMapping {
-            pages: Vec::new(),
-            count,
-        }
+        let pages: Vec<Option<PageRef>> = iter::repeat(None).take(count).collect();
+        RawAllocMapping { pages, count }
     }
 
-    /// Allocates the backing pages of type PageFile
+    /// Allocates a single backing page of type PageFile if the page has not already
+    /// been allocated
+    ///
+    /// # Argument
+    ///
+    /// * 'offset' - The offset in bytes from the start of the mapping
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` if the page has been allocated, `Err(SvsmError::Mem)` otherwise
+    pub fn alloc_page(&mut self, offset: usize) -> Result<(), SvsmError> {
+        let index = offset >> PAGE_SHIFT;
+        if index < self.count {
+            let entry = self.pages.get_mut(index).ok_or(SvsmError::Mem)?;
+            entry.get_or_insert(allocate_file_page_ref()?);
+        }
+        Ok(())
+    }
+
+    /// Allocates a full set of backing pages of type PageFile
     ///
     /// # Returns
     ///
     /// `Ok(())` when all pages could be allocated, `Err(SvsmError::Mem)` otherwise
     pub fn alloc_pages(&mut self) -> Result<(), SvsmError> {
-        for _ in 0..self.count {
-            self.pages.push(allocate_file_page_ref()?);
+        for index in 0..self.count {
+            self.alloc_page(index * PAGE_SIZE)?;
         }
-
         Ok(())
     }
 
@@ -75,7 +93,9 @@ impl RawAllocMapping {
     /// Physical address to map for the given offset.
     pub fn map(&self, offset: usize) -> Option<PhysAddr> {
         let pfn = offset >> PAGE_SHIFT;
-        self.pages.get(pfn).map(|r| r.phys_addr())
+        self.pages
+            .get(pfn)
+            .and_then(|r| r.as_ref().map(|r| r.phys_addr()))
     }
 
     /// Unmap call-back - currently nothing to do in this function
@@ -85,5 +105,20 @@ impl RawAllocMapping {
     /// * `_offset` - Byte offset into the mapping
     pub fn unmap(&self, _offset: usize) {
         // Nothing to do for now
+    }
+
+    /// Check if a page has been allocated
+    ///
+    /// # Arguments
+    ///
+    /// * 'offset' - Byte offset into the mapping
+    ///
+    /// # Returns
+    ///
+    /// 'true' if the page containing the offset has been allocated
+    /// otherwise 'false'.
+    pub fn present(&self, offset: usize) -> bool {
+        let pfn = offset >> PAGE_SHIFT;
+        self.pages.get(pfn).and_then(|r| r.as_ref()).is_some()
     }
 }

--- a/src/mm/vm/mapping/reserved.rs
+++ b/src/mm/vm/mapping/reserved.rs
@@ -55,7 +55,7 @@ impl VirtualMapping for VMReserved {
         None
     }
 
-    fn pt_flags(&self) -> PTEntryFlags {
+    fn pt_flags(&self, _offset: usize) -> PTEntryFlags {
         PTEntryFlags::NX | PTEntryFlags::ACCESSED | PTEntryFlags::WRITABLE | PTEntryFlags::DIRTY
     }
 }

--- a/src/mm/vm/mapping/vmalloc.rs
+++ b/src/mm/vm/mapping/vmalloc.rs
@@ -70,7 +70,7 @@ impl VirtualMapping for VMalloc {
         self.alloc.unmap(offset);
     }
 
-    fn pt_flags(&self) -> PTEntryFlags {
+    fn pt_flags(&self, _offset: usize) -> PTEntryFlags {
         PTEntryFlags::WRITABLE | PTEntryFlags::NX | PTEntryFlags::ACCESSED | PTEntryFlags::DIRTY
     }
 }

--- a/src/mm/vm/mod.rs
+++ b/src/mm/vm/mod.rs
@@ -8,7 +8,7 @@ mod mapping;
 mod range;
 
 pub use mapping::{
-    Mapping, RawAllocMapping, VMKernelStack, VMMAdapter, VMPhysMem, VMReserved, VMalloc,
-    VirtualMapping, VMM,
+    Mapping, RawAllocMapping, VMFileMapping, VMFileMappingPermission, VMKernelStack, VMMAdapter,
+    VMPhysMem, VMReserved, VMalloc, VirtualMapping, VMM,
 };
 pub use range::{VMRMapping, VMR, VMR_GRANULE};

--- a/src/mm/vm/range.rs
+++ b/src/mm/vm/range.rs
@@ -155,7 +155,6 @@ impl VMR {
         let (vmm_start, vmm_end) = vmm.range();
         let mut pgtbl_parts = self.pgtbl_parts.lock_write();
         let mapping = vmm.get_mapping();
-        let pt_flags = self.pt_flags | mapping.pt_flags() | PTEntryFlags::PRESENT;
         let mut offset: usize = 0;
         let page_size = mapping.page_size();
         let shared = mapping.shared();
@@ -163,6 +162,7 @@ impl VMR {
         while vmm_start + offset < vmm_end {
             let idx = PageTable::index::<3>(VirtAddr::from(vmm_start - rstart));
             if let Some(paddr) = mapping.map(offset) {
+                let pt_flags = self.pt_flags | mapping.pt_flags(offset) | PTEntryFlags::PRESENT;
                 if page_size == PAGE_SIZE {
                     pgtbl_parts[idx].map_4k(vmm_start + offset, paddr, pt_flags, shared)?;
                 } else if page_size == PAGE_SIZE_2M {

--- a/src/mm/vm/range.rs
+++ b/src/mm/vm/range.rs
@@ -373,6 +373,68 @@ impl VMR {
             );
         }
     }
+
+    /// Notify the range that a page fault has occurred. This should be called from
+    /// the page fault handler. The mappings withing this virtual memory region are
+    /// examined and if they overlap with the page fault address then
+    /// [`VirtualMemoryRange::handle_page_fault()`] is called to handle the page
+    /// fault within that range.
+    ///
+    /// # Arguments
+    ///
+    /// * `vaddr` - Virtual memory address that was the subject of the page fault
+    ///
+    /// * 'write' - 'true' if a write was attempted. 'false' if a read was attempted.
+    ///
+    /// # Returns
+    ///
+    /// '()' if the page fault was successfully handled.
+    ///
+    /// 'SvsmError::Mem' if the page fault should propogate to the next handler.
+    pub fn handle_page_fault(&self, vaddr: VirtAddr, write: bool) -> Result<(), SvsmError> {
+        // Get the mapping that contains the faulting address. This needs to
+        // be done as a separate step, returning a reference to the mapping to
+        // avoid issues with the mapping page fault handler needing mutable access
+        // to `self.tree` via `insert()`.
+        let pf_mapping = {
+            let tree = self.tree.lock_read();
+            let addr = vaddr.pfn();
+            let cursor = tree.find(&addr);
+            if let Some(node) = cursor.get() {
+                let (start, end) = node.range();
+                if vaddr >= start && vaddr < end {
+                    Some((node.get_mapping_clone(), start))
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        };
+
+        if let Some((pf_mapping, start)) = pf_mapping {
+            let resolution = pf_mapping
+                .get_mut()
+                .handle_page_fault(self, vaddr - start, write)?;
+            // The handler has resolved the page fault by allocating a new page.
+            // Update the page table accordingly.
+            let vaddr = vaddr.page_align();
+            let page_size = pf_mapping.get().page_size();
+            let shared = pf_mapping.get().shared();
+            let mut pgtbl_parts = self.pgtbl_parts.lock_write();
+
+            let (rstart, _) = self.virt_range();
+            let idx = PageTable::index::<3>(VirtAddr::from(vaddr - rstart));
+            if page_size == PAGE_SIZE {
+                pgtbl_parts[idx].map_4k(vaddr, resolution.paddr, resolution.flags, shared)?;
+            } else if page_size == PAGE_SIZE_2M {
+                pgtbl_parts[idx].map_2m(vaddr, resolution.paddr, resolution.flags, shared)?;
+            }
+            Ok(())
+        } else {
+            Err(SvsmError::Mem)
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/src/task/tasks.rs
+++ b/src/task/tasks.rs
@@ -254,6 +254,10 @@ impl Task {
         self.affinity = affinity;
     }
 
+    pub fn handle_pf(&self, vaddr: VirtAddr, write: bool) -> Result<(), SvsmError> {
+        self.vm_kernel_range.handle_page_fault(vaddr, write)
+    }
+
     fn allocate_stack(entry: extern "C" fn()) -> Result<(Arc<Mapping>, VirtAddr), SvsmError> {
         let stack = VMKernelStack::new()?;
         let offset = stack.top_of_stack(VirtAddr::from(0u64));


### PR DESCRIPTION
In order to be able to provide the ability to load and map ELF files into a task virtual memory space, we need the ability to take RamFS files and create virtual memory ranges to map the file physical pages to virtual memory addresses.

This PR uses the new `VirtualRange` trait and `VMR` ranges to implement a range that takes ownership of a file handle and allows a view of the file to be created as a virtual memory range and added to any `VMR` such as within the current task or the PerCpu range.

The goal of the implementation is to keep the file system contents as immutable, providing read-only access to the backing pages and copy-on-write access for writable access.

Multiple `VMFileMapping` ranges can be created over a single file by opening multiple file handles on the same file.