### PR TITLE
mm/alloc: multiple simplifications and cleanups

### DIFF
--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -130,7 +130,7 @@ impl AllocatedInfo {
 
     fn decode(mem: PageStorageType) -> Self {
         let order = mem.decode_order();
-        AllocatedInfo { order }
+        Self { order }
     }
 }
 
@@ -172,7 +172,7 @@ impl ReservedInfo {
     }
 
     fn decode(_mem: PageStorageType) -> Self {
-        ReservedInfo {}
+        Self {}
     }
 }
 
@@ -184,7 +184,7 @@ struct FileInfo {
 
 impl FileInfo {
     const fn new(ref_count: u64) -> Self {
-        FileInfo { ref_count }
+        Self { ref_count }
     }
 
     fn encode(&self) -> PageStorageType {
@@ -667,7 +667,7 @@ pub struct PageRef {
 
 impl PageRef {
     pub const fn new(virt_addr: VirtAddr, phys_addr: PhysAddr) -> Self {
-        PageRef {
+        Self {
             virt_addr,
             phys_addr,
         }
@@ -794,7 +794,7 @@ struct SlabPage {
 
 impl SlabPage {
     const fn new() -> Self {
-        SlabPage {
+        Self {
             vaddr: VirtAddr::null(),
             capacity: 0,
             free: 0,
@@ -902,7 +902,7 @@ struct SlabCommon {
 
 impl SlabCommon {
     const fn new(item_size: u16) -> Self {
-        SlabCommon {
+        Self {
             item_size,
             capacity: 0,
             free: 0,
@@ -1028,7 +1028,7 @@ struct SlabPageSlab {
 
 impl SlabPageSlab {
     const fn new() -> Self {
-        SlabPageSlab {
+        Self {
             common: SlabCommon::new(size_of::<SlabPage>() as u16),
         }
     }
@@ -1089,7 +1089,7 @@ struct Slab {
 
 impl Slab {
     const fn new(item_size: u16) -> Self {
-        Slab {
+        Self {
             common: SlabCommon::new(item_size),
         }
     }

--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -164,7 +164,7 @@ impl CompoundInfo {
 }
 
 #[derive(Clone, Copy, Debug)]
-struct ReservedInfo {}
+struct ReservedInfo;
 
 impl ReservedInfo {
     fn encode(&self) -> PageStorageType {
@@ -172,7 +172,7 @@ impl ReservedInfo {
     }
 
     fn decode(_mem: PageStorageType) -> Self {
-        Self {}
+        Self
     }
 }
 
@@ -640,7 +640,7 @@ impl MemoryRegion {
 
         /* Mark page storage as reserved */
         for i in 0..meta_pages {
-            let pg = PageInfo::Reserved(ReservedInfo {});
+            let pg = PageInfo::Reserved(ReservedInfo);
             self.write_page_info(i, pg);
         }
 

--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -328,8 +328,11 @@ impl MemoryRegion {
     fn read_page_info(&self, pfn: usize) -> PageInfo {
         self.check_pfn(pfn);
 
-        let virt = self.page_info_virt_addr(pfn).as_ptr::<u64>();
-        let info = unsafe { PageStorageType(*virt) };
+        let info = unsafe {
+            self.page_info_virt_addr(pfn)
+                .as_ptr::<PageStorageType>()
+                .read()
+        };
 
         PageInfo::from_mem(info)
     }

--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -1122,7 +1122,7 @@ impl Slab {
             return Err(e);
         }
 
-        self.common.add_slab_page(&mut *slab_page);
+        self.common.add_slab_page(slab_page);
         Ok(())
     }
 

--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -490,7 +490,7 @@ impl MemoryRegion {
         }
 
         let nr_pages: usize = 1 << (order + 1);
-        let pfn = if pfn1 < pfn2 { pfn1 } else { pfn2 };
+        let pfn = pfn1.min(pfn2);
 
         // Write new compound head
         let pg = PageInfo::Allocated(AllocatedInfo { order: order + 1 });

--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -98,6 +98,7 @@ impl PageStorageType {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
 struct FreeInfo {
     next_page: usize,
     order: usize,
@@ -117,6 +118,7 @@ impl FreeInfo {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
 struct AllocatedInfo {
     order: usize,
 }
@@ -132,6 +134,7 @@ impl AllocatedInfo {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
 struct SlabPageInfo;
 
 impl SlabPageInfo {
@@ -144,6 +147,7 @@ impl SlabPageInfo {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
 struct CompoundInfo {
     order: usize,
 }
@@ -159,6 +163,7 @@ impl CompoundInfo {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
 struct ReservedInfo {}
 
 impl ReservedInfo {
@@ -171,6 +176,7 @@ impl ReservedInfo {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
 struct FileInfo {
     /// Reference count
     ref_count: u64,
@@ -191,6 +197,7 @@ impl FileInfo {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
 enum PageInfo {
     Free(FreeInfo),
     Allocated(AllocatedInfo),
@@ -201,7 +208,7 @@ enum PageInfo {
 }
 
 impl PageInfo {
-    fn to_mem(&self) -> PageStorageType {
+    fn to_mem(self) -> PageStorageType {
         match self {
             Self::Free(fi) => fi.encode(),
             Self::Allocated(ai) => ai.encode(),

--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -770,11 +770,11 @@ pub fn allocate_file_page_ref() -> Result<PageRef, SvsmError> {
     Ok(PageRef::new(v, p))
 }
 
-pub fn get_file_page(vaddr: VirtAddr) -> Result<(), SvsmError> {
+fn get_file_page(vaddr: VirtAddr) -> Result<(), SvsmError> {
     ROOT_MEM.lock().get_file_page(vaddr)
 }
 
-pub fn put_file_page(vaddr: VirtAddr) -> Result<(), SvsmError> {
+fn put_file_page(vaddr: VirtAddr) -> Result<(), SvsmError> {
     ROOT_MEM.lock().put_file_page(vaddr)
 }
 

--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -1206,8 +1206,7 @@ unsafe impl GlobalAlloc for SvsmAllocator {
             }
         };
 
-        ret.map(|addr| addr.as_mut_ptr::<u8>())
-            .unwrap_or_else(|_| ptr::null_mut())
+        ret.map_or_else(|_| ptr::null_mut(), |addr| addr.as_mut_ptr::<u8>())
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {

--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -374,8 +374,8 @@ impl MemoryRegion {
         });
         self.write_page_info(pfn, head);
 
+        let compound = PageInfo::Compound(CompoundInfo { order });
         for i in 1..nr_pages {
-            let compound = PageInfo::Compound(CompoundInfo { order });
             self.write_page_info(pfn + i, compound);
         }
     }
@@ -518,8 +518,8 @@ impl MemoryRegion {
         self.write_page_info(pfn, pg);
 
         // Write compound pages
+        let pg = PageInfo::Compound(CompoundInfo { order: order + 1 });
         for i in 1..nr_pages {
-            let pg = PageInfo::Compound(CompoundInfo { order: order + 1 });
             self.write_page_info(pfn + i, pg);
         }
 

--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -387,18 +387,13 @@ impl MemoryRegion {
     }
 
     fn refill_page_list(&mut self, order: usize) -> Result<(), SvsmError> {
-        if order >= MAX_ORDER {
-            return Err(SvsmError::Mem);
-        }
-
-        if self.next_page[order] != 0 {
+        let next_page = *self.next_page.get(order).ok_or(SvsmError::Mem)?;
+        if next_page != 0 {
             return Ok(());
         }
 
         self.refill_page_list(order + 1)?;
-
         let pfn = self.get_next_page(order + 1)?;
-
         self.split_page(pfn, order + 1)
     }
 

--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -963,7 +963,7 @@ impl SlabCommon {
                 return vaddr;
             }
 
-            let next_page = (*page).get_next_page();
+            let next_page = page.get_next_page();
             assert!(!next_page.is_null()); // Cannot happen with free slots on entry.
             page = unsafe { &mut *next_page.as_mut_ptr::<SlabPage>() };
         }

--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -1078,7 +1078,7 @@ impl SlabPageSlab {
 
     fn allocate(&mut self) -> Result<*mut SlabPage, SvsmError> {
         self.grow_slab()?;
-        Ok(unsafe { &mut *self.common.allocate_slot().as_mut_ptr::<SlabPage>() })
+        Ok(self.common.allocate_slot().as_mut_ptr::<SlabPage>())
     }
 
     fn deallocate(&mut self, slab_page: *mut SlabPage) {

--- a/src/mm/mod.rs
+++ b/src/mm/mod.rs
@@ -22,6 +22,4 @@ pub use ptguards::*;
 
 pub use pagetable::PageTablePart;
 
-pub use alloc::{
-    allocate_file_page, allocate_file_page_ref, get_file_page, put_file_page, PageRef,
-};
+pub use alloc::{allocate_file_page, allocate_file_page_ref, PageRef};


### PR DESCRIPTION
Simplify certain code paths, mostly related to heap page management, and simplify syntax where possible.