### PR TITLE
Add support for running tests inside stage2

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,8 @@ jobs:
       # ld to work, so build all the objects without performing the
       # final linking step.
       - name: Build
-        run: make FEATURES="default,enable-gdb" stage1/kernel.elf stage1/stage1.o stage1/reset.o
+        run: make FEATURES="default,enable-gdb" stage1/kernel.elf stage1/test-kernel.elf stage1/stage2.bin stage1/test-stage2.bin stage1/stage1.o stage1/reset.o
+
 
       - name: Run tests
         run: make test

--- a/build.rs
+++ b/build.rs
@@ -18,7 +18,7 @@ fn main() {
     println!("cargo:rustc-link-arg-bin=svsm=-Tsvsm.lds");
     println!("cargo:rustc-link-arg-bin=svsm=-no-pie");
 
-    // Extra linker args for tests.
+    // Extra linker args for svsm kernel tests.
     println!("cargo:rerun-if-env-changed=LINK_TEST");
     if std::env::var("LINK_TEST").is_ok() {
         println!("cargo:rustc-cfg=test_in_svsm");
@@ -26,6 +26,16 @@ fn main() {
         println!("cargo:rustc-link-arg=--build-id=none");
         println!("cargo:rustc-link-arg=--no-relax");
         println!("cargo:rustc-link-arg=-Tsvsm.lds");
+        println!("cargo:rustc-link-arg=-no-pie");
+    }
+
+    // Extra linker args for stage2 tests.
+    println!("cargo:rerun-if-env-changed=LINK_STAGE2_TEST");
+    if std::env::var("LINK_STAGE2_TEST").is_ok() {
+        println!("cargo:rustc-cfg=test_in_stage2");
+        println!("cargo:rustc-link-arg=-nostdlib");
+        println!("cargo:rustc-link-arg=--build-id=none");
+        println!("cargo:rustc-link-arg=-Tstage2.lds");
         println!("cargo:rustc-link-arg=-no-pie");
     }
 }

--- a/src/fs/filesystem.rs
+++ b/src/fs/filesystem.rs
@@ -485,7 +485,7 @@ mod tests {
     use crate::mm::alloc::{TestRootMem, DEFAULT_TEST_MEMORY_SIZE};
 
     #[test]
-    #[cfg_attr(test_in_svsm, ignore = "FIXME")]
+    #[cfg_attr(any(test_in_svsm, test_in_stage2), ignore = "FIXME")]
     fn create_dir() {
         let _test_mem = TestRootMem::setup(DEFAULT_TEST_MEMORY_SIZE);
         initialize_fs();
@@ -510,7 +510,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(test_in_svsm, ignore = "FIXME")]
+    #[cfg_attr(any(test_in_svsm, test_in_stage2), ignore = "FIXME")]
     fn create_and_unlink_file() {
         let _test_mem = TestRootMem::setup(DEFAULT_TEST_MEMORY_SIZE);
         initialize_fs();
@@ -541,7 +541,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(test_in_svsm, ignore = "FIXME")]
+    #[cfg_attr(any(test_in_svsm, test_in_stage2), ignore = "FIXME")]
     fn create_sub_dir() {
         let _test_mem = TestRootMem::setup(DEFAULT_TEST_MEMORY_SIZE);
         initialize_fs();
@@ -570,7 +570,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(test_in_svsm, ignore = "FIXME")]
+    #[cfg_attr(any(test_in_svsm, test_in_stage2), ignore = "FIXME")]
     fn test_unlink() {
         let _test_mem = TestRootMem::setup(DEFAULT_TEST_MEMORY_SIZE);
         initialize_fs();
@@ -600,7 +600,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(test_in_svsm, ignore = "FIXME")]
+    #[cfg_attr(any(test_in_svsm, test_in_stage2), ignore = "FIXME")]
     fn test_open_read_write_seek() {
         let _test_mem = TestRootMem::setup(DEFAULT_TEST_MEMORY_SIZE);
         initialize_fs();
@@ -652,7 +652,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(test_in_svsm, ignore = "FIXME")]
+    #[cfg_attr(any(test_in_svsm, test_in_stage2), ignore = "FIXME")]
     fn test_multiple_file_handles() {
         let _test_mem = TestRootMem::setup(DEFAULT_TEST_MEMORY_SIZE);
         initialize_fs();

--- a/src/fs/ramfs.rs
+++ b/src/fs/ramfs.rs
@@ -387,7 +387,7 @@ mod tests {
     use crate::mm::alloc::{TestRootMem, DEFAULT_TEST_MEMORY_SIZE};
 
     #[test]
-    #[cfg_attr(test_in_svsm, ignore = "FIXME")]
+    #[cfg_attr(any(test_in_svsm, test_in_stage2), ignore = "FIXME")]
     fn test_ramfs_file_read_write() {
         let _test_mem = TestRootMem::setup(DEFAULT_TEST_MEMORY_SIZE);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,10 +7,19 @@
 #![no_std]
 #![deny(missing_copy_implementations)]
 #![deny(missing_debug_implementations)]
-#![cfg_attr(all(test, test_in_svsm), no_main)]
-#![cfg_attr(all(test, test_in_svsm), feature(custom_test_frameworks))]
-#![cfg_attr(all(test, test_in_svsm), test_runner(crate::testing::svsm_test_runner))]
-#![cfg_attr(all(test, test_in_svsm), reexport_test_harness_main = "test_main")]
+#![cfg_attr(all(test, any(test_in_svsm, test_in_stage2)), no_main)]
+#![cfg_attr(
+    all(test, any(test_in_svsm, test_in_stage2)),
+    feature(custom_test_frameworks)
+)]
+#![cfg_attr(
+    all(test, any(test_in_svsm, test_in_stage2)),
+    test_runner(crate::testing::svsm_test_runner)
+)]
+#![cfg_attr(
+    all(test, any(test_in_svsm, test_in_stage2)),
+    reexport_test_harness_main = "test_main"
+)]
 
 pub mod acpi;
 pub mod address;
@@ -48,8 +57,14 @@ fn test_nop() {}
 #[path = "svsm.rs"]
 pub mod svsm_bin;
 // The kernel expects to access this crate as svsm, so reexport.
-#[cfg(all(test, test_in_svsm))]
+#[cfg(all(test, any(test_in_svsm, test_in_stage2)))]
 extern crate self as svsm;
 // Include a module containing the test runner.
-#[cfg(all(test, test_in_svsm))]
+#[cfg(all(test, any(test_in_svsm, test_in_stage2)))]
 pub mod testing;
+
+// When running tests inside the SVSM:
+// Build the kernel entrypoint.
+#[cfg(all(test, test_in_stage2))]
+#[path = "stage2.rs"]
+pub mod stage2_bin;

--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -1313,14 +1313,14 @@ impl Drop for TestRootMem<'_> {
 }
 
 #[test]
-#[cfg_attr(test_in_svsm, ignore = "FIXME")]
+#[cfg_attr(any(test_in_svsm, test_in_stage2), ignore = "FIXME")]
 fn test_root_mem_setup() {
     let test_mem_lock = TestRootMem::setup(DEFAULT_TEST_MEMORY_SIZE);
     drop(test_mem_lock);
 }
 
 #[test]
-#[cfg_attr(test_in_svsm, ignore = "FIXME")]
+#[cfg_attr(any(test_in_svsm, test_in_stage2), ignore = "FIXME")]
 // Allocate one page and free it again, verify that memory_info() reflects it.
 fn test_page_alloc_one() {
     let _test_mem = TestRootMem::setup(DEFAULT_TEST_MEMORY_SIZE);
@@ -1335,7 +1335,7 @@ fn test_page_alloc_one() {
 }
 
 #[test]
-#[cfg_attr(test_in_svsm, ignore = "FIXME")]
+#[cfg_attr(any(test_in_svsm, test_in_stage2), ignore = "FIXME")]
 // Allocate and free all available compound pages, verify that memory_info()
 // reflects it.
 fn test_page_alloc_all_compound() {
@@ -1368,7 +1368,7 @@ fn test_page_alloc_all_compound() {
 }
 
 #[test]
-#[cfg_attr(test_in_svsm, ignore = "FIXME")]
+#[cfg_attr(any(test_in_svsm, test_in_stage2), ignore = "FIXME")]
 // Allocate and free all available 4k pages, verify that memory_info()
 // reflects it.
 fn test_page_alloc_all_single() {
@@ -1401,7 +1401,7 @@ fn test_page_alloc_all_single() {
 }
 
 #[test]
-#[cfg_attr(test_in_svsm, ignore = "FIXME")]
+#[cfg_attr(any(test_in_svsm, test_in_stage2), ignore = "FIXME")]
 // Allocate and free all available compound pages, verify that any subsequent
 // allocation fails.
 fn test_page_alloc_oom() {
@@ -1439,7 +1439,7 @@ fn test_page_alloc_oom() {
 }
 
 #[test]
-#[cfg_attr(test_in_svsm, ignore = "FIXME")]
+#[cfg_attr(any(test_in_svsm, test_in_stage2), ignore = "FIXME")]
 fn test_page_file() {
     let _mem_lock = TestRootMem::setup(DEFAULT_TEST_MEMORY_SIZE);
     let mut root_mem = ROOT_MEM.lock();
@@ -1474,7 +1474,7 @@ fn test_page_file() {
 const TEST_SLAB_SIZES: [usize; 7] = [32, 64, 128, 256, 512, 1024, 2048];
 
 #[test]
-#[cfg_attr(test_in_svsm, ignore = "FIXME")]
+#[cfg_attr(any(test_in_svsm, test_in_stage2), ignore = "FIXME")]
 // Allocate and free a couple of objects for each slab size.
 fn test_slab_alloc_free_many() {
     extern crate alloc;
@@ -1514,7 +1514,7 @@ fn test_slab_alloc_free_many() {
 }
 
 #[test]
-#[cfg_attr(test_in_svsm, ignore = "FIXME")]
+#[cfg_attr(any(test_in_svsm, test_in_stage2), ignore = "FIXME")]
 // Allocate enough objects so that the SlabPageSlab will need a SlabPage for
 // itself twice.
 fn test_slab_page_slab_for_self() {
@@ -1551,7 +1551,7 @@ fn test_slab_page_slab_for_self() {
 }
 
 #[test]
-#[cfg_attr(test_in_svsm, ignore = "FIXME")]
+#[cfg_attr(any(test_in_svsm, test_in_stage2), ignore = "FIXME")]
 // Allocate enough objects to hit an OOM situation and verify null gets
 // returned at some point.
 fn test_slab_oom() {

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -4,8 +4,8 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
-#![no_std]
-#![no_main]
+#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(test), no_main)]
 
 pub mod boot_stage2;
 
@@ -142,7 +142,7 @@ fn map_and_validate(vaddr: VirtAddr, paddr: PhysAddr, len: usize) {
 // Launch info from stage1, usually at the bottom of the stack
 // The layout has to match the order in which the parts are pushed to the stack
 // in stage1/stage1.S
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone, Copy)]
 #[repr(C, packed)]
 pub struct Stage1LaunchInfo {
     kernel_elf_start: u32,
@@ -296,6 +296,9 @@ pub extern "C" fn stage2_main(launch_info: &Stage1LaunchInfo) {
 
     let kernel_entry = kernel_elf.get_entry(kernel_vaddr_alloc_base);
     let valid_bitmap = valid_bitmap_addr();
+
+    #[cfg(test)]
+    crate::test_main();
 
     // Shut down the GHCB
     shutdown_percpu();


### PR DESCRIPTION
In the same way that support was added for running tests inside the svsm kernel, add tests that run inside stage2. This is useful for stage2-specific componenets such as the stage 2 #VC handler.