### PR TITLE
svsm: add missing `Copy` and `Debug` derives

### DIFF
--- a/src/acpi/tables.rs
+++ b/src/acpi/tables.rs
@@ -456,6 +456,7 @@ pub struct ACPICPUInfo {
 /// use svsm::fw_cfg::FwCfg;
 /// use svsm::io::IOPort;
 ///
+/// #[derive(Debug)]
 /// struct MyIo;
 ///
 /// impl IOPort for MyIo {

--- a/src/console.rs
+++ b/src/console.rs
@@ -10,6 +10,7 @@ use crate::utils::immut_after_init::ImmutAfterInitCell;
 use core::fmt;
 use log;
 
+#[derive(Clone, Copy)]
 pub struct Console {
     writer: Option<&'static dyn Terminal>,
 }

--- a/src/cpu/cpuid.rs
+++ b/src/cpu/cpuid.rs
@@ -51,6 +51,7 @@ pub fn register_cpuid_table(table: &'static SnpCpuidTable) {
         .expect("Could not initialize CPUID page");
 }
 
+#[derive(Clone, Copy)]
 pub struct CpuidResult {
     pub eax: u32,
     pub ebx: u32,

--- a/src/cpu/cpuid.rs
+++ b/src/cpu/cpuid.rs
@@ -51,7 +51,7 @@ pub fn register_cpuid_table(table: &'static SnpCpuidTable) {
         .expect("Could not initialize CPUID page");
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct CpuidResult {
     pub eax: u32,
     pub ebx: u32,

--- a/src/cpu/gdt.rs
+++ b/src/cpu/gdt.rs
@@ -11,7 +11,7 @@ use core::arch::asm;
 use core::mem;
 
 #[repr(C, packed(2))]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct GdtDesc {
     size: u16,
     addr: VirtAddr,

--- a/src/cpu/gdt.rs
+++ b/src/cpu/gdt.rs
@@ -11,6 +11,7 @@ use core::arch::asm;
 use core::mem;
 
 #[repr(C, packed(2))]
+#[derive(Clone, Copy)]
 pub struct GdtDesc {
     size: u16,
     addr: VirtAddr,

--- a/src/cpu/idt.rs
+++ b/src/cpu/idt.rs
@@ -40,7 +40,7 @@ pub const VC_VECTOR: usize = 29;
 pub const _SX_VECTOR: usize = 30;
 
 #[repr(C, packed)]
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone, Copy)]
 pub struct X86ExceptionContext {
     pub regs: X86GeneralRegs,
     pub vector: usize,

--- a/src/cpu/percpu.rs
+++ b/src/cpu/percpu.rs
@@ -120,7 +120,7 @@ impl IstStacks {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct GuestVmsaRef {
     vmsa: Option<PhysAddr>,
     caa: Option<PhysAddr>,
@@ -574,7 +574,7 @@ pub fn this_cpu_mut() -> &'static mut PerCpu {
     unsafe { SVSM_PERCPU_BASE.as_mut_ptr::<PerCpu>().as_mut().unwrap() }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct VmsaRegistryEntry {
     pub paddr: PhysAddr,
     pub apic_id: u32,

--- a/src/cpu/registers.rs
+++ b/src/cpu/registers.rs
@@ -25,7 +25,7 @@ pub struct X86GeneralRegs {
 }
 
 #[repr(C, packed)]
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone, Copy)]
 pub struct X86SegmentRegs {
     pub cs: usize,
     pub ds: usize,

--- a/src/cpu/tss.rs
+++ b/src/cpu/tss.rs
@@ -10,7 +10,7 @@ use crate::address::VirtAddr;
 pub const _IST_INVALID: usize = 0;
 pub const IST_DF: usize = 1;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 #[repr(C, packed)]
 pub struct X86Tss {
     reserved1: u32,

--- a/src/debug/stacktrace.rs
+++ b/src/debug/stacktrace.rs
@@ -53,6 +53,7 @@ pub enum UnwoundStackFrame {
 type StacksBounds = [StackBounds; 2];
 
 #[cfg(feature = "enable-stacktrace")]
+#[derive(Debug)]
 pub struct StackUnwinder {
     next_frame: Option<UnwoundStackFrame>,
     stacks: StacksBounds,

--- a/src/elf/mod.rs
+++ b/src/elf/mod.rs
@@ -1786,7 +1786,7 @@ impl Elf64Dynamic {
 }
 
 /// Information about the allocation of a virtual address range
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Elf64ImageLoadVaddrAllocInfo {
     /// The virtual address (vaddr) range to allocate
     pub range: Elf64AddrRange,
@@ -1796,6 +1796,7 @@ pub struct Elf64ImageLoadVaddrAllocInfo {
 }
 
 /// Represents an ELF64 image load segment
+#[derive(Debug)]
 pub struct Elf64ImageLoadSegment<'a> {
     /// The virtual address (vaddr) range covering by this segment
     pub vaddr_range: Elf64AddrRange,
@@ -1806,6 +1807,7 @@ pub struct Elf64ImageLoadSegment<'a> {
 }
 
 /// An iterator over ELF64 image load segments within an ELF file
+#[derive(Debug)]
 pub struct Elf64ImageLoadSegmentIterator<'a> {
     elf_file: &'a Elf64File<'a>,
     load_base: Elf64Xword,
@@ -1938,6 +1940,7 @@ impl Elf64Sym {
 
 /// Represents an ELF64 symbol table ([`Elf64Symtab`]) containing
 /// symbols used within the ELF file.
+#[derive(Debug)]
 struct Elf64Symtab<'a> {
     /// The underlying buffer containing the symbol table data
     syms_buf: &'a [u8],
@@ -2041,6 +2044,7 @@ impl Elf64Rela {
 }
 
 /// Represents a collection of relocation entries in an ELF64 file ([`Elf64Relas`])
+#[derive(Debug)]
 struct Elf64Relas<'a> {
     /// The underlying buffer containing the relocation entries
     relas_buf: &'a [u8],
@@ -2093,6 +2097,7 @@ impl<'a> Elf64Relas<'a> {
 }
 
 /// Represents an iterator over section headers in an ELF64 file
+#[derive(Debug)]
 pub struct Elf64ShdrIterator<'a> {
     /// The ELF64 file from which section headers are being iterated
     elf_file: &'a Elf64File<'a>,
@@ -2170,7 +2175,7 @@ pub trait Elf64RelocProcessor {
 }
 
 /// Relocation processor specifically for x86_64 ELF files.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Elf64X86RelocProcessor;
 
 impl Elf64X86RelocProcessor {
@@ -2265,6 +2270,7 @@ impl Elf64RelocProcessor for Elf64X86RelocProcessor {
 }
 
 /// An iterator that applies relocation operations to ELF64 relocations
+#[derive(Debug)]
 pub struct Elf64AppliedRelaIterator<'a, RP: Elf64RelocProcessor> {
     /// The ELF64 relocation processor used for applying relocations
     rela_proc: RP,

--- a/src/elf/mod.rs
+++ b/src/elf/mod.rs
@@ -35,7 +35,7 @@ use core::mem;
 ///
 /// assert_eq!(error_message, "invalid ELF address range");
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum ElfError {
     FileTooShort,
 
@@ -204,7 +204,7 @@ pub type Elf64char = u8;
 ///
 /// In mathematical notation, the range is [vaddr_begin, vaddr_end)
 ///
-#[derive(PartialEq, Eq, Debug, Default)]
+#[derive(PartialEq, Eq, Debug, Default, Clone, Copy)]
 pub struct Elf64AddrRange {
     pub vaddr_begin: Elf64Addr,
     pub vaddr_end: Elf64Addr,
@@ -330,7 +330,7 @@ impl cmp::PartialOrd for Elf64AddrRange {
 
 /// This struct represents a parsed 64-bit ELF file. It contains information
 /// about the ELF file's header, load segments, dynamic section, and more.
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone, Copy)]
 pub struct Elf64FileRange {
     pub offset_begin: usize,
     pub offset_end: usize,
@@ -1005,7 +1005,7 @@ impl<'a> Elf64File<'a> {
 
 /// Header of the ELF64 file, including fields describing properties such
 /// as type, machine architecture, entry point, etc.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct Elf64Hdr {
     #[allow(unused)]
     /// An array of 16 bytes representing the ELF identification, including the ELF magic number
@@ -1786,6 +1786,7 @@ impl Elf64Dynamic {
 }
 
 /// Information about the allocation of a virtual address range
+#[derive(Clone, Copy)]
 pub struct Elf64ImageLoadVaddrAllocInfo {
     /// The virtual address (vaddr) range to allocate
     pub range: Elf64AddrRange,
@@ -1997,7 +1998,7 @@ impl<'a> Elf64Symtab<'a> {
 }
 
 /// Represents a relocation entry in an ELF64 file ([`Elf64Rela`])
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct Elf64Rela {
     /// Offset within the section where the relocation should be applied
     r_offset: Elf64Addr,
@@ -2135,7 +2136,7 @@ impl<'a> Iterator for Elf64ShdrIterator<'a> {
 }
 
 /// Represents a relocation operation
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct Elf64RelocOp {
     /// Destination address where the relocation operation should be applied
     pub dst: Elf64Addr,
@@ -2169,6 +2170,7 @@ pub trait Elf64RelocProcessor {
 }
 
 /// Relocation processor specifically for x86_64 ELF files.
+#[derive(Clone, Copy)]
 pub struct Elf64X86RelocProcessor;
 
 impl Elf64X86RelocProcessor {

--- a/src/fw_cfg.rs
+++ b/src/fw_cfg.rs
@@ -52,7 +52,7 @@ impl From<FwCfgError> for SvsmError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct FwCfgFile {
     size: u32,
     selector: u16,

--- a/src/fw_cfg.rs
+++ b/src/fw_cfg.rs
@@ -29,7 +29,7 @@ const MAX_FW_CFG_FILES: u32 = 0x1000;
 //use crate::println;
 
 #[non_exhaustive]
-
+#[derive(Debug)]
 pub struct FwCfg<'a> {
     driver: &'a dyn IOPort,
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -32,7 +32,7 @@ pub trait IOPort: Sync {
     }
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone, Copy)]
 pub struct DefaultIOPort {}
 
 impl IOPort for DefaultIOPort {}

--- a/src/io.rs
+++ b/src/io.rs
@@ -5,8 +5,9 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 
 use core::arch::asm;
+use core::fmt::Debug;
 
-pub trait IOPort: Sync {
+pub trait IOPort: Sync + Debug {
     fn outb(&self, port: u16, value: u8) {
         unsafe { asm!("outb %al, %dx", in("al") value, in("dx") port, options(att_syntax)) }
     }

--- a/src/kernel_launch.rs
+++ b/src/kernel_launch.rs
@@ -4,7 +4,7 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct KernelLaunchInfo {
     /// Start of the kernel in physical memory.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 
 #![no_std]
 #![deny(missing_copy_implementations)]
+#![deny(missing_debug_implementations)]
 #![cfg_attr(all(test, test_in_svsm), no_main)]
 #![cfg_attr(all(test, test_in_svsm), feature(custom_test_frameworks))]
 #![cfg_attr(all(test, test_in_svsm), test_runner(crate::testing::svsm_test_runner))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 // Author: Nicolai Stange <nstange@suse.de>
 
 #![no_std]
+#![deny(missing_copy_implementations)]
 #![cfg_attr(all(test, test_in_svsm), no_main)]
 #![cfg_attr(all(test, test_in_svsm), feature(custom_test_frameworks))]
 #![cfg_attr(all(test, test_in_svsm), test_runner(crate::testing::svsm_test_runner))]

--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -228,7 +228,7 @@ impl Page {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct MemInfo {
     total_pages: [usize; MAX_ORDER],
     free_pages: [usize; MAX_ORDER],

--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -1282,8 +1282,9 @@ static TEST_ROOT_MEM_LOCK: SpinLock<()> = SpinLock::new(());
 #[cfg(test)]
 pub const DEFAULT_TEST_MEMORY_SIZE: usize = 16usize * 1024 * 1024;
 
-#[cfg(any(test, fuzzing))]
 /// A dummy struct to acquire a lock over global memory
+#[cfg(any(test, fuzzing))]
+#[derive(Debug)]
 pub struct TestRootMem<'a>(LockGuard<'a, ()>);
 
 #[cfg(any(test, fuzzing))]

--- a/src/mm/guestmem.rs
+++ b/src/mm/guestmem.rs
@@ -171,6 +171,7 @@ unsafe fn do_movsb<T>(src: *const T, dst: *mut T) -> Result<(), SvsmError> {
     }
 }
 
+#[derive(Debug)]
 pub struct GuestPtr<T>
 where
     T: Sized + Copy,

--- a/src/mm/pagetable.rs
+++ b/src/mm/pagetable.rs
@@ -179,6 +179,7 @@ impl IndexMut<usize> for PTPage {
     }
 }
 
+#[derive(Debug)]
 pub enum Mapping<'a> {
     Level3(&'a mut PTEntry),
     Level2(&'a mut PTEntry),

--- a/src/mm/ptguards.rs
+++ b/src/mm/ptguards.rs
@@ -14,6 +14,7 @@ use crate::mm::virtualrange::{
 };
 use crate::types::{PAGE_SIZE, PAGE_SIZE_2M};
 
+#[derive(Debug)]
 struct RawPTMappingGuard {
     start: VirtAddr,
     end: VirtAddr,
@@ -25,6 +26,7 @@ impl RawPTMappingGuard {
     }
 }
 
+#[derive(Debug)]
 #[must_use = "if unused the mapping will immediately be unmapped"]
 pub struct PerCPUPageMappingGuard {
     mapping: Option<RawPTMappingGuard>,

--- a/src/mm/vm/mapping/phys_mem.rs
+++ b/src/mm/vm/mapping/phys_mem.rs
@@ -10,7 +10,7 @@ use crate::mm::pagetable::PTEntryFlags;
 use super::{Mapping, VirtualMapping};
 
 /// Map physically contiguous memory
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone, Copy)]
 pub struct VMPhysMem {
     /// Physical base address to map
     base: PhysAddr,

--- a/src/mm/vm/mapping/reserved.rs
+++ b/src/mm/vm/mapping/reserved.rs
@@ -12,7 +12,7 @@ use super::{Mapping, VirtualMapping};
 /// Reserve a region of address space so that no other mapping will be
 /// established there. The map function for this type will always return
 /// `None`.
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone, Copy)]
 pub struct VMReserved {
     /// Size in bytes to reserve. Must be aligned to PAGE_SIZE
     size: usize,

--- a/src/protocols/mod.rs
+++ b/src/protocols/mod.rs
@@ -9,7 +9,7 @@ pub mod errors;
 
 use crate::sev::vmsa::{GuestVMExit, VMSA};
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct RequestParams {
     pub guest_exit_code: GuestVMExit,
     sev_features: u64,

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -32,6 +32,7 @@ pub trait Terminal: Sync {
     }
 }
 
+#[derive(Debug)]
 pub struct SerialPort<'a> {
     pub driver: &'a dyn IOPort,
     pub port: u16,

--- a/src/sev/ghcb.rs
+++ b/src/sev/ghcb.rs
@@ -41,14 +41,14 @@ const OFF_VERSION: u16 = 0xffa;
 const OFF_USAGE: u16 = 0xffc;
 
 #[repr(C, packed)]
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct PageStateChangeHeader {
     cur_entry: u16,
     end_entry: u16,
     reserved: u32,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum PageStateChangeOp {
     PscPrivate,
     PscShared,
@@ -126,6 +126,7 @@ impl GHCBExitCode {
     pub const RUN_VMPL: u64 = 0x80000018;
 }
 
+#[derive(Clone, Copy)]
 pub enum GHCBIOSize {
     Size8,
     Size16,

--- a/src/sev/ghcb.rs
+++ b/src/sev/ghcb.rs
@@ -70,6 +70,7 @@ const PSC_FLAG_HUGE: u64 = 1 << PSC_FLAG_HUGE_SHIFT;
 const GHCB_BUFFER_SIZE: usize = 0x7f0;
 
 #[repr(C, packed)]
+#[derive(Debug)]
 pub struct GHCB {
     reserved_1: [u8; 0xcb],
     cpl: u8,
@@ -126,7 +127,7 @@ impl GHCBExitCode {
     pub const RUN_VMPL: u64 = 0x80000018;
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum GHCBIOSize {
     Size8,
     Size16,

--- a/src/sev/msr_protocol.rs
+++ b/src/sev/msr_protocol.rs
@@ -26,7 +26,7 @@ impl From<GhcbMsrError> for SvsmError {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 pub enum GHCBMsr {}
 

--- a/src/sev/msr_protocol.rs
+++ b/src/sev/msr_protocol.rs
@@ -26,6 +26,7 @@ impl From<GhcbMsrError> for SvsmError {
     }
 }
 
+#[derive(Clone, Copy)]
 #[non_exhaustive]
 pub enum GHCBMsr {}
 

--- a/src/sev/secrets_page.rs
+++ b/src/sev/secrets_page.rs
@@ -7,7 +7,7 @@
 use crate::address::VirtAddr;
 use crate::sev::vmsa::VMPL_MAX;
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 #[repr(C, packed)]
 pub struct SecretsPage {
     pub version: u32,

--- a/src/sev/vmsa.rs
+++ b/src/sev/vmsa.rs
@@ -62,6 +62,7 @@ pub struct VMSASegment {
 }
 
 #[repr(C, packed)]
+#[derive(Debug)]
 pub struct VMSA {
     pub es: VMSASegment,
     pub cs: VMSASegment,

--- a/src/sev/vmsa.rs
+++ b/src/sev/vmsa.rs
@@ -53,7 +53,7 @@ pub enum GuestVMExit {
 }
 
 #[repr(C, packed)]
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct VMSASegment {
     pub selector: u16,
     pub flags: u16,

--- a/src/svsm_console.rs
+++ b/src/svsm_console.rs
@@ -9,7 +9,7 @@ use crate::io::IOPort;
 use crate::sev::ghcb::GHCBIOSize;
 use crate::sev::msr_protocol::request_termination_msr;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct SVSMIOPort {}
 
 impl SVSMIOPort {

--- a/src/svsm_console.rs
+++ b/src/svsm_console.rs
@@ -9,6 +9,7 @@ use crate::io::IOPort;
 use crate::sev::ghcb::GHCBIOSize;
 use crate::sev::msr_protocol::request_termination_msr;
 
+#[derive(Clone, Copy)]
 pub struct SVSMIOPort {}
 
 impl SVSMIOPort {

--- a/src/task/tasks.rs
+++ b/src/task/tasks.rs
@@ -125,7 +125,7 @@ impl TaskRuntime for TscRuntime {
 
 /// Tracks task runtime based on the number of times the task has been
 /// scheduled
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone, Copy)]
 #[repr(transparent)]
 pub struct CountRuntime {
     count: u64,
@@ -159,7 +159,7 @@ impl TaskRuntime for CountRuntime {
 type TaskRuntimeImpl = CountRuntime;
 
 #[repr(C)]
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone, Copy)]
 pub struct TaskContext {
     pub regs: X86GeneralRegs,
     pub flags: u64,

--- a/src/utils/bitmap_allocator.rs
+++ b/src/utils/bitmap_allocator.rs
@@ -22,7 +22,7 @@ pub trait BitmapAllocator {
 
 pub type BitmapAllocator1024 = BitmapAllocatorTree<BitmapAllocator64>;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct BitmapAllocator64 {
     bits: u64,
 }

--- a/src/utils/immut_after_init.rs
+++ b/src/utils/immut_after_init.rs
@@ -66,6 +66,7 @@ pub enum ImmutAfterInitError {
 /// }
 /// ```
 ///
+#[derive(Debug)]
 pub struct ImmutAfterInitCell<T> {
     #[doc(hidden)]
     data: UnsafeCell<MaybeUninit<T>>,
@@ -221,6 +222,7 @@ unsafe impl<T> Sync for ImmutAfterInitCell<T> {}
 /// }
 /// ```
 ///
+#[derive(Debug)]
 pub struct ImmutAfterInitRef<'a, T: 'a> {
     #[doc(hidden)]
     ptr: ImmutAfterInitCell<*const T>,


### PR DESCRIPTION
* Add missing `Copy` derives, plus a lint to prevent their absence in the future.
* Add missing `Debug` derives, plus a lint to prevent their absence in the future.