### PR TITLE
cpu/vc,idt: drop debug support in stage2

### DIFF
--- a/src/cpu/idt/stage2.rs
+++ b/src/cpu/idt/stage2.rs
@@ -4,12 +4,11 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
-use super::common::{load_idt, Idt, IdtEntry, BP_VECTOR, DF_VECTOR, GLOBAL_IDT, VC_VECTOR};
+use super::common::{load_idt, Idt, IdtEntry, DF_VECTOR, GLOBAL_IDT, VC_VECTOR};
 use crate::address::VirtAddr;
 use crate::cpu::control_regs::read_cr2;
 use crate::cpu::vc::{stage2_handle_vc_exception, stage2_handle_vc_exception_no_ghcb};
 use crate::cpu::X86ExceptionContext;
-use crate::debug::gdbstub::svsm_gdbstub::handle_debug_exception;
 use core::arch::global_asm;
 
 fn init_idt(idt: &mut Idt, handler_array: *const u8) {
@@ -50,7 +49,6 @@ pub extern "C" fn stage2_generic_idt_handler(ctx: &mut X86ExceptionContext) {
             );
         }
         VC_VECTOR => stage2_handle_vc_exception(ctx),
-        BP_VECTOR => handle_debug_exception(ctx, ctx.vector),
         _ => {
             let err = ctx.error_code;
             let vec = ctx.vector;
@@ -77,7 +75,6 @@ pub extern "C" fn stage2_generic_idt_handler_no_ghcb(ctx: &mut X86ExceptionConte
             );
         }
         VC_VECTOR => stage2_handle_vc_exception_no_ghcb(ctx),
-        BP_VECTOR => handle_debug_exception(ctx, ctx.vector),
         _ => {
             let err = ctx.error_code;
             let vec = ctx.vector;

--- a/src/cpu/vc.rs
+++ b/src/cpu/vc.rs
@@ -69,9 +69,6 @@ pub fn stage2_handle_vc_exception_no_ghcb(ctx: &mut X86ExceptionContext) {
     let insn = vc_decode_insn(ctx).expect("Could not decode instructions");
 
     match err {
-        // If the debugger is enabled then handle the DB exception
-        // by directly invoking the exception handler
-        X86_TRAP_DB => handle_db_exception(ctx),
         SVM_EXIT_CPUID => handle_cpuid(ctx).expect("Could not handle CPUID #VC exception"),
         _ => {
             panic!(
@@ -99,12 +96,6 @@ pub fn stage2_handle_vc_exception(ctx: &mut X86ExceptionContext) {
     let insn = vc_decode_insn(ctx).expect("Could not decode instructions");
 
     match err {
-        // If the debugger is enabled then handle the DB exception
-        // by directly invoking the exception handler
-        X86_TRAP_DB => {
-            handle_db_exception(ctx);
-        }
-
         SVM_EXIT_CPUID => handle_cpuid(ctx).expect("Could not handle CPUID #VC exception"),
         SVM_EXIT_IOIO => {
             handle_ioio(ctx, ghcb, &insn).expect("Could not handle IOIO #VC exception")


### PR DESCRIPTION
The #VC handler added in stage 2 breaks the gdb-enabled builds due to a too big stage 2 binary.

Breakpoints handling in stage 2 is breaking, and useless so we can drop the handler function calls so that gdbstub code is not included in stage 2 binary.