### PR TITLE
Draft: Add support for loadable modules at CPL-3

### DIFF
--- a/src/cpu/gdt.rs
+++ b/src/cpu/gdt.rs
@@ -21,11 +21,14 @@ const GDT_SIZE: u16 = 8;
 
 static mut GDT: [u64; GDT_SIZE as usize] = [
     0,
-    0x00af9a000000ffff, // 64-bit code segment
-    0x00cf92000000ffff, // 64-bit data segment
-    0,                  // Reserved for User code
-    0,                  // Reserver for User data
-    0,                  // Reverved
+    0x00af9a000000ffff, // 64-bit CPL=0 code segment
+    0x00cf92000000ffff, // 64-bit CPL=0 data segment
+    // The layout of the CPL-3 entries is dictated by the requirements of
+    // the STAR MSR (C000_0081h). See 6.1.1 in the AMD64 Architecture
+    // Programmer's Manual Volume 2.
+    0,                  // 32-bit CPL=3 code (unused)
+    0x00cff2000000ffff, // 64-bit CPL=3 data segment
+    0x00affa000000ffff, // 64-bit CPL=3 code segment
     0,                  // TSS
     0,                  // TSS continued
 ];

--- a/src/cpu/smp.rs
+++ b/src/cpu/smp.rs
@@ -70,6 +70,7 @@ fn start_ap() {
     // Create the task making sure the task only runs on this new AP
     create_task(
         ap_request_loop,
+        0,
         TASK_FLAG_SHARE_PT,
         Some(this_cpu().get_apic_id()),
     )
@@ -77,7 +78,7 @@ fn start_ap() {
 }
 
 #[no_mangle]
-pub extern "C" fn ap_request_loop() {
+pub extern "C" fn ap_request_loop(_param: u64) {
     request_loop();
     panic!("Returned from request_loop!");
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,8 +35,10 @@ pub enum SvsmError {
     Acpi,
     // Errors from file systems
     FileSystem(FsError),
-    // Task management errors,
+    // Task management errors
     Task(TaskError),
     // Errors from #VC handler
     Vc(VcError),
+    // Errors related to modules
+    Module,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub mod io;
 pub mod kernel_launch;
 pub mod locking;
 pub mod mm;
+pub mod module;
 pub mod protocols;
 pub mod requests;
 pub mod serial;

--- a/src/mm/address_space.rs
+++ b/src/mm/address_space.rs
@@ -153,3 +153,15 @@ pub const SVSM_PERTASK_END: VirtAddr = SVSM_PERTASK_BASE.const_add(SIZE_LEVEL3);
 
 /// Kernel stack for a task
 pub const SVSM_PERTASK_STACK_BASE: VirtAddr = SVSM_PERTASK_BASE;
+
+/// Task CPL-3 mappings level 3 index
+pub const PGTABLE_LVL3_IDX_PERTASK_CPL3: usize = 0;
+
+/// Base address of task memory region
+pub const SVSM_PERTASK_BASE_CPL3: VirtAddr = virt_from_idx(PGTABLE_LVL3_IDX_PERTASK_CPL3);
+
+/// End address of task memory region
+pub const SVSM_PERTASK_END_CPL3: VirtAddr = SVSM_PERTASK_BASE_CPL3.const_add(SIZE_LEVEL3);
+
+/// User stack for a task
+pub const SVSM_PERTASK_STACK_BASE_CPL3: VirtAddr = SVSM_PERTASK_BASE_CPL3;

--- a/src/mm/mod.rs
+++ b/src/mm/mod.rs
@@ -11,6 +11,7 @@ pub mod memory;
 pub mod pagetable;
 pub mod ptguards;
 pub mod stack;
+pub mod taskmem;
 pub mod validate;
 pub mod virtualrange;
 pub mod vm;

--- a/src/mm/taskmem.rs
+++ b/src/mm/taskmem.rs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2022-2023 SUSE LLC
+//
+// Author: Roy Hopkins <rhopkins@suse.de>
+
+use crate::{
+    address::VirtAddr, cpu::percpu::this_cpu, error::SvsmError, task::TaskError, types::PAGE_SIZE,
+};
+
+/**
+ * Allocate a virtual address range. The range is not mapped
+ * to any physical address.
+ */
+pub fn valloc(size: usize) -> Result<VirtAddr, SvsmError> {
+    // Align size up to next page boundary
+    let size = (size + PAGE_SIZE - 1) & !(PAGE_SIZE - 1);
+    let t = this_cpu()
+        .runqueue()
+        .lock_read()
+        .current_task()
+        .ok_or(SvsmError::Task(TaskError::NotInitialised))?;
+    let result = t.task.lock_write().virtual_alloc(size, 0);
+    result
+}
+
+pub fn vfree(addr: VirtAddr, size: usize) {
+    let t = this_cpu()
+        .runqueue()
+        .lock_read()
+        .current_task()
+        .expect("The task system has not been initialised");
+    t.task.lock_write().virtual_free(addr, size);
+}

--- a/src/mm/vm/mapping/mod.rs
+++ b/src/mm/vm/mapping/mod.rs
@@ -10,6 +10,7 @@ pub mod kernel_stack;
 pub mod phys_mem;
 pub mod rawalloc;
 pub mod reserved;
+pub mod user_stack;
 pub mod vmalloc;
 
 pub use api::{Mapping, VMMAdapter, VMPageFaultResolution, VirtualMapping, VMM};
@@ -18,4 +19,5 @@ pub use kernel_stack::VMKernelStack;
 pub use phys_mem::VMPhysMem;
 pub use rawalloc::RawAllocMapping;
 pub use reserved::VMReserved;
+pub use user_stack::VMUserStack;
 pub use vmalloc::VMalloc;

--- a/src/mm/vm/mapping/user_stack.rs
+++ b/src/mm/vm/mapping/user_stack.rs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2022-2023 SUSE LLC
+//
+// Author: Joerg Roedel <jroedel@suse.de>
+// Author: Roy Hopkins <rhopkins@suse.de>
+
+use super::VirtualMapping;
+use crate::address::{PhysAddr, VirtAddr};
+use crate::error::SvsmError;
+use crate::mm::address_space::STACK_SIZE;
+use crate::mm::pagetable::PTEntryFlags;
+use crate::types::{PAGE_SHIFT, PAGE_SIZE};
+use crate::utils::page_align_up;
+
+use super::rawalloc::RawAllocMapping;
+use super::Mapping;
+
+/// Mapping to be used as a user mode stack. This maps a stack including guard
+/// pages at the top and bottom.
+#[derive(Default, Debug)]
+pub struct VMUserStack {
+    /// Allocation for stack pages
+    alloc: RawAllocMapping,
+    /// Number of guard pages to reserve address space for
+    guard_pages: usize,
+}
+
+impl VMUserStack {
+    /// Returns the virtual address for the top of this user mode stack
+    ///
+    /// # Arguments
+    ///
+    /// * `base` - Virtual base address this stack is mapped at (including
+    ///            guard pages).
+    ///
+    /// # Returns
+    ///
+    /// Virtual address to program into the hardware stack register
+    pub fn top_of_stack(&self, base: VirtAddr) -> VirtAddr {
+        let guard_size = self.guard_pages * PAGE_SIZE;
+        base + guard_size + self.alloc.mapping_size()
+    }
+
+    /// Create a new [`VMUserStack`] with a given size. This function will
+    /// already allocate the backing pages for the stack.
+    ///
+    /// # Arguments
+    ///
+    /// * `size` - Size of the user stack, without guard pages
+    ///
+    /// # Returns
+    ///
+    /// Initialized stack on success, Err(SvsmError::Mem) on error
+    pub fn new_size(size: usize) -> Result<Self, SvsmError> {
+        // Make sure size is page-aligned
+        let size = page_align_up(size);
+        // At least two guard-pages needed
+        let total_size = (size + 2 * PAGE_SIZE).next_power_of_two();
+        let guard_pages = ((total_size - size) >> PAGE_SHIFT) / 2;
+        let mut stack = VMUserStack {
+            alloc: RawAllocMapping::new(size),
+            guard_pages,
+        };
+        stack.alloc_pages()?;
+
+        Ok(stack)
+    }
+
+    /// Create a new [`VMUserStack`] with the default size. This function
+    /// will already allocate the backing pages for the stack.
+    ///
+    /// # Returns
+    ///
+    /// Initialized stack on success, Err(SvsmError::Mem) on error
+    pub fn new() -> Result<Self, SvsmError> {
+        VMUserStack::new_size(STACK_SIZE)
+    }
+
+    /// Create a new [`VMUserStack`] with the default size, packed into a
+    /// [`Mapping`]. This function / will already allocate the backing pages for
+    /// the stack.
+    ///
+    /// # Returns
+    ///
+    /// Initialized Mapping to stack on success, Err(SvsmError::Mem) on error
+    pub fn new_mapping() -> Result<Mapping, SvsmError> {
+        Ok(Mapping::new(Self::new()?))
+    }
+
+    fn alloc_pages(&mut self) -> Result<(), SvsmError> {
+        self.alloc.alloc_pages()
+    }
+}
+
+impl VirtualMapping for VMUserStack {
+    fn mapping_size(&self) -> usize {
+        self.alloc.mapping_size() + ((self.guard_pages * 2) << PAGE_SHIFT)
+    }
+
+    fn map(&self, offset: usize) -> Option<PhysAddr> {
+        let pfn = offset >> PAGE_SHIFT;
+        let guard_offset = self.guard_pages << PAGE_SHIFT;
+
+        if pfn >= self.guard_pages {
+            self.alloc.map(offset - guard_offset)
+        } else {
+            None
+        }
+    }
+
+    fn unmap(&self, offset: usize) {
+        let pfn = offset >> PAGE_SHIFT;
+
+        if pfn >= self.guard_pages {
+            self.alloc.unmap(pfn - self.guard_pages);
+        }
+    }
+
+    fn pt_flags(&self, _offset: usize) -> PTEntryFlags {
+        PTEntryFlags::WRITABLE
+            | PTEntryFlags::NX
+            | PTEntryFlags::ACCESSED
+            | PTEntryFlags::DIRTY
+            | PTEntryFlags::USER
+    }
+}

--- a/src/mm/vm/mod.rs
+++ b/src/mm/vm/mod.rs
@@ -9,6 +9,6 @@ mod range;
 
 pub use mapping::{
     Mapping, RawAllocMapping, VMFileMapping, VMFileMappingPermission, VMKernelStack, VMMAdapter,
-    VMPhysMem, VMReserved, VMalloc, VirtualMapping, VMM,
+    VMPhysMem, VMReserved, VMUserStack, VMalloc, VirtualMapping, VMM,
 };
 pub use range::{VMRMapping, VMR, VMR_GRANULE};

--- a/src/mm/vm/range.rs
+++ b/src/mm/vm/range.rs
@@ -449,6 +449,15 @@ impl<'a> VMRMapping<'a> {
         Ok(Self { vmr, va })
     }
 
+    pub fn new_at(
+        vmr: &'a mut VMR,
+        mapping: Arc<Mapping>,
+        va: VirtAddr,
+    ) -> Result<Self, SvsmError> {
+        let va = vmr.insert_at(va, mapping)?;
+        Ok(Self { vmr, va })
+    }
+
     pub fn virt_addr(&self) -> VirtAddr {
         self.va
     }

--- a/src/module/loader.rs
+++ b/src/module/loader.rs
@@ -47,7 +47,7 @@ impl ModuleLoader {
 #[derive(Debug)]
 pub struct Module {
     file_segments: Vec<(VirtAddr, Arc<Mapping>)>,
-    entry_point: extern "C" fn(),
+    entry_point: extern "C" fn(u64),
     task_node: Option<Arc<TaskNode>>,
 }
 
@@ -59,7 +59,7 @@ struct SegmentInfo {
 }
 
 impl Module {
-    pub fn entry_point(&self) -> extern "C" fn() {
+    pub fn entry_point(&self) -> extern "C" fn(u64) {
         self.entry_point
     }
 
@@ -72,7 +72,7 @@ impl Module {
         Ok(())
     }
 
-    fn get_segment_info(path: &str) -> Result<(extern "C" fn(), Vec<SegmentInfo>), SvsmError> {
+    fn get_segment_info(path: &str) -> Result<(extern "C" fn(u64), Vec<SegmentInfo>), SvsmError> {
         // Temporarily map the file's physical memory into the percpu virtual address space
         let file = open(path)?;
         let file_size = file.size();

--- a/src/module/loader.rs
+++ b/src/module/loader.rs
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2022-2023 SUSE LLC
+//
+// Author: Roy Hopkins <rhopkins@suse.de>
+
+extern crate alloc;
+
+use crate::address::VirtAddr;
+use crate::cpu::percpu::this_cpu_mut;
+use crate::elf;
+use crate::error::SvsmError;
+use crate::fs::{list_dir, open};
+use crate::mm::vm::{Mapping, VMFileMapping, VMFileMappingPermission};
+use crate::task::{create_task_for_module, TaskNode};
+use alloc::string::String;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+
+#[derive(Debug)]
+pub struct ModuleLoader {
+    pub modules: Vec<Module>,
+}
+
+impl ModuleLoader {
+    pub fn enumerate() -> Result<Self, SvsmError> {
+        let mut modules: Vec<Module> = Vec::new();
+
+        let module_files = list_dir("/modules")?;
+        for module in module_files {
+            let path = String::from("/modules/") + &module.as_str();
+            // Each module is an ELF file
+            let module = Module::load(path.as_str());
+            match module {
+                Ok(mut m) => {
+                    create_task_for_module(&mut m, 0, None)?;
+                    modules.push(m);
+                    log::info!("Module {} loaded ok", path);
+                }
+                Err(_) => log::info!("Module {} load failed", path),
+            }
+        }
+        Ok(Self { modules })
+    }
+}
+
+#[derive(Debug)]
+pub struct Module {
+    file_segments: Vec<(VirtAddr, Arc<Mapping>)>,
+    entry_point: extern "C" fn(),
+    task_node: Option<Arc<TaskNode>>,
+}
+
+struct SegmentInfo {
+    vaddr: VirtAddr,
+    file_offset: usize,
+    size: usize,
+    flags: VMFileMappingPermission,
+}
+
+impl Module {
+    pub fn entry_point(&self) -> extern "C" fn() {
+        self.entry_point
+    }
+
+    pub fn assign(&mut self, task_node: Arc<TaskNode>) -> Result<(), SvsmError> {
+        self.task_node = Some(task_node.clone());
+        let mut task = task_node.task.lock_write();
+        for (vaddr, segment) in &self.file_segments {
+            task.vmr_user().insert_at(*vaddr, segment.clone())?;
+        }
+        Ok(())
+    }
+
+    fn get_segment_info(path: &str) -> Result<(extern "C" fn(), Vec<SegmentInfo>), SvsmError> {
+        // Temporarily map the file's physical memory into the percpu virtual address space
+        let file = open(path)?;
+        let file_size = file.size();
+        let file_mapping = Arc::new(Mapping::new(VMFileMapping::new(
+            file,
+            0,
+            file_size,
+            crate::mm::vm::VMFileMappingPermission::Read,
+        )?));
+        let mapping = this_cpu_mut().new_mapping(file_mapping)?;
+
+        let buf =
+            unsafe { core::slice::from_raw_parts_mut(mapping.virt_addr().as_mut_ptr(), file_size) };
+
+        let elf = match elf::Elf64File::read(buf) {
+            Ok(elf) => elf,
+            Err(_) => return Err(SvsmError::Module),
+        };
+        let default_base = elf.default_base();
+        let entry_point = unsafe { core::mem::transmute(elf.get_entry(default_base) as *const ()) };
+
+        let mut info = Vec::<SegmentInfo>::new();
+
+        // Setup the pagetable for the virtual memory ranges described in the file
+        for segment in elf.image_load_segment_iter(default_base) {
+            let vaddr_start = VirtAddr::from(segment.vaddr_range.vaddr_begin);
+            let flags = if segment.flags.contains(elf::Elf64PhdrFlags::EXECUTE) {
+                VMFileMappingPermission::Execute
+            } else if segment.flags.contains(elf::Elf64PhdrFlags::WRITE) {
+                VMFileMappingPermission::Write
+            } else {
+                VMFileMappingPermission::Read
+            };
+
+            info.push(SegmentInfo {
+                vaddr: vaddr_start,
+                file_offset: segment.file_range.offset_begin,
+                size: segment.file_range.offset_end - segment.file_range.offset_begin,
+                flags,
+            });
+        }
+        Ok((entry_point, info))
+    }
+
+    fn load(path: &str) -> Result<Self, SvsmError> {
+        let (entry_point, segments) = Module::get_segment_info(path)?;
+        let mut file_segments = Vec::<(VirtAddr, Arc<Mapping>)>::new();
+        for seg in segments {
+            let file = open(path)?;
+            let mapping = Arc::new(Mapping::new(VMFileMapping::new(
+                file,
+                seg.file_offset,
+                seg.size,
+                seg.flags,
+            )?));
+            file_segments.push((seg.vaddr, mapping));
+        }
+
+        Ok(Module {
+            file_segments,
+            entry_point,
+            task_node: None,
+        })
+    }
+}

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2022-2023 SUSE LLC
+//
+// Author: Roy Hopkins <rhopkins@suse.de>
+
+mod loader;
+
+pub use loader::{Module, ModuleLoader};

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -407,6 +407,7 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
     // Create the root task that runs the entry point then handles the request loop
     create_task(
         svsm_main,
+        0,
         TASK_FLAG_SHARE_PT,
         Some(this_cpu().get_apic_id()),
     )
@@ -416,7 +417,7 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
 }
 
 #[no_mangle]
-pub extern "C" fn svsm_main() {
+pub extern "C" fn svsm_main(_param: u64) {
     // If required, the GDB stub can be started earlier, just after the console
     // is initialised in svsm_start() above.
     gdbstub_start().expect("Could not start GDB stub");

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -48,7 +48,7 @@ use svsm::sev::sev_status_init;
 use svsm::sev::utils::{rmp_adjust, RMPFlags};
 use svsm::svsm_console::SVSMIOPort;
 use svsm::svsm_paging::{init_page_table, invalidate_stage2};
-use svsm::task::{create_task, TASK_FLAG_SHARE_PT};
+use svsm::task::{create_task, init_syscall, TASK_FLAG_SHARE_PT};
 use svsm::types::{PageSize, GUEST_VMPL, PAGE_SIZE};
 use svsm::utils::{halt, immut_after_init::ImmutAfterInitCell, zero_mem_region, MemoryRegion};
 
@@ -435,6 +435,8 @@ pub extern "C" fn svsm_main(_param: u64) {
 
     populate_ram_fs(LAUNCH_INFO.kernel_fs_start, LAUNCH_INFO.kernel_fs_end)
         .expect("Failed to unpack FS archive");
+
+    init_syscall();
 
     ModuleLoader::enumerate().expect("Failed to initialise loadable modules");
 

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -39,6 +39,7 @@ use svsm::mm::memory::init_memory_map;
 use svsm::mm::pagetable::paging_init;
 use svsm::mm::virtualrange::virt_log_usage;
 use svsm::mm::{init_kernel_mapping_info, PerCPUPageMappingGuard, SIZE_1G};
+use svsm::module::ModuleLoader;
 use svsm::requests::{request_loop, update_mappings};
 use svsm::serial::SerialPort;
 use svsm::serial::SERIAL_PORT;
@@ -433,6 +434,8 @@ pub extern "C" fn svsm_main() {
 
     populate_ram_fs(LAUNCH_INFO.kernel_fs_start, LAUNCH_INFO.kernel_fs_end)
         .expect("Failed to unpack FS archive");
+
+    ModuleLoader::enumerate().expect("Failed to initialise loadable modules");
 
     let cpus = load_acpi_cpu_info(&fw_cfg).expect("Failed to load ACPI tables");
     let mut nr_cpus = 0;

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -8,6 +8,7 @@ mod schedule;
 mod tasks;
 
 pub use schedule::{
-    create_task, is_current_task, schedule, RunQueue, TaskNode, TaskPointer, TASKLIST,
+    create_task, create_task_for_module, is_current_task, schedule, RunQueue, TaskNode,
+    TaskPointer, TASKLIST,
 };
 pub use tasks::{Task, TaskContext, TaskError, TaskState, INITIAL_TASK_ID, TASK_FLAG_SHARE_PT};

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -5,10 +5,12 @@
 // Author: Roy Hopkins <rhopkins@suse.de>
 
 mod schedule;
+mod syscall;
 mod tasks;
 
 pub use schedule::{
     create_task, create_task_for_module, is_current_task, schedule, RunQueue, TaskNode,
     TaskPointer, TASKLIST,
 };
+pub use syscall::init_syscall;
 pub use tasks::{Task, TaskContext, TaskError, TaskState, INITIAL_TASK_ID, TASK_FLAG_SHARE_PT};

--- a/src/task/schedule.rs
+++ b/src/task/schedule.rs
@@ -328,11 +328,12 @@ fn task_switch_hook(_: &Task) {
 }
 
 pub fn create_task(
-    entry: extern "C" fn(),
+    entry: extern "C" fn(u64),
+    param: u64,
     flags: u16,
     affinity: Option<u32>,
 ) -> Result<TaskPointer, SvsmError> {
-    let mut task = Task::create(entry, flags)?;
+    let mut task = Task::create(entry, param, flags)?;
     task.set_affinity(affinity);
     task.set_on_switch_hook(Some(task_switch_hook));
     let node = Arc::new(TaskNode {
@@ -356,7 +357,7 @@ pub fn create_task_for_module(
     flags: u16,
     affinity: Option<u32>,
 ) -> Result<(), SvsmError> {
-    let mut task = Task::create(module.entry_point(), flags)?;
+    let mut task = Task::create(module.entry_point(), 0, flags)?;
     task.set_affinity(affinity);
     task.set_on_switch_hook(Some(task_switch_hook));
 

--- a/src/task/schedule.rs
+++ b/src/task/schedule.rs
@@ -357,7 +357,7 @@ pub fn create_task_for_module(
     flags: u16,
     affinity: Option<u32>,
 ) -> Result<(), SvsmError> {
-    let mut task = Task::create(module.entry_point(), 0, flags)?;
+    let mut task = Task::user_create(module.entry_point(), 0, flags)?;
     task.set_affinity(affinity);
     task.set_on_switch_hook(Some(task_switch_hook));
 

--- a/src/task/syscall.rs
+++ b/src/task/syscall.rs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2022-2023 SUSE LLC
+//
+// Author: Roy Hopkins <rhopkins@suse.de>
+
+use core::{
+    arch::global_asm,
+    ffi::{c_char, CStr},
+};
+
+use crate::cpu::{
+    efer::{read_efer, write_efer, EFERFlags},
+    msr::write_msr,
+    percpu::this_cpu,
+};
+use crate::types::{SVSM_CS, SVSM_USER_CS32};
+
+use super::schedule;
+
+pub enum SyscallRet {
+    Ok,
+    Unknown,
+    Terminate,
+}
+
+extern "C" {
+    static syscall_entry: u64;
+}
+
+const MSR_STAR: u32 = 0xc000_0081;
+const MSR_LSTAR: u32 = 0xc000_0082;
+const MSR_SFMASK: u32 = 0xc000_0084;
+
+#[no_mangle]
+extern "C" fn syscall_handler(index: u32, param1: u64) -> u64 {
+    let ret = match index {
+        // exit
+        0 => SyscallRet::Terminate,
+        // log
+        1 => {
+            unsafe {
+                let str = CStr::from_ptr(param1 as *const c_char);
+                log::info!("{}", str.to_str().unwrap());
+            }
+            SyscallRet::Ok
+        }
+        // sleep
+        2 => SyscallRet::Ok,
+        _ => {
+            log::info!("Invalid syscall received: {}", index);
+            SyscallRet::Unknown
+        }
+    };
+    schedule();
+    ret as u64
+}
+
+pub fn init_syscall() {
+    let mut efer = read_efer();
+    efer.insert(EFERFlags::SCE);
+    write_efer(efer);
+
+    let sysret_cs = SVSM_USER_CS32 as u64;
+    let syscall_cs = SVSM_CS as u64;
+    write_msr(MSR_STAR, sysret_cs << 48 | syscall_cs << 32);
+    unsafe {
+        write_msr(MSR_LSTAR, (&syscall_entry as *const u64) as u64);
+    }
+    // FIXME: Find correct mask for flags
+    write_msr(MSR_SFMASK, 0);
+}
+
+#[no_mangle]
+extern "C" fn get_kernel_rsp() -> u64 {
+    let task_node = this_cpu()
+        .runqueue()
+        .lock_read()
+        .current_task()
+        .expect("Invalid current task");
+    let rsp = task_node
+        .task
+        .lock_read()
+        .user
+        .as_ref()
+        .expect("Syscall from kernel task")
+        .kernel_rsp;
+    rsp
+}
+
+global_asm!(
+    r#"
+        .text
+    syscall_entry:
+        // Switch to the task kernel stack
+        push    %rcx            // User-mode return address
+
+        // Syscall arguments
+        push    %rsi
+        push    %rdi
+
+        call    get_kernel_rsp
+        pop     %rdi
+        pop     %rsi
+
+        subq    $8, %rax
+        movq    %rsp, (%rax)
+        mov     %rax, %rsp
+
+        call    syscall_handler
+
+        // Check to see if the task requested termination
+        cmp     $2, %rax            // SyscallRet::Terminate
+        jne     ret_user
+
+        addq    $8, %rsp            // Skip user mode return address
+        // Kernel stack frame should now be within launch_user_entry()
+        ret
+
+    ret_user:
+        pop     %rsp
+        pop     %rcx
+        movq    $0x202, %r11
+        sysretq
+        "#,
+    options(att_syntax)
+);

--- a/src/task/tasks.rs
+++ b/src/task/tasks.rs
@@ -62,7 +62,7 @@ impl From<TaskError> for SvsmError {
 
 #[derive(Clone, Copy, Debug)]
 struct UserParams {
-    entry_point: usize,
+    entry_point: extern "C" fn(u64),
     param: u64,
 }
 
@@ -281,7 +281,11 @@ impl Task {
         Ok(task)
     }
 
-    pub fn user_create(entry: usize, param: u64, flags: u16) -> Result<Box<Task>, SvsmError> {
+    pub fn user_create(
+        entry: extern "C" fn(u64),
+        param: u64,
+        flags: u16,
+    ) -> Result<Box<Task>, SvsmError> {
         // Launch via the user-mode entry point
         let entry_param = Box::new(UserParams {
             entry_point: entry,

--- a/src/types.rs
+++ b/src/types.rs
@@ -29,8 +29,9 @@ impl From<PageSize> for usize {
 #[allow(clippy::identity_op)]
 pub const SVSM_CS: u16 = 1 * 8;
 pub const SVSM_DS: u16 = 2 * 8;
-pub const SVSM_USER_CS: u16 = 3 * 8;
+pub const SVSM_USER_CS32: u16 = 3 * 8;
 pub const SVSM_USER_DS: u16 = 4 * 8;
+pub const SVSM_USER_CS: u16 = 5 * 8;
 pub const SVSM_TSS: u16 = 6 * 8;
 
 pub const SVSM_CS_FLAGS: u16 = 0x29b;


### PR DESCRIPTION
This set of commits was created as an effort to determine the scope of work required to get to the stage where we can support ramfs loadable modules that can be run using coconut SVSM tasks at CPL-3.

This PR is based on an earlier effort, before the scheduler and file virtual memory mapping PRs were merged (#64 and #145). The content of these merged PRs grew out of the PoC work that can be found in this PR. The original work can be seen in this PR in my own repo: https://github.com/roy-hopkins/svsm/pull/2. Although now closed, there are a number of useful comments on that PR that need to be addressed if we decide to take any of this commits forward.

This PR adds support for enumerating ELF binaries packaged into the initial ramfs image, loading and parsing those binaries and creating user-mode tasks with the relevant segments of the ELF binary mapped to the requested per-task virtual address. The SYSCALL/SYSRET interface is initialised and used to switch to CPL-3 to call the module entry point. A very basic SYSCALL handler has been put into place to allow termination, logging and sleeping (context switch) from the CPL-3 module.

Treat this PR at this stage as incomplete work, or as a basis for picking out useful features and implementing as separate PRs. I have taken a few shortcuts and assumptions in order to get a full end-to-end CPL-3 module test working, particularly around handling stacks around the CPL switch. But please feel free to take a look, try it out and comment on this PR.

I have created a sample module here: https://github.com/roy-hopkins/svsm-module. The README.md for the sample module has details on how to build it and add it to the initial ramfs image.