### PR TITLE
debug: remove handle_db_exception

### DIFF
--- a/src/cpu/vc.rs
+++ b/src/cpu/vc.rs
@@ -8,7 +8,7 @@ use super::idt::common::X86ExceptionContext;
 use crate::cpu::cpuid::{cpuid_table_raw, CpuidLeaf};
 use crate::cpu::insn::{insn_fetch, Instruction};
 use crate::cpu::percpu::this_cpu_mut;
-use crate::debug::gdbstub::svsm_gdbstub::handle_db_exception;
+use crate::debug::gdbstub::svsm_gdbstub::handle_debug_exception;
 use crate::error::SvsmError;
 use crate::sev::ghcb::{GHCBIOSize, GHCB};
 use core::fmt;
@@ -128,7 +128,7 @@ pub fn handle_vc_exception(ctx: &mut X86ExceptionContext) {
     match error_code {
         // If the debugger is enabled then handle the DB exception
         // by directly invoking the exception handler
-        X86_TRAP_DB => handle_db_exception(ctx),
+        X86_TRAP_DB => handle_debug_exception(ctx, ctx.vector),
         SVM_EXIT_CPUID => handle_cpuid(ctx).expect("Could not handle CPUID #VC exception"),
         SVM_EXIT_IOIO => {
             handle_ioio(ctx, ghcb, &insn).expect("Could not handle IOIO #VC exception")

--- a/src/debug/gdbstub.rs
+++ b/src/debug/gdbstub.rs
@@ -15,7 +15,7 @@ pub mod svsm_gdbstub {
 
     use crate::address::{Address, VirtAddr};
     use crate::cpu::control_regs::read_cr3;
-    use crate::cpu::idt::common::{X86ExceptionContext, BP_VECTOR};
+    use crate::cpu::idt::common::{X86ExceptionContext, BP_VECTOR, VC_VECTOR};
     use crate::cpu::percpu::{this_cpu, this_cpu_mut};
     use crate::cpu::X86GeneralRegs;
     use crate::error::SvsmError;
@@ -72,13 +72,10 @@ pub mod svsm_gdbstub {
     pub fn handle_debug_exception(ctx: &mut X86ExceptionContext, exception: usize) {
         let tp = match exception {
             BP_VECTOR => ExceptionType::SwBreakpoint,
+            VC_VECTOR => ExceptionType::Debug,
             _ => ExceptionType::PageFault,
         };
         handle_exception(ctx, tp);
-    }
-
-    pub fn handle_db_exception(ctx: &mut X86ExceptionContext) {
-        handle_exception(ctx, ExceptionType::Debug);
     }
 
     fn handle_exception(ctx: &mut X86ExceptionContext, exception_type: ExceptionType) {


### PR DESCRIPTION
handle_db_exception was only used in the SVSM #VC handler. This function was calling handle_debug_exception under the hood.

We can remove handle_db_exception and integreate its logic into handle_debug_exception so that it remains only 1 debug exception handling function.