### PR TITLE
stage2: rename `push_regs` to `push_regs_stage2`

### DIFF
--- a/src/cpu/idt/stage2.rs
+++ b/src/cpu/idt/stage2.rs
@@ -135,7 +135,7 @@ global_asm!(
         
         /* Stage 2 handler array setup */
         .text
-    push_regs:
+    push_regs_stage2:
         pushq   %rax
         pushq   %rbx
         pushq   %rcx
@@ -167,7 +167,7 @@ global_asm!(
         pushq   $0
         .endif
         pushq   $i  /* Vector Number */
-        jmp push_regs
+        jmp push_regs_stage2
         i = i + 1
         .endr
     "#,


### PR DESCRIPTION
When building the fuzzing harnesses, rustc would complain that `push_regs` was defined twice. Fix this by renaming `push_regs` in stage 2 to `push_regs_stage2`.

```
error: symbol 'push_regs' is already defined
    |
note: instantiated into assembly here
   --> <inline asm>:105:5
    |
105 |     push_regs:
    |     ^

error: could not compile `svsm` (lib) due to previous error
```

This would happen because both symbols were declared globally in both binaries (svsm and stage2), and would both get included by the fuzzing harnesses, which depend on the whole svsm crate.