### PR TITLE
utils/tests: fix undefined behavior in `test_zero_mem_region()`

### DIFF
--- a/src/utils/util.rs
+++ b/src/utils/util.rs
@@ -87,8 +87,8 @@ mod tests {
     #[test]
     fn test_zero_mem_region() {
         let mut data: [u8; 10] = [1; 10];
-        let start = VirtAddr::new(&mut data[0] as *mut u8 as usize);
-        let end = start + 10;
+        let start = VirtAddr::from(data.as_mut_ptr());
+        let end = start + core::mem::size_of_val(&data);
 
         zero_mem_region(start, end);
 


### PR DESCRIPTION
Miri emits an error for `test_zero_mem_region()` (trace below) because `start` is a mutable reference only to the first element of the array, but we end up writing to the whole buffer, for which we do not have write access.

Take a mutable pointer to the whole buffer instead.

<details>

<summary>Miri trace</summary>

```
Miri error:

test utils::util::tests::test_zero_mem_region ... error: Undefined Behavior: attempting a write access using <wildcard> at alloc65762[0x1], but no exposed tags have suitable permission in the borrow stack for this location
  --> src/utils/util.rs:47:14
   |
47 |     unsafe { start.as_mut_ptr::<u8>().write_bytes(0, size) }
   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |              |
   |              attempting a write access using <wildcard> at alloc65762[0x1], but no exposed tags have suitable permission in the borrow stack for this location
   |              this error occurs as part of an access at alloc65762[0x0..0xa]
   |
   = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
   = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
   = note: BACKTRACE:
   = note: inside `utils::util::zero_mem_region` at src/utils/util.rs:47:14: 47:59
note: inside `utils::util::tests::test_zero_mem_region`
  --> src/utils/util.rs:93:9
   |
93 |         zero_mem_region(start, end);
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside closure
  --> src/utils/util.rs:88:30
   |
87 |     #[test]
   |     ------- in this procedural macro expansion
88 |     fn test_zero_mem_region() {
   |                              ^
   = note: this error originates in the attribute macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
```

</details>