### PR TITLE
fuzz: add x86 instructions decoder harness

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -50,3 +50,9 @@ name = "alloc"
 path = "fuzz_targets/alloc.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "insn"
+path = "fuzz_targets/insn.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/insn.rs
+++ b/fuzz/fuzz_targets/insn.rs
@@ -1,0 +1,18 @@
+#![no_main]
+
+use libfuzzer_sys::{fuzz_target, Corpus};
+use svsm::cpu::insn::{Instruction, MAX_INSN_SIZE};
+
+fuzz_target!(|input: &[u8]| -> Corpus {
+    let Some(input) = input.get(..MAX_INSN_SIZE) else {
+        return Corpus::Reject;
+    };
+
+    let mut data = [0u8; MAX_INSN_SIZE];
+    data.copy_from_slice(input);
+
+    let mut insn = Instruction::new(data);
+    let _ = core::hint::black_box(insn.decode());
+
+    Corpus::Keep
+});


### PR DESCRIPTION
The x86 instructions decoder is very convenient attack surface.

For the moment, the decoder code is only reachable from CPL-0, but it will be reachable from less privileged code when CPL-3 will be supported. The decoder is currently reachable from a #VC exception.