### PR TITLE
greq: bugfixes, layout correctness tests and other cleanups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,6 +269,7 @@ dependencies = [
  "gdbstub_arch",
  "intrusive-collections",
  "log",
+ "memoffset",
  "packit",
  "test",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,6 @@ test = { version = "0.1.0", path = "test" }
 default = ["enable-stacktrace"]
 enable-stacktrace = []
 enable-gdb = ["dep:gdbstub", "dep:gdbstub_arch"]
+
+[dev-dependencies]
+memoffset = "0.9.0"

--- a/src/greq/driver.rs
+++ b/src/greq/driver.rs
@@ -11,6 +11,7 @@
 extern crate alloc;
 
 use alloc::boxed::Box;
+use core::ptr::addr_of_mut;
 use core::{cell::OnceCell, mem::size_of};
 
 use crate::{
@@ -158,9 +159,9 @@ impl SnpGuestRequestDriver {
     fn send(&mut self, req_class: SnpGuestRequestClass) -> Result<(), SvsmReqError> {
         self.response.clear();
 
-        let req_page = VirtAddr::from(&mut *self.request as *mut SnpGuestRequestMsg);
-        let resp_page = VirtAddr::from(&mut *self.response as *mut SnpGuestRequestMsg);
-        let data_pages = VirtAddr::from(&mut *self.ext_data as *mut SnpGuestRequestExtData);
+        let req_page = VirtAddr::from(addr_of_mut!(*self.request));
+        let resp_page = VirtAddr::from(addr_of_mut!(*self.response));
+        let data_pages = VirtAddr::from(addr_of_mut!(*self.ext_data));
 
         if req_class == SnpGuestRequestClass::Extended {
             let num_user_pages = (self.user_extdata_size >> PAGE_SHIFT) as u64;

--- a/src/greq/msg.rs
+++ b/src/greq/msg.rs
@@ -558,13 +558,8 @@ impl SnpGuestRequestExtData {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        greq::msg::{
-            SnpGuestRequestMsg, SnpGuestRequestMsgHdr, SnpGuestRequestMsgType, MSG_HDR_SIZE,
-            MSG_PAYLOAD_SIZE,
-        },
-        sev::secrets_page::VMPCK_SIZE,
-    };
+    use super::*;
+    use crate::sev::secrets_page::VMPCK_SIZE;
 
     #[test]
     fn u16_from_guest_msg_hdr_size() {

--- a/src/greq/msg.rs
+++ b/src/greq/msg.rs
@@ -14,7 +14,7 @@ use alloc::{
 };
 use core::{
     mem::size_of,
-    ptr::addr_of,
+    ptr::{addr_of, addr_of_mut},
     slice::{from_raw_parts, from_raw_parts_mut, from_ref},
 };
 
@@ -175,7 +175,7 @@ impl SnpGuestRequestMsgHdr {
 
     /// Get [`SnpGuestRequestMsgHdr`] as a mutable slice reference
     fn as_slice_mut(&mut self) -> &mut [u8] {
-        unsafe { from_raw_parts_mut(self as *mut _ as *mut u8, size_of::<Self>()) }
+        unsafe { from_raw_parts_mut(addr_of_mut!(*self).cast(), size_of::<Self>()) }
     }
 }
 
@@ -244,7 +244,7 @@ impl SnpGuestRequestMsg {
     ///   before the object is dropped. Shared pages should not be freed
     ///   (returned to the allocator)
     pub fn set_shared(&mut self) -> Result<(), SvsmReqError> {
-        let vaddr = VirtAddr::from(self as *mut Self);
+        let vaddr = VirtAddr::from(addr_of!(*self));
         this_cpu_mut()
             .get_pgtable()
             .set_shared_4k(vaddr)
@@ -264,7 +264,7 @@ impl SnpGuestRequestMsg {
 
     /// Set the C-bit (memory encryption bit) for the Self page
     pub fn set_encrypted(&mut self) -> Result<(), SvsmReqError> {
-        let vaddr = VirtAddr::from(self as *mut Self);
+        let vaddr = VirtAddr::from(addr_of!(*self));
         this_cpu_mut()
             .get_pgtable()
             .set_encrypted_4k(vaddr)
@@ -505,14 +505,14 @@ impl SnpGuestRequestExtData {
     ///   before the object is dropped. Shared pages should not be freed
     ///   (returned to the allocator)
     pub fn set_shared(&mut self) -> Result<(), SvsmReqError> {
-        let start = VirtAddr::from(self as *mut Self);
+        let start = VirtAddr::from(addr_of!(*self));
         let end = start + size_of::<Self>();
         set_shared_region_4k(start, end)
     }
 
     /// Set the C-bit (memory encryption bit) for the Self pages
     pub fn set_encrypted(&mut self) -> Result<(), SvsmReqError> {
-        let start = VirtAddr::from(self as *mut Self);
+        let start = VirtAddr::from(addr_of!(*self));
         let end = start + size_of::<Self>();
         set_encrypted_region_4k(start, end)
     }

--- a/src/greq/msg.rs
+++ b/src/greq/msg.rs
@@ -55,13 +55,9 @@ impl TryFrom<u8> for SnpGuestRequestMsgType {
 
     fn try_from(v: u8) -> Result<Self, Self::Error> {
         match v {
-            x if x == SnpGuestRequestMsgType::Invalid as u8 => Ok(SnpGuestRequestMsgType::Invalid),
-            x if x == SnpGuestRequestMsgType::ReportRequest as u8 => {
-                Ok(SnpGuestRequestMsgType::ReportRequest)
-            }
-            x if x == SnpGuestRequestMsgType::ReportResponse as u8 => {
-                Ok(SnpGuestRequestMsgType::ReportResponse)
-            }
+            x if x == Self::Invalid as u8 => Ok(Self::Invalid),
+            x if x == Self::ReportRequest as u8 => Ok(Self::ReportRequest),
+            x if x == Self::ReportResponse as u8 => Ok(Self::ReportResponse),
             _ => Err(SvsmReqError::invalid_parameter()),
         }
     }
@@ -179,7 +175,7 @@ impl SnpGuestRequestMsgHdr {
 
     /// Get [`SnpGuestRequestMsgHdr`] as a mutable slice reference
     fn as_slice_mut(&mut self) -> &mut [u8] {
-        unsafe { from_raw_parts_mut(self as *mut _ as *mut u8, MSG_HDR_SIZE) }
+        unsafe { from_raw_parts_mut(self as *mut _ as *mut u8, size_of::<Self>()) }
     }
 }
 
@@ -509,19 +505,15 @@ impl SnpGuestRequestExtData {
     ///   before the object is dropped. Shared pages should not be freed
     ///   (returned to the allocator)
     pub fn set_shared(&mut self) -> Result<(), SvsmReqError> {
-        const EXT_DATA_SIZE: usize = size_of::<SnpGuestRequestExtData>();
-
         let start = VirtAddr::from(self as *mut Self);
-        let end = start + EXT_DATA_SIZE;
+        let end = start + size_of::<Self>();
         set_shared_region_4k(start, end)
     }
 
     /// Set the C-bit (memory encryption bit) for the Self pages
     pub fn set_encrypted(&mut self) -> Result<(), SvsmReqError> {
-        const EXT_DATA_SIZE: usize = size_of::<SnpGuestRequestExtData>();
-
         let start = VirtAddr::from(self as *mut Self);
-        let end = start + EXT_DATA_SIZE;
+        let end = start + size_of::<Self>();
         set_encrypted_region_4k(start, end)
     }
 

--- a/src/greq/msg.rs
+++ b/src/greq/msg.rs
@@ -28,8 +28,6 @@ use crate::{
     types::{PageSize, PAGE_SIZE},
 };
 
-// Message Header Format (AMD SEV-SNP spec. table 98)
-
 /// Version of the message header
 const HDR_VERSION: u8 = 1;
 /// Version of the message payload
@@ -78,7 +76,7 @@ const MSG_PAYLOAD_SIZE: usize = PAGE_SIZE - MSG_HDR_SIZE;
 /// SEV-SNP certificates
 pub const SNP_GUEST_REQ_MAX_DATA_SIZE: usize = 4 * PAGE_SIZE;
 
-/// `SNP_GUEST_REQUEST` message header format
+/// `SNP_GUEST_REQUEST` message header format (AMD SEV-SNP spec. table 98)
 #[repr(C, packed)]
 #[derive(Clone, Copy, Debug)]
 pub struct SnpGuestRequestMsgHdr {

--- a/src/greq/msg.rs
+++ b/src/greq/msg.rs
@@ -78,14 +78,6 @@ const MSG_PAYLOAD_SIZE: usize = PAGE_SIZE - MSG_HDR_SIZE;
 /// SEV-SNP certificates
 pub const SNP_GUEST_REQ_MAX_DATA_SIZE: usize = 4 * PAGE_SIZE;
 
-/// `SNP_GUEST_REQUEST` message format
-#[repr(C, packed)]
-#[derive(Clone, Copy, Debug)]
-pub struct SnpGuestRequestMsg {
-    hdr: SnpGuestRequestMsgHdr,
-    pld: [u8; MSG_PAYLOAD_SIZE],
-}
-
 /// `SNP_GUEST_REQUEST` message header format
 #[repr(C, packed)]
 #[derive(Clone, Copy, Debug)]
@@ -213,6 +205,14 @@ impl Default for SnpGuestRequestMsgHdr {
             rsvd3: [0; 35],
         }
     }
+}
+
+/// `SNP_GUEST_REQUEST` message format
+#[repr(C, packed)]
+#[derive(Clone, Copy, Debug)]
+pub struct SnpGuestRequestMsg {
+    hdr: SnpGuestRequestMsgHdr,
+    pld: [u8; MSG_PAYLOAD_SIZE],
 }
 
 impl SnpGuestRequestMsg {

--- a/src/greq/msg.rs
+++ b/src/greq/msg.rs
@@ -604,27 +604,25 @@ mod tests {
         let vmpck0 = [5u8; VMPCK_SIZE];
         let vmpck0_seqno: u64 = 1;
 
-        let result = msg.encrypt_set(
+        msg.encrypt_set(
             SnpGuestRequestMsgType::ReportRequest,
             vmpck0_seqno,
             &vmpck0,
             PLAINTEXT,
-        );
-
-        assert!(result.is_ok());
+        )
+        .unwrap();
 
         let mut outbuf = [0u8; PLAINTEXT.len()];
 
-        let result = msg.decrypt_get(
-            SnpGuestRequestMsgType::ReportRequest,
-            vmpck0_seqno,
-            &vmpck0,
-            &mut outbuf,
-        );
+        let outbuf_len = msg
+            .decrypt_get(
+                SnpGuestRequestMsgType::ReportRequest,
+                vmpck0_seqno,
+                &vmpck0,
+                &mut outbuf,
+            )
+            .unwrap();
 
-        assert!(result.is_ok());
-
-        let outbuf_len = result.unwrap();
         assert_eq!(outbuf_len, PLAINTEXT.len());
 
         assert_eq!(outbuf, PLAINTEXT);

--- a/src/greq/msg.rs
+++ b/src/greq/msg.rs
@@ -551,6 +551,29 @@ mod tests {
     use super::*;
     use crate::mm::alloc::{TestRootMem, DEFAULT_TEST_MEMORY_SIZE};
     use crate::sev::secrets_page::VMPCK_SIZE;
+    use memoffset::offset_of;
+
+    #[test]
+    fn test_snp_guest_request_hdr_offsets() {
+        assert_eq!(offset_of!(SnpGuestRequestMsgHdr, authtag), 0);
+        assert_eq!(offset_of!(SnpGuestRequestMsgHdr, msg_seqno), 0x20);
+        assert_eq!(offset_of!(SnpGuestRequestMsgHdr, rsvd1), 0x28);
+        assert_eq!(offset_of!(SnpGuestRequestMsgHdr, algo), 0x30);
+        assert_eq!(offset_of!(SnpGuestRequestMsgHdr, hdr_version), 0x31);
+        assert_eq!(offset_of!(SnpGuestRequestMsgHdr, hdr_sz), 0x32);
+        assert_eq!(offset_of!(SnpGuestRequestMsgHdr, msg_type), 0x34);
+        assert_eq!(offset_of!(SnpGuestRequestMsgHdr, msg_version), 0x35);
+        assert_eq!(offset_of!(SnpGuestRequestMsgHdr, msg_sz), 0x36);
+        assert_eq!(offset_of!(SnpGuestRequestMsgHdr, rsvd2), 0x38);
+        assert_eq!(offset_of!(SnpGuestRequestMsgHdr, msg_vmpck), 0x3c);
+        assert_eq!(offset_of!(SnpGuestRequestMsgHdr, rsvd3), 0x3d);
+    }
+
+    #[test]
+    fn test_snp_guest_request_msg_offsets() {
+        assert_eq!(offset_of!(SnpGuestRequestMsg, hdr), 0);
+        assert_eq!(offset_of!(SnpGuestRequestMsg, pld), 0x60);
+    }
 
     #[test]
     fn test_requestmsg_boxed_new() {

--- a/src/greq/msg.rs
+++ b/src/greq/msg.rs
@@ -514,7 +514,7 @@ impl SnpGuestRequestExtData {
         const EXT_DATA_SIZE: usize = size_of::<SnpGuestRequestExtData>();
 
         let start = VirtAddr::from(self as *mut Self);
-        let end = VirtAddr::from(start.bits() + EXT_DATA_SIZE);
+        let end = start + EXT_DATA_SIZE;
         set_shared_region_4k(start, end)
     }
 
@@ -523,7 +523,7 @@ impl SnpGuestRequestExtData {
         const EXT_DATA_SIZE: usize = size_of::<SnpGuestRequestExtData>();
 
         let start = VirtAddr::from(self as *mut Self);
-        let end = VirtAddr::from(start.bits() + EXT_DATA_SIZE);
+        let end = start + EXT_DATA_SIZE;
         set_encrypted_region_4k(start, end)
     }
 

--- a/src/greq/pld_report.rs
+++ b/src/greq/pld_report.rs
@@ -42,6 +42,10 @@ impl SnpReportRequest {
             .get(..size_of::<Self>())
             .ok_or_else(SvsmReqError::invalid_parameter)?;
 
+        // SAFETY: SnpReportRequest has no invalid representations, as it is
+        // comprised entirely of integer types. It is repr(packed), so its
+        // required alignment is simply 1. We have checked the size, so this
+        // is entirely safe.
         let request = unsafe { &*buffer.as_ptr().cast::<Self>() };
 
         if !request.is_reserved_clear() {
@@ -89,6 +93,10 @@ impl SnpReportResponse {
             .get(..size_of::<Self>())
             .ok_or_else(SvsmReqError::invalid_parameter)?;
 
+        // SAFETY: SnpReportResponse has no invalid representations, as it is
+        // comprised entirely of integer types. It is repr(packed), so its
+        // required alignment is simply 1. We have checked the size, so this
+        // is entirely safe.
         let response = unsafe { &*buffer.as_ptr().cast::<Self>() };
         Ok(response)
     }

--- a/src/greq/pld_report.rs
+++ b/src/greq/pld_report.rs
@@ -102,19 +102,12 @@ impl SnpReportResponse {
     }
 
     /// Validate the [SnpReportResponse] fields
-    ///
-    /// # Panic
-    ///
-    /// * The size of the struct [`AttestationReport`] must fit in a u32
     pub fn validate(&self) -> Result<(), SvsmReqError> {
         if self.status != SnpReportResponseStatus::Success as u32 {
             return Err(SvsmReqError::invalid_request());
         }
 
-        const REPORT_SIZE: usize = size_of::<AttestationReport>();
-        assert!(u32::try_from(REPORT_SIZE).is_ok());
-
-        if self.report_size != REPORT_SIZE as u32 {
+        if self.report_size != size_of::<AttestationReport>() as u32 {
             return Err(SvsmReqError::invalid_format());
         }
 
@@ -198,6 +191,8 @@ pub struct AttestationReport {
     /// Signature of bytes 0h to 29Fh inclusive of this report
     signature: Signature,
 }
+
+const _: () = assert!(size_of::<AttestationReport>() <= u32::MAX as usize);
 
 #[cfg(test)]
 mod tests {

--- a/src/greq/pld_report.rs
+++ b/src/greq/pld_report.rs
@@ -198,3 +198,59 @@ pub struct AttestationReport {
     /// Signature of bytes 0h to 29Fh inclusive of this report
     signature: Signature,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use memoffset::offset_of;
+
+    #[test]
+    fn test_snp_report_request_offsets() {
+        assert_eq!(offset_of!(SnpReportRequest, user_data), 0x0);
+        assert_eq!(offset_of!(SnpReportRequest, vmpl), 0x40);
+        assert_eq!(offset_of!(SnpReportRequest, flags), 0x44);
+        assert_eq!(offset_of!(SnpReportRequest, rsvd), 0x48);
+    }
+
+    #[test]
+    fn test_snp_report_response_offsets() {
+        assert_eq!(offset_of!(SnpReportResponse, status), 0x0);
+        assert_eq!(offset_of!(SnpReportResponse, report_size), 0x4);
+        assert_eq!(offset_of!(SnpReportResponse, _reserved), 0x8);
+        assert_eq!(offset_of!(SnpReportResponse, report), 0x20);
+    }
+
+    #[test]
+    fn test_ecdsa_p384_sha384_signature_offsets() {
+        assert_eq!(offset_of!(Signature, r), 0x0);
+        assert_eq!(offset_of!(Signature, s), 0x48);
+        assert_eq!(offset_of!(Signature, reserved), 0x90);
+    }
+
+    #[test]
+    fn test_attestation_report_offsets() {
+        assert_eq!(offset_of!(AttestationReport, version), 0x0);
+        assert_eq!(offset_of!(AttestationReport, guest_svn), 0x4);
+        assert_eq!(offset_of!(AttestationReport, policy), 0x8);
+        assert_eq!(offset_of!(AttestationReport, family_id), 0x10);
+        assert_eq!(offset_of!(AttestationReport, image_id), 0x20);
+        assert_eq!(offset_of!(AttestationReport, vmpl), 0x30);
+        assert_eq!(offset_of!(AttestationReport, signature_algo), 0x34);
+        assert_eq!(offset_of!(AttestationReport, platform_version), 0x38);
+        assert_eq!(offset_of!(AttestationReport, platform_info), 0x40);
+        assert_eq!(offset_of!(AttestationReport, flags), 0x48);
+        assert_eq!(offset_of!(AttestationReport, reserved0), 0x4c);
+        assert_eq!(offset_of!(AttestationReport, report_data), 0x50);
+        assert_eq!(offset_of!(AttestationReport, measurement), 0x90);
+        assert_eq!(offset_of!(AttestationReport, host_data), 0xc0);
+        assert_eq!(offset_of!(AttestationReport, id_key_digest), 0xe0);
+        assert_eq!(offset_of!(AttestationReport, author_key_digest), 0x110);
+        assert_eq!(offset_of!(AttestationReport, report_id), 0x140);
+        assert_eq!(offset_of!(AttestationReport, report_id_ma), 0x160);
+        assert_eq!(offset_of!(AttestationReport, reported_tcb), 0x180);
+        assert_eq!(offset_of!(AttestationReport, reserved1), 0x188);
+        assert_eq!(offset_of!(AttestationReport, chip_id), 0x1a0);
+        assert_eq!(offset_of!(AttestationReport, reserved2), 0x1e0);
+        assert_eq!(offset_of!(AttestationReport, signature), 0x2a0);
+    }
+}

--- a/src/greq/pld_report.rs
+++ b/src/greq/pld_report.rs
@@ -39,10 +39,10 @@ impl SnpReportRequest {
     /// Take a slice and return a reference for Self
     pub fn try_from_as_ref(buffer: &[u8]) -> Result<&Self, SvsmReqError> {
         let buffer = buffer
-            .get(..size_of::<SnpReportRequest>())
+            .get(..size_of::<Self>())
             .ok_or_else(SvsmReqError::invalid_parameter)?;
 
-        let request = unsafe { &*buffer.as_ptr().cast::<SnpReportRequest>() };
+        let request = unsafe { &*buffer.as_ptr().cast::<Self>() };
 
         if !request.is_reserved_clear() {
             return Err(SvsmReqError::invalid_parameter());
@@ -86,10 +86,10 @@ pub enum SnpReportResponseStatus {
 impl SnpReportResponse {
     pub fn try_from_as_ref(buffer: &[u8]) -> Result<&Self, SvsmReqError> {
         let buffer = buffer
-            .get(..size_of::<SnpReportResponse>())
+            .get(..size_of::<Self>())
             .ok_or_else(SvsmReqError::invalid_parameter)?;
 
-        let response = unsafe { &*buffer.as_ptr().cast::<SnpReportResponse>() };
+        let response = unsafe { &*buffer.as_ptr().cast::<Self>() };
         Ok(response)
     }
 


### PR DESCRIPTION
* Fix UB in `SnpGuestRequestMsgHdr::get_aad_slice()`
* Fix reachable assertions in `SnpGuestRequestExtData::boxed_new()` and `SnpGuestRequestMsg::boxed_new()`.
* Add tests for layout-sensitive structs.
* Refactor assertions that can be evaluated at compile time
* Other syntax & readability cleanups