### PR TITLE
tests: enable `TestRootMem` for tests inside the SVSM

### DIFF
--- a/src/greq/msg.rs
+++ b/src/greq/msg.rs
@@ -547,6 +547,7 @@ mod tests {
     use memoffset::offset_of;
 
     #[test]
+    #[cfg_attr(test_in_svsm, ignore = "offset_of")]
     fn test_snp_guest_request_hdr_offsets() {
         assert_eq!(offset_of!(SnpGuestRequestMsgHdr, authtag), 0);
         assert_eq!(offset_of!(SnpGuestRequestMsgHdr, msg_seqno), 0x20);
@@ -563,6 +564,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(test_in_svsm, ignore = "offset_of")]
     fn test_snp_guest_request_msg_offsets() {
         assert_eq!(offset_of!(SnpGuestRequestMsg, hdr), 0);
         assert_eq!(offset_of!(SnpGuestRequestMsg, pld), 0x60);

--- a/src/greq/pld_report.rs
+++ b/src/greq/pld_report.rs
@@ -200,6 +200,7 @@ mod tests {
     use memoffset::offset_of;
 
     #[test]
+    #[cfg_attr(test_in_svsm, ignore = "offset_of")]
     fn test_snp_report_request_offsets() {
         assert_eq!(offset_of!(SnpReportRequest, user_data), 0x0);
         assert_eq!(offset_of!(SnpReportRequest, vmpl), 0x40);
@@ -208,6 +209,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(test_in_svsm, ignore = "offset_of")]
     fn test_snp_report_response_offsets() {
         assert_eq!(offset_of!(SnpReportResponse, status), 0x0);
         assert_eq!(offset_of!(SnpReportResponse, report_size), 0x4);
@@ -216,6 +218,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(test_in_svsm, ignore = "offset_of")]
     fn test_ecdsa_p384_sha384_signature_offsets() {
         assert_eq!(offset_of!(Signature, r), 0x0);
         assert_eq!(offset_of!(Signature, s), 0x48);
@@ -223,6 +226,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(test_in_svsm, ignore = "offset_of")]
     fn test_attestation_report_offsets() {
         assert_eq!(offset_of!(AttestationReport, version), 0x0);
         assert_eq!(offset_of!(AttestationReport, guest_svn), 0x4);

--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -1322,14 +1322,12 @@ impl Drop for TestRootMem<'_> {
 }
 
 #[test]
-#[cfg_attr(test_in_svsm, ignore = "FIXME")]
 fn test_root_mem_setup() {
     let test_mem_lock = TestRootMem::setup(DEFAULT_TEST_MEMORY_SIZE);
     drop(test_mem_lock);
 }
 
 #[test]
-#[cfg_attr(test_in_svsm, ignore = "FIXME")]
 // Allocate one page and free it again, verify that memory_info() reflects it.
 fn test_page_alloc_one() {
     let _test_mem = TestRootMem::setup(DEFAULT_TEST_MEMORY_SIZE);
@@ -1448,7 +1446,6 @@ fn test_page_alloc_oom() {
 }
 
 #[test]
-#[cfg_attr(test_in_svsm, ignore = "FIXME")]
 fn test_page_file() {
     let _mem_lock = TestRootMem::setup(DEFAULT_TEST_MEMORY_SIZE);
     let mut root_mem = ROOT_MEM.lock();
@@ -1483,7 +1480,6 @@ fn test_page_file() {
 const TEST_SLAB_SIZES: [usize; 7] = [32, 64, 128, 256, 512, 1024, 2048];
 
 #[test]
-#[cfg_attr(test_in_svsm, ignore = "FIXME")]
 // Allocate and free a couple of objects for each slab size.
 fn test_slab_alloc_free_many() {
     extern crate alloc;


### PR DESCRIPTION
* Fix some tests relying on `offset_of!()` inside the SVSM, as they cause faults due to excessive stack usage.
* Enable the use of `TestRootMem` inside the SVSM via `cfg(test_in_svsm)` gating.
* Enable a few disabled tests in mm/alloc.
* TODO: enable filesystem tests. They still require some logic to avoid reinitializing the filesystem when running inside the SVSM. 