### PR TITLE
mm: replace recently unstable bitmap_len()

### DIFF
--- a/src/mm/validate.rs
+++ b/src/mm/validate.rs
@@ -148,7 +148,12 @@ impl ValidBitmap {
     /// The number of u64's in the bitmap
     fn bitmap_len(&self) -> usize {
         let num_pages = self.region.len() / PAGE_SIZE;
-        num_pages.div_ceil(u64::BITS as usize)
+        let additional_u64 = if self.region.len() % PAGE_SIZE != 0 {
+            1
+        } else {
+            0
+        };
+        num_pages + additional_u64
     }
 
     fn migrate(&mut self, new_bitmap: *mut u64) {


### PR DESCRIPTION
The usage of the unstable library feature 'int_roundings' would trigger a compilation error (See Rust issue #88581). Replace it with a standard integer division.

This is the error:

```
error[E0658]: use of unstable library feature 'int_roundings'
   --> src/mm/validate.rs:151:19
    |
151 |         num_pages.div_ceil(u64::BITS as usize)
    |                   ^^^^^^^^
    |
    = note: see issue #88581 <https://github.com/rust-lang/rust/issues/88581> for more information

```

Fixes: 2b0162d6 (mm/validate: migrate all pages in bitmap)