### PR TITLE
mm: Add unit tests for kernel mapping, guestmem ops, address checks

### DIFF
--- a/src/mm/guestmem.rs
+++ b/src/mm/guestmem.rs
@@ -222,3 +222,33 @@ impl<T: Sized + Copy> GuestPtr<T> {
         unsafe { GuestPtr::from_ptr(self.ptr.offset(count)) }
     }
 }
+
+mod tests {
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_read_u8_valid_address() {
+        use crate::mm::guestmem::*;
+        // Create a region to read from
+        let test_buffer: [u8; 6] = [0; 6];
+        let test_address = VirtAddr::from(test_buffer.as_ptr());
+
+        let result = read_u8(test_address).unwrap();
+
+        assert_eq!(result, test_buffer[0]);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_write_u8_valid_address() {
+        use crate::mm::guestmem::*;
+        // Create a mutable region we can write into
+        let mut test_buffer: [u8; 6] = [0; 6];
+        let test_address = VirtAddr::from(test_buffer.as_mut_ptr());
+        let data_to_write = 0x42;
+
+        write_u8(test_address, data_to_write).unwrap();
+
+        assert_eq!(test_buffer[0], data_to_write);
+    }
+}

--- a/src/mm/memory.rs
+++ b/src/mm/memory.rs
@@ -101,6 +101,7 @@ pub fn writable_phys_addr(paddr: PhysAddr) -> bool {
 }
 
 #[cfg(test)]
+#[cfg_attr(test_in_svsm, ignore = "Offline testing")]
 mod tests {
     use super::*;
     use crate::address::PhysAddr;

--- a/src/mm/memory.rs
+++ b/src/mm/memory.rs
@@ -99,3 +99,23 @@ pub fn writable_phys_addr(paddr: PhysAddr) -> bool {
 
     valid_phys_address(paddr)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::address::PhysAddr;
+
+    #[test]
+    fn test_valid_phys_address() {
+        let start = PhysAddr::new(0x1000);
+        let end = PhysAddr::new(0x2000);
+        let region = MemoryRegion::from_addresses(start, end);
+
+        MEMORY_MAP.lock_write().push(region);
+
+        // Inside the region
+        assert!(valid_phys_address(PhysAddr::new(0x1500)));
+        // Outside the region
+        assert!(!valid_phys_address(PhysAddr::new(0x3000)));
+    }
+}

--- a/src/mm/memory.rs
+++ b/src/mm/memory.rs
@@ -106,6 +106,7 @@ mod tests {
     use crate::address::PhysAddr;
 
     #[test]
+    #[cfg_attr(test_in_svsm, ignore = "Offline testing")]
     fn test_valid_phys_address() {
         let start = PhysAddr::new(0x1000);
         let end = PhysAddr::new(0x2000);


### PR DESCRIPTION
Add unit tests to evaluate offline correct behavior of memory components: kernel mappings (address_space.rs), read and write operations (guestmem.rs) and valid physical address checking (memory.rs).