### PR TITLE
Optimize VMM creation of reserved ranges

### DIFF
--- a/src/mm/vm/mapping/api.rs
+++ b/src/mm/vm/mapping/api.rs
@@ -39,6 +39,17 @@ pub trait VirtualMapping: core::fmt::Debug {
     /// Mapping size. Will always be a multiple of `VirtualMapping::page_size()`
     fn mapping_size(&self) -> usize;
 
+    /// Indicates whether the mapping has any associated data.
+    ///
+    /// # Returns
+    ///
+    /// `true' if there is associated physical data, or `false' if there is
+    /// none.
+    fn has_data(&self) -> bool {
+        // Defaults to true
+        true
+    }
+
     /// Request physical address to map for a given offset
     ///
     /// # Arguments

--- a/src/mm/vm/mapping/reserved.rs
+++ b/src/mm/vm/mapping/reserved.rs
@@ -51,6 +51,10 @@ impl VirtualMapping for VMReserved {
         self.size
     }
 
+    fn has_data(&self) -> bool {
+        false
+    }
+
     fn map(&self, _offset: usize) -> Option<PhysAddr> {
         None
     }

--- a/src/mm/vm/range.rs
+++ b/src/mm/vm/range.rs
@@ -159,6 +159,11 @@ impl VMR {
         let page_size = mapping.page_size();
         let shared = mapping.shared();
 
+        // Exit early if the mapping has no data.
+        if !mapping.has_data() {
+            return Ok(());
+        }
+
         while vmm_start + offset < vmm_end {
             let idx = PageTable::index::<3>(VirtAddr::from(vmm_start - rstart));
             if let Some(paddr) = mapping.map(offset) {


### PR DESCRIPTION
Add a flag to the virtual mapping object indicating whether the mapping is backed by any data.  This permits the VMM creation code to avoid thousands of worthless calls to "get data" on large reserved ranges which supply no data to map.