### PR TITLE
Acquire the choice of debug serial port from the IGVM parameter block

### DIFF
--- a/igvm_params/src/lib.rs
+++ b/igvm_params/src/lib.rs
@@ -52,11 +52,14 @@ pub struct IgvmParamBlock {
     /// The guest physical address of the secrets page.
     pub secrets_page: u32,
 
+    /// The port number of the serial port to use for debugging.
+    pub debug_serial_port: u16,
+
     /// A flag indicating whether the kernel should proceed with the flow
     /// to launch guest firmware once kernel initialization is complete.
     pub launch_fw: u8,
 
-    _reserved: [u8; 3],
+    _reserved: u8,
 
     /// The amount of space that must be reserved at the base of the kernel
     /// memory region (e.g. for VMSA contents).

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,7 @@ use crate::address::PhysAddr;
 use crate::error::SvsmError;
 use crate::fw_cfg::FwCfg;
 use crate::igvm_params::IgvmParams;
+use crate::serial::SERIAL_PORT;
 use crate::utils::MemoryRegion;
 use alloc::vec::Vec;
 
@@ -61,6 +62,13 @@ impl<'a> SvsmConfig<'a> {
         match self {
             SvsmConfig::FirmwareConfig(_) => true,
             SvsmConfig::IgvmConfig(igvm_params) => igvm_params.should_launch_fw(),
+        }
+    }
+
+    pub fn debug_serial_port(&self) -> u16 {
+        match self {
+            SvsmConfig::FirmwareConfig(_) => SERIAL_PORT,
+            SvsmConfig::IgvmConfig(igvm_params) => igvm_params.debug_serial_port(),
         }
     }
 }

--- a/src/igvm_params.rs
+++ b/src/igvm_params.rs
@@ -134,4 +134,8 @@ impl IgvmParams<'_> {
     pub fn should_launch_fw(&self) -> bool {
         self.igvm_param_block.launch_fw != 0
     }
+
+    pub fn debug_serial_port(&self) -> u16 {
+        self.igvm_param_block.debug_serial_port
+    }
 }

--- a/src/kernel_launch.rs
+++ b/src/kernel_launch.rs
@@ -25,6 +25,7 @@ pub struct KernelLaunchInfo {
     pub secrets_page: u64,
     pub igvm_params_phys_addr: u64,
     pub igvm_params_virt_addr: u64,
+    pub debug_serial_port: u16,
 }
 
 impl KernelLaunchInfo {


### PR DESCRIPTION
Permit the IGVM configuration to specify a debug output port other than COM1.  This is specified at the time the IGVM file is built and is not selectable by the host loader.