### PR TITLE
IGVM: Add support for launching OVMF firmware when using an IGVM file for guest configuration

### DIFF
--- a/igvm_params/src/lib.rs
+++ b/igvm_params/src/lib.rs
@@ -55,11 +55,16 @@ pub struct IgvmParamBlock {
     /// The port number of the serial port to use for debugging.
     pub debug_serial_port: u16,
 
-    /// A flag indicating whether the kernel should proceed with the flow
-    /// to launch guest firmware once kernel initialization is complete.
-    pub launch_fw: u8,
+    _reserved: u16,
+    /// The guest physical address of the start of the guest firmware. The
+    /// permissions on the pages in the firmware range are adjusted to the guest
+    /// VMPL. If this field is zero then no firmware is launched after
+    /// initialization is complete.
+    pub fw_start: u32,
 
-    _reserved: u8,
+    /// The number of pages of guest firmware. If the firmware size is zero then
+    /// no firmware is launched after initialization is complete.
+    pub fw_size: u32,
 
     /// The amount of space that must be reserved at the base of the kernel
     /// memory region (e.g. for VMSA contents).

--- a/igvm_params/src/lib.rs
+++ b/igvm_params/src/lib.rs
@@ -56,6 +56,7 @@ pub struct IgvmParamBlock {
     pub debug_serial_port: u16,
 
     _reserved: u16,
+
     /// The guest physical address of the start of the guest firmware. The
     /// permissions on the pages in the firmware range are adjusted to the guest
     /// VMPL. If this field is zero then no firmware is launched after
@@ -65,6 +66,15 @@ pub struct IgvmParamBlock {
     /// The number of pages of guest firmware. If the firmware size is zero then
     /// no firmware is launched after initialization is complete.
     pub fw_size: u32,
+
+    /// The guest physical address of the page that contains metadata that
+    /// corresponds to the firmware. The SVSM expects the page to contain
+    /// metadata in the format defined by OVMF. If this field is zero but
+    /// a firmware range has been provided then the firmware is launched
+    /// without parsing any metadata.
+    pub fw_metadata: u32,
+
+    _reserved2: u32,
 
     /// The amount of space that must be reserved at the base of the kernel
     /// memory region (e.g. for VMSA contents).

--- a/src/config.rs
+++ b/src/config.rs
@@ -71,4 +71,13 @@ impl<'a> SvsmConfig<'a> {
             SvsmConfig::IgvmConfig(igvm_params) => igvm_params.debug_serial_port(),
         }
     }
+
+    pub fn get_fw_regions(&self) -> Result<Vec<MemoryRegion<PhysAddr>>, SvsmError> {
+        match self {
+            SvsmConfig::FirmwareConfig(fw_cfg) => {
+                Ok(fw_cfg.iter_flash_regions().collect::<Vec<_>>())
+            }
+            SvsmConfig::IgvmConfig(igvm_params) => igvm_params.get_fw_regions(),
+        }
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,7 @@ use crate::address::PhysAddr;
 use crate::error::SvsmError;
 use crate::fw_cfg::FwCfg;
 use crate::igvm_params::IgvmParams;
+use crate::mm::{PAGE_SIZE, SIZE_1G};
 use crate::serial::SERIAL_PORT;
 use crate::utils::MemoryRegion;
 use alloc::vec::Vec;
@@ -69,6 +70,16 @@ impl<'a> SvsmConfig<'a> {
         match self {
             SvsmConfig::FirmwareConfig(_) => SERIAL_PORT,
             SvsmConfig::IgvmConfig(igvm_params) => igvm_params.debug_serial_port(),
+        }
+    }
+
+    pub fn get_fw_metadata(&self) -> Option<PhysAddr> {
+        match self {
+            SvsmConfig::FirmwareConfig(_) => {
+                // The metadata location always starts at 32 bytes below 4GB
+                Some(PhysAddr::from((4 * SIZE_1G) - PAGE_SIZE))
+            }
+            SvsmConfig::IgvmConfig(igvm_params) => igvm_params.get_fw_metadata(),
         }
     }
 

--- a/src/fw_cfg.rs
+++ b/src/fw_cfg.rs
@@ -217,7 +217,7 @@ impl<'a> FwCfg<'a> {
     // This needs to be &mut self to prevent iterator invalidation, where the caller
     // could do fw_cfg.select() while iterating. Having a mutable reference prevents
     // other references.
-    pub fn iter_flash_regions(&mut self) -> impl Iterator<Item = MemoryRegion<PhysAddr>> + '_ {
+    pub fn iter_flash_regions(&self) -> impl Iterator<Item = MemoryRegion<PhysAddr>> + '_ {
         let num = match self.file_selector("etc/flash") {
             Ok(file) => {
                 self.select(file.selector);

--- a/src/igvm_params.rs
+++ b/src/igvm_params.rs
@@ -12,6 +12,7 @@ use crate::error::SvsmError;
 use crate::error::SvsmError::Firmware;
 use crate::mm::PAGE_SIZE;
 use crate::utils::MemoryRegion;
+use alloc::vec;
 use alloc::vec::Vec;
 
 use core::mem::size_of;
@@ -137,5 +138,16 @@ impl IgvmParams<'_> {
 
     pub fn debug_serial_port(&self) -> u16 {
         self.igvm_param_block.debug_serial_port
+    }
+
+    pub fn get_fw_regions(&self) -> Result<Vec<MemoryRegion<PhysAddr>>, SvsmError> {
+        if !self.should_launch_fw() {
+            Err(Firmware)
+        } else {
+            Ok(vec![MemoryRegion::new(
+                PhysAddr::new(self.igvm_param_block.fw_start as usize),
+                self.igvm_param_block.fw_size as usize * PAGE_SIZE,
+            )])
+        }
     }
 }

--- a/src/igvm_params.rs
+++ b/src/igvm_params.rs
@@ -132,7 +132,7 @@ impl IgvmParams<'_> {
     }
 
     pub fn should_launch_fw(&self) -> bool {
-        self.igvm_param_block.launch_fw != 0
+        self.igvm_param_block.fw_size != 0
     }
 
     pub fn debug_serial_port(&self) -> u16 {

--- a/src/igvm_params.rs
+++ b/src/igvm_params.rs
@@ -140,6 +140,14 @@ impl IgvmParams<'_> {
         self.igvm_param_block.debug_serial_port
     }
 
+    pub fn get_fw_metadata(&self) -> Option<PhysAddr> {
+        if !self.should_launch_fw() || self.igvm_param_block.fw_metadata == 0 {
+            None
+        } else {
+            Some(PhysAddr::from(self.igvm_param_block.fw_metadata as u64))
+        }
+    }
+
     pub fn get_fw_regions(&self) -> Result<Vec<MemoryRegion<PhysAddr>>, SvsmError> {
         if !self.should_launch_fw() {
             Err(Firmware)

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -9,7 +9,6 @@
 
 extern crate alloc;
 
-use alloc::vec::Vec;
 use svsm::fw_meta::{parse_fw_meta_data, print_fw_meta, validate_fw_memory, SevFWMetaData};
 
 use core::arch::global_asm;
@@ -219,10 +218,8 @@ fn launch_fw() -> Result<(), SvsmError> {
     Ok(())
 }
 
-fn validate_flash() -> Result<(), SvsmError> {
-    let fw_cfg = FwCfg::new(&CONSOLE_IO);
-
-    let flash_regions = fw_cfg.iter_flash_regions().collect::<Vec<_>>();
+fn validate_fw(config: &SvsmConfig) -> Result<(), SvsmError> {
+    let flash_regions = config.get_fw_regions()?;
     let kernel_region = LAUNCH_INFO.kernel_region();
     let flash_range = {
         let one_gib = 1024 * 1024 * 1024usize;
@@ -480,8 +477,7 @@ pub extern "C" fn svsm_main() {
         if let Err(e) = copy_tables_to_fw(fw_meta) {
             panic!("Failed to copy firmware tables: {:#?}", e);
         }
-
-        if let Err(e) = validate_flash() {
+        if let Err(e) = validate_fw(&config) {
             panic!("Failed to validate flash memory: {:#?}", e);
         }
     }

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -220,7 +220,7 @@ fn launch_fw() -> Result<(), SvsmError> {
 }
 
 fn validate_flash() -> Result<(), SvsmError> {
-    let mut fw_cfg = FwCfg::new(&CONSOLE_IO);
+    let fw_cfg = FwCfg::new(&CONSOLE_IO);
 
     let flash_regions = fw_cfg.iter_flash_regions().collect::<Vec<_>>();
     let kernel_region = LAUNCH_INFO.kernel_region();


### PR DESCRIPTION
This changes the IGVM parameter block to replace the flag that indicates whether to boot OVMF with two parameters that define the GPA range of the OVMF region. 

The same constraints on OVMF location are currently still true - the OVMF pages must be aligned up to the 4GB boundary therefore the IGVM builder must ensure this alignment for OVMF to be booted correctly.

