### PR TITLE
Switch to the latest IGVM definition of "environment info"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "igvm_defs"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5930f41716c295685e466befcd97169e6a00e61b5b037bf32e579b5c932e0a"
+checksum = "757d494b41d5e46cfdc6b0dd8aeaf61f8f557a62b546dc4cb000a0d86d195b84"
 dependencies = [
  "bitfield-struct",
  "open-enum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ log = { version = "0.4.17", features = ["max_level_info", "release_max_level_inf
 packit = { git = "https://github.com/coconut-svsm/packit", version = "0.1.0" }
 aes-gcm = { version = "0.10.3", default-features = false, features = ["aes", "alloc"] }
 igvm_params = { path = "igvm_params" }
-igvm_defs = { version = "0.1.0" }
+igvm_defs = { version = "0.1.3", features = ["unstable"] }
 
 [target."x86_64-unknown-none".dev-dependencies]
 test = { version = "0.1.0", path = "test" }

--- a/igvm_params/src/lib.rs
+++ b/igvm_params/src/lib.rs
@@ -19,13 +19,10 @@ pub struct IgvmParamPage {
     /// The number of vCPUs that are configured for the guest VM.
     pub cpu_count: u32,
 
-    /// A flag indicating whether the default state of guest memory is shared
-    /// (not assigned to the guest) or private (assigned to the guest).
-    /// Shared pages must undergo a page state change to private before they
-    /// can be accepted for guest use.  A zero value here means that the
-    /// default state is private, and a non-zero value means that the default
-    /// state is shared.
-    pub default_shared_pages: u32,
+    /// The environment informatiom supplied to describe the execution
+    /// environment.  This is defined as a u32 and is converted to an
+    /// IgvmEnvironmentInfo when it is used.
+    pub environment_info: u32,
 }
 
 /// The IGVM parameter block is a measured page constructed by the IGVM file

--- a/src/igvm_params.rs
+++ b/src/igvm_params.rs
@@ -15,7 +15,7 @@ use crate::utils::MemoryRegion;
 use alloc::vec::Vec;
 
 use core::mem::size_of;
-use igvm_defs::{MemoryMapEntryType, IGVM_VHS_MEMORY_MAP_ENTRY};
+use igvm_defs::{IgvmEnvironmentInfo, MemoryMapEntryType, IGVM_VHS_MEMORY_MAP_ENTRY};
 use igvm_params::{IgvmParamBlock, IgvmParamPage};
 
 const IGVM_MEMORY_ENTRIES_PER_PAGE: usize = PAGE_SIZE / size_of::<IGVM_VHS_MEMORY_MAP_ENTRY>();
@@ -69,7 +69,8 @@ impl IgvmParams<'_> {
     }
 
     pub fn page_state_change_required(&self) -> bool {
-        self.igvm_param_page.default_shared_pages != 0
+        let environment_info = IgvmEnvironmentInfo::from(self.igvm_param_page.environment_info);
+        environment_info.memory_is_shared()
     }
 
     pub fn get_cpuid_page_address(&self) -> u64 {

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -330,7 +330,7 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
     load_gdt();
     early_idt_init();
 
-    // Capture the debug serial port befure the launch info disappears from
+    // Capture the debug serial port before the launch info disappears from
     // the address space.
     let debug_serial_port = li.debug_serial_port;
 


### PR DESCRIPTION
The IGVM format was just extended to define "environment information", which permits the loader to declare some information about the environment, such as whether or not the hosting environment pre-assigns all memory to the guest or whether the memory begins in the unassigned state.  This PR modifies the IGVM parameter handling to conform to the new IGVM parameter.