### PR TITLE
fuzzing: restore documentation link to cargo-fuzz

### DIFF
--- a/FUZZING.md
+++ b/FUZZING.md
@@ -5,8 +5,9 @@ The COCONUT SVSM includes several fuzzing harnesses to find bugs in
 security-critical interfaces. These do not currently provide coverage
 of all interesting interfaces, so contributions are welcome.
 
-At the moment, fuzzing is done through cargo-fuzz. You may find a complete
-tutorial for this tool on the
+At the moment, fuzzing is done through
+[cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz). You may find a
+complete tutorial for this tool on the
 [rust-fuzz website](https://rust-fuzz.github.io/book/cargo-fuzz.html).
 
 Requirements


### PR DESCRIPTION
A broken link was removed but not replaced with a working one.

Fixes: 51db3292 ("fuzzing: remove broken link (404 page not found)")