### PR TITLE
Enter the guest VMSA from a consistent place

### DIFF
--- a/src/requests.rs
+++ b/src/requests.rs
@@ -72,13 +72,35 @@ fn request_loop_once(
 
 pub fn request_loop() {
     loop {
-        if update_mappings().is_err() {
-            log::debug!("No VMSA or CAA! Halting");
-            halt();
-            continue;
-        }
+        // Determine whether the guest is runnable.  If not, halt and wait for
+        // the guest to execute.  When halting, assume that the hypervisor
+        // will schedule the guest VMPL on its own.
+        let vmsa = if update_mappings().is_ok() {
+            let vmsa = this_cpu_mut().guest_vmsa();
 
-        let vmsa = this_cpu_mut().guest_vmsa();
+            // Make VMSA runnable again by setting EFER.SVME
+            vmsa.enable();
+
+            flush_tlb_global_sync();
+
+            this_cpu_mut()
+                .ghcb()
+                .run_vmpl(GUEST_VMPL as u64)
+                .expect("Failed to run guest VMPL");
+
+            vmsa
+        } else {
+            loop {
+                log::debug!("No VMSA or CAA! Halting");
+                halt();
+
+                if update_mappings().is_ok() {
+                    break;
+                }
+            }
+
+            this_cpu_mut().guest_vmsa()
+        };
 
         // Clear EFER.SVME in guest VMSA
         vmsa.disable();
@@ -114,18 +136,5 @@ pub fn request_loop() {
 
         // Write back results
         params.write_back(vmsa);
-
-        // Make VMSA runable again by setting EFER.SVME
-        vmsa.enable();
-
-        flush_tlb_global_sync();
-
-        // Check if mappings still valid
-        if update_mappings().is_ok() {
-            this_cpu_mut()
-                .ghcb()
-                .run_vmpl(GUEST_VMPL as u64)
-                .expect("Failed to run guest VMPL");
-        }
     }
 }

--- a/src/sev/ghcb.rs
+++ b/src/sev/ghcb.rs
@@ -480,6 +480,21 @@ impl GHCB {
         Ok(())
     }
 
+    pub fn register_guest_vmsa(
+        &mut self,
+        vmsa_gpa: PhysAddr,
+        apic_id: u64,
+        vmpl: u64,
+        sev_features: u64,
+    ) -> Result<(), SvsmError> {
+        self.clear();
+        let exit_info_1: u64 = (vmpl & 0xf) << 16 | apic_id << 32;
+        let exit_info_2: u64 = vmsa_gpa.into();
+        self.set_rax(sev_features);
+        self.vmgexit(GHCBExitCode::AP_CREATE, exit_info_1, exit_info_2)?;
+        Ok(())
+    }
+
     pub fn guest_request(
         &mut self,
         req_page: VirtAddr,

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -207,13 +207,12 @@ fn launch_fw() -> Result<(), SvsmError> {
 
     log::info!("VMSA PA: {:#x}", vmsa_pa);
 
-    vmsa.enable();
     let sev_features = vmsa.sev_features;
 
     log::info!("Launching Firmware");
     this_cpu_mut()
         .ghcb()
-        .ap_create(vmsa_pa, 0, GUEST_VMPL as u64, sev_features)?;
+        .register_guest_vmsa(vmsa_pa, 0, GUEST_VMPL as u64, sev_features)?;
 
     Ok(())
 }


### PR DESCRIPTION
Ensure that every entry to the guest VMPL occurs from the same point in the execution loop.  This will become important in the future when REFLECT_VC is enabled, and will be critical on non-SNP platforms that do not use simple GHCB calls for guest entry.