### PR TITLE
Permit guest execution without a calling area

### DIFF
--- a/src/requests.rs
+++ b/src/requests.rs
@@ -32,9 +32,8 @@ pub fn update_mappings() -> Result<(), SvsmError> {
         None => ret = Err(SvsmError::MissingVMSA),
     }
 
-    match locked.caa_phys() {
-        Some(paddr) => this_cpu_mut().map_guest_caa(paddr)?,
-        None => ret = Err(SvsmError::MissingCAA),
+    if let Some(paddr) = locked.caa_phys() {
+        this_cpu_mut().map_guest_caa(paddr)?
     }
 
     locked.set_updated();


### PR DESCRIPTION
Permit the guest to execute without having a calling area configured.  In the future, when running in a paravisor configuration, there will be no calling area, so execution must not be blocked due to the absence of a calling area.  When running in a pure SVSM configuration, lack of a calling area renders the SVSM useless but does not introduce any functional issue.