### PR TITLE
Additional firmware configuration via IGVM

### DIFF
--- a/bootlib/src/igvm_params.rs
+++ b/bootlib/src/igvm_params.rs
@@ -48,7 +48,11 @@ pub struct IgvmParamBlock {
     /// The port number of the serial port to use for debugging.
     pub debug_serial_port: u16,
 
-    _reserved: u16,
+    /// Indicates that the initial location of firmware is at the base of
+    /// memory and will not be loaded into the ROM range.
+    pub fw_in_low_memory: u8,
+
+    _reserved: u8,
 
     /// The guest physical address of the start of the guest firmware. The
     /// permissions on the pages in the firmware range are adjusted to the guest

--- a/bootlib/src/igvm_params.rs
+++ b/bootlib/src/igvm_params.rs
@@ -39,6 +39,10 @@ pub struct IgvmParamBlock {
     /// of the memory map (which is in IGVM format).
     pub memory_map_offset: u32,
 
+    /// The offset, in bytes, of the guest context, or zero if no guest
+    /// context is present.
+    pub guest_context_offset: u32,
+
     /// The guest physical address of the CPUID page.
     pub cpuid_page: u32,
 
@@ -71,8 +75,6 @@ pub struct IgvmParamBlock {
     /// without parsing any metadata.
     pub fw_metadata: u32,
 
-    _reserved2: u32,
-
     /// The amount of space that must be reserved at the base of the kernel
     /// memory region (e.g. for VMSA contents).
     pub kernel_reserved_size: u32,
@@ -82,4 +84,37 @@ pub struct IgvmParamBlock {
 
     /// The guest physical address of the base of the kernel memory region.
     pub kernel_base: u64,
+}
+
+/// The IGVM context page is a measured page that is used to specify the start
+/// context for the guest VMPL.  If present, it overrides the processor state
+/// initialized at reset.
+#[derive(Copy, Debug, Clone)]
+#[repr(C, packed)]
+pub struct IgvmGuestContext {
+    pub cr0: u64,
+    pub cr3: u64,
+    pub cr4: u64,
+    pub efer: u64,
+    pub gdt_base: u64,
+    pub gdt_limit: u32,
+    pub code_selector: u16,
+    pub data_selector: u16,
+    pub rip: u64,
+    pub rax: u64,
+    pub rcx: u64,
+    pub rdx: u64,
+    pub rbx: u64,
+    pub rsp: u64,
+    pub rbp: u64,
+    pub rsi: u64,
+    pub rdi: u64,
+    pub r8: u64,
+    pub r9: u64,
+    pub r10: u64,
+    pub r11: u64,
+    pub r12: u64,
+    pub r13: u64,
+    pub r14: u64,
+    pub r15: u64,
 }

--- a/bootlib/src/igvm_params.rs
+++ b/bootlib/src/igvm_params.rs
@@ -84,6 +84,9 @@ pub struct IgvmParamBlock {
 
     /// The guest physical address of the base of the kernel memory region.
     pub kernel_base: u64,
+
+    /// The value of vTOM used by the guest, or zero if not used.
+    pub vtom: u64,
 }
 
 /// The IGVM context page is a measured page that is used to specify the start

--- a/igvmbld/igvmbld.c
+++ b/igvmbld/igvmbld.c
@@ -25,6 +25,7 @@ typedef struct {
     uint32_t param_area_size;
     uint32_t param_page_offset;
     uint32_t memory_map_offset;
+    uint32_t guest_context_offset;
     uint32_t cpuid_page;
     uint32_t secrets_page;
     uint16_t debug_serial_port;
@@ -33,7 +34,6 @@ typedef struct {
     uint32_t fw_start;
     uint32_t fw_size;
     uint32_t fw_metadata;
-    uint32_t _reserved2;
     uint32_t kernel_reserved_size;
     uint32_t kernel_size;
     uint64_t kernel_base;

--- a/igvmbld/igvmbld.c
+++ b/igvmbld/igvmbld.c
@@ -28,7 +28,8 @@ typedef struct {
     uint32_t cpuid_page;
     uint32_t secrets_page;
     uint16_t debug_serial_port;
-    uint16_t _reserved1;
+    uint8_t fw_in_low_memory;
+    uint8_t _reserved1;
     uint32_t fw_start;
     uint32_t fw_size;
     uint32_t fw_metadata;

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,7 @@ use crate::mm::{PAGE_SIZE, SIZE_1G};
 use crate::serial::SERIAL_PORT;
 use crate::utils::MemoryRegion;
 use alloc::vec::Vec;
+use cpuarch::vmsa::VMSA;
 
 fn check_ovmf_regions(
     flash_regions: &[MemoryRegion<PhysAddr>],
@@ -152,6 +153,13 @@ impl<'a> SvsmConfig<'a> {
         match self {
             SvsmConfig::FirmwareConfig(_) => false,
             SvsmConfig::IgvmConfig(_) => true,
+        }
+    }
+
+    pub fn initialize_guest_vmsa(&self, vmsa: &mut VMSA) {
+        match self {
+            SvsmConfig::FirmwareConfig(_) => (),
+            SvsmConfig::IgvmConfig(igvm_params) => igvm_params.initialize_guest_vmsa(vmsa),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,44 @@ use crate::serial::SERIAL_PORT;
 use crate::utils::MemoryRegion;
 use alloc::vec::Vec;
 
+fn check_ovmf_regions(
+    flash_regions: &[MemoryRegion<PhysAddr>],
+    kernel_region: &MemoryRegion<PhysAddr>,
+) {
+    let flash_range = {
+        let one_gib = 1024 * 1024 * 1024usize;
+        let start = PhysAddr::from(3 * one_gib);
+        MemoryRegion::new(start, one_gib)
+    };
+
+    // Sanity-check flash regions.
+    for region in flash_regions.iter() {
+        // Make sure that the regions are between 3GiB and 4GiB.
+        if !region.overlap(&flash_range) {
+            panic!("flash region in unexpected region");
+        }
+
+        // Make sure that no regions overlap with the kernel.
+        if region.overlap(kernel_region) {
+            panic!("flash region overlaps with kernel");
+        }
+    }
+
+    // Make sure that regions don't overlap.
+    for (i, outer) in flash_regions.iter().enumerate() {
+        for inner in flash_regions[..i].iter() {
+            if outer.overlap(inner) {
+                panic!("flash regions overlap");
+            }
+        }
+        // Make sure that one regions ends at 4GiB.
+        let one_region_ends_at_4gib = flash_regions
+            .iter()
+            .any(|region| region.end() == flash_range.end());
+        assert!(one_region_ends_at_4gib);
+    }
+}
+
 #[derive(Debug)]
 pub enum SvsmConfig<'a> {
     FirmwareConfig(FwCfg<'a>),
@@ -83,12 +121,30 @@ impl<'a> SvsmConfig<'a> {
         }
     }
 
-    pub fn get_fw_regions(&self) -> Result<Vec<MemoryRegion<PhysAddr>>, SvsmError> {
+    pub fn get_fw_regions(
+        &self,
+        kernel_region: &MemoryRegion<PhysAddr>,
+    ) -> Vec<MemoryRegion<PhysAddr>> {
         match self {
             SvsmConfig::FirmwareConfig(fw_cfg) => {
-                Ok(fw_cfg.iter_flash_regions().collect::<Vec<_>>())
+                let flash_regions = fw_cfg.iter_flash_regions().collect::<Vec<_>>();
+                check_ovmf_regions(&flash_regions, kernel_region);
+                flash_regions
             }
-            SvsmConfig::IgvmConfig(igvm_params) => igvm_params.get_fw_regions(),
+            SvsmConfig::IgvmConfig(igvm_params) => {
+                let flash_regions = igvm_params.get_fw_regions();
+                if !igvm_params.fw_in_low_memory() {
+                    check_ovmf_regions(&flash_regions, kernel_region);
+                }
+                flash_regions
+            }
+        }
+    }
+
+    pub fn fw_in_low_memory(&self) -> bool {
+        match self {
+            SvsmConfig::FirmwareConfig(_) => false,
+            SvsmConfig::IgvmConfig(igvm_params) => igvm_params.fw_in_low_memory(),
         }
     }
 

--- a/src/igvm_params.rs
+++ b/src/igvm_params.rs
@@ -264,6 +264,12 @@ impl IgvmParams<'_> {
             vmsa.es = vmsa.ds;
             vmsa.fs = vmsa.ds;
             vmsa.gs = vmsa.ds;
+
+            // Configure vTOM if reqqested.
+            if self.igvm_param_block.vtom != 0 {
+                vmsa.vtom = self.igvm_param_block.vtom;
+                vmsa.sev_features |= 2; // VTOM feature
+            }
         }
     }
 }

--- a/src/igvm_params.rs
+++ b/src/igvm_params.rs
@@ -8,6 +8,7 @@ extern crate alloc;
 
 use crate::acpi::tables::ACPICPUInfo;
 use crate::address::{PhysAddr, VirtAddr};
+use crate::cpu::efer::EFERFlags;
 use crate::error::SvsmError;
 use crate::error::SvsmError::Firmware;
 use crate::mm::{PerCPUPageMappingGuard, PAGE_SIZE};
@@ -16,8 +17,9 @@ use crate::sev::{rmp_adjust, RMPFlags};
 use crate::types::PageSize;
 use crate::utils::MemoryRegion;
 use alloc::vec::Vec;
+use cpuarch::vmsa::VMSA;
 
-use bootlib::igvm_params::{IgvmParamBlock, IgvmParamPage};
+use bootlib::igvm_params::{IgvmGuestContext, IgvmParamBlock, IgvmParamPage};
 use core::mem::size_of;
 use igvm_defs::{IgvmEnvironmentInfo, MemoryMapEntryType, IGVM_VHS_MEMORY_MAP_ENTRY};
 
@@ -34,6 +36,7 @@ pub struct IgvmParams<'a> {
     igvm_param_block: &'a IgvmParamBlock,
     igvm_param_page: &'a IgvmParamPage,
     igvm_memory_map: &'a IgvmMemoryMap,
+    igvm_guest_context_address: VirtAddr,
 }
 
 impl IgvmParams<'_> {
@@ -43,11 +46,17 @@ impl IgvmParams<'_> {
         let param_page = unsafe { &*param_page_address.as_ptr::<IgvmParamPage>() };
         let memory_map_address = addr + param_block.memory_map_offset.try_into().unwrap();
         let memory_map = unsafe { &*memory_map_address.as_ptr::<IgvmMemoryMap>() };
+        let guest_context_address = if param_block.guest_context_offset != 0 {
+            addr + param_block.guest_context_offset.try_into().unwrap()
+        } else {
+            VirtAddr::null()
+        };
 
         Self {
             igvm_param_block: param_block,
             igvm_param_page: param_page,
             igvm_memory_map: memory_map,
+            igvm_guest_context_address: guest_context_address,
         }
     }
 
@@ -201,5 +210,60 @@ impl IgvmParams<'_> {
 
     pub fn fw_in_low_memory(&self) -> bool {
         self.igvm_param_block.fw_in_low_memory != 0
+    }
+
+    pub fn initialize_guest_vmsa(&self, vmsa: &mut VMSA) {
+        if self.igvm_param_block.guest_context_offset != 0 {
+            let guest_context =
+                unsafe { &*self.igvm_guest_context_address.as_ptr::<IgvmGuestContext>() };
+
+            // Copy the specified registers into the VMSA.
+            vmsa.cr0 = guest_context.cr0;
+            vmsa.cr3 = guest_context.cr3;
+            vmsa.cr4 = guest_context.cr4;
+            vmsa.efer = guest_context.efer;
+            vmsa.rip = guest_context.rip;
+            vmsa.rax = guest_context.rax;
+            vmsa.rcx = guest_context.rcx;
+            vmsa.rdx = guest_context.rdx;
+            vmsa.rbx = guest_context.rbx;
+            vmsa.rsp = guest_context.rsp;
+            vmsa.rbp = guest_context.rbp;
+            vmsa.rsi = guest_context.rsi;
+            vmsa.rdi = guest_context.rdi;
+            vmsa.r8 = guest_context.r8;
+            vmsa.r9 = guest_context.r9;
+            vmsa.r10 = guest_context.r10;
+            vmsa.r11 = guest_context.r11;
+            vmsa.r12 = guest_context.r12;
+            vmsa.r13 = guest_context.r13;
+            vmsa.r14 = guest_context.r14;
+            vmsa.r15 = guest_context.r15;
+            vmsa.gdt.base = guest_context.gdt_base;
+            vmsa.gdt.limit = guest_context.gdt_limit;
+            vmsa.cs.selector = guest_context.code_selector;
+
+            // Set the code segment attributes based on EFER.LMA.
+            let efer_lma = EFERFlags::LMA;
+            if (vmsa.efer & efer_lma.bits()) != 0 {
+                vmsa.cs.flags = 0xA9B;
+            } else {
+                vmsa.cs.flags = 0xC9B;
+                vmsa.cs.limit = 0xFFFFFFFF;
+            }
+
+            let efer_svme = EFERFlags::SVME;
+            vmsa.efer &= !efer_svme.bits();
+
+            // Modify the data segment attributes to be compatible with
+            // protected mode.
+            vmsa.ds.selector = guest_context.data_selector;
+            vmsa.ds.flags = 0xA93;
+            vmsa.ds.limit = 0xFFFFFFFF;
+            vmsa.ss = vmsa.ds;
+            vmsa.es = vmsa.ds;
+            vmsa.fs = vmsa.ds;
+            vmsa.gs = vmsa.ds;
+        }
     }
 }

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -206,9 +206,11 @@ fn prepare_fw_launch(fw_metadata: Option<&SevFWMetaData>) -> Result<(), SvsmErro
     Ok(())
 }
 
-fn launch_fw() -> Result<(), SvsmError> {
+fn launch_fw(config: &SvsmConfig) -> Result<(), SvsmError> {
     let vmsa_pa = this_cpu_mut().guest_vmsa_ref().vmsa_phys().unwrap();
     let vmsa = this_cpu_mut().guest_vmsa();
+
+    config.initialize_guest_vmsa(vmsa);
 
     log::info!("VMSA PA: {:#x}", vmsa_pa);
 
@@ -461,7 +463,7 @@ pub extern "C" fn svsm_main() {
     virt_log_usage();
 
     if config.should_launch_fw() {
-        if let Err(e) = launch_fw() {
+        if let Err(e) = launch_fw(&config) {
             panic!("Failed to launch FW: {:#?}", e);
         }
     }

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -50,7 +50,7 @@ use svsm::svsm_console::SVSMIOPort;
 use svsm::svsm_paging::{init_page_table, invalidate_early_boot_memory};
 use svsm::task::{create_task, TASK_FLAG_SHARE_PT};
 use svsm::types::{PageSize, GUEST_VMPL, PAGE_SIZE};
-use svsm::utils::{halt, immut_after_init::ImmutAfterInitCell, zero_mem_region, MemoryRegion};
+use svsm::utils::{halt, immut_after_init::ImmutAfterInitCell, zero_mem_region};
 
 use svsm::mm::validate::{init_valid_bitmap_ptr, migrate_valid_bitmap};
 
@@ -223,39 +223,8 @@ fn launch_fw() -> Result<(), SvsmError> {
 }
 
 fn validate_fw(config: &SvsmConfig, launch_info: &KernelLaunchInfo) -> Result<(), SvsmError> {
-    let flash_regions = config.get_fw_regions()?;
     let kernel_region = new_kernel_region(launch_info);
-    let flash_range = {
-        let one_gib = 1024 * 1024 * 1024usize;
-        let start = PhysAddr::from(3 * one_gib);
-        MemoryRegion::new(start, one_gib)
-    };
-
-    // Sanity-check flash regions.
-    for region in flash_regions.iter() {
-        // Make sure that the regions are between 3GiB and 4GiB.
-        if !region.overlap(&flash_range) {
-            panic!("flash region in unexpected region");
-        }
-
-        // Make sure that no regions overlap with the kernel.
-        if region.overlap(&kernel_region) {
-            panic!("flash region overlaps with kernel");
-        }
-    }
-    // Make sure that regions don't overlap.
-    for (i, outer) in flash_regions.iter().enumerate() {
-        for inner in flash_regions[..i].iter() {
-            if outer.overlap(inner) {
-                panic!("flash regions overlap");
-            }
-        }
-    }
-    // Make sure that one regions ends at 4GiB.
-    let one_region_ends_at_4gib = flash_regions
-        .iter()
-        .any(|region| region.end() == flash_range.end());
-    assert!(one_region_ends_at_4gib);
+    let flash_regions = config.get_fw_regions(&kernel_region);
 
     for (i, region) in flash_regions.into_iter().enumerate() {
         log::info!(

--- a/src/svsm_paging.rs
+++ b/src/svsm_paging.rs
@@ -133,9 +133,12 @@ pub fn invalidate_early_boot_memory(
 ) -> Result<(), SvsmError> {
     // Early boot memory must be invalidated after changing to the SVSM page
     // page table to avoid invalidating page tables currently in use.  Always
-    // invalidate stage 2 memory, and invalidate the boot data if required.
-    let stage2_region = MemoryRegion::new(PhysAddr::null(), 640 * 1024);
-    invalidate_boot_memory_region(config, stage2_region)?;
+    // invalidate stage 2 memory, unless firmware is loaded into low memory.
+    // Also invalidate the boot data if required.
+    if !config.fw_in_low_memory() {
+        let stage2_region = MemoryRegion::new(PhysAddr::null(), 640 * 1024);
+        invalidate_boot_memory_region(config, stage2_region)?;
+    }
 
     if config.invalidate_boot_data() {
         let kernel_elf_size =


### PR DESCRIPTION
This change introduces additional configuration information in the IGVM to support firmware other than OVMF.  In particular, it permits the firmware to live at the base of the address space instead of the ROM area; it permits the guest to configure initial context state that differs from the processor's architected reset state; and it permits the guest to enable vTOM in accordance with the vTOM policy described to the loader by the IGVM file.