### PR TITLE
igvm_params: Modify fw_size parameter to be in bytes rather than pages

### DIFF
--- a/igvm_params/src/lib.rs
+++ b/igvm_params/src/lib.rs
@@ -60,7 +60,7 @@ pub struct IgvmParamBlock {
     /// initialization is complete.
     pub fw_start: u32,
 
-    /// The number of pages of guest firmware. If the firmware size is zero then
+    /// The size of the guest firmware in bytes. If the firmware size is zero then
     /// no firmware is launched after initialization is complete.
     pub fw_size: u32,
 

--- a/src/igvm_params.rs
+++ b/src/igvm_params.rs
@@ -155,7 +155,7 @@ impl IgvmParams<'_> {
         } else {
             Ok(vec![MemoryRegion::new(
                 PhysAddr::new(self.igvm_param_block.fw_start as usize),
-                self.igvm_param_block.fw_size as usize * PAGE_SIZE,
+                self.igvm_param_block.fw_size as usize,
             )])
         }
     }


### PR DESCRIPTION
The other fields in IgvmParams that describe sizes are in bytes rather than pages whereas fw_size is in pages. This commit updates fw_size to describe the firmware size in bytes to be consistent.