### PR TITLE
Fix issues with IGVM boot

### DIFF
--- a/igvmbld/igvmbld.c
+++ b/igvmbld/igvmbld.c
@@ -885,9 +885,11 @@ int main(int argc, const char *argv[])
     cpuid_page->page_type = IgvmPageType_Cpuid;
     fill_cpuid_page((SNP_CPUID_PAGE *)cpuid_page->data);
 
-    // Construct a data object for the kernel image.  The kernel is always
-    // loaded at 640K.
-    kernel_data = construct_file_data_object(kernel_filename, 0xA0000);
+    // Load the kernel data at a base address of 1 MB.
+    address = 1 << 20;
+
+    // Construct a data object for the kernel.
+    kernel_data = construct_file_data_object(kernel_filename, address);
     if (kernel_data == NULL)
     {
         return 1;

--- a/src/config.rs
+++ b/src/config.rs
@@ -91,4 +91,11 @@ impl<'a> SvsmConfig<'a> {
             SvsmConfig::IgvmConfig(igvm_params) => igvm_params.get_fw_regions(),
         }
     }
+
+    pub fn invalidate_boot_data(&self) -> bool {
+        match self {
+            SvsmConfig::FirmwareConfig(_) => false,
+            SvsmConfig::IgvmConfig(_) => true,
+        }
+    }
 }

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -47,7 +47,7 @@ use svsm::sev::secrets_page::{copy_secrets_page, disable_vmpck0, SecretsPage};
 use svsm::sev::sev_status_init;
 use svsm::sev::utils::{rmp_adjust, RMPFlags};
 use svsm::svsm_console::SVSMIOPort;
-use svsm::svsm_paging::{init_page_table, invalidate_stage2};
+use svsm::svsm_paging::{init_page_table, invalidate_early_boot_memory};
 use svsm::task::{create_task, TASK_FLAG_SHARE_PT};
 use svsm::types::{PageSize, GUEST_VMPL, PAGE_SIZE};
 use svsm::utils::{halt, immut_after_init::ImmutAfterInitCell, zero_mem_region, MemoryRegion};
@@ -440,14 +440,15 @@ pub extern "C" fn svsm_main() {
         SvsmConfig::FirmwareConfig(FwCfg::new(&CONSOLE_IO))
     };
 
-    invalidate_stage2(&config).expect("Failed to invalidate Stage2 memory");
-
     init_memory_map(&config, &LAUNCH_INFO).expect("Failed to init guest memory map");
 
     initialize_fs();
 
     populate_ram_fs(LAUNCH_INFO.kernel_fs_start, LAUNCH_INFO.kernel_fs_end)
         .expect("Failed to unpack FS archive");
+
+    invalidate_early_boot_memory(&config, launch_info)
+        .expect("Failed to invalidate early boot memory");
 
     let cpus = config.load_cpu_info().expect("Failed to load ACPI tables");
     let mut nr_cpus = 0;


### PR DESCRIPTION
- Move the kernel ELF/fileystem so they do not collide with low memory ROMs
- Invalidate the kernel ELF/filesystem memory so it can be reused by OVMF