### PR TITLE
Supply firmware metadata information via the IGVM parameter block

### DIFF
--- a/bootlib/src/igvm_params.rs
+++ b/bootlib/src/igvm_params.rs
@@ -42,7 +42,7 @@ pub struct IgvmParamBlock {
     /// The guest physical address of the CPUID page.
     pub cpuid_page: u32,
 
-    /// The guest physical address of the secrets page.
+    /// The guest physical address of the SVSM secrets page.
     pub secrets_page: u32,
 
     /// The port number of the serial port to use for debugging.
@@ -66,6 +66,14 @@ pub struct IgvmParamBlock {
     /// a firmware range has been provided then the firmware is launched
     /// without parsing any metadata.
     pub fw_metadata: u32,
+
+    /// The guest physical address at which the firmware expects to find the
+    /// secrets page.
+    pub fw_secrets_page: u32,
+
+    /// The guest physical address at which the firmware expects to find the
+    /// calling area page.
+    pub fw_caa_page: u32,
 
     _reserved2: u32,
 

--- a/igvmbld/igvmbld.c
+++ b/igvmbld/igvmbld.c
@@ -32,6 +32,8 @@ typedef struct {
     uint32_t fw_start;
     uint32_t fw_size;
     uint32_t fw_metadata;
+    uint32_t fw_secrets_page;
+    uint32_t fw_caa_page;
     uint32_t _reserved2;
     uint32_t kernel_reserved_size;
     uint32_t kernel_size;

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,7 @@ use crate::acpi::tables::{load_acpi_cpu_info, ACPICPUInfo};
 use crate::address::PhysAddr;
 use crate::error::SvsmError;
 use crate::fw_cfg::FwCfg;
+use crate::fw_meta::SevFWMetaData;
 use crate::igvm_params::IgvmParams;
 use crate::mm::{PAGE_SIZE, SIZE_1G};
 use crate::serial::SERIAL_PORT;
@@ -73,12 +74,19 @@ impl<'a> SvsmConfig<'a> {
         }
     }
 
-    pub fn get_fw_metadata(&self) -> Option<PhysAddr> {
+    pub fn get_fw_metadata_address(&self) -> Option<PhysAddr> {
         match self {
             SvsmConfig::FirmwareConfig(_) => {
                 // The metadata location always starts at 32 bytes below 4GB
                 Some(PhysAddr::from((4 * SIZE_1G) - PAGE_SIZE))
             }
+            SvsmConfig::IgvmConfig(igvm_params) => igvm_params.get_fw_metadata_address(),
+        }
+    }
+
+    pub fn get_fw_metadata(&self) -> Option<SevFWMetaData> {
+        match self {
+            SvsmConfig::FirmwareConfig(_) => None,
             SvsmConfig::IgvmConfig(igvm_params) => igvm_params.get_fw_metadata(),
         }
     }


### PR DESCRIPTION
This change permits the IGVM file to specify firmware metadata that would normally be read out of QEMU firmware metadata.  This permits the IGVM file to specify metadata without external reference, and permits SVSM configuration of firmware metadata on platforms other than QEMU.