### PR TITLE
IGVM: Embed firmware in IGVM file and parse OVMF metadata into IGVM parameter block

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,13 @@ KERNEL_ELF = "target/x86_64-unknown-none/${TARGET_PATH}/svsm"
 TEST_KERNEL_ELF = target/x86_64-unknown-none/${TARGET_PATH}/svsm-test
 FS_FILE ?= none
 
+FW_FILE ?= none
+ifneq ($(FW_FILE), none)
+BUILD_FW = --firmware ${FW_FILE}
+else
+BUILD_FW = 
+endif
+
 C_BIT_POS ?= 51
 
 STAGE1_OBJS = stage1/stage1.o stage1/reset.o
@@ -29,12 +36,12 @@ all: stage1/kernel.elf svsm.bin igvm
 
 igvm: $(IGVM_FILES)
 
-$(IGVMBLD): igvmbld/igvmbld.c igvmbld/igvm_defs.h igvmbld/sev-snp.h
+$(IGVMBLD): igvmbld/igvmbld.c igvmbld/ovmfmeta.c igvmbld/ovmfmeta.h igvmbld/igvm_defs.h igvmbld/sev-snp.h
 	mkdir -v -p bin
-	$(CC) -o $@ -O -Iigvmbld igvmbld/igvmbld.c
+	$(CC) -o $@ -O -Iigvmbld igvmbld/igvmbld.c igvmbld/ovmfmeta.c
 
 bin/coconut-qemu.igvm: $(IGVMBLD) stage1/kernel.elf stage1/stage2.bin
-	$(IGVMBLD) --output $@ --stage2 stage1/stage2.bin --kernel stage1/kernel.elf --qemu
+	$(IGVMBLD) --output $@ --stage2 stage1/stage2.bin --kernel stage1/kernel.elf --qemu ${BUILD_FW}
 
 bin/coconut-hyperv.igvm: $(IGVMBLD) stage1/kernel.elf stage1/stage2.bin
 	$(IGVMBLD) --output $@ --stage2 stage1/stage2.bin --kernel stage1/kernel.elf --hyperv --com-port 3

--- a/bootlib/src/igvm_params.rs
+++ b/bootlib/src/igvm_params.rs
@@ -21,6 +21,63 @@ pub struct IgvmParamPage {
     pub environment_info: u32,
 }
 
+/// An entry that represents an area of pre-validated memory defined by the
+/// firmware in the IGVM file.
+#[repr(C, packed)]
+#[derive(Clone, Copy, Debug)]
+pub struct IgvmParamBlockFwMem {
+    /// The base physical address of the prevalidated memory region.
+    pub base: u32,
+
+    /// The length of the prevalidated memory region in bytes.
+    pub size: u32,
+}
+
+/// The portion of the IGVM parameter block that describes metadata about
+/// the firmware image embedded in the IGVM file.
+#[repr(C, packed)]
+#[derive(Clone, Copy, Debug)]
+pub struct IgvmParamBlockFwInfo {
+    /// The guest physical address of the start of the guest firmware. The
+    /// permissions on the pages in the firmware range are adjusted to the guest
+    /// VMPL. If this field is zero then no firmware is launched after
+    /// initialization is complete.
+    pub start: u32,
+
+    /// The size of the guest firmware in bytes. If the firmware size is zero then
+    /// no firmware is launched after initialization is complete.
+    pub size: u32,
+
+    /// The guest physical address of the page that contains metadata that
+    /// corresponds to the firmware. The SVSM expects the page to contain
+    /// metadata in the format defined by OVMF. If this field is zero but
+    /// a firmware range has been provided then the firmware is launched
+    /// without parsing any metadata.
+    pub metadata: u32,
+
+    /// The guest physical address at which the firmware expects to find the
+    /// secrets page.
+    pub secrets_page: u32,
+
+    /// The guest physical address at which the firmware expects to find the
+    /// calling area page.
+    pub caa_page: u32,
+
+    /// The guest physical address at which the firmware expects to find the
+    /// CPUID page.
+    pub cpuid_page: u32,
+
+    /// The guest physical address at which the firmware expects the reset
+    /// vector to be defined.
+    pub reset_addr: u32,
+
+    /// The number of prevalidated memory regions defined by the firmware.
+    pub prevalidated_count: u32,
+
+    /// The prevalidated memory regions defined by the firmware.
+    pub prevalidated: [IgvmParamBlockFwMem; 8],
+}
+
 /// The IGVM parameter block is a measured page constructed by the IGVM file
 /// builder which describes where the additional IGVM parameter information
 /// has been placed into the guest address space.
@@ -50,32 +107,9 @@ pub struct IgvmParamBlock {
 
     _reserved: u16,
 
-    /// The guest physical address of the start of the guest firmware. The
-    /// permissions on the pages in the firmware range are adjusted to the guest
-    /// VMPL. If this field is zero then no firmware is launched after
-    /// initialization is complete.
-    pub fw_start: u32,
-
-    /// The size of the guest firmware in bytes. If the firmware size is zero then
-    /// no firmware is launched after initialization is complete.
-    pub fw_size: u32,
-
-    /// The guest physical address of the page that contains metadata that
-    /// corresponds to the firmware. The SVSM expects the page to contain
-    /// metadata in the format defined by OVMF. If this field is zero but
-    /// a firmware range has been provided then the firmware is launched
-    /// without parsing any metadata.
-    pub fw_metadata: u32,
-
-    /// The guest physical address at which the firmware expects to find the
-    /// secrets page.
-    pub fw_secrets_page: u32,
-
-    /// The guest physical address at which the firmware expects to find the
-    /// calling area page.
-    pub fw_caa_page: u32,
-
-    _reserved2: u32,
+    /// Metadata containing information about the firmware image embedded in the
+    /// IGVM file.
+    pub firmware: IgvmParamBlockFwInfo,
 
     /// The amount of space that must be reserved at the base of the kernel
     /// memory region (e.g. for VMSA contents).

--- a/bootlib/src/igvm_params.rs
+++ b/bootlib/src/igvm_params.rs
@@ -48,12 +48,7 @@ pub struct IgvmParamBlockFwInfo {
     /// no firmware is launched after initialization is complete.
     pub size: u32,
 
-    /// The guest physical address of the page that contains metadata that
-    /// corresponds to the firmware. The SVSM expects the page to contain
-    /// metadata in the format defined by OVMF. If this field is zero but
-    /// a firmware range has been provided then the firmware is launched
-    /// without parsing any metadata.
-    pub metadata: u32,
+    _reserved: u32,
 
     /// The guest physical address at which the firmware expects to find the
     /// secrets page.

--- a/igvmbld/igvm_defs.h
+++ b/igvmbld/igvm_defs.h
@@ -3,6 +3,9 @@
 // Copyright (c) Microsoft Corporation
 //
 // Author: Jon Lange (jlange@microsoft.com)
+#pragma once
+
+#include <stdint.h>
 
 typedef enum {
     IGVM_VHT_SUPPORTED_PLATFORM = 0x1,
@@ -94,3 +97,35 @@ typedef struct {
     uint16_t Reserved;
     uint32_t padding;
 } IGVM_VHS_VP_CONTEXT;
+
+typedef struct {
+    uint32_t base;
+    uint32_t len;
+} IgvmParamBlockFwMem;
+
+typedef struct {
+    uint32_t start;
+    uint32_t size;
+    uint32_t metadata;
+    uint32_t secrets_page;
+    uint32_t caa_page;
+    uint32_t cpuid_page;
+    uint32_t reset_addr;
+    uint32_t prevalidated_count;
+    IgvmParamBlockFwMem prevalidated[8];
+} IgvmParamBlockFwInfo;
+
+typedef struct {
+    uint32_t param_area_size;
+    uint32_t param_page_offset;
+    uint32_t memory_map_offset;
+    uint32_t cpuid_page;
+    uint32_t secrets_page;
+    uint16_t debug_serial_port;
+    uint16_t _reserved1;
+    IgvmParamBlockFwInfo firmware;
+    uint32_t kernel_reserved_size;
+    uint32_t kernel_size;
+    uint64_t kernel_base;
+} IgvmParamBlock;
+

--- a/igvmbld/igvm_defs.h
+++ b/igvmbld/igvm_defs.h
@@ -106,7 +106,7 @@ typedef struct {
 typedef struct {
     uint32_t start;
     uint32_t size;
-    uint32_t metadata;
+    uint32_t _reserved;
     uint32_t secrets_page;
     uint32_t caa_page;
     uint32_t cpuid_page;
@@ -122,7 +122,7 @@ typedef struct {
     uint32_t cpuid_page;
     uint32_t secrets_page;
     uint16_t debug_serial_port;
-    uint16_t _reserved1;
+    uint16_t _reserved;
     IgvmParamBlockFwInfo firmware;
     uint32_t kernel_reserved_size;
     uint32_t kernel_size;

--- a/igvmbld/igvmbld.c
+++ b/igvmbld/igvmbld.c
@@ -16,6 +16,7 @@
 #include <unistd.h>
 #include "sev-snp.h"
 #include "igvm_defs.h"
+#include "ovmfmeta.h"
 
 #define PAGE_SIZE 0x1000
 
@@ -67,9 +68,13 @@ const char *stage2_filename;
 const char *kernel_filename;
 const char *filesystem_filename;
 const char *output_filename;
+const char *fw_filename;
+uint32_t fw_size;
+uint32_t fw_base;
 int is_qemu;
 int is_hyperv;
 int com_port = 1;
+int is_verbose;
 
 const uint16_t com_io_ports[] = { 0x3f8, 0x2f8, 0x3e8, 0x2e8 };
 
@@ -669,6 +674,50 @@ WriteError:
     return 0;
 }
 
+static int check_firmware_options() 
+{
+    if (is_qemu)
+    {
+        FILE *fp;
+
+        if (!fw_filename)
+        {
+            // Firmware image is optional.
+            return 0;
+        }
+
+        // Get the firmware file size so we can determine the top and bottom address
+        // range.
+        fp = fopen(fw_filename, "rb");
+        if (!fp)
+        {
+            fprintf(stderr, "Firmware file cannot be opened: \"%s\"\n", fw_filename);
+            return 1;
+            
+        }
+        if (fseek(fp, 0, SEEK_END) != 0)
+        {
+            fprintf(stderr, "Failed to read firmware file: \"%s\"\n", fw_filename);
+            fclose(fp);
+            return 1;
+        }
+        fw_size = ftell(fp);
+        fclose(fp);
+
+        // OVMF firmware must be aligned with the top at 4GB.
+        fw_base = 0xffffffff - fw_size + 1;
+    }
+    else
+    {
+        if (fw_filename)
+        {
+            fprintf(stderr, "The --firmware parameter is not currently supported for Hyper-V\n");
+            return 1;
+        }
+    }
+    return 0;
+}
+
 int parse_options(int argc, const char *argv[])
 {
     while (argc != 0)
@@ -766,6 +815,27 @@ int parse_options(int argc, const char *argv[])
         {
             is_hyperv = 1;
         }
+        else if ((0 == strcmp(argv[0], "--verbose")) || 
+                 (0 == strcmp(argv[0], "-v")))
+        {
+            is_verbose = 1;
+        }
+        else if (0 == strcmp(argv[0], "--firmware"))
+        {
+            if (fw_filename != NULL)
+            {
+                fprintf(stderr, "--firmware specified more than once\n");
+                return 1;
+            }
+            if (argc == 1)
+            {
+                fprintf(stderr, "missing argument for --firmware\n");
+                return 1;
+            }
+            fw_filename = argv[1];
+            argc -= 1;
+            argv += 1;
+        }
         else
         {
             fprintf(stderr, "unknown option %s\n", argv[0]);
@@ -796,9 +866,34 @@ int parse_options(int argc, const char *argv[])
     {
         fprintf(stderr, "exactly one of --qemu and --hyperv must be specified\n");
         return 1;
-    }        
+    }
+
+    if (check_firmware_options() != 0) 
+    {
+        return 1;
+    }
 
     return 0;
+}
+
+static void print_fw_metadata(IgvmParamBlock *igvm_parameter_block)
+{
+    uint32_t i;
+
+    printf("Firmware configuration\n======================\n");
+    printf("  start: %X\n", igvm_parameter_block->firmware.start);
+    printf("  size: %X\n", igvm_parameter_block->firmware.size);
+    printf("  metadata: %X\n", igvm_parameter_block->firmware.metadata);
+    printf("  secrets_page: %X\n", igvm_parameter_block->firmware.secrets_page);
+    printf("  caa_page: %X\n", igvm_parameter_block->firmware.caa_page);
+    printf("  cpuid_page: %X\n", igvm_parameter_block->firmware.cpuid_page);
+    printf("  reset_addr: %X\n", igvm_parameter_block->firmware.reset_addr);
+    printf("  prevalidated_count: %X\n", igvm_parameter_block->firmware.prevalidated_count);
+    for (i = 0; i < igvm_parameter_block->firmware.prevalidated_count; ++i)
+    {
+        printf("    prevalidated[%d].base: %X\n", i, igvm_parameter_block->firmware.prevalidated[i].base);
+        printf("    prevalidated[%d].len: %X\n", i, igvm_parameter_block->firmware.prevalidated[i].len);
+    }
 }
 
 int main(int argc, const char *argv[])
@@ -963,6 +1058,28 @@ int main(int argc, const char *argv[])
         // won't actually be consumed by QEMU anyway.
         vmsa_address = address;
         address += PAGE_SIZE;
+    }
+
+    // If a firmware file has been specified then add it and set the relevant 
+    // parameter block entries.
+    if (fw_filename)
+    {
+        igvm_parameter_block->firmware.size = fw_size;
+        igvm_parameter_block->firmware.start = fw_base;
+        if (!construct_file_data_object(fw_filename, fw_base))
+        {
+            return 1;
+        }
+
+        // If the firmware file is an OVMF binary then we can extract the OVMF
+        // metadata from it. If the firmware is not OVMF then this function has
+        // no effect.
+        parse_ovmf_metadata(fw_filename, igvm_parameter_block);
+        
+        if (is_verbose)
+        {
+            print_fw_metadata(igvm_parameter_block);
+        }
     }
 
     // Generate a header to describe the memory that will be used as the

--- a/igvmbld/igvmbld.c
+++ b/igvmbld/igvmbld.c
@@ -883,7 +883,6 @@ static void print_fw_metadata(IgvmParamBlock *igvm_parameter_block)
     printf("Firmware configuration\n======================\n");
     printf("  start: %X\n", igvm_parameter_block->firmware.start);
     printf("  size: %X\n", igvm_parameter_block->firmware.size);
-    printf("  metadata: %X\n", igvm_parameter_block->firmware.metadata);
     printf("  secrets_page: %X\n", igvm_parameter_block->firmware.secrets_page);
     printf("  caa_page: %X\n", igvm_parameter_block->firmware.caa_page);
     printf("  cpuid_page: %X\n", igvm_parameter_block->firmware.cpuid_page);

--- a/igvmbld/igvmbld.c
+++ b/igvmbld/igvmbld.c
@@ -22,25 +22,6 @@
 #define FIELD_OFFSET(type, field) ((int)((uint8_t *)&((type *)NULL)->field - (uint8_t *)NULL))
 
 typedef struct {
-    uint32_t param_area_size;
-    uint32_t param_page_offset;
-    uint32_t memory_map_offset;
-    uint32_t cpuid_page;
-    uint32_t secrets_page;
-    uint16_t debug_serial_port;
-    uint16_t _reserved1;
-    uint32_t fw_start;
-    uint32_t fw_size;
-    uint32_t fw_metadata;
-    uint32_t fw_secrets_page;
-    uint32_t fw_caa_page;
-    uint32_t _reserved2;
-    uint32_t kernel_reserved_size;
-    uint32_t kernel_size;
-    uint64_t kernel_base;
-} IgvmParamBlock;
-
-typedef struct {
     uint32_t cpu_count;
     uint32_t environment_info;
 } IgvmParamPage;
@@ -897,7 +878,7 @@ int main(int argc, const char *argv[])
         return 1;
     }
     address = (kernel_data->address + kernel_data->size + PAGE_SIZE - 1) &
-              ~(PAGE_SIZE - 1);
+              ~(PAGE_SIZE - 1);    
 
     // If a filesystem image is present, then load it after the kernel.  It is
     // rounded up to the next page boundary to avoid overlapping with any of

--- a/igvmbld/ovmfmeta.c
+++ b/igvmbld/ovmfmeta.c
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 SUSE LLC
+//
+// Author: Joerg Roedel <jroedel@suse.de>
+// Author: Roy Hopkins <roy.hopkins@suse.com>
+
+#include "ovmfmeta.h"
+#include "igvm_defs.h"
+#include <stdio.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <byteswap.h>
+#include <stdint.h>
+#include <string.h>
+
+#define UUID_FMT "%02hhx%02hhx%02hhx%02hhx-" \
+    "%02hhx%02hhx-%02hhx%02hhx-" \
+    "%02hhx%02hhx-" \
+    "%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx"
+
+struct UUID {
+    union {
+        unsigned char data[16];
+        struct {
+            /* Generated in BE endian, can be swapped with qemu_uuid_bswap. */
+            uint32_t time_low;
+            uint16_t time_mid;
+            uint16_t time_high_and_version;
+            uint8_t  clock_seq_and_reserved;
+            uint8_t  clock_seq_low;
+            uint8_t  node[6];
+        } fields;
+    };
+};
+
+void bswap16s(uint16_t *s)
+{
+    *s = bswap_16(*s);
+}
+
+void bswap32s(uint32_t *s)
+{
+    *s = bswap_32(*s);
+}
+
+struct UUID uuid_bswap(struct UUID uuid)
+{
+    bswap32s(&uuid.fields.time_low);
+    bswap16s(&uuid.fields.time_mid);
+    bswap16s(&uuid.fields.time_high_and_version);
+    return uuid;
+}
+
+int uuid_parse(const char *str, struct UUID *uuid)
+{
+    unsigned char *uu = &uuid->data[0];
+    int ret;
+
+    ret = sscanf(str, UUID_FMT, &uu[0], &uu[1], &uu[2], &uu[3],
+            &uu[4], &uu[5], &uu[6], &uu[7], &uu[8], &uu[9],
+            &uu[10], &uu[11], &uu[12], &uu[13], &uu[14],
+            &uu[15]);
+
+    if (ret != 16) {
+        return -1;
+    }
+    return 0;
+}
+
+int uuid_cmp(const struct UUID *u1, const struct UUID *u2)
+{
+    return memcmp(u1, u2, sizeof(*u1));
+}
+
+#define OVMF_TABLE_FOOTER_GUID     "96b582de-1fb2-45f7-baea-a366c55a082d"
+#define OVMF_SEV_META_DATA_GUID    "dc886566-984a-4798-a75e-5585a7bf67cc"
+#define SEV_INFO_BLOCK_GUID        "00f771de-1a7e-4fcb-890e-68c77e2fb44e"
+
+#define SEV_META_DESC_TYPE_MEM     1
+#define SEV_META_DESC_TYPE_SECRETS 2
+#define SEV_META_DESC_TYPE_CPUID   3
+#define SEV_META_DESC_TYPE_CAA     4
+
+enum meta_data_type {
+    SEV_DESC_TYPE_UNDEF,
+    SEV_DESC_TYPE_SNP_SEC_MEM,
+    SEV_DESC_TYPE_SNP_SECRETS,
+    SEV_DESC_TYPE_CPUID,
+    SEV_DESC_TYPE_CAA
+};
+
+struct __attribute__((__packed__)) meta_data_desc {
+    uint32_t base;
+    uint32_t len;
+    uint32_t type;
+};
+
+struct __attribute__((__packed__)) sev_meta_data {
+    char sig[4];
+    uint32_t len;
+    uint32_t version;
+    uint32_t num_desc;
+    struct meta_data_desc descs[];
+};
+
+static void parse_sev_info_block(void *data, IgvmParamBlock *params)
+{
+    params->firmware.reset_addr = *(uint32_t *)data;
+}
+
+static void parse_sev_meta_data(void *data, uint8_t *buffer, size_t size, IgvmParamBlock *params)
+{
+    uint32_t *d = data;
+    struct sev_meta_data *meta;
+    int i;
+
+    meta = (struct sev_meta_data *)(buffer + size - *d);
+
+    for (i = 0; i < meta->num_desc; ++i) 
+    {
+        switch (meta->descs[i].type) 
+        {
+            case SEV_DESC_TYPE_SNP_SEC_MEM:
+            {
+                uint32_t entry = params->firmware.prevalidated_count;
+                uint32_t max_entries = sizeof(params->firmware.prevalidated) / sizeof(IgvmParamBlockFwMem);
+                if (entry == max_entries)
+                {
+                    fprintf(stderr, "OVMF metadata defines too many memory regions\n");
+                    exit(1);
+                }
+                params->firmware.prevalidated[entry].base = meta->descs[i].base;
+                params->firmware.prevalidated[entry].len = meta->descs[i].len;
+                ++params->firmware.prevalidated_count;
+                break;
+            }
+
+            case SEV_DESC_TYPE_SNP_SECRETS:
+                params->firmware.secrets_page = meta->descs[i].base;
+                break;
+
+            case SEV_DESC_TYPE_CPUID:
+                params->firmware.cpuid_page = meta->descs[i].base;
+                break;
+
+            case SEV_DESC_TYPE_CAA:
+                params->firmware.caa_page = meta->descs[i].base;
+                break;
+        }
+    }
+}
+
+static uint8_t *parse_inner_table(uint8_t *ptr, uint8_t *buffer, size_t size, IgvmParamBlock *params)
+{
+    struct UUID *entry_uuid, meta_uuid, info_uuid;
+    int len;
+    void *data;
+
+    entry_uuid = (struct UUID *)(ptr - sizeof(struct UUID));
+    len = *(uint16_t *)(ptr - sizeof(struct UUID) - sizeof(uint16_t));
+    data = (void*)(ptr - len);
+
+    uuid_parse(OVMF_SEV_META_DATA_GUID, &meta_uuid);
+    meta_uuid = uuid_bswap(meta_uuid);
+
+    uuid_parse(SEV_INFO_BLOCK_GUID, &info_uuid);
+    info_uuid = uuid_bswap(info_uuid);
+
+    if (!uuid_cmp(entry_uuid, &meta_uuid)) {
+        parse_sev_meta_data(data, buffer, size, params);
+    } else if (!uuid_cmp(entry_uuid, &info_uuid)) {
+        parse_sev_info_block(data, params);
+    }
+    return ptr - len;
+}
+
+static void parse_table(uint8_t *buffer, size_t size, IgvmParamBlock *params)
+{
+    struct UUID uuid;
+    uint8_t *ptr;
+    int table_size;
+    uint8_t *table_ptr;
+
+    uuid_parse(OVMF_TABLE_FOOTER_GUID, &uuid);
+    uuid = uuid_bswap(uuid);
+    ptr = buffer + size - 48;
+
+    if (uuid_cmp((struct UUID *)ptr, &uuid))
+        return;
+
+    ptr -= 2;
+    table_size = (*(uint16_t*) ptr) - sizeof(struct UUID) - sizeof(uint16_t);
+    table_ptr = ptr;
+
+    while (table_ptr > (ptr - table_size)) {
+        table_ptr = parse_inner_table(table_ptr, buffer, size, params);
+    }
+}
+
+int parse_ovmf_metadata(const char *ovmf_filename, IgvmParamBlock *params)
+{
+    struct stat statbuf;
+    uint8_t *buffer;
+    size_t size;
+    int fd;
+
+    if (stat(ovmf_filename, &statbuf)) {
+        fprintf(stderr, "stat() failed\n");
+        return 1;
+    }
+
+    size = statbuf.st_size;
+    buffer = malloc(size);
+    if (!buffer) {
+        fprintf(stderr, "Cannot allocate buffer\n");
+        return 1;
+    }
+
+    fd = open(ovmf_filename, O_RDONLY);
+    if (fd < 0) {
+        fprintf(stderr, "Can't open file %s\n", ovmf_filename);
+        return 1;
+    }
+
+    if (read(fd, buffer, size) != size) {
+        fprintf(stderr, "Failed to read file\n");
+        return 1;
+    }
+
+    close(fd);
+
+    parse_table(buffer, size, params);
+
+    return 0;
+}

--- a/igvmbld/ovmfmeta.h
+++ b/igvmbld/ovmfmeta.h
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 SUSE LLC
+//
+// Author: Roy Hopkins <roy.hopkins@suse.com>
+
+#pragma once
+
+#include <stdint.h>
+#include "igvm_defs.h"
+
+int parse_ovmf_metadata(const char *ovmf_filename, IgvmParamBlock *params);

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,13 +6,15 @@
 
 extern crate alloc;
 
+use core::slice;
+
 use crate::acpi::tables::{load_acpi_cpu_info, ACPICPUInfo};
 use crate::address::PhysAddr;
 use crate::error::SvsmError;
 use crate::fw_cfg::FwCfg;
-use crate::fw_meta::SevFWMetaData;
+use crate::fw_meta::{parse_fw_meta_data, SevFWMetaData};
 use crate::igvm_params::IgvmParams;
-use crate::mm::{PAGE_SIZE, SIZE_1G};
+use crate::mm::{PerCPUPageMappingGuard, PAGE_SIZE, SIZE_1G};
 use crate::serial::SERIAL_PORT;
 use crate::utils::MemoryRegion;
 use alloc::vec::Vec;
@@ -74,19 +76,19 @@ impl<'a> SvsmConfig<'a> {
         }
     }
 
-    pub fn get_fw_metadata_address(&self) -> Option<PhysAddr> {
-        match self {
-            SvsmConfig::FirmwareConfig(_) => {
-                // The metadata location always starts at 32 bytes below 4GB
-                Some(PhysAddr::from((4 * SIZE_1G) - PAGE_SIZE))
-            }
-            SvsmConfig::IgvmConfig(igvm_params) => igvm_params.get_fw_metadata_address(),
-        }
-    }
-
     pub fn get_fw_metadata(&self) -> Option<SevFWMetaData> {
         match self {
-            SvsmConfig::FirmwareConfig(_) => None,
+            SvsmConfig::FirmwareConfig(_) => {
+                // Map the metadata location which is defined by the firmware config
+                let guard =
+                    PerCPUPageMappingGuard::create_4k(PhysAddr::from(4 * SIZE_1G - PAGE_SIZE))
+                        .expect("Failed to map FW metadata page");
+                let vstart = guard.virt_addr().as_ptr::<u8>();
+                // Safety: we just mapped a page, so the size must hold. The type
+                // of the slice elements is `u8` so there are no alignment requirements.
+                let metadata = unsafe { slice::from_raw_parts(vstart, PAGE_SIZE) };
+                Some(parse_fw_meta_data(metadata).expect("Failed to parse FW SEV meta-data"))
+            }
             SvsmConfig::IgvmConfig(igvm_params) => igvm_params.get_fw_metadata(),
         }
     }

--- a/src/igvm_params.rs
+++ b/src/igvm_params.rs
@@ -135,7 +135,7 @@ impl IgvmParams<'_> {
     }
 
     pub fn should_launch_fw(&self) -> bool {
-        self.igvm_param_block.fw_size != 0
+        self.igvm_param_block.firmware.size != 0
     }
 
     pub fn debug_serial_port(&self) -> u16 {
@@ -143,10 +143,12 @@ impl IgvmParams<'_> {
     }
 
     pub fn get_fw_metadata_address(&self) -> Option<PhysAddr> {
-        if !self.should_launch_fw() || self.igvm_param_block.fw_metadata == 0 {
+        if !self.should_launch_fw() || self.igvm_param_block.firmware.metadata == 0 {
             None
         } else {
-            Some(PhysAddr::from(self.igvm_param_block.fw_metadata as u64))
+            Some(PhysAddr::from(
+                self.igvm_param_block.firmware.metadata as u64,
+            ))
         }
     }
 
@@ -156,15 +158,19 @@ impl IgvmParams<'_> {
         } else {
             let mut fw_meta = SevFWMetaData::new();
 
-            if self.igvm_param_block.fw_caa_page != 0 {
+            if self.igvm_param_block.firmware.caa_page != 0 {
                 fw_meta.caa_page = Some(PhysAddr::new(
-                    self.igvm_param_block.fw_caa_page.try_into().unwrap(),
+                    self.igvm_param_block.firmware.caa_page.try_into().unwrap(),
                 ));
             }
 
-            if self.igvm_param_block.fw_secrets_page != 0 {
+            if self.igvm_param_block.firmware.secrets_page != 0 {
                 fw_meta.secrets_page = Some(PhysAddr::new(
-                    self.igvm_param_block.fw_secrets_page.try_into().unwrap(),
+                    self.igvm_param_block
+                        .firmware
+                        .secrets_page
+                        .try_into()
+                        .unwrap(),
                 ));
             }
 
@@ -177,8 +183,8 @@ impl IgvmParams<'_> {
             Err(Firmware)
         } else {
             Ok(vec![MemoryRegion::new(
-                PhysAddr::new(self.igvm_param_block.fw_start as usize),
-                self.igvm_param_block.fw_size as usize,
+                PhysAddr::new(self.igvm_param_block.firmware.start as usize),
+                self.igvm_param_block.firmware.size as usize,
             )])
         }
     }


### PR DESCRIPTION
This PR adds support for embedding firmware, particularly OVMF into an IGVM file using the IGVM builder. 

The Makefile has been updated to allow the OVMF file to be specified by the `FW_FILE` environment variable. This needs to be set to the `OVMF.fd` file (and not the separate `OVMF_CODE.fd` and `OVMF_VARS.fd` files). When provided, the firmware binary is parsed by the IGVM builder during the build to extract metadata which is then populated into the IGVM parameter block, passed to SVSM.

By providing the metadata in the IGVM parameter block, SVSM does not need to parse the OVMF metadata when using an IGVM file. The SVSM has been updated to reflect this by removing the `fw_metadata` IGVM parameter that specified the OVMF metadata page. In the future, if IGVM is solely used to configure the SVSM then the OVMF metadata parsing can be removed entirely from SVSM.