### PR TITLE
Move shared CPU state into a separate structure

### DIFF
--- a/src/protocols/core.rs
+++ b/src/protocols/core.rs
@@ -343,7 +343,7 @@ fn core_remap_ca(params: &RequestParams) -> Result<(), SvsmReqError> {
     let pending = GuestPtr::<u64>::new(vaddr);
     pending.write(0)?;
 
-    this_cpu_mut().update_guest_caa(gpa);
+    this_cpu_mut().shared.update_guest_caa(gpa);
 
     Ok(())
 }

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -195,7 +195,7 @@ fn prepare_fw_launch(fw_meta: &SevFWMetaData) -> Result<(), SvsmError> {
     let cpu = this_cpu_mut();
 
     if let Some(caa) = fw_meta.caa_page {
-        cpu.update_guest_caa(caa);
+        cpu.shared.update_guest_caa(caa);
     }
 
     cpu.alloc_guest_vmsa()?;


### PR DESCRIPTION
In order to preserve the Rust guarantees of mutually exclusive mutable and immutable references, it must never be possible for a PerCpu object to be accessible across threads, even to access fields that are designed to be thread-safe.  This change moves globally shared per-CPU fields into a separate structure that supports only immutable references, and fields contained within are synchronized using appropriate locking primitives that permit safe interior mutability.