### PR TITLE
igvmbld: Extend verbose mode to show guest memory and igvm params

### DIFF
--- a/igvmbld/igvmbld.h
+++ b/igvmbld/igvmbld.h
@@ -86,8 +86,8 @@ IGVM_VHS *allocate_var_headers(
     uint32_t header_size,
     int count);
 
-DATA_OBJ *construct_empty_data_object(uint64_t address, uint32_t size);
-DATA_OBJ *construct_mem_data_object(uint64_t address, uint32_t size);
+DATA_OBJ *construct_empty_data_object(uint64_t address, uint32_t size, const char *description);
+DATA_OBJ *construct_mem_data_object(uint64_t address, uint32_t size, const char *description);
 
 int read_hyperv_igvm_file(const char *file_name, FirmwareIgvmInfo *fw_info);
 

--- a/igvmbld/igvmcopy.c
+++ b/igvmbld/igvmcopy.c
@@ -345,7 +345,7 @@ IncompatibleFile:
                     // the SVSM.
                     if (page_data.FileOffset == 0)
                     {
-                        data_obj = construct_empty_data_object(page_data.GPA, PAGE_SIZE);
+                        data_obj = construct_empty_data_object(page_data.GPA, PAGE_SIZE, file_name);
                         data_obj->page_type = page_data.DataType;
                     }
                     else
@@ -354,7 +354,7 @@ IncompatibleFile:
                         {
                             goto ReadError;
                         }
-                        data_obj = construct_mem_data_object(page_data.GPA, PAGE_SIZE);
+                        data_obj = construct_mem_data_object(page_data.GPA, PAGE_SIZE, file_name);
                         data_obj->page_type = page_data.DataType;
 
                         if (0 != fseek(file, page_data.FileOffset, SEEK_SET))
@@ -426,7 +426,7 @@ IncompatibleFile:
                 // in the VP context object here is not relevant, because the
                 // SVSM IGVM headers expect the guest context to be part of
                 // the IGVM parameter area.
-                data_obj = construct_mem_data_object(0, PAGE_SIZE);
+                data_obj = construct_mem_data_object(0, PAGE_SIZE, file_name);
                 guest_context = data_obj->data;
                 memset(guest_context, 0, PAGE_SIZE);
                 fill_guest_context(guest_context, vmsa);


### PR DESCRIPTION
In order to help validate and debug issues around allocation of guest physical address ranges, and to ensure it matches the expectations of coconut SVSM, it is useful to see what is generated by the IGVM file builder.

This commit extends the verbose output from the tool to show the purpose and the range for each block of guest physical memory defined by the generated IGVM file as well as giving a detailed summary of the contents of the IGVM parameter block.