### PR TITLE
Ensure all boot memory is invalidated when QEMU guest is configured with IGVM

### DIFF
--- a/bootlib/src/kernel_launch.rs
+++ b/bootlib/src/kernel_launch.rs
@@ -20,6 +20,8 @@ pub struct KernelLaunchInfo {
     pub kernel_fs_end: u64,
     pub cpuid_page: u64,
     pub secrets_page: u64,
+    pub stage2_igvm_params_phys_addr: u64,
+    pub stage2_igvm_params_size: u64,
     pub igvm_params_phys_addr: u64,
     pub igvm_params_virt_addr: u64,
     pub debug_serial_port: u16,

--- a/igvmbld/igvmbld.h
+++ b/igvmbld/igvmbld.h
@@ -86,8 +86,8 @@ IGVM_VHS *allocate_var_headers(
     uint32_t header_size,
     int count);
 
-DATA_OBJ *construct_empty_data_object(uint64_t address, uint32_t size);
-DATA_OBJ *construct_mem_data_object(uint64_t address, uint32_t size);
+DATA_OBJ *construct_empty_data_object(uint64_t address, uint32_t size, const char *description);
+DATA_OBJ *construct_mem_data_object(uint64_t address, uint32_t size, const char *description);
 
 int read_hyperv_igvm_file(const char *file_name, FirmwareIgvmInfo *fw_info);
 

--- a/igvmbld/igvmcopy.c
+++ b/igvmbld/igvmcopy.c
@@ -345,7 +345,7 @@ IncompatibleFile:
                     // the SVSM.
                     if (page_data.FileOffset == 0)
                     {
-                        data_obj = construct_empty_data_object(page_data.GPA, PAGE_SIZE);
+                        data_obj = construct_empty_data_object(page_data.GPA, PAGE_SIZE, file_name);
                         data_obj->page_type = page_data.DataType;
                     }
                     else
@@ -354,7 +354,7 @@ IncompatibleFile:
                         {
                             goto ReadError;
                         }
-                        data_obj = construct_mem_data_object(page_data.GPA, PAGE_SIZE);
+                        data_obj = construct_mem_data_object(page_data.GPA, PAGE_SIZE, file_name);
                         data_obj->page_type = page_data.DataType;
 
                         if (0 != fseek(file, page_data.FileOffset, SEEK_SET))
@@ -426,7 +426,7 @@ IncompatibleFile:
                 // in the VP context object here is not relevant, because the
                 // SVSM IGVM headers expect the guest context to be part of
                 // the IGVM parameter area.
-                data_obj = construct_mem_data_object(0, PAGE_SIZE);
+                data_obj = construct_mem_data_object(0, PAGE_SIZE, file_name);
                 guest_context = data_obj->data;
                 memset(guest_context, 0, PAGE_SIZE);
                 fill_guest_context(guest_context, vmsa);

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -285,10 +285,11 @@ pub extern "C" fn stage2_main(launch_info: &Stage1LaunchInfo) {
     // after the kernel.
     let mut igvm_params_virt_address = VirtAddr::null();
     let mut igvm_params_phys_address = PhysAddr::null();
+    let mut igvm_params_size = 0;
     if let SvsmConfig::IgvmConfig(ref igvm_params) = config {
         igvm_params_virt_address = loaded_kernel_virt_end;
         igvm_params_phys_address = loaded_kernel_phys_end;
-        let igvm_params_size = igvm_params.size();
+        igvm_params_size = igvm_params.size();
 
         map_and_validate(
             &config,
@@ -337,6 +338,8 @@ pub extern "C" fn stage2_main(launch_info: &Stage1LaunchInfo) {
         kernel_fs_end: u64::from(launch_info.kernel_fs_end),
         cpuid_page: config.get_cpuid_page_address(),
         secrets_page: config.get_secrets_page_address(),
+        stage2_igvm_params_phys_addr: u64::from(launch_info.igvm_params),
+        stage2_igvm_params_size: igvm_params_size as u64,
         igvm_params_phys_addr: u64::from(igvm_params_phys_address),
         igvm_params_virt_addr: u64::from(igvm_params_virt_address),
         debug_serial_port: config.debug_serial_port(),

--- a/src/svsm_paging.rs
+++ b/src/svsm_paging.rs
@@ -150,11 +150,21 @@ pub fn invalidate_early_boot_memory(
         invalidate_boot_memory_region(config, kernel_elf_region)?;
 
         let kernel_fs_size = launch_info.kernel_fs_end - launch_info.kernel_fs_start;
-        let kernel_fs_region = MemoryRegion::new(
-            PhysAddr::new(launch_info.kernel_fs_start.try_into().unwrap()),
-            kernel_fs_size.try_into().unwrap(),
-        );
-        invalidate_boot_memory_region(config, kernel_fs_region)?;
+        if kernel_fs_size > 0 {
+            let kernel_fs_region = MemoryRegion::new(
+                PhysAddr::new(launch_info.kernel_fs_start.try_into().unwrap()),
+                kernel_fs_size.try_into().unwrap(),
+            );
+            invalidate_boot_memory_region(config, kernel_fs_region)?;
+        }
+
+        if launch_info.stage2_igvm_params_size > 0 {
+            let igvm_params_region = MemoryRegion::new(
+                PhysAddr::new(launch_info.stage2_igvm_params_phys_addr.try_into().unwrap()),
+                launch_info.stage2_igvm_params_size as usize,
+            );
+            invalidate_boot_memory_region(config, igvm_params_region)?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
When booting using an IGVM configuration, the current IGVM builder places some of the prevalidated pages outside the first 640K of low memory. These need to be invalidated prior to booting the firmware. 

This PR moves some of the regions in the IGVM builder and detects and invalidates the relevant sections in the SVSM when using IGVM.

Note that this PR is based on a branch which already includes the commit under separate review #206. Please ignore commit d6b606cfb1e283d3973b357f450a3a6a30fa4a41 when reviewing this PR.