### PR TITLE
scripts/check-signed-off: check that commits do not have an empty body

### DIFF
--- a/scripts/check-signed-off.sh
+++ b/scripts/check-signed-off.sh
@@ -42,7 +42,7 @@ fi
 start=$1
 end=$2
 
-commits=$(git log "${start}".."${end}" --pretty=format:"%H")
+commits=$(git log "${start}".."${end}" --format="%H")
 for c in ${commits[@]}; do
 
 	echo "Checking $c"
@@ -57,8 +57,8 @@ for c in ${commits[@]}; do
 		exit 1
 	fi
 
-	commit_email=$(git show --no-patch --pretty="format:%ae" "$c" || exit 1)
-	commit_name=$(git show --no-patch --pretty="format:%an" "$c" || exit 1)
+	commit_email=$(git show --no-patch --format="%ae" "$c" || exit 1)
+	commit_name=$(git show --no-patch --format="%an" "$c" || exit 1)
 	sign_names=$(git show --no-patch "$c" | sed -nr 's/^[[:space:]]*Signed-off-by: (.*) <(.*)>/\1/p' || exit 1)
 	sign_emails=$(git show --no-patch "$c" | sed -nr 's/^[[:space:]]*Signed-off-by: (.*) <(.*)>/\2/p' || exit 1)
 


### PR DESCRIPTION
Check that all new commits have a commit body besides the summary line and git trailers.

Unfortunately git does not have a direct option to show the body (i.e. everything after the summary line) without the trailers, so we have to filter them out manually.