### PR TITLE
Remove references to SEV_INFO OVMF metadata since it is never used

### DIFF
--- a/bootlib/src/igvm_params.rs
+++ b/bootlib/src/igvm_params.rs
@@ -52,7 +52,7 @@ pub struct IgvmParamBlockFwInfo {
     /// memory and will not be loaded into the ROM range.
     pub in_low_memory: u8,
 
-    _reserved: [u8; 3],
+    _reserved: [u8; 7],
 
     /// The guest physical address at which the firmware expects to find the
     /// secrets page.
@@ -65,10 +65,6 @@ pub struct IgvmParamBlockFwInfo {
     /// The guest physical address at which the firmware expects to find the
     /// CPUID page.
     pub cpuid_page: u32,
-
-    /// The guest physical address at which the firmware expects the reset
-    /// vector to be defined.
-    pub reset_addr: u32,
 
     /// The number of prevalidated memory regions defined by the firmware.
     pub prevalidated_count: u32,

--- a/igvmbld/igvmbld.c
+++ b/igvmbld/igvmbld.c
@@ -873,7 +873,6 @@ static void print_fw_metadata(IgvmParamBlock *igvm_parameter_block)
     printf("    secrets_page: 0x%X\n", igvm_parameter_block->firmware.secrets_page);
     printf("    caa_page: 0x%X\n", igvm_parameter_block->firmware.caa_page);
     printf("    cpuid_page: 0x%X\n", igvm_parameter_block->firmware.cpuid_page);
-    printf("    reset_addr: 0x%X\n", igvm_parameter_block->firmware.reset_addr);
     printf("    prevalidated_count: 0x%X\n", igvm_parameter_block->firmware.prevalidated_count);
     for (i = 0; i < igvm_parameter_block->firmware.prevalidated_count; ++i)
     {

--- a/igvmbld/igvmbld.h
+++ b/igvmbld/igvmbld.h
@@ -25,11 +25,10 @@ typedef struct {
     uint32_t start;
     uint32_t size;
     uint8_t in_low_memory;
-    uint8_t _reserved[3];
+    uint8_t _reserved[7];
     uint32_t secrets_page;
     uint32_t caa_page;
     uint32_t cpuid_page;
-    uint32_t reset_addr;
     uint32_t prevalidated_count;
     IgvmParamBlockFwMem prevalidated[8];
 } IgvmParamBlockFwInfo;

--- a/igvmbld/ovmfmeta.c
+++ b/igvmbld/ovmfmeta.c
@@ -71,7 +71,6 @@ int uuid_cmp(const struct UUID *u1, const struct UUID *u2)
 
 #define OVMF_TABLE_FOOTER_GUID     "96b582de-1fb2-45f7-baea-a366c55a082d"
 #define OVMF_SEV_META_DATA_GUID    "dc886566-984a-4798-a75e-5585a7bf67cc"
-#define SEV_INFO_BLOCK_GUID        "00f771de-1a7e-4fcb-890e-68c77e2fb44e"
 
 #define SEV_META_DESC_TYPE_MEM     1
 #define SEV_META_DESC_TYPE_SECRETS 2
@@ -99,11 +98,6 @@ struct __attribute__((__packed__)) sev_meta_data {
     uint32_t num_desc;
     struct meta_data_desc descs[];
 };
-
-static void parse_sev_info_block(void *data, IgvmParamBlock *params)
-{
-    params->firmware.reset_addr = *(uint32_t *)data;
-}
 
 static void parse_sev_meta_data(void *data, uint8_t *buffer, size_t size, IgvmParamBlock *params)
 {
@@ -149,7 +143,7 @@ static void parse_sev_meta_data(void *data, uint8_t *buffer, size_t size, IgvmPa
 
 static uint8_t *parse_inner_table(uint8_t *ptr, uint8_t *buffer, size_t size, IgvmParamBlock *params)
 {
-    struct UUID *entry_uuid, meta_uuid, info_uuid;
+    struct UUID *entry_uuid, meta_uuid;
     int len;
     void *data;
 
@@ -160,13 +154,8 @@ static uint8_t *parse_inner_table(uint8_t *ptr, uint8_t *buffer, size_t size, Ig
     uuid_parse(OVMF_SEV_META_DATA_GUID, &meta_uuid);
     meta_uuid = uuid_bswap(meta_uuid);
 
-    uuid_parse(SEV_INFO_BLOCK_GUID, &info_uuid);
-    info_uuid = uuid_bswap(info_uuid);
-
     if (!uuid_cmp(entry_uuid, &meta_uuid)) {
         parse_sev_meta_data(data, buffer, size, params);
-    } else if (!uuid_cmp(entry_uuid, &info_uuid)) {
-        parse_sev_info_block(data, params);
     }
     return ptr - len;
 }

--- a/src/igvm_params.rs
+++ b/src/igvm_params.rs
@@ -195,16 +195,6 @@ impl IgvmParams<'_> {
                 fw_meta.add_valid_mem(base, size);
             }
 
-            if self.igvm_param_block.firmware.reset_addr != 0 {
-                fw_meta.reset_ip = Some(PhysAddr::new(
-                    self.igvm_param_block
-                        .firmware
-                        .reset_addr
-                        .try_into()
-                        .unwrap(),
-                ));
-            }
-
             Some(fw_meta)
         }
     }


### PR DESCRIPTION
The data from the SEV_INFO metadata field is never consumed anywhere, so
there is no reason to collect any data from it.