### PR TITLE
igvmbld: Zero stage2 stack page before populating it

### DIFF
--- a/igvmbld/igvmbld.c
+++ b/igvmbld/igvmbld.c
@@ -1029,6 +1029,7 @@ int main(int argc, const char *argv[])
     }
 
     // Construct the initial stack contents.
+    memset(initial_stack->data, 0, PAGE_SIZE);
     stage2_stack = (Stage2Stack *)((uint8_t *)initial_stack->data + PAGE_SIZE) - 1;
     stage2_stack->kernel_start = (uint32_t)kernel_data->address;
     stage2_stack->kernel_end = (uint32_t)kernel_data->address + kernel_data->size;


### PR DESCRIPTION
The stage2 stack page memory is allocated with a call to construct_mem_data_object(). This function zeros any padding outside of the requested data size but does not zero the memory where the data resides.

The stage2 stack is allocated as a full page, meaning the stack is not initialised to zero. This results in uninitialised data being present below the populated stack frame and in the _reserved part of the stack.

This commit zeroes the entire stack page to ensure it is initialised.