### PR TITLE
Rework Task and Scheduler Code

### DIFF
--- a/src/cpu/percpu.rs
+++ b/src/cpu/percpu.rs
@@ -27,7 +27,7 @@ use crate::mm::{
 use crate::sev::ghcb::GHCB;
 use crate::sev::utils::RMPFlags;
 use crate::sev::vmsa::allocate_new_vmsa;
-use crate::task::RunQueue;
+use crate::task::{RunQueue, TaskPointer};
 use crate::types::{PAGE_SHIFT, PAGE_SHIFT_2M, PAGE_SIZE, PAGE_SIZE_2M, SVSM_TR_FLAGS, SVSM_TSS};
 use alloc::sync::Arc;
 use alloc::vec::Vec;
@@ -714,4 +714,8 @@ impl PerCpuVmsas {
 
         Ok(guard.swap_remove(index))
     }
+}
+
+pub fn current_task() -> TaskPointer {
+    this_cpu().runqueue.lock_read().current_task()
 }

--- a/src/cpu/percpu.rs
+++ b/src/cpu/percpu.rs
@@ -266,7 +266,7 @@ impl PerCpu {
             vm_range: VMR::new(SVSM_PERCPU_BASE, SVSM_PERCPU_END, PTEntryFlags::GLOBAL),
             vrange_4k: VirtualRange::new(),
             vrange_2m: VirtualRange::new(),
-            runqueue: RWLock::new(RunQueue::new(apic_id)),
+            runqueue: RWLock::new(RunQueue::new()),
             current_stack: StackBounds::default(),
         }
     }
@@ -603,12 +603,6 @@ impl PerCpu {
 
     pub fn handle_pf(&self, vaddr: VirtAddr, write: bool) -> Result<(), SvsmError> {
         self.vm_range.handle_page_fault(vaddr, write)
-    }
-
-    /// Allocate any candidate unallocated tasks from the global task list to our
-    /// CPU runqueue.
-    pub fn allocate_tasks(&mut self) {
-        self.runqueue.lock_write().allocate();
     }
 
     /// Access the PerCpu runqueue protected with a lock

--- a/src/cpu/percpu.rs
+++ b/src/cpu/percpu.rs
@@ -439,6 +439,10 @@ impl PerCpu {
         self.register_ghcb()
     }
 
+    pub fn setup_idle_task(&self, entry: extern "C" fn()) -> Result<(), SvsmError> {
+        self.runqueue.lock_read().allocate_idle_task(entry)
+    }
+
     pub fn load_pgtable(&mut self) {
         self.get_pgtable().load();
     }

--- a/src/cpu/smp.rs
+++ b/src/cpu/smp.rs
@@ -61,6 +61,10 @@ fn start_ap() {
         .setup_on_cpu()
         .expect("setup_on_cpu() failed");
 
+    this_cpu()
+        .setup_idle_task(ap_request_loop)
+        .expect("Failed to allocated idle task for AP");
+
     // Send a life-sign
     log::info!("AP with APIC-ID {} is online", this_cpu_mut().get_apic_id());
 

--- a/src/cpu/smp.rs
+++ b/src/cpu/smp.rs
@@ -10,7 +10,7 @@ use crate::acpi::tables::ACPICPUInfo;
 use crate::cpu::percpu::{this_cpu, this_cpu_mut, PerCpu};
 use crate::cpu::vmsa::init_svsm_vmsa;
 use crate::requests::request_loop;
-use crate::task::{create_task, TASK_FLAG_SHARE_PT};
+use crate::task::schedule_init;
 
 fn start_cpu(apic_id: u32) {
     unsafe {
@@ -71,13 +71,7 @@ fn start_ap() {
     // Set CPU online so that BSP can proceed
     this_cpu_mut().set_online();
 
-    // Create the task making sure the task only runs on this new AP
-    create_task(
-        ap_request_loop,
-        TASK_FLAG_SHARE_PT,
-        Some(this_cpu().get_apic_id()),
-    )
-    .expect("Failed to create AP initial task");
+    schedule_init();
 }
 
 #[no_mangle]

--- a/src/cpu/smp.rs
+++ b/src/cpu/smp.rs
@@ -9,8 +9,8 @@ extern crate alloc;
 use crate::acpi::tables::ACPICPUInfo;
 use crate::cpu::percpu::{this_cpu, this_cpu_mut, PerCpu};
 use crate::cpu::vmsa::init_svsm_vmsa;
-use crate::requests::request_loop;
-use crate::task::schedule_init;
+use crate::requests::{request_loop, request_processing_main};
+use crate::task::{create_kernel_task, schedule_init, TASK_FLAG_SHARE_PT};
 
 fn start_cpu(apic_id: u32) {
     unsafe {
@@ -76,6 +76,8 @@ fn start_ap() {
 
 #[no_mangle]
 pub extern "C" fn ap_request_loop() {
+    create_kernel_task(request_processing_main, TASK_FLAG_SHARE_PT)
+        .expect("Failed to launch request processing task");
     request_loop();
     panic!("Returned from request_loop!");
 }

--- a/src/debug/gdbstub.rs
+++ b/src/debug/gdbstub.rs
@@ -24,7 +24,7 @@ pub mod svsm_gdbstub {
     use crate::mm::PerCPUPageMappingGuard;
     use crate::serial::{SerialPort, Terminal};
     use crate::svsm_console::SVSMIOPort;
-    use crate::task::{is_current_task, TaskContext, TaskState, INITIAL_TASK_ID, TASKLIST};
+    use crate::task::{is_current_task, TaskContext, INITIAL_TASK_ID, TASKLIST};
     use core::arch::asm;
     use core::fmt;
     use core::sync::atomic::{AtomicBool, Ordering};
@@ -572,9 +572,10 @@ pub mod svsm_gdbstub {
             let str = match tl.get_task(tid.get() as u32) {
                 Some(t) => {
                     let t = t.task.lock_read();
-                    match t.state {
-                        TaskState::RUNNING => "Running".as_bytes(),
-                        TaskState::TERMINATED => "Terminated".as_bytes(),
+                    if t.is_running() {
+                        "Running".as_bytes()
+                    } else {
+                        "Terminated".as_bytes()
                     }
                 }
                 None => "Stopped".as_bytes(),

--- a/src/debug/gdbstub.rs
+++ b/src/debug/gdbstub.rs
@@ -548,7 +548,7 @@ pub mod svsm_gdbstub {
 
                 let mut cursor = tl.list().front_mut();
                 while cursor.get().is_some() {
-                    let this_task = cursor.get().unwrap().task.lock_read().id;
+                    let this_task = cursor.get().unwrap().task.lock_read().get_task_id();
                     if this_task != current_task {
                         thread_is_active(Tid::new(this_task as usize).unwrap());
                     }

--- a/src/debug/gdbstub.rs
+++ b/src/debug/gdbstub.rs
@@ -570,8 +570,10 @@ pub mod svsm_gdbstub {
                 Some(task) => {
                     if task.is_running() {
                         "Running".as_bytes()
-                    } else {
+                    } else if task.is_terminated() {
                         "Terminated".as_bytes()
+                    } else {
+                        "Blocked".as_bytes()
                     }
                 }
                 None => "Stopped".as_bytes(),

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -342,6 +342,11 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
         .expect("Failed to run percpu.setup_on_cpu()");
     bsp_percpu.load();
 
+    // Idle task must be allocated after PerCPU data is mapped
+    bsp_percpu
+        .setup_idle_task(svsm_main)
+        .expect("Failed to allocate idle task for BSP");
+
     idt_init();
 
     CONSOLE_SERIAL

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -49,7 +49,7 @@ use svsm::sev::utils::{rmp_adjust, RMPFlags};
 use svsm::sev::{init_hypervisor_ghcb_features, secrets_page, secrets_page_mut, sev_status_init};
 use svsm::svsm_console::SVSMIOPort;
 use svsm::svsm_paging::{init_page_table, invalidate_early_boot_memory};
-use svsm::task::{create_task, TASK_FLAG_SHARE_PT};
+use svsm::task::schedule_init;
 use svsm::types::{PageSize, GUEST_VMPL, PAGE_SIZE};
 use svsm::utils::{halt, immut_after_init::ImmutAfterInitCell, zero_mem_region};
 
@@ -371,13 +371,7 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
 
     log::info!("BSP Runtime stack starts @ {:#018x}", bp);
 
-    // Create the root task that runs the entry point then handles the request loop
-    create_task(
-        svsm_main,
-        TASK_FLAG_SHARE_PT,
-        Some(this_cpu().get_apic_id()),
-    )
-    .expect("Failed to create initial task");
+    schedule_init();
 
     panic!("SVSM entry point terminated unexpectedly");
 }

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -6,11 +6,15 @@
 
 mod schedule;
 mod tasks;
+mod waiting;
 
 pub use schedule::{
-    create_kernel_task, is_current_task, schedule, schedule_init, RunQueue, TASKLIST,
+    create_kernel_task, is_current_task, schedule, schedule_init, schedule_task, RunQueue, TASKLIST,
 };
+
 pub use tasks::{
     Task, TaskContext, TaskError, TaskListAdapter, TaskPointer, TaskRunListAdapter, TaskState,
     INITIAL_TASK_ID, TASK_FLAG_SHARE_PT,
 };
+
+pub use waiting::WaitQueue;

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -7,8 +7,8 @@
 mod schedule;
 mod tasks;
 
-pub use schedule::{
-    create_task, is_current_task, schedule, schedule_init, RunQueue, TaskNode, TaskPointer,
-    TASKLIST,
+pub use schedule::{create_task, is_current_task, schedule, schedule_init, RunQueue, TASKLIST};
+pub use tasks::{
+    Task, TaskContext, TaskError, TaskListAdapter, TaskPointer, TaskRunListAdapter, TaskState,
+    INITIAL_TASK_ID, TASK_FLAG_SHARE_PT,
 };
-pub use tasks::{Task, TaskContext, TaskError, TaskState, INITIAL_TASK_ID, TASK_FLAG_SHARE_PT};

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -8,6 +8,7 @@ mod schedule;
 mod tasks;
 
 pub use schedule::{
-    create_task, is_current_task, schedule, RunQueue, TaskNode, TaskPointer, TASKLIST,
+    create_task, is_current_task, schedule, schedule_init, schedule_rr, RunQueue, TaskNode,
+    TaskPointer, TASKLIST,
 };
 pub use tasks::{Task, TaskContext, TaskError, TaskState, INITIAL_TASK_ID, TASK_FLAG_SHARE_PT};

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -8,7 +8,7 @@ mod schedule;
 mod tasks;
 
 pub use schedule::{
-    create_task, is_current_task, schedule, schedule_init, schedule_rr, RunQueue, TaskNode,
-    TaskPointer, TASKLIST,
+    create_task, is_current_task, schedule, schedule_init, RunQueue, TaskNode, TaskPointer,
+    TASKLIST,
 };
 pub use tasks::{Task, TaskContext, TaskError, TaskState, INITIAL_TASK_ID, TASK_FLAG_SHARE_PT};

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -7,7 +7,9 @@
 mod schedule;
 mod tasks;
 
-pub use schedule::{create_task, is_current_task, schedule, schedule_init, RunQueue, TASKLIST};
+pub use schedule::{
+    create_kernel_task, is_current_task, schedule, schedule_init, RunQueue, TASKLIST,
+};
 pub use tasks::{
     Task, TaskContext, TaskError, TaskListAdapter, TaskPointer, TaskRunListAdapter, TaskState,
     INITIAL_TASK_ID, TASK_FLAG_SHARE_PT,

--- a/src/task/schedule.rs
+++ b/src/task/schedule.rs
@@ -44,9 +44,16 @@ use intrusive_collections::LinkedList;
 
 #[derive(Debug, Default)]
 pub struct RunQueue {
+    /// Linked list with runable tasks
     run_list: LinkedList<TaskRunListAdapter>,
+
+    /// Pointer to currently running task
     current_task: Option<TaskPointer>,
+
+    /// Idle task - runs when there is no other runnable task
     idle_task: OnceCell<TaskPointer>,
+
+    /// Temporary storage for tasks which are about to be terminated
     terminated_task: Option<TaskPointer>,
 }
 

--- a/src/task/schedule.rs
+++ b/src/task/schedule.rs
@@ -106,7 +106,7 @@ impl RunQueue {
     /// after the task-switch.
     fn handle_task(&mut self, taskptr: TaskPointer) {
         let task = taskptr.task.lock_read();
-        if (task.state == TaskState::RUNNING) && !task.idle_task {
+        if (task.state == TaskState::RUNNING) && !task.is_idle_task() {
             self.run_list.push_back(taskptr.clone());
         } else if task.state == TaskState::TERMINATED {
             self.terminated_task = Some(taskptr.clone());
@@ -170,7 +170,7 @@ impl RunQueue {
     /// Ok(()) on success, SvsmError on failure
     pub fn allocate_idle_task(&self, entry: extern "C" fn()) -> Result<(), SvsmError> {
         let mut task = Task::create(entry, TASK_FLAG_SHARE_PT)?;
-        task.idle_task = true;
+        task.set_idle_task();
         let node = Arc::new(TaskNode {
             list_link: LinkedListAtomicLink::default(),
             runlist_link: LinkedListAtomicLink::default(),

--- a/src/task/schedule.rs
+++ b/src/task/schedule.rs
@@ -169,7 +169,7 @@ impl RunQueue {
     ///
     /// Ok(()) on success, SvsmError on failure
     pub fn allocate_idle_task(&self, entry: extern "C" fn()) -> Result<(), SvsmError> {
-        let mut task = Task::create(entry, TASK_FLAG_SHARE_PT)?;
+        let task = Task::create(entry, TASK_FLAG_SHARE_PT)?;
         task.set_idle_task();
         let node = Arc::new(TaskNode {
             list_link: LinkedListAtomicLink::default(),

--- a/src/task/schedule.rs
+++ b/src/task/schedule.rs
@@ -159,7 +159,7 @@ impl RunQueue {
     pub fn current_task_id(&self) -> u32 {
         self.current_task
             .as_ref()
-            .map_or(INITIAL_TASK_ID, |t| t.task.lock_read().id)
+            .map_or(INITIAL_TASK_ID, |t| t.task.lock_read().get_task_id())
     }
 
     /// Allocates the idle task for this RunQueue. This function sets a
@@ -212,7 +212,7 @@ impl TaskList {
         let task_list = &self.list.as_ref()?;
         let mut cursor = task_list.front();
         while let Some(task_node) = cursor.get() {
-            if task_node.task.lock_read().id == id {
+            if task_node.task.lock_read().get_task_id() == id {
                 return cursor.clone_pointer();
             }
             cursor.move_next();
@@ -254,7 +254,7 @@ pub fn create_task(entry: extern "C" fn(), flags: u16) -> Result<TaskPointer, Sv
 /// Check to see if the task scheduled on the current processor has the given id
 pub fn is_current_task(id: u32) -> bool {
     match &this_cpu().runqueue().lock_read().current_task {
-        Some(current_task) => current_task.task.lock_read().id == id,
+        Some(current_task) => current_task.task.lock_read().get_task_id() == id,
         None => id == INITIAL_TASK_ID,
     }
 }

--- a/src/task/schedule.rs
+++ b/src/task/schedule.rs
@@ -396,6 +396,10 @@ impl RunQueue {
         cursor.remove();
         task_node.task.lock_write().allocation = None;
     }
+
+    pub fn current_task(&self) -> TaskPointer {
+        self.current_task.as_ref().unwrap().clone()
+    }
 }
 
 /// Global task list

--- a/src/task/schedule.rs
+++ b/src/task/schedule.rs
@@ -310,6 +310,12 @@ pub fn schedule() {
         .take();
 }
 
+pub fn schedule_task(task: TaskPointer) {
+    task.set_task_running();
+    this_cpu().runqueue().lock_write().handle_task(task);
+    schedule();
+}
+
 global_asm!(
     r#"
         .text

--- a/src/task/schedule.rs
+++ b/src/task/schedule.rs
@@ -115,6 +115,7 @@ impl RunQueue {
     pub fn allocate_idle_task(&self, entry: extern "C" fn()) -> Result<(), SvsmError> {
         let mut task = Task::create(entry, TASK_FLAG_SHARE_PT)?;
         task.set_on_switch_hook(Some(task_switch_hook));
+        task.idle_task = true;
         let node = Arc::new(TaskNode {
             tree_link: RBTreeAtomicLink::default(),
             list_link: LinkedListAtomicLink::default(),

--- a/src/task/schedule.rs
+++ b/src/task/schedule.rs
@@ -374,7 +374,6 @@ global_asm!(
         addq        $8, %rsp
 
         mov         %rbx, %rdi
-        call        on_switch
 
         // Restore the task context
         popq        %r15

--- a/src/task/tasks.rs
+++ b/src/task/tasks.rs
@@ -177,7 +177,7 @@ pub struct Task {
     pub state: TaskState,
 
     /// ID of the task
-    pub id: u32,
+    id: u32,
 
     /// Amount of CPU resource the task has consumed
     pub runtime: TaskRuntimeImpl,
@@ -232,6 +232,10 @@ impl Task {
 
     pub fn stack_bounds(&self) -> StackBounds {
         self.stack_bounds
+    }
+
+    pub fn get_task_id(&self) -> u32 {
+        self.id
     }
 
     pub fn set_idle_task(&mut self) {

--- a/src/task/tasks.rs
+++ b/src/task/tasks.rs
@@ -30,6 +30,7 @@ pub const INITIAL_TASK_ID: u32 = 1;
 #[derive(PartialEq, Debug, Copy, Clone, Default)]
 pub enum TaskState {
     RUNNING,
+    BLOCKED,
     #[default]
     TERMINATED,
 }
@@ -284,6 +285,10 @@ impl Task {
 
     pub fn set_task_terminated(&self) {
         self.sched_state.lock_write().state = TaskState::TERMINATED;
+    }
+
+    pub fn set_task_blocked(&self) {
+        self.sched_state.lock_write().state = TaskState::BLOCKED;
     }
 
     pub fn is_running(&self) -> bool {

--- a/src/task/tasks.rs
+++ b/src/task/tasks.rs
@@ -177,15 +177,6 @@ pub struct Task {
     /// Current state of the task
     pub state: TaskState,
 
-    /// Task affinity
-    /// None: The task can be scheduled to any CPU
-    /// u32:  The APIC ID of the CPU that the task must run on
-    pub affinity: Option<u32>,
-
-    // APIC ID of the CPU that task has been assigned to. If 'None' then
-    // the task is not currently assigned to a CPU
-    pub allocation: Option<u32>,
-
     /// ID of the task
     pub id: u32,
 
@@ -202,7 +193,6 @@ impl fmt::Debug for Task {
         f.debug_struct("Task")
             .field("rsp", &self.rsp)
             .field("state", &self.state)
-            .field("affinity", &self.affinity)
             .field("id", &self.id)
             .field("runtime", &self.runtime)
             .finish()
@@ -239,8 +229,6 @@ impl Task {
             vm_kernel_range,
             idle_task: false,
             state: TaskState::RUNNING,
-            affinity: None,
-            allocation: None,
             id: TASK_ID_ALLOCATOR.next_id(),
             runtime: TaskRuntimeImpl::default(),
             on_switch_hook: None,
@@ -271,10 +259,6 @@ impl Task {
                 in("rdi") new_task_addr,
                 options(att_syntax));
         }
-    }
-
-    pub fn set_affinity(&mut self, affinity: Option<u32>) {
-        self.affinity = affinity;
     }
 
     pub fn handle_pf(&self, vaddr: VirtAddr, write: bool) -> Result<(), SvsmError> {

--- a/src/task/tasks.rs
+++ b/src/task/tasks.rs
@@ -174,7 +174,7 @@ pub struct Task {
     idle_task: bool,
 
     /// Current state of the task
-    pub state: TaskState,
+    state: TaskState,
 
     /// ID of the task
     id: u32,
@@ -236,6 +236,22 @@ impl Task {
 
     pub fn get_task_id(&self) -> u32 {
         self.id
+    }
+
+    pub fn set_task_running(&mut self) {
+        self.state = TaskState::RUNNING;
+    }
+
+    pub fn set_task_terminated(&mut self) {
+        self.state = TaskState::TERMINATED;
+    }
+
+    pub fn is_running(&self) -> bool {
+        self.state == TaskState::RUNNING
+    }
+
+    pub fn is_terminated(&self) -> bool {
+        self.state == TaskState::TERMINATED
     }
 
     pub fn set_idle_task(&mut self) {

--- a/src/task/tasks.rs
+++ b/src/task/tasks.rs
@@ -181,10 +181,6 @@ pub struct Task {
 
     /// Amount of CPU resource the task has consumed
     pub runtime: TaskRuntimeImpl,
-
-    /// Optional hook that is called immediately after switching to this task
-    /// before the context is restored
-    pub on_switch_hook: Option<fn(&Self)>,
 }
 
 impl fmt::Debug for Task {
@@ -230,7 +226,6 @@ impl Task {
             state: TaskState::RUNNING,
             id: TASK_ID_ALLOCATOR.next_id(),
             runtime: TaskRuntimeImpl::default(),
-            on_switch_hook: None,
         });
         Ok(task)
     }
@@ -241,10 +236,6 @@ impl Task {
 
     pub fn handle_pf(&self, vaddr: VirtAddr, write: bool) -> Result<(), SvsmError> {
         self.vm_kernel_range.handle_page_fault(vaddr, write)
-    }
-
-    pub fn set_on_switch_hook(&mut self, hook: Option<fn(&Task)>) {
-        self.on_switch_hook = hook;
     }
 
     fn allocate_stack(
@@ -296,13 +287,5 @@ extern "C" fn apply_new_context(new_task: *mut Task) -> u64 {
         let mut pt = (*new_task).page_table.lock();
         this_cpu().populate_page_table(&mut pt);
         pt.cr3_value().bits() as u64
-    }
-}
-
-#[allow(unused)]
-#[no_mangle]
-extern "C" fn on_switch(new_task: &mut Task) {
-    if let Some(hook) = new_task.on_switch_hook {
-        hook(new_task);
     }
 }

--- a/src/task/tasks.rs
+++ b/src/task/tasks.rs
@@ -214,7 +214,8 @@ impl Task {
             Self::allocate_page_table()?
         };
 
-        let mut vm_kernel_range = VMR::new(SVSM_PERTASK_BASE, SVSM_PERTASK_END, PTEntryFlags::USER);
+        let mut vm_kernel_range =
+            VMR::new(SVSM_PERTASK_BASE, SVSM_PERTASK_END, PTEntryFlags::empty());
         vm_kernel_range.initialize()?;
 
         let (stack, raw_bounds, rsp_offset) = Self::allocate_stack(entry)?;

--- a/src/task/tasks.rs
+++ b/src/task/tasks.rs
@@ -174,6 +174,15 @@ struct TaskSchedState {
     pub runtime: TaskRuntimeImpl,
 }
 
+impl TaskSchedState {
+    pub fn panic_on_idle(&mut self, msg: &str) -> &mut Self {
+        if self.idle_task {
+            panic!("{}", msg);
+        }
+        self
+    }
+}
+
 #[repr(C)]
 pub struct Task {
     pub rsp: u64,
@@ -284,11 +293,17 @@ impl Task {
     }
 
     pub fn set_task_terminated(&self) {
-        self.sched_state.lock_write().state = TaskState::TERMINATED;
+        self.sched_state
+            .lock_write()
+            .panic_on_idle("Trying to terminate idle task")
+            .state = TaskState::TERMINATED;
     }
 
     pub fn set_task_blocked(&self) {
-        self.sched_state.lock_write().state = TaskState::BLOCKED;
+        self.sched_state
+            .lock_write()
+            .panic_on_idle("Trying to block idle task")
+            .state = TaskState::BLOCKED;
     }
 
     pub fn is_running(&self) -> bool {

--- a/src/task/tasks.rs
+++ b/src/task/tasks.rs
@@ -349,6 +349,7 @@ global_asm!(
     r#"
         .text
 
+    .globl switch_context
     switch_context:
         // Save the current context. The layout must match the TaskContext structure.
         pushfq

--- a/src/task/tasks.rs
+++ b/src/task/tasks.rs
@@ -171,7 +171,7 @@ pub struct Task {
     vm_kernel_range: VMR,
 
     /// Whether this is an idle task
-    pub idle_task: bool,
+    idle_task: bool,
 
     /// Current state of the task
     pub state: TaskState,
@@ -232,6 +232,14 @@ impl Task {
 
     pub fn stack_bounds(&self) -> StackBounds {
         self.stack_bounds
+    }
+
+    pub fn set_idle_task(&mut self) {
+        self.idle_task = true;
+    }
+
+    pub fn is_idle_task(&self) -> bool {
+        self.idle_task
     }
 
     pub fn handle_pf(&self, vaddr: VirtAddr, write: bool) -> Result<(), SvsmError> {

--- a/src/task/tasks.rs
+++ b/src/task/tasks.rs
@@ -171,6 +171,9 @@ pub struct Task {
     /// Task virtual memory range for use at CPL 0
     vm_kernel_range: VMR,
 
+    /// Whether this is an idle task
+    pub idle_task: bool,
+
     /// Current state of the task
     pub state: TaskState,
 
@@ -234,6 +237,7 @@ impl Task {
             stack_bounds: bounds,
             page_table: SpinLock::new(pgtable),
             vm_kernel_range,
+            idle_task: false,
             state: TaskState::RUNNING,
             affinity: None,
             allocation: None,

--- a/src/task/tasks.rs
+++ b/src/task/tasks.rs
@@ -354,12 +354,3 @@ extern "C" fn task_exit() {
     }
     schedule();
 }
-
-#[allow(unused)]
-#[no_mangle]
-extern "C" fn apply_new_context(new_task: *mut Task) -> u64 {
-    unsafe {
-        let mut pt = (*new_task).page_table.lock();
-        pt.cr3_value().bits() as u64
-    }
-}

--- a/src/task/waiting.rs
+++ b/src/task/waiting.rs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 SUSE LLC
+//
+// Author: Joerg Roedel <jroedel@suse.de>
+
+use super::tasks::TaskPointer;
+use super::{schedule, schedule_task};
+
+use crate::cpu::percpu::current_task;
+
+#[derive(Debug)]
+pub struct WaitQueue {
+    waiter: Option<TaskPointer>,
+}
+
+impl WaitQueue {
+    pub const fn new() -> Self {
+        Self { waiter: None }
+    }
+
+    pub fn wait_for_event(&mut self) {
+        assert!(self.waiter.is_none());
+
+        let task = current_task();
+
+        task.set_task_blocked();
+        self.waiter = Some(task);
+
+        schedule();
+    }
+
+    pub fn wakeup(&mut self) {
+        if self.waiter.is_some() {
+            let task = self.waiter.take().unwrap();
+            schedule_task(task);
+        }
+    }
+}


### PR DESCRIPTION
Here are changes to the Task and Scheduler implemenation of COCONUT-SVSM. The highlights are:

* Move from a time-slice based to a simpler round-robin scheduler
* Remove affinity and allocation code - relying fully on WaitQueues to move tasks between CPUs
* Merge TaskNode and Task structs into one
* Rework locking for struct Task

Building on the Task/Scheduler changes this PR also introduces a simple WaitQueue and a BLOCKING task state, which allows to put tasks to sleep and wake them up again.

Finally the last patch in the PR uses all of that to move core protocol request processing into a separate kernel task.