### PR TITLE
Fix guest VMSA borrowing lifetimes and mutability requirements

### DIFF
--- a/src/cpu/percpu.rs
+++ b/src/cpu/percpu.rs
@@ -173,6 +173,11 @@ impl GuestVmsaRef {
     pub fn caa_phys(&self) -> Option<PhysAddr> {
         self.caa
     }
+
+    pub fn vmsa(&mut self) -> &mut VMSA {
+        assert!(self.vmsa.is_some());
+        unsafe { SVSM_PERCPU_VMSA_BASE.as_mut_ptr::<VMSA>().as_mut().unwrap() }
+    }
 }
 
 #[derive(Debug)]
@@ -498,14 +503,6 @@ impl PerCpu {
 
     pub fn guest_vmsa_ref(&self) -> LockGuard<GuestVmsaRef> {
         self.shared.guest_vmsa.lock()
-    }
-
-    pub fn guest_vmsa(&mut self) -> &mut VMSA {
-        let locked = self.shared.guest_vmsa.lock();
-
-        assert!(locked.vmsa_phys().is_some());
-
-        unsafe { SVSM_PERCPU_VMSA_BASE.as_mut_ptr::<VMSA>().as_mut().unwrap() }
     }
 
     pub fn alloc_guest_vmsa(&mut self) -> Result<(), SvsmError> {

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -184,8 +184,9 @@ fn prepare_fw_launch(fw_meta: &SevFWMetaData) -> Result<(), SvsmError> {
 }
 
 fn launch_fw(config: &SvsmConfig) -> Result<(), SvsmError> {
-    let vmsa_pa = this_cpu_mut().guest_vmsa_ref().vmsa_phys().unwrap();
-    let vmsa = this_cpu_mut().guest_vmsa();
+    let mut vmsa_ref = this_cpu().guest_vmsa_ref();
+    let vmsa_pa = vmsa_ref.vmsa_phys().unwrap();
+    let vmsa = vmsa_ref.vmsa();
 
     config.initialize_guest_vmsa(vmsa);
 


### PR DESCRIPTION
Tie guest VMSA reference lifetime to the VMSA reference lock scope.
Remove requirement for mutability on PerCpu reference to obtain the guest VMSA, since the guest VMSA reference is protected by a spin lock and does not require static borrow checking.