### PR TITLE
Fix relocation error when linking stage1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ stage1/stage1.o: stage1/stage1.S stage1/stage2.bin stage1/svsm-fs.bin
 stage1/reset.o:  stage1/reset.S stage1/meta.bin
 
 stage1/stage1: ${STAGE1_OBJS}
-	$(CC) -o $@ $(STAGE1_OBJS) -nostdlib -Wl,--build-id=none -Wl,-Tstage1/stage1.lds
+	$(CC) -o $@ $(STAGE1_OBJS) -nostdlib -Wl,--build-id=none -Wl,-Tstage1/stage1.lds -no-pie
 
 svsm.bin: stage1/stage1
 	objcopy -O binary $< $@


### PR DESCRIPTION
Closes Issue#72
We've tested the addition of the -no-pie flag here and found it to both close Issue#72 and successfully boot, i.e., the build is correct.