### PR TITLE
Get rid of some mutable global statics

### DIFF
--- a/src/cpu/gdt.rs
+++ b/src/cpu/gdt.rs
@@ -6,78 +6,138 @@
 
 use super::tss::X86Tss;
 use crate::address::VirtAddr;
+use crate::locking::{RWLock, ReadLockGuard, WriteLockGuard};
 use crate::types::{SVSM_CS, SVSM_DS, SVSM_TSS};
 use core::arch::asm;
 use core::mem;
 
 #[repr(C, packed(2))]
 #[derive(Clone, Copy, Debug)]
-pub struct GdtDesc {
+struct GDTDesc {
     size: u16,
     addr: VirtAddr,
 }
 
-const GDT_SIZE: u16 = 8;
+#[derive(Copy, Clone, Debug)]
+pub struct GDTEntry(u64);
 
-static mut GDT: [u64; GDT_SIZE as usize] = [
-    0,
-    0x00af9a000000ffff, // 64-bit code segment
-    0x00cf92000000ffff, // 64-bit data segment
-    0,                  // Reserved for User code
-    0,                  // Reserver for User data
-    0,                  // Reverved
-    0,                  // TSS
-    0,                  // TSS continued
-];
+impl GDTEntry {
+    pub const fn from_raw(entry: u64) -> Self {
+        Self(entry)
+    }
 
-pub fn load_tss(tss: &X86Tss) {
-    let (desc0, desc1) = tss.to_gdt_entry();
+    pub fn to_raw(&self) -> u64 {
+        self.0
+    }
 
-    unsafe {
-        let idx = (SVSM_TSS / 8) as usize;
-        GDT[idx] = desc0;
-        GDT[idx + 1] = desc1;
+    pub const fn null() -> Self {
+        Self(0u64)
+    }
 
-        asm!("ltr %ax", in("ax") SVSM_TSS, options(att_syntax));
+    pub const fn code_64_kernel() -> Self {
+        Self(0x00af9a000000ffffu64)
+    }
+
+    pub const fn data_64_kernel() -> Self {
+        Self(0x00cf92000000ffffu64)
     }
 }
 
-pub fn gdt_base_limit() -> (u64, u32) {
-    unsafe {
+const GDT_SIZE: u16 = 8;
+
+#[derive(Copy, Clone, Debug)]
+pub struct GDT {
+    entries: [GDTEntry; GDT_SIZE as usize],
+}
+
+impl GDT {
+    pub const fn new() -> Self {
+        GDT {
+            entries: [
+                GDTEntry::null(),
+                GDTEntry::code_64_kernel(),
+                GDTEntry::data_64_kernel(),
+                GDTEntry::null(),
+                GDTEntry::null(),
+                GDTEntry::null(),
+                GDTEntry::null(),
+                GDTEntry::null(),
+            ],
+        }
+    }
+
+    pub fn base_limit(&self) -> (u64, u32) {
         let gdt_entries = GDT_SIZE as usize;
-        let base = (&GDT as *const [u64; GDT_SIZE as usize]) as u64;
+        let base = (self as *const GDT) as u64;
         let limit = ((mem::size_of::<u64>() * gdt_entries) - 1) as u32;
         (base, limit)
     }
+
+    fn descriptor(&self) -> GDTDesc {
+        GDTDesc {
+            size: (GDT_SIZE * 8) - 1,
+            addr: VirtAddr::from(self.entries.as_ptr()),
+        }
+    }
+
+    pub fn load(&self) {
+        let gdt_desc = self.descriptor();
+        unsafe {
+            asm!(r#" /* Load GDT */
+                 lgdt   (%rax)
+
+                 /* Reload data segments */
+                 movw   %cx, %ds
+                 movw   %cx, %es
+                 movw   %cx, %fs
+                 movw   %cx, %gs
+                 movw   %cx, %ss
+
+                 /* Reload code segment */
+                 pushq  %rdx
+                 leaq   1f(%rip), %rax
+                 pushq  %rax
+                 lretq
+            1:
+                 "#,
+                in("rax") &gdt_desc,
+                in("rdx") SVSM_CS,
+                in("rcx") SVSM_DS,
+                options(att_syntax));
+        }
+    }
+
+    fn set_tss_entry(&mut self, desc0: GDTEntry, desc1: GDTEntry) {
+        let idx = (SVSM_TSS / 8) as usize;
+
+        self.entries[idx] = desc0;
+        self.entries[idx + 1] = desc1;
+    }
+
+    fn clear_tss_entry(&mut self) {
+        let idx = (SVSM_TSS / 8) as usize;
+
+        self.entries[idx] = GDTEntry::null();
+        self.entries[idx + 1] = GDTEntry::null();
+    }
+
+    pub fn load_tss(&mut self, tss: &X86Tss) {
+        let (desc0, desc1) = tss.to_gdt_entry();
+
+        self.set_tss_entry(desc0, desc1);
+        unsafe {
+            asm!("ltr %ax", in("ax") SVSM_TSS, options(att_syntax));
+        }
+        self.clear_tss_entry()
+    }
 }
 
-pub fn load_gdt() {
-    unsafe {
-        let gdt_desc: GdtDesc = GdtDesc {
-            size: (GDT_SIZE * 8) - 1,
-            addr: VirtAddr::from(GDT.as_ptr()),
-        };
+static GDT: RWLock<GDT> = RWLock::new(GDT::new());
 
-        asm!(r#" /* Load GDT */
-             lgdt   (%rax)
+pub fn gdt() -> ReadLockGuard<'static, GDT> {
+    GDT.lock_read()
+}
 
-             /* Reload data segments */
-             movw   %cx, %ds
-             movw   %cx, %es
-             movw   %cx, %fs
-             movw   %cx, %gs
-             movw   %cx, %ss
-
-             /* Reload code segment */
-             pushq  %rdx
-             leaq   1f(%rip), %rax
-             pushq  %rax
-             lretq
-        1:
-             "#,
-            in("rax") &gdt_desc,
-            in("rdx") SVSM_CS,
-            in("rcx") SVSM_DS,
-            options(att_syntax));
-    }
+pub fn gdt_mut() -> WriteLockGuard<'static, GDT> {
+    GDT.lock_write()
 }

--- a/src/cpu/idt/mod.rs
+++ b/src/cpu/idt/mod.rs
@@ -7,3 +7,5 @@
 pub mod common;
 pub mod stage2;
 pub mod svsm;
+
+pub use common::{idt, idt_mut};

--- a/src/cpu/idt/stage2.rs
+++ b/src/cpu/idt/stage2.rs
@@ -4,35 +4,25 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
-use super::common::{load_idt, Idt, IdtEntry, DF_VECTOR, GLOBAL_IDT, HV_VECTOR, VC_VECTOR};
-use crate::address::VirtAddr;
+use super::common::{idt_mut, DF_VECTOR, HV_VECTOR, VC_VECTOR};
 use crate::cpu::control_regs::read_cr2;
 use crate::cpu::vc::{stage2_handle_vc_exception, stage2_handle_vc_exception_no_ghcb};
 use crate::cpu::X86ExceptionContext;
 use core::arch::global_asm;
 
-fn init_idt(idt: &mut Idt, handler_array: *const u8) {
-    // Set IDT handlers
-    let handlers = VirtAddr::from(handler_array);
-    for (i, entry) in idt.iter_mut().enumerate() {
-        *entry = IdtEntry::entry(handlers + (32 * i));
-    }
-}
-
 pub fn early_idt_init_no_ghcb() {
     unsafe {
-        init_idt(
-            &mut GLOBAL_IDT,
-            &stage2_idt_handler_array_no_ghcb as *const u8,
-        );
-        load_idt(&GLOBAL_IDT);
+        idt_mut()
+            .init(&stage2_idt_handler_array_no_ghcb as *const u8, 32)
+            .load();
     }
 }
 
 pub fn early_idt_init() {
     unsafe {
-        init_idt(&mut GLOBAL_IDT, &stage2_idt_handler_array as *const u8);
-        load_idt(&GLOBAL_IDT);
+        idt_mut()
+            .init(&stage2_idt_handler_array as *const u8, 32)
+            .load();
     }
 }
 

--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -21,6 +21,7 @@ pub mod tss;
 pub mod vc;
 pub mod vmsa;
 
+pub use gdt::{gdt, gdt_mut};
 pub use idt::common::X86ExceptionContext;
 pub use registers::{X86GeneralRegs, X86InterruptFrame, X86SegmentRegs};
 pub use tlb::*;

--- a/src/cpu/percpu.rs
+++ b/src/cpu/percpu.rs
@@ -6,7 +6,7 @@
 
 extern crate alloc;
 
-use super::gdt::load_tss;
+use super::gdt_mut;
 use super::tss::{X86Tss, IST_DF};
 use crate::address::{Address, PhysAddr, VirtAddr};
 use crate::cpu::tss::TSS_LIMIT;
@@ -429,7 +429,7 @@ impl PerCpu {
     }
 
     pub fn load_tss(&mut self) {
-        load_tss(&self.tss);
+        gdt_mut().load_tss(&self.tss);
     }
 
     pub fn load(&mut self) {

--- a/src/cpu/tss.rs
+++ b/src/cpu/tss.rs
@@ -4,6 +4,7 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
+use super::gdt::GDTEntry;
 use crate::address::VirtAddr;
 
 // IST offsets
@@ -35,7 +36,7 @@ impl X86Tss {
         }
     }
 
-    pub fn to_gdt_entry(&self) -> (u64, u64) {
+    pub fn to_gdt_entry(&self) -> (GDTEntry, GDTEntry) {
         let addr = (self as *const X86Tss) as u64;
 
         let mut desc0: u64 = 0;
@@ -56,6 +57,6 @@ impl X86Tss {
         // Type
         desc0 |= 0x9u64 << 40;
 
-        (desc0, desc1)
+        (GDTEntry::from_raw(desc0), GDTEntry::from_raw(desc1))
     }
 }

--- a/src/cpu/tss.rs
+++ b/src/cpu/tss.rs
@@ -34,4 +34,28 @@ impl X86Tss {
             io_bmp_base: (TSS_LIMIT + 1) as u16,
         }
     }
+
+    pub fn to_gdt_entry(&self) -> (u64, u64) {
+        let addr = (self as *const X86Tss) as u64;
+
+        let mut desc0: u64 = 0;
+        let mut desc1: u64 = 0;
+
+        // Limit
+        desc0 |= TSS_LIMIT & 0xffffu64;
+        desc0 |= ((TSS_LIMIT >> 16) & 0xfu64) << 48;
+
+        // Address
+        desc0 |= (addr & 0x00ff_ffffu64) << 16;
+        desc0 |= (addr & 0xff00_0000u64) << 32;
+        desc1 |= addr >> 32;
+
+        // Present
+        desc0 |= 1u64 << 47;
+
+        // Type
+        desc0 |= 0x9u64 << 40;
+
+        (desc0, desc1)
+    }
 }

--- a/src/cpu/vmsa.rs
+++ b/src/cpu/vmsa.rs
@@ -11,7 +11,7 @@ use cpuarch::vmsa::{VMSASegment, VMSA};
 use super::control_regs::{read_cr0, read_cr3, read_cr4};
 use super::efer::read_efer;
 use super::gdt;
-use super::idt::common::idt_base_limit;
+use super::idt::common::idt;
 use super::msr::read_msr;
 
 fn svsm_code_segment() -> VMSASegment {
@@ -43,7 +43,7 @@ fn svsm_gdt_segment() -> VMSASegment {
 }
 
 fn svsm_idt_segment() -> VMSASegment {
-    let (base, limit) = idt_base_limit();
+    let (base, limit) = idt().base_limit();
     VMSASegment {
         selector: 0,
         flags: 0,

--- a/src/cpu/vmsa.rs
+++ b/src/cpu/vmsa.rs
@@ -10,7 +10,7 @@ use cpuarch::vmsa::{VMSASegment, VMSA};
 
 use super::control_regs::{read_cr0, read_cr3, read_cr4};
 use super::efer::read_efer;
-use super::gdt::gdt_base_limit;
+use super::gdt;
 use super::idt::common::idt_base_limit;
 use super::msr::read_msr;
 
@@ -33,7 +33,7 @@ fn svsm_data_segment() -> VMSASegment {
 }
 
 fn svsm_gdt_segment() -> VMSASegment {
-    let (base, limit) = gdt_base_limit();
+    let (base, limit) = gdt().base_limit();
     VMSASegment {
         selector: 0,
         flags: 0,

--- a/src/mm/alloc.rs
+++ b/src/mm/alloc.rs
@@ -1318,6 +1318,7 @@ pub const DEFAULT_TEST_MEMORY_SIZE: usize = 16usize * 1024 * 1024;
 /// A dummy struct to acquire a lock over global memory for tests.
 #[cfg(any(test, fuzzing))]
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct TestRootMem<'a>(LockGuard<'a, ()>);
 
 #[cfg(any(test, fuzzing))]

--- a/src/sev/mod.rs
+++ b/src/sev/mod.rs
@@ -13,6 +13,7 @@ pub mod vmsa;
 pub mod utils;
 
 pub use msr_protocol::init_hypervisor_ghcb_features;
+pub use secrets_page::{secrets_page, secrets_page_mut, SecretsPage, VMPCK_SIZE};
 pub use status::sev_status_init;
 pub use status::sev_status_verify;
 pub use status::{sev_es_enabled, sev_snp_enabled};

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -18,7 +18,7 @@ use svsm::address::{Address, PhysAddr, VirtAddr};
 use svsm::config::SvsmConfig;
 use svsm::console::{init_console, install_console_logger, WRITER};
 use svsm::cpu::cpuid::{dump_cpuid_table, register_cpuid_table};
-use svsm::cpu::gdt::load_gdt;
+use svsm::cpu::gdt;
 use svsm::cpu::idt::stage2::{early_idt_init, early_idt_init_no_ghcb};
 use svsm::cpu::percpu::{this_cpu_mut, PerCpu};
 use svsm::elf;
@@ -84,7 +84,7 @@ static CONSOLE_IO: SVSMIOPort = SVSMIOPort::new();
 static CONSOLE_SERIAL: ImmutAfterInitCell<SerialPort> = ImmutAfterInitCell::uninit();
 
 fn setup_env(config: &SvsmConfig) {
-    load_gdt();
+    gdt().load();
     early_idt_init_no_ghcb();
 
     install_console_logger("Stage2");

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -22,7 +22,7 @@ use svsm::console::{init_console, install_console_logger, WRITER};
 use svsm::cpu::control_regs::{cr0_init, cr4_init};
 use svsm::cpu::cpuid::{dump_cpuid_table, register_cpuid_table};
 use svsm::cpu::efer::efer_init;
-use svsm::cpu::gdt::load_gdt;
+use svsm::cpu::gdt;
 use svsm::cpu::idt::svsm::{early_idt_init, idt_init};
 use svsm::cpu::percpu::PerCpu;
 use svsm::cpu::percpu::{this_cpu, this_cpu_mut};
@@ -286,7 +286,7 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
 
     init_valid_bitmap_ptr(new_kernel_region(&launch_info), vb_ptr);
 
-    load_gdt();
+    gdt().load();
     early_idt_init();
 
     // Capture the debug serial port before the launch info disappears from


### PR DESCRIPTION
Add decent implementations for the GDT, IDT and SecretsPage which require proper locking to make modifications.

This fixes a couple of warnings triggered by the latest Rust nightly compiler.