### PR TITLE
igvm_params: avoid creating misaligned references and other small improvements

### DIFF
--- a/kernel/src/igvm_params.rs
+++ b/kernel/src/igvm_params.rs
@@ -163,50 +163,50 @@ impl IgvmParams<'_> {
 
     pub fn get_fw_metadata(&self) -> Option<SevFWMetaData> {
         if !self.should_launch_fw() {
-            None
-        } else {
-            let mut fw_meta = SevFWMetaData::new();
-
-            if self.igvm_param_block.firmware.caa_page != 0 {
-                fw_meta.caa_page = Some(PhysAddr::new(
-                    self.igvm_param_block.firmware.caa_page.try_into().unwrap(),
-                ));
-            }
-
-            if self.igvm_param_block.firmware.secrets_page != 0 {
-                fw_meta.secrets_page = Some(PhysAddr::new(
-                    self.igvm_param_block
-                        .firmware
-                        .secrets_page
-                        .try_into()
-                        .unwrap(),
-                ));
-            }
-
-            if self.igvm_param_block.firmware.cpuid_page != 0 {
-                fw_meta.cpuid_page = Some(PhysAddr::new(
-                    self.igvm_param_block
-                        .firmware
-                        .cpuid_page
-                        .try_into()
-                        .unwrap(),
-                ));
-            }
-
-            let preval_count = self.igvm_param_block.firmware.prevalidated_count as usize;
-            for preval in self
-                .igvm_param_block
-                .firmware
-                .prevalidated
-                .iter()
-                .take(preval_count)
-            {
-                let base = PhysAddr::from(preval.base as usize);
-                fw_meta.add_valid_mem(base, preval.size as usize);
-            }
-
-            Some(fw_meta)
+            return None;
         }
+
+        let mut fw_meta = SevFWMetaData::new();
+
+        if self.igvm_param_block.firmware.caa_page != 0 {
+            fw_meta.caa_page = Some(PhysAddr::new(
+                self.igvm_param_block.firmware.caa_page.try_into().unwrap(),
+            ));
+        }
+
+        if self.igvm_param_block.firmware.secrets_page != 0 {
+            fw_meta.secrets_page = Some(PhysAddr::new(
+                self.igvm_param_block
+                    .firmware
+                    .secrets_page
+                    .try_into()
+                    .unwrap(),
+            ));
+        }
+
+        if self.igvm_param_block.firmware.cpuid_page != 0 {
+            fw_meta.cpuid_page = Some(PhysAddr::new(
+                self.igvm_param_block
+                    .firmware
+                    .cpuid_page
+                    .try_into()
+                    .unwrap(),
+            ));
+        }
+
+        let preval_count = self.igvm_param_block.firmware.prevalidated_count as usize;
+        for preval in self
+            .igvm_param_block
+            .firmware
+            .prevalidated
+            .iter()
+            .take(preval_count)
+        {
+            let base = PhysAddr::from(preval.base as usize);
+            fw_meta.add_valid_mem(base, preval.size as usize);
+        }
+
+        Some(fw_meta)
     }
 
     pub fn get_fw_regions(&self) -> Vec<MemoryRegion<PhysAddr>> {

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -168,7 +168,8 @@ pub extern "C" fn stage2_main(launch_info: &Stage1LaunchInfo) {
     let kernel_elf_end: PhysAddr = PhysAddr::from(launch_info.kernel_elf_end as u64);
 
     let config = if launch_info.igvm_params != 0 {
-        let igvm_params = IgvmParams::new(VirtAddr::from(launch_info.igvm_params as u64));
+        let igvm_params = IgvmParams::new(VirtAddr::from(launch_info.igvm_params as u64))
+            .expect("Invalid IGVM parameters");
         SvsmConfig::IgvmConfig(igvm_params)
     } else {
         SvsmConfig::FirmwareConfig(FwCfg::new(&CONSOLE_IO))

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -320,7 +320,7 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
     };
 
     paging_init();
-    init_page_table(&launch_info, &kernel_elf);
+    init_page_table(&launch_info, &kernel_elf).expect("Could not initialize the page table");
 
     // SAFETY: this PerCpu has just been allocated and no other CPUs have been
     // brought up, thus it cannot be aliased and we can get a mutable
@@ -388,7 +388,8 @@ pub extern "C" fn svsm_main() {
 
     let launch_info = &*LAUNCH_INFO;
     let config = if launch_info.igvm_params_virt_addr != 0 {
-        let igvm_params = IgvmParams::new(VirtAddr::from(launch_info.igvm_params_virt_addr));
+        let igvm_params = IgvmParams::new(VirtAddr::from(launch_info.igvm_params_virt_addr))
+            .expect("Invalid IGVM parameters");
         SvsmConfig::IgvmConfig(igvm_params)
     } else {
         SvsmConfig::FirmwareConfig(FwCfg::new(&CONSOLE_IO))


### PR DESCRIPTION
In Rust, references to `T` that are not aligned to that `T`'s requirements are undefined behavior. Check that the addresses obtained from the IGVM configuration are properly aligned before attempting to read the appropriate structures from them.

While we are at it, perform some minor code improvements.