### PR TITLE
fs/filesystem: make trait bounds more concise

### DIFF
--- a/src/fs/filesystem.rs
+++ b/src/fs/filesystem.rs
@@ -257,7 +257,7 @@ impl Drop for TestFileSystemGuard {
 ///
 ///  [`impl Iterator <Item = &str> + DoubleEndedIterator`]: iterator over all the
 ///  directory and file names in the path.
-fn split_path_allow_empty(path: &str) -> impl Iterator<Item = &str> + DoubleEndedIterator {
+fn split_path_allow_empty(path: &str) -> impl DoubleEndedIterator<Item = &str> {
     path.split('/').filter(|x| !x.is_empty())
 }
 
@@ -272,7 +272,7 @@ fn split_path_allow_empty(path: &str) -> impl Iterator<Item = &str> + DoubleEnde
 ///
 ///  [`impl Iterator <Item = &str> + DoubleEndedIterator`]: iterator over all the
 ///  directory and file names in the path.
-fn split_path(path: &str) -> Result<impl Iterator<Item = &str> + DoubleEndedIterator, SvsmError> {
+fn split_path(path: &str) -> Result<impl DoubleEndedIterator<Item = &str>, SvsmError> {
     let mut path_items = split_path_allow_empty(path).peekable();
     path_items
         .peek()


### PR DESCRIPTION
Fix the following clippy warning that comes up with the nightly toolchain:

```
warning: this bound is already specified as the supertrait of `DoubleEndedIterator`
   --> src/fs/filesystem.rs:260:47
    |
260 | fn split_path_allow_empty(path: &str) -> impl Iterator<Item = &str> + DoubleEndedIterator {
    |                                               ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#implied_bounds_in_impls
    = note: `#[warn(clippy::implied_bounds_in_impls)]` on by default
help: try removing this bound
    |
260 - fn split_path_allow_empty(path: &str) -> impl Iterator<Item = &str> + DoubleEndedIterator {
260 + fn split_path_allow_empty(path: &str) -> impl DoubleEndedIterator<Item = &str> {
```