### PR TITLE
cpu/percpu: do not create a reference to uninitialized memory

### DIFF
--- a/src/cpu/percpu.rs
+++ b/src/cpu/percpu.rs
@@ -14,7 +14,7 @@ use crate::cpu::vmsa::init_guest_vmsa;
 use crate::cpu::vmsa::vmsa_mut_ref_from_vaddr;
 use crate::error::SvsmError;
 use crate::locking::{LockGuard, RWLock, SpinLock};
-use crate::mm::alloc::{allocate_page, allocate_zeroed_page};
+use crate::mm::alloc::{allocate_zeroed_page, free_page};
 use crate::mm::pagetable::{get_init_pgtable_locked, PTEntryFlags, PageTableRef};
 use crate::mm::virtualrange::VirtualRange;
 use crate::mm::vm::{Mapping, VMKernelStack, VMPhysMem, VMRMapping, VMReserved, VMR};
@@ -334,9 +334,13 @@ impl PerCpu {
     }
 
     pub fn setup_ghcb(&mut self) -> Result<(), SvsmError> {
-        let ghcb_page = allocate_page().expect("Failed to allocate GHCB page");
-        self.ghcb = ghcb_page.as_mut_ptr::<GHCB>();
-        unsafe { (*self.ghcb).init() }
+        let ghcb_page = allocate_zeroed_page().expect("Failed to allocate GHCB page");
+        if let Err(e) = GHCB::init(ghcb_page) {
+            free_page(ghcb_page);
+            return Err(e);
+        };
+        self.ghcb = ghcb_page.as_mut_ptr();
+        Ok(())
     }
 
     pub fn register_ghcb(&self) -> Result<(), SvsmError> {

--- a/src/sev/ghcb.rs
+++ b/src/sev/ghcb.rs
@@ -137,8 +137,7 @@ pub enum GHCBIOSize {
 }
 
 impl GHCB {
-    pub fn init(&mut self) -> Result<(), SvsmError> {
-        let vaddr = VirtAddr::from(self as *const GHCB);
+    pub fn init(vaddr: VirtAddr) -> Result<(), SvsmError> {
         let paddr = virt_to_phys(vaddr);
 
         if sev_snp_enabled() {


### PR DESCRIPTION
In `PerCpu::setup_ghcb()`, a pointer to allocated but uninitialized memory was being cast to a pointer to a GHCB struct. This pointer in turn was used to call `GHCB::init()`, which takes `&mut self`, which creates a reference to uninitialized memory. The GHCB struct consists simply of scalar values, so it has no invalid representations, but this is unnecessarily unsafe.

To avoid an unsafe block and potential future issues, allocate the page zeroed, and make `GHCB::init()` take a `VirtAddr` which can properly be initialized.

While we are at it, do not store the pointer in the `PerCpu` struct until it has been properly initialized.