### PR TITLE
Add more uses of `MemoryRegion`

### DIFF
--- a/src/mm/pagetable.rs
+++ b/src/mm/pagetable.rs
@@ -575,52 +575,38 @@ impl PageTable {
 
     pub fn map_region_4k(
         &mut self,
-        start: VirtAddr,
-        end: VirtAddr,
+        vregion: MemoryRegion<VirtAddr>,
         phys: PhysAddr,
         flags: PTEntryFlags,
     ) -> Result<(), SvsmError> {
-        for addr in (start.bits()..end.bits())
-            .step_by(PAGE_SIZE)
-            .map(VirtAddr::from)
-        {
-            let offset = addr - start;
+        for addr in vregion.iter_pages(PageSize::Regular) {
+            let offset = addr - vregion.start();
             self.map_4k(addr, phys + offset, flags)?;
         }
         Ok(())
     }
 
-    pub fn unmap_region_4k(&mut self, start: VirtAddr, end: VirtAddr) {
-        for addr in (start.bits()..end.bits())
-            .step_by(PAGE_SIZE)
-            .map(VirtAddr::from)
-        {
+    pub fn unmap_region_4k(&mut self, vregion: MemoryRegion<VirtAddr>) {
+        for addr in vregion.iter_pages(PageSize::Regular) {
             self.unmap_4k(addr);
         }
     }
 
     pub fn map_region_2m(
         &mut self,
-        start: VirtAddr,
-        end: VirtAddr,
+        vregion: MemoryRegion<VirtAddr>,
         phys: PhysAddr,
         flags: PTEntryFlags,
     ) -> Result<(), SvsmError> {
-        for addr in (start.bits()..end.bits())
-            .step_by(PAGE_SIZE_2M)
-            .map(VirtAddr::from)
-        {
-            let offset = addr - start;
+        for addr in vregion.iter_pages(PageSize::Huge) {
+            let offset = addr - vregion.start();
             self.map_2m(addr, phys + offset, flags)?;
         }
         Ok(())
     }
 
-    pub fn unmap_region_2m(&mut self, start: VirtAddr, end: VirtAddr) {
-        for addr in (start.bits()..end.bits())
-            .step_by(PAGE_SIZE_2M)
-            .map(VirtAddr::from)
-        {
+    pub fn unmap_region_2m(&mut self, vregion: MemoryRegion<VirtAddr>) {
+        for addr in vregion.iter_pages(PageSize::Huge) {
             self.unmap_2m(addr);
         }
     }

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -39,8 +39,8 @@ use svsm::sev::msr_protocol::verify_ghcb_version;
 use svsm::sev::{pvalidate_range, sev_status_init, sev_status_verify, PvalidateOp};
 use svsm::svsm_console::SVSMIOPort;
 use svsm::types::{PageSize, PAGE_SIZE};
-use svsm::utils::halt;
 use svsm::utils::immut_after_init::ImmutAfterInitCell;
+use svsm::utils::{halt, MemoryRegion};
 
 extern "C" {
     pub static heap_start: u8;
@@ -144,7 +144,7 @@ fn map_and_validate(config: &SvsmConfig, vaddr: VirtAddr, paddr: PhysAddr, len: 
             )
             .expect("GHCB::PAGE_STATE_CHANGE call failed for kernel region");
     }
-    pvalidate_range(vaddr, vaddr + len, PvalidateOp::Valid)
+    pvalidate_range(MemoryRegion::new(vaddr, len), PvalidateOp::Valid)
         .expect("PVALIDATE kernel region failed");
     valid_bitmap_set_valid_range(paddr, paddr + len);
 }


### PR DESCRIPTION
The type is fitting for more uses in a couple of subsystems, so use it instead of address pairs in several places. This homogenizes several interfaces and makes code simpler to follow, as a single variable is passed around instead of two.