### PR TITLE
Stack trace fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,7 @@ cpuarch = { path = "cpuarch" }
 test = { version = "0.1.0", path = "test" }
 
 [features]
-default = ["enable-stacktrace"]
-enable-stacktrace = []
+default = []
 enable-gdb = ["dep:gdbstub", "dep:gdbstub_arch"]
 
 [dev-dependencies]

--- a/src/cpu/idt/common.rs
+++ b/src/cpu/idt/common.rs
@@ -176,12 +176,10 @@ pub fn triple_fault() {
     }
 }
 
-#[cfg(feature = "enable-stacktrace")]
 extern "C" {
     static generic_idt_handler_return: u8;
 }
 
-#[cfg(feature = "enable-stacktrace")]
 pub fn is_exception_handler_return_site(rip: VirtAddr) -> bool {
     let addr = unsafe { VirtAddr::from(&generic_idt_handler_return as *const u8) };
     addr == rip

--- a/src/cpu/percpu.rs
+++ b/src/cpu/percpu.rs
@@ -16,6 +16,7 @@ use crate::error::SvsmError;
 use crate::locking::{LockGuard, RWLock, SpinLock};
 use crate::mm::alloc::{allocate_zeroed_page, free_page};
 use crate::mm::pagetable::{get_init_pgtable_locked, PTEntryFlags, PageTableRef};
+use crate::mm::stack::StackBounds;
 use crate::mm::virtualrange::VirtualRange;
 use crate::mm::vm::{Mapping, VMKernelStack, VMPhysMem, VMRMapping, VMReserved, VMR};
 use crate::mm::{
@@ -243,6 +244,10 @@ pub struct PerCpu {
 
     /// Task list that has been assigned for scheduling on this CPU
     runqueue: RWLock<RunQueue>,
+
+    /// Stack boundaries of the currently running task. This is stored in
+    /// [PerCpu] because it needs lockless read access.
+    pub current_stack: StackBounds,
 }
 
 impl PerCpu {
@@ -262,6 +267,7 @@ impl PerCpu {
             vrange_4k: VirtualRange::new(),
             vrange_2m: VirtualRange::new(),
             runqueue: RWLock::new(RunQueue::new(apic_id)),
+            current_stack: StackBounds::default(),
         }
     }
 

--- a/src/debug/stacktrace.rs
+++ b/src/debug/stacktrace.rs
@@ -9,23 +9,9 @@ use crate::{
     cpu::idt::common::{is_exception_handler_return_site, X86ExceptionContext},
     cpu::percpu::this_cpu,
     mm::address_space::STACK_SIZE,
+    mm::stack::StackBounds,
 };
 use core::{arch::asm, mem};
-
-#[derive(Debug, Default)]
-struct StackBounds {
-    bottom: VirtAddr,
-    top: VirtAddr,
-}
-
-impl StackBounds {
-    fn range_is_on_stack(&self, begin: VirtAddr, len: usize) -> bool {
-        match begin.checked_add(len) {
-            Some(end) => begin >= self.bottom && end <= self.top,
-            None => false,
-        }
-    }
-}
 
 #[derive(Clone, Copy, Debug, Default)]
 struct StackFrame {

--- a/src/debug/stacktrace.rs
+++ b/src/debug/stacktrace.rs
@@ -4,24 +4,20 @@
 //
 // Author: Nicolai Stange <nstange@suse.de>
 
-#[cfg(feature = "enable-stacktrace")]
 use crate::{
     address::{Address, VirtAddr},
     cpu::idt::common::{is_exception_handler_return_site, X86ExceptionContext},
     cpu::percpu::this_cpu,
     mm::address_space::STACK_SIZE,
 };
-#[cfg(feature = "enable-stacktrace")]
 use core::{arch::asm, mem};
 
-#[cfg(feature = "enable-stacktrace")]
 #[derive(Debug, Default)]
 struct StackBounds {
     bottom: VirtAddr,
     top: VirtAddr,
 }
 
-#[cfg(feature = "enable-stacktrace")]
 impl StackBounds {
     fn range_is_on_stack(&self, begin: VirtAddr, len: usize) -> bool {
         match begin.checked_add(len) {
@@ -31,7 +27,6 @@ impl StackBounds {
     }
 }
 
-#[cfg(feature = "enable-stacktrace")]
 #[derive(Clone, Copy, Debug, Default)]
 struct StackFrame {
     rbp: VirtAddr,
@@ -42,24 +37,20 @@ struct StackFrame {
     _stack_depth: usize, // Not needed for frame unwinding, only as diagnostic information.
 }
 
-#[cfg(feature = "enable-stacktrace")]
 #[derive(Clone, Copy, Debug)]
 enum UnwoundStackFrame {
     Valid(StackFrame),
     Invalid,
 }
 
-#[cfg(feature = "enable-stacktrace")]
 type StacksBounds = [StackBounds; 2];
 
-#[cfg(feature = "enable-stacktrace")]
 #[derive(Debug)]
 struct StackUnwinder {
     next_frame: Option<UnwoundStackFrame>,
     stacks: StacksBounds,
 }
 
-#[cfg(feature = "enable-stacktrace")]
 impl StackUnwinder {
     pub fn unwind_this_cpu() -> Self {
         let mut rbp: usize;
@@ -177,7 +168,6 @@ impl StackUnwinder {
     }
 }
 
-#[cfg(feature = "enable-stacktrace")]
 impl Iterator for StackUnwinder {
     type Item = UnwoundStackFrame;
 
@@ -209,7 +199,6 @@ impl Iterator for StackUnwinder {
     }
 }
 
-#[cfg(feature = "enable-stacktrace")]
 pub fn print_stack(skip: usize) {
     let unwinder = StackUnwinder::unwind_this_cpu();
     log::info!("---BACKTRACE---:");
@@ -220,9 +209,4 @@ pub fn print_stack(skip: usize) {
         }
     }
     log::info!("---END---");
-}
-
-#[cfg(not(feature = "enable-stacktrace"))]
-pub fn print_stack(_: usize) {
-    log::info!("Stack unwinding not supported - set 'enable-stacktrace' at compile time");
 }

--- a/src/debug/stacktrace.rs
+++ b/src/debug/stacktrace.rs
@@ -29,7 +29,7 @@ enum UnwoundStackFrame {
     Invalid,
 }
 
-type StacksBounds = [StackBounds; 2];
+type StacksBounds = [StackBounds; 3];
 
 #[derive(Debug)]
 struct StackUnwinder {
@@ -57,6 +57,7 @@ impl StackUnwinder {
                 bottom: top_of_df_stack - STACK_SIZE,
                 top: top_of_df_stack,
             },
+            this_cpu().current_stack,
         ];
 
         Self::new(VirtAddr::from(rbp), stacks)

--- a/src/mm/stack.rs
+++ b/src/mm/stack.rs
@@ -44,6 +44,22 @@ impl StackBounds {
             None => false,
         }
     }
+
+    /// Creates a remapped version of this stuct StackBounds
+    ///
+    /// # Arguments
+    ///
+    /// * `base`: Virtual base address where stack is mapped
+    ///
+    /// # Returns
+    ///
+    /// New struct StackBounds with remapped values
+    pub fn map_at(&self, base: VirtAddr) -> Self {
+        Self {
+            top: self.top + base.bits(),
+            bottom: self.bottom + base.bits(),
+        }
+    }
 }
 
 // Limit maximum number of stacks for now, address range support 2**16 8k stacks

--- a/src/mm/stack.rs
+++ b/src/mm/stack.rs
@@ -17,6 +17,35 @@ use crate::mm::{
 use crate::types::PAGE_SIZE;
 use crate::utils::MemoryRegion;
 
+/// Covers a virtual address range of a stack
+#[derive(Debug, Default, Copy, Clone)]
+pub struct StackBounds {
+    /// Stack bottom virtual address
+    pub bottom: VirtAddr,
+
+    /// Stack top virtual address
+    pub top: VirtAddr,
+}
+
+impl StackBounds {
+    /// Checks whether a given virtual address range is fully on the stack
+    ///
+    /// # Arguments
+    ///
+    /// * `begin` - Start virtual address of the checked range
+    /// * `len` - Length of the checked range in bytes
+    ///
+    /// # Returns
+    ///
+    /// `true` if range is fully on the stack, `false` if not.
+    pub fn range_is_on_stack(&self, begin: VirtAddr, len: usize) -> bool {
+        match begin.checked_add(len) {
+            Some(end) => begin >= self.bottom && end <= self.top,
+            None => false,
+        }
+    }
+}
+
 // Limit maximum number of stacks for now, address range support 2**16 8k stacks
 const MAX_STACKS: usize = 1024;
 const BMP_QWORDS: usize = MAX_STACKS / 64;

--- a/src/mm/vm/mapping/kernel_stack.rs
+++ b/src/mm/vm/mapping/kernel_stack.rs
@@ -9,6 +9,7 @@ use crate::address::{PhysAddr, VirtAddr};
 use crate::error::SvsmError;
 use crate::mm::address_space::STACK_SIZE;
 use crate::mm::pagetable::PTEntryFlags;
+use crate::mm::stack::StackBounds;
 use crate::types::{PAGE_SHIFT, PAGE_SIZE};
 use crate::utils::page_align_up;
 
@@ -39,6 +40,26 @@ impl VMKernelStack {
     pub fn top_of_stack(&self, base: VirtAddr) -> VirtAddr {
         let guard_size = self.guard_pages * PAGE_SIZE;
         base + guard_size + self.alloc.mapping_size()
+    }
+
+    /// Returns the stack bounds of this kernel stack
+    ///
+    /// # Arguments
+    ///
+    /// * `base` - Virtual base address this stack is mapped at (including
+    ///            guard pages).
+    ///
+    /// # Returns
+    ///
+    /// [StackBounds] object containing the actual bottom and top addresses for
+    /// the stack
+    pub fn bounds(&self, base: VirtAddr) -> StackBounds {
+        let mapping_size = self.alloc.mapping_size();
+        let guard_size = self.guard_pages * PAGE_SIZE;
+        StackBounds {
+            bottom: base + guard_size,
+            top: base + guard_size + mapping_size,
+        }
     }
 
     /// Create a new [`VMKernelStack`] with a given size. This function will


### PR DESCRIPTION
The stack trace code is not yet aware of task stacks. This causes no stack-traces to be collected or printed at all at the moment, when the stack trace is collected from task context.

This PR fixes that and also the assumption about when the end of the stack is reached.