### PR TITLE
Documentation: Update build/install instructions to use IGVM

### DIFF
--- a/Documentation/INSTALL.md
+++ b/Documentation/INSTALL.md
@@ -309,6 +309,43 @@ in the terminal:
 ...
 ```
 
+Launch Script
+-------------
+
+A script is provided in `scripts/launch_guest.sh` that makes it easy to launch a
+guest that supports SEV-SNP with COCONUT-SVSM. If the QEMU built in the previous
+step is installed and in your PATH then you can start the guest by running the
+script from the root of the repository:
+
+```
+scripts/launch_guest.sh
+```
+
+The script makes use of the `cbit` utility to determine the correct value for
+the `cbitpos` QEMU parameter. This needs to be built with the following command:
+
+```
+make utils/cbit
+```
+
+The path to QEMU can also be specified either by setting the `QEMU` variable, or
+by passing the path as a parameter:
+
+```
+QEMU=/path/to/qemu-system-x86_64 scripts/launch_guest.sh
+
+scripts/launch_guest --qemu /path/to/qemu-system-x86_64
+```
+
+The script supports a number of other options described in the table below
+
+| Command-line     | Variable | Default               | Description                                                                  |
+| ---------------- | -------- | --------------------- | ---------------------------------------------------------------------------- |
+| `--qemu [path]`  | QEMU     | qemu-system-x86_64    | Path to QEMU binary to use.                                                  |
+| `--igvm [path]`  | IGVM     | bin/coconut-qemu.igvm | Path to the IGVM binary to launch.                                           |
+| `--image [path]` | IMAGE    | [None]                | The QEMU disk image to use. If unset then no disk is provided on the guest.  |
+| `--debugserial`  | N/A      | not set               | Define a second serial port that can be used with the COCONUT-SVSM GDB stub. |
+
 Debugging using GDB
 -------------------
 

--- a/Makefile
+++ b/Makefile
@@ -57,10 +57,13 @@ bin/coconut-qemu.igvm: $(IGVMBUILDER) bin/svsm-kernel.elf bin/stage2.bin
 bin/coconut-hyperv.igvm: $(IGVMBUILDER) bin/svsm-kernel.elf bin/stage2.bin
 	$(IGVMBUILDER) --sort --output $@ --stage2 bin/stage2.bin --kernel bin/svsm-kernel.elf --comport 3 hyper-v
 
+bin/coconut-test-qemu.igvm: $(IGVMBUILDER) bin/test-kernel.elf bin/stage2.bin
+	$(IGVMBUILDER) --sort --output $@ --stage2 bin/stage2.bin --kernel bin/test-kernel.elf qemu
+
 test:
 	cargo test --workspace --target=x86_64-unknown-linux-gnu
 
-test-in-svsm: utils/cbit bin/svsm-test.bin
+test-in-svsm: utils/cbit bin/coconut-test-qemu.igvm
 	./scripts/test-in-svsm.sh
 
 doc:
@@ -115,9 +118,6 @@ bin/stage1-test: ${STAGE1_TEST_OBJS}
 	$(CC) -o $@ $(STAGE1_TEST_OBJS) -nostdlib -Wl,--build-id=none -Wl,-Tstage1/stage1.lds -no-pie
 
 bin/svsm.bin: bin/stage1
-	objcopy -O binary $< $@
-
-bin/svsm-test.bin: bin/stage1-test
 	objcopy -O binary $< $@
 
 clippy:

--- a/README.md
+++ b/README.md
@@ -77,8 +77,6 @@ any way:
   * vTPM emulation
 * Attestation support
 * Persistency layer (needed for TPM and others)
-* Carry FW as payload of SVSM to make the SVSM binary a drop-in
-  replacement for the FW when launching QEMU
 * Live migration
 
 Documentation

--- a/scripts/launch_guest.sh
+++ b/scripts/launch_guest.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+#
+# Copyright (c) 2024 SUSE LLC
+#
+# Author: Roy Hopkins <roy.hopkins@suse.com>
+set -e
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+: "${QEMU:=qemu-system-x86_64}"
+: "${IGVM:=$SCRIPT_DIR/../bin/coconut-qemu.igvm}"
+
+C_BIT_POS=`$SCRIPT_DIR/../utils/cbit`
+DEBUG_SERIAL=""
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -q|--qemu)
+      QEMU="$2"
+      shift
+      shift
+      ;;
+    -i|--igvm)
+      IGVM="$2"
+      shift
+      shift
+      ;;
+    --image)
+      IMAGE="$2"
+      shift
+      shift
+      ;;
+    -d|--debugserial)
+      DEBUG_SERIAL="-serial pty"
+      shift
+      ;;
+    -*|--*)
+      echo "Unknown option $1"
+      exit 1
+      ;;
+    *)
+      echo "Invalid parameter $1"
+      exit 1
+      ;;
+  esac
+done
+
+# Split the QEMU version number so we can specify the correct parameters
+QEMU_VERSION=`$QEMU --version | grep -Po '(?<=version )[^ ]+'`
+QEMU_MAJOR=${QEMU_VERSION%%.*}
+QEMU_BUILD=${QEMU_VERSION##*.}
+QEMU_MINOR=${QEMU_VERSION##$QEMU_MAJOR.}
+QEMU_MINOR=${QEMU_MINOR%%.$QEMU_BUILD}
+
+# The QEMU machine and memory command line changed after QEMU 8.2.0 from
+# the coconut-svsm git repository.
+if (( (QEMU_MAJOR > 8) || ((QEMU_MAJOR == 8) && (QEMU_MINOR >= 2)) )); then
+  MACHINE=q35,confidential-guest-support=sev0,memory-backend=mem0
+  MEMORY=memory-backend-memfd,size=8G,id=mem0,share=true,prealloc=false,reserve=false
+else
+  MACHINE=q35,confidential-guest-support=sev0,memory-backend=mem0,kvm-type=protected
+  MEMORY=memory-backend-memfd-private,size=8G,id=mem0,share=true
+fi
+
+# Setup a disk if an image has been specified
+if [ ! -z $IMAGE ]; then
+  IMAGE_DISK="-drive file=$IMAGE,if=none,id=disk0,format=qcow2,snapshot=on \
+    -device virtio-scsi-pci,id=scsi0,disable-legacy=on,iommu_platform=on \
+    -device scsi-hd,drive=disk0,bootindex=0"
+fi
+
+if [ "$EUID" -ne 0 ]; then
+	SUDO_CMD="sudo"
+else
+	SUDO_CMD=""
+fi
+
+echo "============================="
+echo "Launching SVSM guest"
+echo "============================="
+echo "QEMU:         ${QEMU}"
+echo "QEMU Version: ${QEMU_VERSION}"
+echo "IGVM:         ${IGVM}"
+echo "IMAGE:        ${IMAGE}"
+echo "============================="
+echo "Press Ctrl-] to interrupt"
+echo "============================="
+
+# Remap Ctrl-C to Ctrl-] to allow the guest to handle Ctrl-C.
+stty intr ^]
+
+$SUDO_CMD \
+  $QEMU \
+    -enable-kvm \
+    -cpu EPYC-v4 \
+    -machine $MACHINE \
+    -object $MEMORY \
+    -object sev-snp-guest,id=sev0,cbitpos=$C_BIT_POS,reduced-phys-bits=1,init-flags=1,igvm-file=$IGVM \
+    -smp 4 \
+    -no-reboot \
+    -netdev user,id=vmnic -device e1000,netdev=vmnic,romfile= \
+    $IMAGE_DISK \
+    -nographic \
+    -monitor none \
+    -serial stdio \
+    $DEBUG_SERIAL
+
+stty intr ^C

--- a/scripts/test-in-svsm.sh
+++ b/scripts/test-in-svsm.sh
@@ -7,32 +7,10 @@
 
 set -e
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
 if [ "$QEMU" == "" ]; then
 	echo "Set QEMU environment variable to QEMU installation path" && exit 1
 fi
-if [ "$OVMF_PATH" == "" ]; then
-	echo "Set OVMF_PATH environment variable to a folder containing OVMF_CODE.fd and OVMF_VARS.fd" && exit 1
-fi
-if [ "$SUDO" != "" ]; then
-	SUDO_CMD="sudo"
-else
-	SUDO_CMD=""
-fi
 
-C_BIT_POS=`utils/cbit`
-
-$SUDO_CMD $QEMU \
-	-enable-kvm \
-	-cpu EPYC-v4 \
-	-machine q35,confidential-guest-support=sev0,memory-backend=ram1,kvm-type=protected \
-	-object memory-backend-memfd-private,id=ram1,size=1G,share=true \
-	-object sev-snp-guest,id=sev0,cbitpos=$C_BIT_POS,reduced-phys-bits=1,svsm=on \
-	-smp 8 \
-	-no-reboot \
-	-drive if=pflash,format=raw,unit=0,file=$OVMF_PATH/OVMF_CODE.fd,readonly=on \
-	-drive if=pflash,format=raw,unit=1,file=$OVMF_PATH/OVMF_VARS.fd,snapshot=on \
-	-drive if=pflash,format=raw,unit=2,file=./svsm-test.bin,readonly=on \
-	-nographic \
-	-monitor none \
-	-serial stdio \
-	-device isa-debug-exit,iobase=0xf4,iosize=0x04 || true
+$SCRIPT_DIR/launch_guest.sh --igvm $SCRIPT_DIR/../bin/coconut-test-qemu.igvm


### PR DESCRIPTION
Coconut SVSM supports launch using two different custom builds of QEMU:

1. https://github.com/coconut-svsm/qemu/tree/svsm-v8.0.0 which contains a coconut SVSM specific launch protocol for the guest.
2. https://github.com/coconut-svsm/qemu/tree/svsm-igvm which supports launching a guest using IGVM.

The current installation instructions describe how to launch SVSM using 1. However, the plan is to move to only supporting IGVM. Therefore the documentaton has been updated to describe how to build an IGVM file containing SVSM/OVMF, build the required branch of QEMU and launch the guest.

The IGVM file packages SVSM with OVMF, therefore the item in the TODO list in README.md has been removed.

Note that the documentation refers to cloning and building the IGVM github repository. This currently does not include the required C API and is waiting on https://github.com/microsoft/igvm/pull/3 to be merged, hence this PR is marked as draft.