### PR TITLE
RUSTDOC-GUIDELINES: Fix minor typo

### DIFF
--- a/Documentation/RUSTDOC-GUIDELINES.md
+++ b/Documentation/RUSTDOC-GUIDELINES.md
@@ -51,7 +51,7 @@ fn get_object() -> MyType {
 }
 ```
 
-- It is good practice to document arguments under a `# Arguements` section, as
+- It is good practice to document arguments under a `# Arguments` section, as
   well as return values under `# Returns`.
 
 ```rust


### PR DESCRIPTION
Fix minor typo in Rustdoc guidelines.
Signed-off-by: Carlos Bilbao <carlos.bilbao@amd.com>