### PR TITLE
mm/stack: remove the `StackBounds` type

### DIFF
--- a/src/cpu/percpu.rs
+++ b/src/cpu/percpu.rs
@@ -16,7 +16,6 @@ use crate::error::SvsmError;
 use crate::locking::{LockGuard, RWLock, SpinLock};
 use crate::mm::alloc::{allocate_zeroed_page, free_page};
 use crate::mm::pagetable::{get_init_pgtable_locked, PTEntryFlags, PageTableRef};
-use crate::mm::stack::StackBounds;
 use crate::mm::virtualrange::VirtualRange;
 use crate::mm::vm::{Mapping, VMKernelStack, VMPhysMem, VMRMapping, VMReserved, VMR};
 use crate::mm::{
@@ -29,6 +28,7 @@ use crate::sev::utils::RMPFlags;
 use crate::sev::vmsa::allocate_new_vmsa;
 use crate::task::{RunQueue, TaskPointer, WaitQueue};
 use crate::types::{PAGE_SHIFT, PAGE_SHIFT_2M, PAGE_SIZE, PAGE_SIZE_2M, SVSM_TR_FLAGS, SVSM_TSS};
+use crate::utils::MemoryRegion;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::cell::UnsafeCell;
@@ -247,7 +247,7 @@ pub struct PerCpu {
 
     /// Stack boundaries of the currently running task. This is stored in
     /// [PerCpu] because it needs lockless read access.
-    pub current_stack: StackBounds,
+    pub current_stack: MemoryRegion<VirtAddr>,
 
     /// WaitQueue for request processing
     request_waitqueue: WaitQueue,
@@ -278,7 +278,7 @@ impl PerCpu {
             vrange_4k: VirtualRange::new(),
             vrange_2m: VirtualRange::new(),
             runqueue: RWLock::new(RunQueue::new()),
-            current_stack: StackBounds::default(),
+            current_stack: MemoryRegion::new(VirtAddr::null(), 0),
             request_waitqueue: WaitQueue::new(),
         }
     }

--- a/src/mm/stack.rs
+++ b/src/mm/stack.rs
@@ -17,51 +17,6 @@ use crate::mm::{
 use crate::types::PAGE_SIZE;
 use crate::utils::MemoryRegion;
 
-/// Covers a virtual address range of a stack
-#[derive(Debug, Default, Copy, Clone)]
-pub struct StackBounds {
-    /// Stack bottom virtual address
-    pub bottom: VirtAddr,
-
-    /// Stack top virtual address
-    pub top: VirtAddr,
-}
-
-impl StackBounds {
-    /// Checks whether a given virtual address range is fully on the stack
-    ///
-    /// # Arguments
-    ///
-    /// * `begin` - Start virtual address of the checked range
-    /// * `len` - Length of the checked range in bytes
-    ///
-    /// # Returns
-    ///
-    /// `true` if range is fully on the stack, `false` if not.
-    pub fn range_is_on_stack(&self, begin: VirtAddr, len: usize) -> bool {
-        match begin.checked_add(len) {
-            Some(end) => begin >= self.bottom && end <= self.top,
-            None => false,
-        }
-    }
-
-    /// Creates a remapped version of this stuct StackBounds
-    ///
-    /// # Arguments
-    ///
-    /// * `base`: Virtual base address where stack is mapped
-    ///
-    /// # Returns
-    ///
-    /// New struct StackBounds with remapped values
-    pub fn map_at(&self, base: VirtAddr) -> Self {
-        Self {
-            top: self.top + base.bits(),
-            bottom: self.bottom + base.bits(),
-        }
-    }
-}
-
 // Limit maximum number of stacks for now, address range support 2**16 8k stacks
 const MAX_STACKS: usize = 1024;
 const BMP_QWORDS: usize = MAX_STACKS / 64;

--- a/src/mm/vm/mapping/kernel_stack.rs
+++ b/src/mm/vm/mapping/kernel_stack.rs
@@ -9,9 +9,8 @@ use crate::address::{PhysAddr, VirtAddr};
 use crate::error::SvsmError;
 use crate::mm::address_space::STACK_SIZE;
 use crate::mm::pagetable::PTEntryFlags;
-use crate::mm::stack::StackBounds;
 use crate::types::{PAGE_SHIFT, PAGE_SIZE};
-use crate::utils::page_align_up;
+use crate::utils::{page_align_up, MemoryRegion};
 
 use super::rawalloc::RawAllocMapping;
 use super::Mapping;
@@ -51,15 +50,12 @@ impl VMKernelStack {
     ///
     /// # Returns
     ///
-    /// [StackBounds] object containing the actual bottom and top addresses for
+    /// A [`MemoryRegion`] object containing the bottom and top addresses for
     /// the stack
-    pub fn bounds(&self, base: VirtAddr) -> StackBounds {
+    pub fn bounds(&self, base: VirtAddr) -> MemoryRegion<VirtAddr> {
         let mapping_size = self.alloc.mapping_size();
         let guard_size = self.guard_pages * PAGE_SIZE;
-        StackBounds {
-            bottom: base + guard_size,
-            top: base + guard_size + mapping_size,
-        }
+        MemoryRegion::new(base + guard_size, mapping_size)
     }
 
     /// Create a new [`VMKernelStack`] with a given size. This function will

--- a/src/task/tasks.rs
+++ b/src/task/tasks.rs
@@ -348,8 +348,7 @@ impl Task {
 
         // We need to setup a context on the stack that matches the stack layout
         // defined in switch_context below.
-        let stack_ptr: *mut u64 =
-            (percpu_mapping.virt_addr().bits() + bounds.end().bits()) as *mut u64;
+        let stack_ptr = (percpu_mapping.virt_addr() + bounds.end().bits()).as_mut_ptr::<u64>();
 
         // 'Push' the task frame onto the stack
         unsafe {

--- a/src/utils/memory_region.rs
+++ b/src/utils/memory_region.rs
@@ -203,4 +203,22 @@ where
     pub fn contains(&self, addr: A) -> bool {
         self.start() <= addr && addr < self.end()
     }
+
+    /// Check whether this region fully contains a different region.
+    ///
+    /// ```rust
+    /// # use svsm::address::VirtAddr;
+    /// # use svsm::utils::MemoryRegion;
+    /// # use svsm::types::PAGE_SIZE;
+    /// let big = MemoryRegion::new(VirtAddr::from(0xffffff1000u64), PAGE_SIZE * 2);
+    /// let small = MemoryRegion::new(VirtAddr::from(0xffffff1000u64), PAGE_SIZE);
+    /// let overlapping = MemoryRegion::new(VirtAddr::from(0xffffff0000u64), PAGE_SIZE * 2);
+    /// assert!(big.contains_region(&small));
+    /// assert!(!small.contains_region(&big));
+    /// assert!(!overlapping.contains_region(&big));
+    /// assert!(!big.contains_region(&overlapping));
+    /// ```
+    pub fn contains_region(&self, other: &Self) -> bool {
+        self.start() <= other.start() && other.end() <= self.end()
+    }
 }


### PR DESCRIPTION
The `StackBounds` type contains mostly a subset of the functionality of `MemoryRegion`, so simply remove the type and replace its uses. This makes the codebase more homogeneous and reduces code duplication.