### PR TITLE
mm: fix error message

### DIFF
--- a/src/mm/page_visibility.rs
+++ b/src/mm/page_visibility.rs
@@ -60,7 +60,7 @@ pub fn make_page_private(vaddr: VirtAddr) {
             PageSize::Regular,
             PageStateChangeOp::PscPrivate,
         )
-        .expect("Hypervisor failed to make page shared");
+        .expect("Hypervisor failed to make page private");
 
     // Revoke page validation before changing page state.
     pvalidate(vaddr, PageSize::Regular, PvalidateOp::Valid)


### PR DESCRIPTION
In the function "make_page_private", there is an error message when trying to set page private. fix it.