### PR TITLE
Ensure that guest VMPLs do not enable restricted injection

### DIFF
--- a/src/sev/status.rs
+++ b/src/sev/status.rs
@@ -134,7 +134,7 @@ fn read_sev_status() -> SEVStatusFlags {
     SEVStatusFlags::from_bits_truncate(read_msr(SEV_STATUS))
 }
 
-fn sev_flags() -> SEVStatusFlags {
+pub fn sev_flags() -> SEVStatusFlags {
     *SEV_FLAGS
 }
 
@@ -176,5 +176,12 @@ pub fn sev_status_verify() {
     if !not_supported_check.is_empty() {
         log::error!("Unsupported features enabled: {}", not_supported_check);
         panic!("Unsupported SEV features enabled");
+    }
+}
+
+impl SEVStatusFlags {
+    pub fn as_sev_features(&self) -> u64 {
+        let sev_features = self.bits();
+        sev_features >> 2
     }
 }


### PR DESCRIPTION
Guest VMPLs will not enable exactly the same SEV features as SVSM VMPLs. In particular, guest VMPLs will not use restricted injection even if the SVSM does, and in the future, guest VMPLs may need to enable (or disable) other features such as alternate injection, REFLECT_VC, or vTOM.  This change refactors the determination of SEV features for guest VMPLs so that it is possible to change features in a robust way.

Note that this will become critical once QEMU begins loading the VMSA from the IGVM file, because the IGVM file specifies restricted injection which is not compatible with guest VMPL execution.