### PR TITLE
Makefile: add `stage1/kernel.elf` as a dependecy of `stage1/stage1.o`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ ifneq ($(FS_FILE), none)
 endif
 	touch stage1/svsm-fs.bin
 
-stage1/stage1.o: stage1/stage1.S stage1/stage2.bin stage1/svsm-fs.bin
+stage1/stage1.o: stage1/stage1.S stage1/stage2.bin stage1/svsm-fs.bin stage1/kernel.elf
 	cc -c -o $@ stage1/stage1.S
 
 stage1/reset.o:  stage1/reset.S stage1/meta.bin


### PR DESCRIPTION
In `stage1/stage1.S` we include `stage1/kernel.elf` but we don't have this dependency in the Makefile, so the build of `stage1/stage1.o` might fail if `stage1/kernel.elf` isn't built first.

Discovered by running `make -j10`:
    $ make -j10
    ...
    cc -c -o stage1/stage1.o stage1/stage1.S
    stage1/stage1.S: Assembler messages:
    stage1/stage1.S:82: Error: file not found: stage1/kernel.elf
    make: *** [Makefile:95: stage1/stage1.o] Error 1