### PR TITLE
Remove Rust 2018 edition idioms

### DIFF
--- a/src/acpi/tables.rs
+++ b/src/acpi/tables.rs
@@ -41,7 +41,7 @@ impl RSDPDesc {
     ///
     /// A [`Result`] containing the [`RSDPDesc`] if successful, or an [`SvsmError`] on failure.
     ///
-    fn from_fwcfg(fw_cfg: &FwCfg) -> Result<Self, SvsmError> {
+    fn from_fwcfg(fw_cfg: &FwCfg<'_>) -> Result<Self, SvsmError> {
         let mut buf = mem::MaybeUninit::<Self>::uninit();
         let file = fw_cfg.file_selector("etc/acpi/rsdp")?;
         let size = file.size() as usize;
@@ -282,7 +282,7 @@ impl ACPITableBuffer {
     /// # Returns
     ///
     /// A new [`ACPITableBuffer`] instance containing ACPI tables and their metadata.
-    fn from_fwcfg(fw_cfg: &FwCfg) -> Result<Self, SvsmError> {
+    fn from_fwcfg(fw_cfg: &FwCfg<'_>) -> Result<Self, SvsmError> {
         let file = fw_cfg.file_selector("etc/acpi/tables")?;
         let size = file.size() as usize;
 
@@ -320,7 +320,7 @@ impl ACPITableBuffer {
     /// # Returns
     ///
     /// A [`Result`] indicating success or an error if ACPI tables cannot be loaded.
-    fn load_tables(&mut self, fw_cfg: &FwCfg) -> Result<(), SvsmError> {
+    fn load_tables(&mut self, fw_cfg: &FwCfg<'_>) -> Result<(), SvsmError> {
         let desc = RSDPDesc::from_fwcfg(fw_cfg)?;
 
         let rsdt = self.acpi_table_from_offset(desc.rsdt_addr as usize)?;
@@ -480,7 +480,7 @@ pub struct ACPICPUInfo {
 ///     }
 /// }
 /// ```
-pub fn load_acpi_cpu_info(fw_cfg: &FwCfg) -> Result<Vec<ACPICPUInfo>, SvsmError> {
+pub fn load_acpi_cpu_info(fw_cfg: &FwCfg<'_>) -> Result<Vec<ACPICPUInfo>, SvsmError> {
     let buffer = ACPITableBuffer::from_fwcfg(fw_cfg)?;
 
     let apic_table = buffer.acp_table_by_sig("APIC").ok_or(SvsmError::Acpi)?;

--- a/src/console.rs
+++ b/src/console.rs
@@ -57,7 +57,7 @@ pub fn init_console() {
 }
 
 #[doc(hidden)]
-pub fn _print(args: fmt::Arguments) {
+pub fn _print(args: fmt::Arguments<'_>) {
     use core::fmt::Write;
     if !*CONSOLE_INITIALIZED {
         return;
@@ -84,11 +84,11 @@ impl ConsoleLogger {
 }
 
 impl log::Log for ConsoleLogger {
-    fn enabled(&self, _metadata: &log::Metadata) -> bool {
+    fn enabled(&self, _metadata: &log::Metadata<'_>) -> bool {
         true
     }
 
-    fn log(&self, record: &log::Record) {
+    fn log(&self, record: &log::Record<'_>) {
         if !self.enabled(record.metadata()) {
             return;
         }

--- a/src/cpu/cpuid.rs
+++ b/src/cpu/cpuid.rs
@@ -8,7 +8,7 @@ use crate::utils::immut_after_init::ImmutAfterInitRef;
 use cpuarch::snp_cpuid::SnpCpuidTable;
 use log;
 
-static CPUID_PAGE: ImmutAfterInitRef<SnpCpuidTable> = ImmutAfterInitRef::uninit();
+static CPUID_PAGE: ImmutAfterInitRef<'_, SnpCpuidTable> = ImmutAfterInitRef::uninit();
 
 pub fn register_cpuid_table(table: &'static SnpCpuidTable) {
     CPUID_PAGE

--- a/src/cpu/insn.rs
+++ b/src/cpu/insn.rs
@@ -4,8 +4,6 @@
 //
 // Author: Thomas Leroy <tleroy@suse.de>
 
-extern crate alloc;
-
 use crate::cpu::vc::VcError;
 use crate::cpu::vc::VcErrorType;
 use crate::error::SvsmError;

--- a/src/cpu/percpu.rs
+++ b/src/cpu/percpu.rs
@@ -364,7 +364,7 @@ impl PerCpu {
         Ok(())
     }
 
-    pub fn get_pgtable(&self) -> LockGuard<PageTableRef> {
+    pub fn get_pgtable(&self) -> LockGuard<'_, PageTableRef> {
         self.pgtbl.lock()
     }
 
@@ -541,7 +541,7 @@ impl PerCpu {
         Ok(())
     }
 
-    pub fn guest_vmsa_ref(&self) -> LockGuard<GuestVmsaRef> {
+    pub fn guest_vmsa_ref(&self) -> LockGuard<'_, GuestVmsaRef> {
         self.shared.guest_vmsa.lock()
     }
 
@@ -606,7 +606,7 @@ impl PerCpu {
     /// the mapping which remains valid until the ['VRMapping'] is dropped.
     ///
     /// On error, an ['SvsmError'].
-    pub fn new_mapping(&mut self, mapping: Arc<Mapping>) -> Result<VMRMapping, SvsmError> {
+    pub fn new_mapping(&mut self, mapping: Arc<Mapping>) -> Result<VMRMapping<'_>, SvsmError> {
         VMRMapping::new(&mut self.vm_range, mapping)
     }
 

--- a/src/cpu/smp.rs
+++ b/src/cpu/smp.rs
@@ -4,8 +4,6 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
-extern crate alloc;
-
 use crate::acpi::tables::ACPICPUInfo;
 use crate::cpu::ghcb::current_ghcb;
 use crate::cpu::percpu::{this_cpu_mut, PerCpu};

--- a/src/debug/gdbstub.rs
+++ b/src/debug/gdbstub.rs
@@ -11,8 +11,6 @@
 //
 #[cfg(feature = "enable-gdb")]
 pub mod svsm_gdbstub {
-    extern crate alloc;
-
     use crate::address::{Address, VirtAddr};
     use crate::cpu::control_regs::read_cr3;
     use crate::cpu::idt::common::{X86ExceptionContext, BP_VECTOR, VC_VECTOR};
@@ -171,9 +169,9 @@ pub mod svsm_gdbstub {
     }
 
     static GDB_INITIALISED: AtomicBool = AtomicBool::new(false);
-    static GDB_STATE: SpinLock<Option<SvsmGdbStub>> = SpinLock::new(None);
+    static GDB_STATE: SpinLock<Option<SvsmGdbStub<'_>>> = SpinLock::new(None);
     static GDB_IO: SVSMIOPort = SVSMIOPort::new();
-    static mut GDB_SERIAL: SerialPort = SerialPort {
+    static mut GDB_SERIAL: SerialPort<'_> = SerialPort {
         driver: &GDB_IO,
         port: 0x2f8,
     };
@@ -524,7 +522,7 @@ pub mod svsm_gdbstub {
         }
 
         #[inline(always)]
-        fn support_resume(&mut self) -> Option<MultiThreadResumeOps<Self>> {
+        fn support_resume(&mut self) -> Option<MultiThreadResumeOps<'_, Self>> {
             Some(self)
         }
 

--- a/src/elf/mod.rs
+++ b/src/elf/mod.rs
@@ -81,7 +81,7 @@ pub enum ElfError {
 }
 
 impl fmt::Display for ElfError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::FileTooShort => {
                 write!(f, "ELF file too short")
@@ -464,7 +464,7 @@ impl<'a> Elf64File<'a> {
             return Err(ElfError::InvalidSectionIndex);
         }
 
-        let mut sh_strtab: Option<Elf64Strtab> = None;
+        let mut sh_strtab = None;
         for i in 0..elf_hdr.e_shnum {
             let shdr = Self::read_shdr_from_file(elf_file_buf, &elf_hdr, i);
             Self::verify_shdr(&shdr, elf_file_buf.len(), elf_hdr.e_shnum)?;
@@ -691,7 +691,7 @@ impl<'a> Elf64File<'a> {
     /// # Returns
     ///
     /// An [`Elf64ShdrIterator`] over the ELF Section Headers.
-    pub fn shdrs_iter(&self) -> Elf64ShdrIterator {
+    pub fn shdrs_iter(&self) -> Elf64ShdrIterator<'_> {
         Elf64ShdrIterator::new(self)
     }
 

--- a/src/fw_meta.rs
+++ b/src/fw_meta.rs
@@ -120,7 +120,7 @@ impl PartialEq for Uuid {
 }
 
 impl fmt::Display for Uuid {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for i in 0..16 {
             write!(f, "{:02x}", self.data[i])?;
             if i == 3 || i == 5 || i == 7 || i == 9 {
@@ -360,7 +360,7 @@ fn parse_sev_meta(
 }
 
 fn validate_fw_mem_region(
-    config: &SvsmConfig,
+    config: &SvsmConfig<'_>,
     region: MemoryRegion<PhysAddr>,
 ) -> Result<(), SvsmError> {
     let pstart = region.start();
@@ -399,7 +399,7 @@ fn validate_fw_mem_region(
 }
 
 fn validate_fw_memory_vec(
-    config: &SvsmConfig,
+    config: &SvsmConfig<'_>,
     regions: Vec<MemoryRegion<PhysAddr>>,
 ) -> Result<(), SvsmError> {
     if regions.is_empty() {
@@ -422,7 +422,7 @@ fn validate_fw_memory_vec(
 }
 
 pub fn validate_fw_memory(
-    config: &SvsmConfig,
+    config: &SvsmConfig<'_>,
     fw_meta: &SevFWMetaData,
     launch_info: &KernelLaunchInfo,
 ) -> Result<(), SvsmError> {

--- a/src/greq/pld_report.rs
+++ b/src/greq/pld_report.rs
@@ -6,8 +6,6 @@
 
 //! `SNP_GUEST_REQUEST` command to request an attestation report.
 
-extern crate alloc;
-
 use core::mem::size_of;
 
 use crate::protocols::errors::SvsmReqError;

--- a/src/greq/services.rs
+++ b/src/greq/services.rs
@@ -6,8 +6,6 @@
 
 //! API to send `SNP_GUEST_REQUEST` commands to the PSP
 
-extern crate alloc;
-
 use crate::{
     greq::{
         driver::{send_extended_guest_request, send_regular_guest_request},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 #![no_std]
 #![deny(missing_copy_implementations)]
 #![deny(missing_debug_implementations)]
+#![deny(rust_2018_idioms)]
 #![cfg_attr(all(test, test_in_svsm), no_main)]
 #![cfg_attr(all(test, test_in_svsm), feature(custom_test_frameworks))]
 #![cfg_attr(all(test, test_in_svsm), test_runner(crate::testing::svsm_test_runner))]

--- a/src/locking/rwlock.rs
+++ b/src/locking/rwlock.rs
@@ -206,7 +206,7 @@ impl<T> RWLock<T> {
     ///
     /// A [`ReadLockGuard`] that provides read access to the protected data.
     ///
-    pub fn lock_read(&self) -> ReadLockGuard<T> {
+    pub fn lock_read(&self) -> ReadLockGuard<'_, T> {
         loop {
             let val = self.wait_for_writers();
             let (readers, _) = split_val(val);
@@ -235,7 +235,7 @@ impl<T> RWLock<T> {
     ///
     /// A [`WriteLockGuard`] that provides write access to the protected data.
     ///
-    pub fn lock_write(&self) -> WriteLockGuard<T> {
+    pub fn lock_write(&self) -> WriteLockGuard<'_, T> {
         // Waiting for current writer to finish
         loop {
             let val = self.wait_for_writers();

--- a/src/locking/spinlock.rs
+++ b/src/locking/spinlock.rs
@@ -132,7 +132,7 @@ impl<T> SpinLock<T> {
     ///     *guard += 1;
     /// }; // Lock is automatically released when `guard` goes out of scope.
     /// ```
-    pub fn lock(&self) -> LockGuard<T> {
+    pub fn lock(&self) -> LockGuard<'_, T> {
         let ticket = self.current.fetch_add(1, Ordering::Relaxed);
         loop {
             let h = self.holder.load(Ordering::Acquire);
@@ -151,7 +151,7 @@ impl<T> SpinLock<T> {
     /// lock is not available, it returns `None`. If the lock is
     /// successfully acquired, it returns a [`LockGuard`] that automatically
     /// releases the lock when it goes out of scope.
-    pub fn try_lock(&self) -> Option<LockGuard<T>> {
+    pub fn try_lock(&self) -> Option<LockGuard<'_, T>> {
         let current = self.current.load(Ordering::Relaxed);
         let holder = self.holder.load(Ordering::Acquire);
 

--- a/src/mm/memory.rs
+++ b/src/mm/memory.rs
@@ -21,7 +21,7 @@ use super::pagetable::LAUNCH_VMSA_ADDR;
 static MEMORY_MAP: RWLock<Vec<MemoryRegion<PhysAddr>>> = RWLock::new(Vec::new());
 
 pub fn init_memory_map(
-    config: &SvsmConfig,
+    config: &SvsmConfig<'_>,
     launch_info: &KernelLaunchInfo,
 ) -> Result<(), SvsmError> {
     let mut regions = config.get_memory_regions()?;

--- a/src/mm/pagetable.rs
+++ b/src/mm/pagetable.rs
@@ -268,13 +268,13 @@ impl PageTable {
         Some(unsafe { &mut *address.as_mut_ptr::<PTPage>() })
     }
 
-    fn walk_addr_lvl0(page: &mut PTPage, vaddr: VirtAddr) -> Mapping {
+    fn walk_addr_lvl0(page: &mut PTPage, vaddr: VirtAddr) -> Mapping<'_> {
         let idx = PageTable::index::<0>(vaddr);
 
         Mapping::Level0(&mut page[idx])
     }
 
-    fn walk_addr_lvl1(page: &mut PTPage, vaddr: VirtAddr) -> Mapping {
+    fn walk_addr_lvl1(page: &mut PTPage, vaddr: VirtAddr) -> Mapping<'_> {
         let idx = PageTable::index::<1>(vaddr);
         let entry = page[idx];
         let ret = PageTable::entry_to_pagetable(entry);
@@ -285,7 +285,7 @@ impl PageTable {
         };
     }
 
-    fn walk_addr_lvl2(page: &mut PTPage, vaddr: VirtAddr) -> Mapping {
+    fn walk_addr_lvl2(page: &mut PTPage, vaddr: VirtAddr) -> Mapping<'_> {
         let idx = PageTable::index::<2>(vaddr);
         let entry = page[idx];
         let ret = PageTable::entry_to_pagetable(entry);
@@ -296,7 +296,7 @@ impl PageTable {
         };
     }
 
-    fn walk_addr_lvl3(page: &mut PTPage, vaddr: VirtAddr) -> Mapping {
+    fn walk_addr_lvl3(page: &mut PTPage, vaddr: VirtAddr) -> Mapping<'_> {
         let idx = PageTable::index::<3>(vaddr);
         let entry = page[idx];
         let ret = PageTable::entry_to_pagetable(entry);
@@ -307,11 +307,11 @@ impl PageTable {
         };
     }
 
-    pub fn walk_addr(&mut self, vaddr: VirtAddr) -> Mapping {
+    pub fn walk_addr(&mut self, vaddr: VirtAddr) -> Mapping<'_> {
         PageTable::walk_addr_lvl3(&mut self.root, vaddr)
     }
 
-    fn alloc_pte_lvl3(entry: &mut PTEntry, vaddr: VirtAddr, size: PageSize) -> Mapping {
+    fn alloc_pte_lvl3(entry: &mut PTEntry, vaddr: VirtAddr, size: PageSize) -> Mapping<'_> {
         let flags = entry.flags();
 
         if flags.contains(PTEntryFlags::PRESENT) {
@@ -335,7 +335,7 @@ impl PageTable {
         unsafe { PageTable::alloc_pte_lvl2(&mut (*page)[idx], vaddr, size) }
     }
 
-    fn alloc_pte_lvl2(entry: &mut PTEntry, vaddr: VirtAddr, size: PageSize) -> Mapping {
+    fn alloc_pte_lvl2(entry: &mut PTEntry, vaddr: VirtAddr, size: PageSize) -> Mapping<'_> {
         let flags = entry.flags();
 
         if flags.contains(PTEntryFlags::PRESENT) {
@@ -359,7 +359,7 @@ impl PageTable {
         unsafe { PageTable::alloc_pte_lvl1(&mut (*page)[idx], vaddr, size) }
     }
 
-    fn alloc_pte_lvl1(entry: &mut PTEntry, vaddr: VirtAddr, size: PageSize) -> Mapping {
+    fn alloc_pte_lvl1(entry: &mut PTEntry, vaddr: VirtAddr, size: PageSize) -> Mapping<'_> {
         let flags = entry.flags();
 
         if size == PageSize::Huge || flags.contains(PTEntryFlags::PRESENT) {
@@ -383,7 +383,7 @@ impl PageTable {
         unsafe { Mapping::Level0(&mut (*page)[idx]) }
     }
 
-    pub fn alloc_pte_4k(&mut self, vaddr: VirtAddr) -> Mapping {
+    pub fn alloc_pte_4k(&mut self, vaddr: VirtAddr) -> Mapping<'_> {
         let m = self.walk_addr(vaddr);
 
         match m {
@@ -394,7 +394,7 @@ impl PageTable {
         }
     }
 
-    pub fn alloc_pte_2m(&mut self, vaddr: VirtAddr) -> Mapping {
+    pub fn alloc_pte_2m(&mut self, vaddr: VirtAddr) -> Mapping<'_> {
         let m = self.walk_addr(vaddr);
 
         match m {
@@ -431,7 +431,7 @@ impl PageTable {
         Ok(())
     }
 
-    pub fn split_4k(mapping: Mapping) -> Result<(), SvsmError> {
+    pub fn split_4k(mapping: Mapping<'_>) -> Result<(), SvsmError> {
         match mapping {
             Mapping::Level0(_entry) => Ok(()),
             Mapping::Level1(entry) => PageTable::do_split_4k(entry),
@@ -777,11 +777,11 @@ impl RawPageTablePart {
         virt_to_phys(VirtAddr::from(self as *const RawPageTablePart))
     }
 
-    fn walk_addr(&mut self, vaddr: VirtAddr) -> Mapping {
+    fn walk_addr(&mut self, vaddr: VirtAddr) -> Mapping<'_> {
         PageTable::walk_addr_lvl2(&mut self.page, vaddr)
     }
 
-    fn alloc_pte_4k(&mut self, vaddr: VirtAddr) -> Mapping {
+    fn alloc_pte_4k(&mut self, vaddr: VirtAddr) -> Mapping<'_> {
         let m = self.walk_addr(vaddr);
 
         match m {
@@ -792,7 +792,7 @@ impl RawPageTablePart {
         }
     }
 
-    pub fn alloc_pte_2m(&mut self, vaddr: VirtAddr) -> Mapping {
+    pub fn alloc_pte_2m(&mut self, vaddr: VirtAddr) -> Mapping<'_> {
         let m = self.walk_addr(vaddr);
 
         match m {

--- a/src/mm/vm/mapping/api.rs
+++ b/src/mm/vm/mapping/api.rs
@@ -155,11 +155,11 @@ impl Mapping {
         }
     }
 
-    pub fn get(&self) -> ReadLockGuard<Box<dyn VirtualMapping>> {
+    pub fn get(&self) -> ReadLockGuard<'_, Box<dyn VirtualMapping>> {
         self.mapping.lock_read()
     }
 
-    pub fn get_mut(&self) -> WriteLockGuard<Box<dyn VirtualMapping>> {
+    pub fn get_mut(&self) -> WriteLockGuard<'_, Box<dyn VirtualMapping>> {
         self.mapping.lock_write()
     }
 }
@@ -236,11 +236,11 @@ impl VMM {
         )
     }
 
-    pub fn get_mapping(&self) -> ReadLockGuard<Box<dyn VirtualMapping>> {
+    pub fn get_mapping(&self) -> ReadLockGuard<'_, Box<dyn VirtualMapping>> {
         self.mapping.get()
     }
 
-    pub fn get_mapping_mut(&self) -> WriteLockGuard<Box<dyn VirtualMapping>> {
+    pub fn get_mapping_mut(&self) -> WriteLockGuard<'_, Box<dyn VirtualMapping>> {
         self.mapping.get_mut()
     }
 

--- a/src/mm/vm/range.rs
+++ b/src/mm/vm/range.rs
@@ -215,7 +215,7 @@ impl VMR {
         &self,
         mapping: Arc<Mapping>,
         start_pfn: usize,
-        cursor: &mut CursorMut<VMMAdapter>,
+        cursor: &mut CursorMut<'_, VMMAdapter>,
     ) -> Result<(), SvsmError> {
         let vmm = Box::new(VMM::new(start_pfn, mapping));
         if let Err(e) = self.map_vmm(&vmm) {

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -89,7 +89,7 @@ impl<'a> Terminal for SerialPort<'a> {
     }
 }
 
-pub static DEFAULT_SERIAL_PORT: SerialPort = SerialPort {
+pub static DEFAULT_SERIAL_PORT: SerialPort<'_> = SerialPort {
     driver: &DEFAULT_IO_DRIVER,
     port: SERIAL_PORT,
 };

--- a/src/sev/msr_protocol.rs
+++ b/src/sev/msr_protocol.rs
@@ -61,7 +61,7 @@ bitflags! {
 }
 
 impl Display for GHCBHvFeatures {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_fmt(format_args!("{:#x}", self.bits()))
     }
 }

--- a/src/sev/status.rs
+++ b/src/sev/status.rs
@@ -29,7 +29,7 @@ bitflags! {
 }
 
 impl fmt::Display for SEVStatusFlags {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut first = true;
 
         if self.contains(SEVStatusFlags::SEV) {

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -82,9 +82,9 @@ fn shutdown_percpu() {
 }
 
 static CONSOLE_IO: SVSMIOPort = SVSMIOPort::new();
-static CONSOLE_SERIAL: ImmutAfterInitCell<SerialPort> = ImmutAfterInitCell::uninit();
+static CONSOLE_SERIAL: ImmutAfterInitCell<SerialPort<'_>> = ImmutAfterInitCell::uninit();
 
-fn setup_env(config: &SvsmConfig) {
+fn setup_env(config: &SvsmConfig<'_>) {
     gdt().load();
     early_idt_init_no_ghcb();
 
@@ -123,7 +123,7 @@ fn setup_env(config: &SvsmConfig) {
     sev_status_verify();
 }
 
-fn map_and_validate(config: &SvsmConfig, vregion: MemoryRegion<VirtAddr>, paddr: PhysAddr) {
+fn map_and_validate(config: &SvsmConfig<'_>, vregion: MemoryRegion<VirtAddr>, paddr: PhysAddr) {
     let flags = PTEntryFlags::PRESENT
         | PTEntryFlags::WRITABLE
         | PTEntryFlags::ACCESSED
@@ -371,7 +371,7 @@ pub extern "C" fn stage2_main(launch_info: &Stage1LaunchInfo) {
 }
 
 #[panic_handler]
-fn panic(info: &PanicInfo) -> ! {
+fn panic(info: &PanicInfo<'_>) -> ! {
     log::error!("Panic: {}", info);
     loop {
         halt();

--- a/src/string.rs
+++ b/src/string.rs
@@ -96,7 +96,7 @@ impl<const N: usize> PartialEq<FixedString<N>> for FixedString<N> {
 }
 
 impl<const T: usize> fmt::Display for FixedString<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for b in self.data.iter().take(self.len) {
             write!(f, "{}", *b)?;
         }

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -7,8 +7,6 @@
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(not(test), no_main)]
 
-extern crate alloc;
-
 use svsm::fw_meta::{print_fw_meta, validate_fw_memory, SevFWMetaData};
 
 use bootlib::kernel_launch::KernelLaunchInfo;
@@ -187,7 +185,7 @@ fn prepare_fw_launch(fw_meta: &SevFWMetaData) -> Result<(), SvsmError> {
     Ok(())
 }
 
-fn launch_fw(config: &SvsmConfig) -> Result<(), SvsmError> {
+fn launch_fw(config: &SvsmConfig<'_>) -> Result<(), SvsmError> {
     let cpu = this_cpu();
     let mut vmsa_ref = cpu.guest_vmsa_ref();
     let vmsa_pa = vmsa_ref.vmsa_phys().unwrap();
@@ -205,7 +203,7 @@ fn launch_fw(config: &SvsmConfig) -> Result<(), SvsmError> {
     Ok(())
 }
 
-fn validate_fw(config: &SvsmConfig, launch_info: &KernelLaunchInfo) -> Result<(), SvsmError> {
+fn validate_fw(config: &SvsmConfig<'_>, launch_info: &KernelLaunchInfo) -> Result<(), SvsmError> {
     let kernel_region = new_kernel_region(launch_info);
     let flash_regions = config.get_fw_regions(&kernel_region);
 
@@ -243,7 +241,7 @@ pub fn memory_init(launch_info: &KernelLaunchInfo) {
 }
 
 static CONSOLE_IO: SVSMIOPort = SVSMIOPort::new();
-static CONSOLE_SERIAL: ImmutAfterInitCell<SerialPort> = ImmutAfterInitCell::uninit();
+static CONSOLE_SERIAL: ImmutAfterInitCell<SerialPort<'_>> = ImmutAfterInitCell::uninit();
 
 pub fn boot_stack_info() {
     // SAFETY: this is only unsafe because `bsp_stack_end` is an extern
@@ -462,7 +460,7 @@ pub extern "C" fn svsm_main() {
 }
 
 #[panic_handler]
-fn panic(info: &PanicInfo) -> ! {
+fn panic(info: &PanicInfo<'_>) -> ! {
     secrets_page_mut().clear_vmpck(0);
     secrets_page_mut().clear_vmpck(1);
     secrets_page_mut().clear_vmpck(2);

--- a/src/svsm_paging.rs
+++ b/src/svsm_paging.rs
@@ -24,7 +24,7 @@ struct IgvmParamInfo<'a> {
     igvm_params: Option<IgvmParams<'a>>,
 }
 
-pub fn init_page_table(launch_info: &KernelLaunchInfo, kernel_elf: &elf::Elf64File) {
+pub fn init_page_table(launch_info: &KernelLaunchInfo, kernel_elf: &elf::Elf64File<'_>) {
     let vaddr = mm::alloc::allocate_zeroed_page().expect("Failed to allocate root page-table");
     let mut pgtable = PageTableRef::new(unsafe { &mut *vaddr.as_mut_ptr::<PageTable>() });
     let igvm_param_info = if launch_info.igvm_params_virt_addr != 0 {
@@ -100,7 +100,7 @@ pub fn init_page_table(launch_info: &KernelLaunchInfo, kernel_elf: &elf::Elf64Fi
 }
 
 fn invalidate_boot_memory_region(
-    config: &SvsmConfig,
+    config: &SvsmConfig<'_>,
     region: MemoryRegion<PhysAddr>,
 ) -> Result<(), SvsmError> {
     log::info!(
@@ -131,7 +131,7 @@ fn invalidate_boot_memory_region(
 }
 
 pub fn invalidate_early_boot_memory(
-    config: &SvsmConfig,
+    config: &SvsmConfig<'_>,
     launch_info: &KernelLaunchInfo,
 ) -> Result<(), SvsmError> {
     // Early boot memory must be invalidated after changing to the SVSM page

--- a/src/utils/immut_after_init.rs
+++ b/src/utils/immut_after_init.rs
@@ -223,7 +223,7 @@ unsafe impl<T> Sync for ImmutAfterInitCell<T> {}
 /// ```
 ///
 #[derive(Debug)]
-pub struct ImmutAfterInitRef<'a, T: 'a> {
+pub struct ImmutAfterInitRef<'a, T> {
     #[doc(hidden)]
     ptr: ImmutAfterInitCell<*const T>,
     #[doc(hidden)]


### PR DESCRIPTION
Since we are using the Rust 2021 edition, remove 2018 edition idioms. Add a lint to prevent future addition of these idioms.

Most of these changes are the addition of explicit lifetimes and removing `extern crate` statements where they were not needed.

Clippy would warn about these with:

```
cargo clippy --all-features -- -W rust-2018-idioms
```