### PR TITLE
stage2: do not use mutable references to mutable statics

### DIFF
--- a/kernel/src/mm/pagetable.rs
+++ b/kernel/src/mm/pagetable.rs
@@ -693,10 +693,8 @@ pub struct PageTableRef {
 }
 
 impl PageTableRef {
-    pub fn new(pgtable: &mut PageTable) -> PageTableRef {
-        PageTableRef {
-            pgtable_ptr: pgtable as *mut PageTable,
-        }
+    pub fn new(pgtable_ptr: *mut PageTable) -> PageTableRef {
+        Self { pgtable_ptr }
     }
 
     pub const fn unset() -> PageTableRef {

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -12,6 +12,7 @@ pub mod boot_stage2;
 use bootlib::kernel_launch::KernelLaunchInfo;
 use core::arch::asm;
 use core::panic::PanicInfo;
+use core::ptr::addr_of_mut;
 use core::slice;
 use cpuarch::snp_cpuid::SnpCpuidTable;
 use svsm::address::{Address, PhysAddr, VirtAddr};
@@ -66,7 +67,7 @@ fn init_percpu() {
             .as_mut()
             .unwrap();
 
-        bsp_percpu.set_pgtable(PageTableRef::new(&mut pgtable));
+        bsp_percpu.set_pgtable(PageTableRef::new(addr_of_mut!(pgtable)));
         bsp_percpu
             .map_self_stage2()
             .expect("Failed to map per-cpu area");
@@ -100,7 +101,7 @@ fn setup_env(config: &SvsmConfig<'_>) {
     // Bring up the GCHB for use from the SVSMIOPort console.
     verify_ghcb_version();
     sev_status_init();
-    set_init_pgtable(PageTableRef::new(unsafe { &mut pgtable }));
+    set_init_pgtable(PageTableRef::new(unsafe { addr_of_mut!(pgtable) }));
     setup_stage2_allocator();
     init_percpu();
 


### PR DESCRIPTION
Fix a couple of nightly clippy warnings like the following:

```
warning: mutable reference of mutable static is discouraged
  --> src/stage2.rs:69:50
   |
69 |         bsp_percpu.set_pgtable(PageTableRef::new(&mut pgtable));
   |                                                  ^^^^^^^^^^^^ mutable reference of mutable static
   |
   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
   = note: reference of mutable static is a hard error from 2024 edition
   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
   = note: `#[warn(static_mut_ref)]` on by default
help: mutable references are dangerous since if there's any other pointer or reference used for that static while the reference lives, that's UB; use `addr_of_mut!` instead to create a raw pointer
   |
69 |         bsp_percpu.set_pgtable(PageTableRef::new(addr_of_mut!(pgtable)));
```

Fix this by simply using *mut pointers. 