### PR TITLE
Fix incremental build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,4 +121,5 @@ clean:
 	rm -f stage1/stage2.bin svsm.bin stage1/meta.bin stage1/kernel.elf stage1/stage1 stage1/svsm-fs.bin ${STAGE1_OBJS} utils/gen_meta utils/print-meta
 	rm -rf bin
 
-.PHONY: test clean
+.PHONY: test clean stage1/stage2.bin stage1/svsm-kernel.elf
+


### PR DESCRIPTION
The binary targets generated by cargo must be listed as .PHONY targets to ensure that make knows to invoke cargo to force the targets to come up to date.  Without this, executing "make" will not reevaluate the Rust sources to determine whether rebuilds of the kernel or stage2 are necessary.