### PR TITLE
Improve igvmbuilder error reporting

### DIFF
--- a/igvmbuilder/src/gpa_map.rs
+++ b/igvmbuilder/src/gpa_map.rs
@@ -84,8 +84,8 @@ impl GpaMap {
         //   0xFFnn0000-0xFFFFFFFF: OVMF firmware (QEMU only, if specified)
 
         // Obtain the lengths of the binary files
-        let stage2_len = metadata(&options.stage2)?.len() as usize;
-        let kernel_elf_len = metadata(&options.kernel)?.len() as usize;
+        let stage2_len = Self::get_metadata(&options.stage2)?.len() as usize;
+        let kernel_elf_len = Self::get_metadata(&options.kernel)?.len() as usize;
         let kernel_fs_len = if let Some(fs) = &options.filesystem {
             metadata(fs)?.len() as usize
         } else {
@@ -164,5 +164,13 @@ impl GpaMap {
             println!("GPA Map: {gpa_map:#X?}");
         }
         Ok(gpa_map)
+    }
+
+    pub fn get_metadata(path: &String) -> Result<std::fs::Metadata, Box<dyn Error>> {
+        let meta = metadata(path).map_err(|e| {
+            eprintln!("Failed to access {}", path);
+            e
+        })?;
+        Ok(meta)
     }
 }

--- a/igvmbuilder/src/igvm_firmware.rs
+++ b/igvmbuilder/src/igvm_firmware.rs
@@ -48,7 +48,10 @@ impl IgvmFirmware {
     ) -> Result<Box<dyn Firmware>, Box<dyn Error>> {
         // Read and parse Hyper-V firmware.
         let mut igvm_fw = IgvmFirmware::new(parameter_count);
-        let igvm_buffer = fs::read(filename)?;
+        let igvm_buffer = fs::read(filename).map_err(|e| {
+            eprintln!("Failed to open firmware file {}", filename);
+            e
+        })?;
         let igvm = IgvmFile::new_from_binary(igvm_buffer.as_bytes(), None)?;
 
         let directives: Result<Vec<IgvmDirectiveHeader>, Box<dyn Error>> = igvm

--- a/igvmbuilder/src/ovmf_firmware.rs
+++ b/igvmbuilder/src/ovmf_firmware.rs
@@ -216,7 +216,10 @@ impl OvmfFirmware {
         _parameter_count: u32,
         compatibility_mask: u32,
     ) -> Result<Box<dyn Firmware>, Box<dyn Error>> {
-        let mut in_file = File::open(filename)?;
+        let mut in_file = File::open(filename).map_err(|e| {
+            eprintln!("Failed to open firmware file {}", filename);
+            e
+        })?;
         let len = in_file.metadata()?.len() as usize;
         if len > 0xffffffff {
             return Err("OVMF firmware is too large".into());


### PR DESCRIPTION
Errors involving any of the input files or output should report which file access failed and should return the error so it can be decoded and reported.