### PR TITLE
Move all generated binary targets to bin dir

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,7 @@ jobs:
       # ld to work, so build all the objects without performing the
       # final linking step.
       - name: Build
-        run: make FEATURES="default,enable-gdb" stage1/svsm-kernel.elf stage1/stage1.o stage1/reset.o
+        run: make FEATURES="default,enable-gdb" bin/svsm-kernel.elf stage1/stage1.o stage1/reset.o
 
       - name: Run tests
         run: make test

--- a/Documentation/INSTALL.md
+++ b/Documentation/INSTALL.md
@@ -196,8 +196,8 @@ $ make RELEASE=1
 ```
 
 to build the SVSM with the release target. When the build is finished
-there is the ```svsm.bin``` file in the top-directory of the repository. This
-is the file which needs to be passed to QEMU.
+there is the ```svsm.bin``` file in the `bin` directory at the top level of the
+repository. This is the file which needs to be passed to QEMU.
 
 The project also contains a number of unit-tests which can be run by
 

--- a/Makefile
+++ b/Makefile
@@ -38,29 +38,29 @@ IGVM_FILES = bin/coconut-qemu.igvm bin/coconut-hyperv.igvm
 IGVMBUILDER = "target/x86_64-unknown-linux-gnu/${TARGET_PATH}/igvmbuilder"
 IGVMBIN = bin/igvmbld
 
-all: svsm.bin igvm
+all: bin/svsm.bin igvm
 
 igvm: $(IGVM_FILES) $(IGVMBIN)
 
-$(IGVMBIN): $(IGVMBUILDER)
+bin:
 	mkdir -v -p bin
+
+$(IGVMBIN): $(IGVMBUILDER) bin
 	cp -f $(IGVMBUILDER) $@
 
 $(IGVMBUILDER):
 	cargo build ${CARGO_ARGS} --target=x86_64-unknown-linux-gnu -p igvmbuilder
 
-bin/coconut-qemu.igvm: $(IGVMBUILDER) stage1/svsm-kernel.elf stage1/stage2.bin
-	mkdir -v -p bin
-	$(IGVMBUILDER) --sort --output $@ --stage2 stage1/stage2.bin --kernel stage1/svsm-kernel.elf ${BUILD_FW} qemu
+bin/coconut-qemu.igvm: $(IGVMBUILDER) bin/svsm-kernel.elf bin/stage2.bin
+	$(IGVMBUILDER) --sort --output $@ --stage2 bin/stage2.bin --kernel bin/svsm-kernel.elf ${BUILD_FW} qemu
 
-bin/coconut-hyperv.igvm: $(IGVMBUILDER) stage1/svsm-kernel.elf stage1/stage2.bin
-	mkdir -v -p bin
-	$(IGVMBUILDER) --sort --output $@ --stage2 stage1/stage2.bin --kernel stage1/svsm-kernel.elf --comport 3 hyper-v
+bin/coconut-hyperv.igvm: $(IGVMBUILDER) bin/svsm-kernel.elf bin/stage2.bin
+	$(IGVMBUILDER) --sort --output $@ --stage2 bin/stage2.bin --kernel bin/svsm-kernel.elf --comport 3 hyper-v
 
 test:
 	cargo test --workspace --target=x86_64-unknown-linux-gnu
 
-test-in-svsm: utils/cbit svsm-test.bin
+test-in-svsm: utils/cbit bin/svsm-test.bin
 	./scripts/test-in-svsm.sh
 
 doc:
@@ -75,49 +75,49 @@ utils/print-meta: utils/print-meta.c
 utils/cbit: utils/cbit.c
 	cc -O3 -Wall -o $@ $<
 
-stage1/meta.bin: utils/gen_meta utils/print-meta
+bin/meta.bin: utils/gen_meta utils/print-meta
 	./utils/gen_meta $@
 
-stage1/stage2.bin:
+bin/stage2.bin: bin
 	cargo build ${CARGO_ARGS} ${SVSM_ARGS} --bin stage2
 	objcopy -O binary ${STAGE2_ELF} $@
 
-stage1/svsm-kernel.elf:
+bin/svsm-kernel.elf: bin
 	cargo build ${CARGO_ARGS} ${SVSM_ARGS} --bin svsm
 	objcopy -O elf64-x86-64 --strip-unneeded ${SVSM_KERNEL_ELF} $@
 
-stage1/test-kernel.elf:
+bin/test-kernel.elf: bin
 	LINK_TEST=1 cargo +nightly test -p svsm --config 'target.x86_64-unknown-none.runner=["sh", "-c", "cp $$0 ../${TEST_KERNEL_ELF}"]'
-	objcopy -O elf64-x86-64 --strip-unneeded ${TEST_KERNEL_ELF} stage1/test-kernel.elf
+	objcopy -O elf64-x86-64 --strip-unneeded ${TEST_KERNEL_ELF} bin/test-kernel.elf
 
-stage1/svsm-fs.bin:
+bin/svsm-fs.bin: bin
 ifneq ($(FS_FILE), none)
-	cp -f $(FS_FILE) stage1/svsm-fs.bin
+	cp -f $(FS_FILE) bin/svsm-fs.bin
 endif
-	touch stage1/svsm-fs.bin
+	touch bin/svsm-fs.bin
 
-stage1/stage1.o: stage1/stage1.S stage1/stage2.bin stage1/svsm-fs.bin stage1/svsm-kernel.elf
-	ln -sf svsm-kernel.elf stage1/kernel.elf
+stage1/stage1.o: stage1/stage1.S bin/stage2.bin bin/svsm-fs.bin bin/svsm-kernel.elf bin
+	ln -sf svsm-kernel.elf bin/kernel.elf
 	cc -c -o $@ stage1/stage1.S
-	rm -f stage1/kernel.elf
+	rm -f bin/kernel.elf
 
-stage1/stage1-test.o: stage1/stage1.S stage1/stage2.bin stage1/svsm-fs.bin stage1/test-kernel.elf
-	ln -sf test-kernel.elf stage1/kernel.elf
+stage1/stage1-test.o: stage1/stage1.S bin/stage2.bin bin/svsm-fs.bin bin/test-kernel.elf bin
+	ln -sf test-kernel.elf bin/kernel.elf
 	cc -c -o $@ stage1/stage1.S
-	rm -f stage1/kernel.elf
+	rm -f bin/kernel.elf
 
-stage1/reset.o:  stage1/reset.S stage1/meta.bin
+stage1/reset.o:  stage1/reset.S bin/meta.bin
 
-stage1/stage1: ${STAGE1_OBJS}
+bin/stage1: ${STAGE1_OBJS}
 	$(CC) -o $@ $(STAGE1_OBJS) -nostdlib -Wl,--build-id=none -Wl,-Tstage1/stage1.lds -no-pie
 
-stage1/stage1-test: ${STAGE1_TEST_OBJS}
+bin/stage1-test: ${STAGE1_TEST_OBJS}
 	$(CC) -o $@ $(STAGE1_TEST_OBJS) -nostdlib -Wl,--build-id=none -Wl,-Tstage1/stage1.lds -no-pie
 
-svsm.bin: stage1/stage1
+bin/svsm.bin: bin/stage1
 	objcopy -O binary $< $@
 
-svsm-test.bin: stage1/stage1-test
+bin/svsm-test.bin: bin/stage1-test
 	objcopy -O binary $< $@
 
 clippy:
@@ -126,8 +126,9 @@ clippy:
 
 clean:
 	cargo clean
-	rm -f stage1/stage2.bin svsm.bin stage1/meta.bin stage1/kernel.elf stage1/stage1 stage1/svsm-fs.bin ${STAGE1_OBJS} utils/gen_meta utils/print-meta
+	rm -f stage1/*.o stage1/*.bin stage1/*.elf
+	rm -f ${STAGE1_OBJS} utils/gen_meta utils/print-meta
 	rm -rf bin
 
-.PHONY: test clean clippy stage1/stage2.bin stage1/svsm-kernel.elf stage1/test-kernel.elf
+.PHONY: test clean clippy bin/stage2.bin bin/svsm-kernel.elf bin/test-kernel.elf
 

--- a/stage1/reset.S
+++ b/stage1/reset.S
@@ -52,7 +52,7 @@ gdt32_descr:
 END(to_pm_mode)
 
 	.section .sevmeta
-	.incbin "stage1/meta.bin"
+	.incbin "bin/meta.bin"
 
 	.code16gcc
 	.section .resetvector

--- a/stage1/stage1.S
+++ b/stage1/stage1.S
@@ -74,17 +74,17 @@ startup_32:
 
 	.align	4
 stage2_bin:
-	.incbin "stage1/stage2.bin"
+	.incbin "bin/stage2.bin"
 	.align 4
 stage2_bin_end:
 
 kernel_elf:
-	.incbin "stage1/kernel.elf"
+	.incbin "bin/kernel.elf"
 	.align 4
 kernel_elf_end:
 
 kernel_fs_bin:
-	.incbin "stage1/svsm-fs.bin"
+	.incbin "bin/svsm-fs.bin"
 kernel_fs_bin_end:
 
 	.align 4


### PR DESCRIPTION
Besides being more consistent, this improves the process of performing a clean make ("make clean") because all generated targets are in one place and can be removed more consistently.

The "make clean" target contines to refer to the old files in the stage1 directory so that executing "make clean" after picking up this change will correctly remove the old files.