### PR TITLE
workflows: run clippy on tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,6 +55,12 @@ jobs:
           command: clippy
           args: --workspace --all-features --exclude svsm --target=x86_64-unknown-linux-gnu -- -D warnings
 
+      - name: Clippy on tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --workspace --all-features --tests --target=x86_64-unknown-linux-gnu -- -D warnings
+
       - name: Check documentation
         run: make doc
         env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,7 +53,15 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --workspace --all-features --exclude svsm --target=x86_64-unknown-linux-gnu -- -D warnings
+          args: --workspace --all-features --exclude svsm --exclude svsm-fuzz --target=x86_64-unknown-linux-gnu -- -D warnings
+
+      - name: Clippy on svsm-fuzz
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --package svsm-fuzz --all-features --target=x86_64-unknown-linux-gnu -- -D warnings
+        env:
+          RUSTFLAGS: --cfg fuzzing
 
       - name: Clippy on tests
         uses: actions-rs/cargo@v1

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -45,11 +45,9 @@ done
 # Run clippy on SVSM kernel
 cargo clippy --workspace --exclude igvmbuilder --exclude svsm-fuzz --all-features -- -D warnings || exit 1
 # Run clippy on std-dependent packages
-cargo clippy --workspace --all-features --exclude svsm --target=x86_64-unknown-linux-gnu -- -D warnings || exit 1
-RUSTFLAGS="--cfg fuzzing" cargo clippy \
-    --all-features \
-    --target=x86_64-unknown-linux-gnu \
-    --manifest-path fuzz/Cargo.toml -- -D warnings || exit 1
+cargo clippy --workspace --all-features --exclude svsm --exclude svsm-fuzz --target=x86_64-unknown-linux-gnu -- -D warnings || exit 1
+# Run clippy on fuzzing harnesses
+RUSTFLAGS="--cfg fuzzing" cargo clippy --package svsm-fuzz --all-features --target=x86_64-unknown-linux-gnu -- -D warnings || exit 1
 # Run clippy on tests
 cargo clippy --workspace --all-features --tests --target=x86_64-unknown-linux-gnu -- -D warnings || exit 1
 

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -42,12 +42,16 @@ for file in `git diff --name-only --staged`; do
     fi
 done
 
+# Run clippy on SVSM kernel
 cargo clippy --workspace --exclude igvmbuilder --exclude svsm-fuzz --all-features -- -D warnings || exit 1
+# Run clippy on std-dependent packages
 cargo clippy --workspace --all-features --exclude svsm --target=x86_64-unknown-linux-gnu -- -D warnings || exit 1
 RUSTFLAGS="--cfg fuzzing" cargo clippy \
     --all-features \
     --target=x86_64-unknown-linux-gnu \
     --manifest-path fuzz/Cargo.toml -- -D warnings || exit 1
+# Run clippy on tests
+cargo clippy --workspace --all-features --tests --target=x86_64-unknown-linux-gnu -- -D warnings || exit 1
 
 exit $RET
 


### PR DESCRIPTION
During the switch to a workspace repository the clippy run on tests was removed, so add it again.

While we are at it, run clippy on `svsm-fuzz` only with `--cfg fuzzing`.