### PR TITLE
Cargo.toml: extend SVSM kernel lints to whole workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,8 @@ packit = { git = "https://github.com/coconut-svsm/packit", version = "0.1.1" }
 future_incompatible = "deny"
 nonstandard_style = "deny"
 rust_2018_idioms = "deny"
+missing_copy_implementations = "deny"
+missing_debug_implementations = "deny"
 
 [workspace.lints.clippy]
 await_holding_lock = "warn"

--- a/bootlib/src/igvm_params.rs
+++ b/bootlib/src/igvm_params.rs
@@ -10,7 +10,7 @@
 /// The IGVM parameter page is an unmeasured page containing individual
 /// parameters that are provided by the host loader.
 #[repr(C, packed)]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct IgvmParamPage {
     /// The number of vCPUs that are configured for the guest VM.
     pub cpu_count: u32,
@@ -78,7 +78,7 @@ pub struct IgvmParamBlockFwInfo {
 /// builder which describes where the additional IGVM parameter information
 /// has been placed into the guest address space.
 #[repr(C, packed)]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct IgvmParamBlock {
     /// The total size of the parameter area, beginning with the parameter
     /// block itself and including any additional parameter pages which follow.

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -5,9 +5,6 @@
 // Author: Nicolai Stange <nstange@suse.de>
 
 #![no_std]
-#![deny(missing_copy_implementations)]
-#![deny(missing_debug_implementations)]
-#![deny(rust_2018_idioms)]
 #![cfg_attr(all(test, test_in_svsm), no_main)]
 #![cfg_attr(all(test, test_in_svsm), feature(custom_test_frameworks))]
 #![cfg_attr(all(test, test_in_svsm), test_runner(crate::testing::svsm_test_runner))]

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -152,7 +152,7 @@ fn map_and_validate(config: &SvsmConfig<'_>, vregion: MemoryRegion<VirtAddr>, pa
 // Launch info from stage1, usually at the bottom of the stack
 // The layout has to match the order in which the parts are pushed to the stack
 // in stage1/stage1.S
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone, Copy)]
 #[repr(C, packed)]
 pub struct Stage1LaunchInfo {
     kernel_elf_start: u32,


### PR DESCRIPTION
Move required lints in `kernel/src/lib.rs` to Cargo.toml so they apply to all crates in the workspace.