### PR TITLE
gdbstub: Add exception handler for DB_VECTOR for DEBUG_SWAP feature

### DIFF
--- a/kernel/src/cpu/idt/common.rs
+++ b/kernel/src/cpu/idt/common.rs
@@ -12,7 +12,7 @@ use core::arch::{asm, global_asm};
 use core::mem;
 
 pub const _DE_VECTOR: usize = 0;
-pub const _DB_VECTOR: usize = 1;
+pub const DB_VECTOR: usize = 1;
 pub const _NMI_VECTOR: usize = 2;
 pub const BP_VECTOR: usize = 3;
 pub const _OF_VECTOR: usize = 4;

--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -11,7 +11,7 @@ use super::super::tss::IST_DF;
 use super::super::vc::handle_vc_exception;
 use super::common::PF_ERROR_WRITE;
 use super::common::{
-    idt_mut, IdtEntry, BP_VECTOR, DF_VECTOR, GP_VECTOR, HV_VECTOR, PF_VECTOR, VC_VECTOR,
+    idt_mut, IdtEntry, BP_VECTOR, DB_VECTOR, DF_VECTOR, GP_VECTOR, HV_VECTOR, PF_VECTOR, VC_VECTOR,
 };
 use crate::address::VirtAddr;
 use crate::cpu::X86ExceptionContext;
@@ -83,6 +83,7 @@ pub extern "C" fn generic_idt_handler(ctx: &mut X86ExceptionContext) {
         }
         VC_VECTOR => handle_vc_exception(ctx),
         BP_VECTOR => handle_debug_exception(ctx, ctx.vector),
+        DB_VECTOR => handle_debug_exception(ctx, ctx.vector),
         HV_VECTOR =>
             // #HV processing is not required in the SVSM.  If a maskable
         // interrupt occurs, it will be processed prior to the next exit.

--- a/kernel/src/cpu/vc.rs
+++ b/kernel/src/cpu/vc.rs
@@ -126,8 +126,9 @@ pub fn handle_vc_exception(ctx: &mut X86ExceptionContext) {
     let insn = vc_decode_insn(ctx).expect("Could not decode instruction");
 
     match error_code {
-        // If the debugger is enabled then handle the DB exception
-        // by directly invoking the exception handler
+        // If the gdb stub is enabled then debugging operations such as single stepping
+        // will cause either an exception via DB_VECTOR if the DEBUG_SWAP sev_feature is
+        // clear, or a VC exception with an error code of X86_TRAP if set.
         X86_TRAP => handle_debug_exception(ctx, ctx.vector),
         SVM_EXIT_CPUID => handle_cpuid(ctx).expect("Could not handle CPUID #VC exception"),
         SVM_EXIT_IOIO => {

--- a/kernel/src/debug/gdbstub.rs
+++ b/kernel/src/debug/gdbstub.rs
@@ -13,7 +13,7 @@
 pub mod svsm_gdbstub {
     use crate::address::{Address, VirtAddr};
     use crate::cpu::control_regs::read_cr3;
-    use crate::cpu::idt::common::{X86ExceptionContext, BP_VECTOR, VC_VECTOR};
+    use crate::cpu::idt::common::{X86ExceptionContext, BP_VECTOR, DB_VECTOR, VC_VECTOR};
     use crate::cpu::percpu::this_cpu;
     use crate::cpu::X86GeneralRegs;
     use crate::error::SvsmError;
@@ -71,6 +71,7 @@ pub mod svsm_gdbstub {
         fn from(value: usize) -> Self {
             match value {
                 BP_VECTOR => ExceptionType::SwBreakpoint,
+                DB_VECTOR => ExceptionType::Debug,
                 VC_VECTOR => ExceptionType::Debug,
                 _ => ExceptionType::PageFault,
             }


### PR DESCRIPTION
The latest AMD SEV-SNP patch series for SEV-SNP enables the sev_features DEBUG_SWAP bit which delegates debug exceptions to the host rather than the guest VC handler. This patch adds a DB_VECTOR handler to allow these exceptions to be handled by the gdb stub when DEBUG_SWAP is set.