### PR TITLE
igvmbuilder: remove unused `bitflags` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,7 +346,6 @@ dependencies = [
 name = "igvmbuilder"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.4.2",
  "bootlib",
  "clap",
  "igvm",

--- a/igvmbuilder/Cargo.toml
+++ b/igvmbuilder/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [dependencies]
 bootlib.workspace = true
 
-bitflags.workspace = true
 clap = { workspace = true, default-features = true, features = ["derive"] }
 igvm_defs.workspace = true
 igvm.workspace = true


### PR DESCRIPTION
Remove an unused dependency for igvmbuilder.