### PR TITLE
Igvmbuilder/fixes: Fix filesystem image packing/unpacking with IGVM

### DIFF
--- a/igvmbuilder/src/gpa_map.rs
+++ b/igvmbuilder/src/gpa_map.rs
@@ -130,7 +130,7 @@ impl GpaMap {
             }
         };
 
-        let igvm_param_block = GpaRange::new_page(kernel_elf.get_end())?;
+        let igvm_param_block = GpaRange::new_page(kernel_fs.get_end())?;
         let general_params = GpaRange::new_page(igvm_param_block.get_end())?;
         let memory_map = GpaRange::new_page(general_params.get_end())?;
         let guest_context = if let Some(firmware) = firmware {

--- a/igvmbuilder/src/gpa_map.rs
+++ b/igvmbuilder/src/gpa_map.rs
@@ -39,6 +39,7 @@ impl GpaRange {
     pub fn get_start(&self) -> u64 {
         self.start
     }
+
     pub fn get_end(&self) -> u64 {
         self.end
     }
@@ -111,11 +112,11 @@ impl GpaMap {
             }
             Hypervisor::HyperV => {
                 // Load the kernel image after the firmware.
-                firmware_range.end
+                firmware_range.get_end()
             }
         };
         let kernel_elf = GpaRange::new(kernel_address, kernel_elf_len as u64)?;
-        let kernel_fs = GpaRange::new(kernel_elf.end, kernel_fs_len as u64)?;
+        let kernel_fs = GpaRange::new(kernel_elf.get_end(), kernel_fs_len as u64)?;
 
         // Calculate the kernel size and base.
         let kernel = match options.hypervisor {
@@ -129,13 +130,13 @@ impl GpaMap {
             }
         };
 
-        let igvm_param_block = GpaRange::new_page(kernel_elf.end)?;
-        let general_params = GpaRange::new_page(igvm_param_block.end)?;
-        let memory_map = GpaRange::new_page(general_params.end)?;
+        let igvm_param_block = GpaRange::new_page(kernel_elf.get_end())?;
+        let general_params = GpaRange::new_page(igvm_param_block.get_end())?;
+        let memory_map = GpaRange::new_page(general_params.get_end())?;
         let guest_context = if let Some(firmware) = firmware {
             if firmware.get_guest_context().is_some() {
                 // Locate the guest context after the memory map parameter page
-                GpaRange::new_page(memory_map.end)?
+                GpaRange::new_page(memory_map.get_end())?
             } else {
                 GpaRange::new(0, 0)?
             }
@@ -147,7 +148,7 @@ impl GpaMap {
             low_memory: GpaRange::new(0, 0xf000)?,
             stage2_stack: GpaRange::new_page(0xf000)?,
             stage2_image,
-            stage2_free: GpaRange::new(stage2_image.end, 0x9e000 - &stage2_image.end)?,
+            stage2_free: GpaRange::new(stage2_image.get_end(), 0x9e000 - &stage2_image.get_end())?,
             secrets_page: GpaRange::new_page(0x9e000)?,
             cpuid_page: GpaRange::new_page(0x9f000)?,
             kernel_elf,

--- a/igvmbuilder/src/igvm_builder.rs
+++ b/igvmbuilder/src/igvm_builder.rs
@@ -277,6 +277,11 @@ impl IgvmBuilder {
         // Add the IGVM parameter block
         self.add_param_block(param_block);
 
+        // Add optional filesystem image
+        if let Some(fs) = &self.options.filesystem {
+            self.add_data_pages_from_file(&fs.clone(), self.gpa_map.kernel_fs.get_start())?;
+        }
+
         // Add the kernel elf binary
         self.add_data_pages_from_file(
             &self.options.kernel.clone(),

--- a/igvmbuilder/src/stage2_stack.rs
+++ b/igvmbuilder/src/stage2_stack.rs
@@ -29,7 +29,7 @@ impl Stage2Stack {
             kernel_start: gpa_map.kernel_elf.get_start() as u32,
             kernel_end: (gpa_map.kernel_elf.get_start() + gpa_map.kernel_elf.get_size()) as u32,
             filesystem_start: gpa_map.kernel_fs.get_start() as u32,
-            filesystem_end: gpa_map.kernel_fs.get_end() as u32,
+            filesystem_end: (gpa_map.kernel_fs.get_start() + gpa_map.kernel_fs.get_size()) as u32,
             igvm_param_block: gpa_map.igvm_param_block.get_start() as u32,
             reserved: 0,
         }


### PR DESCRIPTION
The IGVM builder does not yet package the filesystem image into the IGVM file for QEMU. Fix that and a couple of other small issues.