### PR TITLE
gdbstub: take task ID into account when writing registers and other improvements

### DIFF
--- a/kernel/src/debug/gdbstub.rs
+++ b/kernel/src/debug/gdbstub.rs
@@ -186,6 +186,7 @@ pub mod svsm_gdbstub {
     }
 
     impl GdbTaskContext {
+        #[must_use = "The task switch will have no effect if the context is dropped"]
         fn switch_to_task(id: u32) -> Self {
             let cr3 = if is_current_task(id) {
                 0

--- a/kernel/src/debug/gdbstub.rs
+++ b/kernel/src/debug/gdbstub.rs
@@ -314,11 +314,11 @@ pub mod svsm_gdbstub {
     struct GdbStubConnection;
 
     impl GdbStubConnection {
-        pub const fn new() -> Self {
+        const fn new() -> Self {
             Self {}
         }
 
-        pub fn read(&mut self) -> Result<u8, &'static str> {
+        fn read(&mut self) -> Result<u8, &'static str> {
             unsafe { Ok(GDB_SERIAL.get_byte()) }
         }
     }
@@ -351,7 +351,7 @@ pub mod svsm_gdbstub {
     }
 
     impl GdbStubTarget {
-        pub const fn new() -> Self {
+        const fn new() -> Self {
             Self {
                 ctx: 0,
                 breakpoints: [GdbStubBreakpoint {
@@ -362,7 +362,7 @@ pub mod svsm_gdbstub {
             }
         }
 
-        pub fn set_regs(&mut self, ctx: &TaskContext) {
+        fn set_regs(&mut self, ctx: &TaskContext) {
             self.ctx = (ctx as *const _) as usize;
         }
 

--- a/kernel/src/debug/gdbstub.rs
+++ b/kernel/src/debug/gdbstub.rs
@@ -477,8 +477,12 @@ pub mod svsm_gdbstub {
         fn write_registers(
             &mut self,
             regs: &<Self::Arch as gdbstub::arch::Arch>::Registers,
-            _tid: Tid,
+            tid: Tid,
         ) -> gdbstub::target::TargetResult<(), Self> {
+            if !is_current_task(tid.get() as u32) {
+                return Err(TargetError::NonFatal);
+            }
+
             let context = self.ctx_mut().unwrap();
 
             context.ret_addr = regs.rip;


### PR DESCRIPTION
Add some safety comments around pointer manipulation, fix a bug where the task ID was not taken into account when writing registers and other minor improvements.