### PR TITLE
address: introduce more alignment check methods + add a missing alignment check

### DIFF
--- a/kernel/src/address.rs
+++ b/kernel/src/address.rs
@@ -13,6 +13,7 @@ type InnerAddr = usize;
 
 const SIGN_BIT: usize = 47;
 
+#[inline]
 const fn sign_extend(addr: InnerAddr) -> InnerAddr {
     let mask = 1usize << SIGN_BIT;
     if (addr & mask) == mask {
@@ -27,50 +28,62 @@ pub trait Address:
 {
     // Transform the address into its inner representation for easier
     /// arithmetic manipulation
+    #[inline]
     fn bits(&self) -> InnerAddr {
         (*self).into()
     }
 
+    #[inline]
     fn is_null(&self) -> bool {
         self.bits() == 0
     }
 
+    #[inline]
     fn align_up(&self, align: InnerAddr) -> Self {
         Self::from((self.bits() + (align - 1)) & !(align - 1))
     }
 
+    #[inline]
     fn page_align_up(&self) -> Self {
         self.align_up(PAGE_SIZE)
     }
 
+    #[inline]
     fn page_align(&self) -> Self {
         Self::from(self.bits() & !(PAGE_SIZE - 1))
     }
 
+    #[inline]
     fn is_aligned(&self, align: InnerAddr) -> bool {
         (self.bits() & (align - 1)) == 0
     }
 
+    #[inline]
     fn is_page_aligned(&self) -> bool {
         self.is_aligned(PAGE_SIZE)
     }
 
+    #[inline]
     fn checked_add(&self, off: InnerAddr) -> Option<Self> {
         self.bits().checked_add(off).map(|addr| addr.into())
     }
 
+    #[inline]
     fn checked_sub(&self, off: InnerAddr) -> Option<Self> {
         self.bits().checked_sub(off).map(|addr| addr.into())
     }
 
+    #[inline]
     fn saturating_add(&self, off: InnerAddr) -> Self {
         Self::from(self.bits().saturating_add(off))
     }
 
+    #[inline]
     fn page_offset(&self) -> usize {
         self.bits() & (PAGE_SIZE - 1)
     }
 
+    #[inline]
     fn crosses_page(&self, size: usize) -> bool {
         let start = self.bits();
         let x1 = start / PAGE_SIZE;
@@ -78,6 +91,7 @@ pub trait Address:
         x1 != x2
     }
 
+    #[inline]
     fn pfn(&self) -> InnerAddr {
         self.bits() >> PAGE_SHIFT
     }
@@ -88,10 +102,12 @@ pub trait Address:
 pub struct PhysAddr(InnerAddr);
 
 impl PhysAddr {
+    #[inline]
     pub const fn new(p: InnerAddr) -> Self {
         Self(p)
     }
 
+    #[inline]
     pub const fn null() -> Self {
         Self(0)
     }
@@ -110,18 +126,21 @@ impl fmt::LowerHex for PhysAddr {
 }
 
 impl From<InnerAddr> for PhysAddr {
+    #[inline]
     fn from(addr: InnerAddr) -> PhysAddr {
         Self(addr)
     }
 }
 
 impl From<PhysAddr> for InnerAddr {
+    #[inline]
     fn from(addr: PhysAddr) -> InnerAddr {
         addr.0
     }
 }
 
 impl From<u64> for PhysAddr {
+    #[inline]
     fn from(addr: u64) -> PhysAddr {
         // The unwrap will get optimized away on 64bit platforms,
         // which should be our only target anyway
@@ -131,6 +150,7 @@ impl From<u64> for PhysAddr {
 }
 
 impl From<PhysAddr> for u64 {
+    #[inline]
     fn from(addr: PhysAddr) -> u64 {
         addr.0 as u64
     }
@@ -140,6 +160,8 @@ impl From<PhysAddr> for u64 {
 // since we normally do this to compute the size of a memory region.
 impl ops::Sub<PhysAddr> for PhysAddr {
     type Output = InnerAddr;
+
+    #[inline]
     fn sub(self, other: PhysAddr) -> Self::Output {
         self.0 - other.0
     }
@@ -148,6 +170,8 @@ impl ops::Sub<PhysAddr> for PhysAddr {
 // Adding and subtracting usize to PhysAddr gives a new PhysAddr
 impl ops::Sub<InnerAddr> for PhysAddr {
     type Output = Self;
+
+    #[inline]
     fn sub(self, other: InnerAddr) -> Self {
         PhysAddr::from(self.0 - other)
     }
@@ -155,6 +179,8 @@ impl ops::Sub<InnerAddr> for PhysAddr {
 
 impl ops::Add<InnerAddr> for PhysAddr {
     type Output = Self;
+
+    #[inline]
     fn add(self, other: InnerAddr) -> Self {
         PhysAddr::from(self.0 + other)
     }
@@ -167,20 +193,24 @@ impl Address for PhysAddr {}
 pub struct VirtAddr(InnerAddr);
 
 impl VirtAddr {
+    #[inline]
     pub const fn null() -> Self {
         Self(0)
     }
 
     // const traits experimental, so for now we need this to make up
     // for the lack of VirtAddr::from() in const contexts.
+    #[inline]
     pub const fn new(addr: InnerAddr) -> Self {
         Self(sign_extend(addr))
     }
 
+    #[inline]
     pub fn as_ptr<T>(&self) -> *const T {
         self.0 as *const T
     }
 
+    #[inline]
     pub fn as_mut_ptr<T>(&self) -> *mut T {
         self.0 as *mut T
     }
@@ -203,18 +233,21 @@ impl fmt::LowerHex for VirtAddr {
 }
 
 impl From<InnerAddr> for VirtAddr {
+    #[inline]
     fn from(addr: InnerAddr) -> Self {
         Self(sign_extend(addr))
     }
 }
 
 impl From<VirtAddr> for InnerAddr {
+    #[inline]
     fn from(addr: VirtAddr) -> Self {
         addr.0
     }
 }
 
 impl From<u64> for VirtAddr {
+    #[inline]
     fn from(addr: u64) -> Self {
         let addr: usize = addr.try_into().unwrap();
         VirtAddr::from(addr)
@@ -222,12 +255,14 @@ impl From<u64> for VirtAddr {
 }
 
 impl From<VirtAddr> for u64 {
+    #[inline]
     fn from(addr: VirtAddr) -> Self {
         addr.0 as u64
     }
 }
 
 impl<T> From<*const T> for VirtAddr {
+    #[inline]
     fn from(ptr: *const T) -> Self {
         Self(ptr as InnerAddr)
     }
@@ -241,6 +276,8 @@ impl<T> From<*mut T> for VirtAddr {
 
 impl ops::Sub<VirtAddr> for VirtAddr {
     type Output = InnerAddr;
+
+    #[inline]
     fn sub(self, other: VirtAddr) -> Self::Output {
         sign_extend(self.0 - other.0)
     }
@@ -248,6 +285,8 @@ impl ops::Sub<VirtAddr> for VirtAddr {
 
 impl ops::Sub<usize> for VirtAddr {
     type Output = Self;
+
+    #[inline]
     fn sub(self, other: usize) -> Self {
         VirtAddr::from(self.0 - other)
     }
@@ -262,12 +301,14 @@ impl ops::Add<InnerAddr> for VirtAddr {
 }
 
 impl Address for VirtAddr {
+    #[inline]
     fn checked_add(&self, off: InnerAddr) -> Option<Self> {
         self.bits()
             .checked_add(off)
             .map(|addr| sign_extend(addr).into())
     }
 
+    #[inline]
     fn checked_sub(&self, off: InnerAddr) -> Option<Self> {
         self.bits()
             .checked_sub(off)

--- a/kernel/src/address.rs
+++ b/kernel/src/address.rs
@@ -59,6 +59,11 @@ pub trait Address:
     }
 
     #[inline]
+    fn is_aligned_to<T>(&self) -> bool {
+        self.is_aligned(core::mem::align_of::<T>())
+    }
+
+    #[inline]
     fn is_page_aligned(&self) -> bool {
         self.is_aligned(PAGE_SIZE)
     }
@@ -213,6 +218,34 @@ impl VirtAddr {
     #[inline]
     pub fn as_mut_ptr<T>(&self) -> *mut T {
         self.0 as *mut T
+    }
+
+    /// Converts the `VirtAddr` to a reference to the given type, checking
+    /// that the address is not NULL and properly aligned.
+    ///
+    /// # Safety
+    ///
+    /// All safety requirements for pointers apply, minus alignment and NULL
+    /// checks, which this function already does.
+    #[inline]
+    pub unsafe fn aligned_ref<'a, T>(&self) -> Option<&'a T> {
+        self.is_aligned_to::<T>()
+            .then(|| self.as_ptr::<T>().as_ref())
+            .flatten()
+    }
+
+    /// Converts the `VirtAddr` to a reference to the given type, checking
+    /// that the address is not NULL and properly aligned.
+    ///
+    /// # Safety
+    ///
+    /// All safety requirements for pointers apply, minus alignment and NULL
+    /// checks, which this function already does.
+    #[inline]
+    pub unsafe fn aligned_mut<'a, T>(&self) -> Option<&'a mut T> {
+        self.is_aligned_to::<T>()
+            .then(|| self.as_mut_ptr::<T>().as_mut())
+            .flatten()
     }
 
     pub const fn const_add(&self, offset: usize) -> Self {

--- a/kernel/src/config.rs
+++ b/kernel/src/config.rs
@@ -166,9 +166,9 @@ impl SvsmConfig<'_> {
         }
     }
 
-    pub fn initialize_guest_vmsa(&self, vmsa: &mut VMSA) {
+    pub fn initialize_guest_vmsa(&self, vmsa: &mut VMSA) -> Result<(), SvsmError> {
         match self {
-            SvsmConfig::FirmwareConfig(_) => (),
+            SvsmConfig::FirmwareConfig(_) => Ok(()),
             SvsmConfig::IgvmConfig(igvm_params) => igvm_params.initialize_guest_vmsa(vmsa),
         }
     }

--- a/kernel/src/igvm_params.rs
+++ b/kernel/src/igvm_params.rs
@@ -231,69 +231,73 @@ impl IgvmParams<'_> {
         self.igvm_param_block.firmware.in_low_memory != 0
     }
 
-    pub fn initialize_guest_vmsa(&self, vmsa: &mut VMSA) {
-        if self.igvm_param_block.guest_context_offset != 0 {
-            let guest_context =
-                unsafe { &*self.igvm_guest_context_address.as_ptr::<IgvmGuestContext>() };
+    pub fn initialize_guest_vmsa(&self, vmsa: &mut VMSA) -> Result<(), SvsmError> {
+        if self.igvm_param_block.guest_context_offset == 0 {
+            return Ok(());
+        }
 
-            // Copy the specified registers into the VMSA.
-            vmsa.cr0 = guest_context.cr0;
-            vmsa.cr3 = guest_context.cr3;
-            vmsa.cr4 = guest_context.cr4;
-            vmsa.efer = guest_context.efer;
-            vmsa.rip = guest_context.rip;
-            vmsa.rax = guest_context.rax;
-            vmsa.rcx = guest_context.rcx;
-            vmsa.rdx = guest_context.rdx;
-            vmsa.rbx = guest_context.rbx;
-            vmsa.rsp = guest_context.rsp;
-            vmsa.rbp = guest_context.rbp;
-            vmsa.rsi = guest_context.rsi;
-            vmsa.rdi = guest_context.rdi;
-            vmsa.r8 = guest_context.r8;
-            vmsa.r9 = guest_context.r9;
-            vmsa.r10 = guest_context.r10;
-            vmsa.r11 = guest_context.r11;
-            vmsa.r12 = guest_context.r12;
-            vmsa.r13 = guest_context.r13;
-            vmsa.r14 = guest_context.r14;
-            vmsa.r15 = guest_context.r15;
-            vmsa.gdt.base = guest_context.gdt_base;
-            vmsa.gdt.limit = guest_context.gdt_limit;
+        let guest_context =
+            Self::try_aligned_ref::<IgvmGuestContext>(self.igvm_guest_context_address)?;
 
-            // If a non-zero code selector is specified, then set the code
-            // segment attributes based on EFER.LMA.
-            if guest_context.code_selector != 0 {
-                vmsa.cs.selector = guest_context.code_selector;
-                let efer_lma = EFERFlags::LMA;
-                if (vmsa.efer & efer_lma.bits()) != 0 {
-                    vmsa.cs.flags = 0xA9B;
-                } else {
-                    vmsa.cs.flags = 0xC9B;
-                    vmsa.cs.limit = 0xFFFFFFFF;
-                }
-            }
+        // Copy the specified registers into the VMSA.
+        vmsa.cr0 = guest_context.cr0;
+        vmsa.cr3 = guest_context.cr3;
+        vmsa.cr4 = guest_context.cr4;
+        vmsa.efer = guest_context.efer;
+        vmsa.rip = guest_context.rip;
+        vmsa.rax = guest_context.rax;
+        vmsa.rcx = guest_context.rcx;
+        vmsa.rdx = guest_context.rdx;
+        vmsa.rbx = guest_context.rbx;
+        vmsa.rsp = guest_context.rsp;
+        vmsa.rbp = guest_context.rbp;
+        vmsa.rsi = guest_context.rsi;
+        vmsa.rdi = guest_context.rdi;
+        vmsa.r8 = guest_context.r8;
+        vmsa.r9 = guest_context.r9;
+        vmsa.r10 = guest_context.r10;
+        vmsa.r11 = guest_context.r11;
+        vmsa.r12 = guest_context.r12;
+        vmsa.r13 = guest_context.r13;
+        vmsa.r14 = guest_context.r14;
+        vmsa.r15 = guest_context.r15;
+        vmsa.gdt.base = guest_context.gdt_base;
+        vmsa.gdt.limit = guest_context.gdt_limit;
 
-            let efer_svme = EFERFlags::SVME;
-            vmsa.efer &= !efer_svme.bits();
-
-            // If a non-zero data selector is specified, then modify the data
-            // segment attributes to be compatible with protected mode.
-            if guest_context.data_selector != 0 {
-                vmsa.ds.selector = guest_context.data_selector;
-                vmsa.ds.flags = 0xA93;
-                vmsa.ds.limit = 0xFFFFFFFF;
-                vmsa.ss = vmsa.ds;
-                vmsa.es = vmsa.ds;
-                vmsa.fs = vmsa.ds;
-                vmsa.gs = vmsa.ds;
-            }
-
-            // Configure vTOM if reqested.
-            if self.igvm_param_block.vtom != 0 {
-                vmsa.vtom = self.igvm_param_block.vtom;
-                vmsa.sev_features |= 2; // VTOM feature
+        // If a non-zero code selector is specified, then set the code
+        // segment attributes based on EFER.LMA.
+        if guest_context.code_selector != 0 {
+            vmsa.cs.selector = guest_context.code_selector;
+            let efer_lma = EFERFlags::LMA;
+            if (vmsa.efer & efer_lma.bits()) != 0 {
+                vmsa.cs.flags = 0xA9B;
+            } else {
+                vmsa.cs.flags = 0xC9B;
+                vmsa.cs.limit = 0xFFFFFFFF;
             }
         }
+
+        let efer_svme = EFERFlags::SVME;
+        vmsa.efer &= !efer_svme.bits();
+
+        // If a non-zero data selector is specified, then modify the data
+        // segment attributes to be compatible with protected mode.
+        if guest_context.data_selector != 0 {
+            vmsa.ds.selector = guest_context.data_selector;
+            vmsa.ds.flags = 0xA93;
+            vmsa.ds.limit = 0xFFFFFFFF;
+            vmsa.ss = vmsa.ds;
+            vmsa.es = vmsa.ds;
+            vmsa.fs = vmsa.ds;
+            vmsa.gs = vmsa.ds;
+        }
+
+        // Configure vTOM if requested.
+        if self.igvm_param_block.vtom != 0 {
+            vmsa.vtom = self.igvm_param_block.vtom;
+            vmsa.sev_features |= 2; // VTOM feature
+        }
+
+        Ok(())
     }
 }

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -191,7 +191,7 @@ fn launch_fw(config: &SvsmConfig<'_>) -> Result<(), SvsmError> {
     let vmsa_pa = vmsa_ref.vmsa_phys().unwrap();
     let vmsa = vmsa_ref.vmsa();
 
-    config.initialize_guest_vmsa(vmsa);
+    config.initialize_guest_vmsa(vmsa)?;
 
     log::info!("VMSA PA: {:#x}", vmsa_pa);
 


### PR DESCRIPTION
Introduce `VirtAddr::aligned_{ref,mut}` helpers to help transform a `VirtAddr` into a `&T` / `&mut T` while checking that the address is non-NULL and properly aligned to `T`'s requirements.

Also, add alignment check I missed in #226.