### PR TITLE
Make #VC handling IST

### DIFF
--- a/kernel/src/cpu/idt/entry.S
+++ b/kernel/src/cpu/idt/entry.S
@@ -58,6 +58,27 @@ asm_entry_\name:
 	jmp	default_return
 .endm
 
+.macro vc_entry name: req handler:req error_code:req vector:req
+	.globl asm_entry_ist_\name
+asm_entry_ist_\name:
+	.if \error_code == 0
+	pushq $0
+	.endif
+	pushq	$\vector
+	push_regs
+
+	// Switch off IST stack to handle nested #VC.
+	// vc_switch_off_ist() moves stack to the current kernel stack's stack,
+	// wheather #VC was raised from CPL-0 or CPL-3.
+	movq	%rsp, %rdi
+	call	vc_switch_off_ist
+	movq %rax, %rsp
+
+    movq %rsp, %rdi
+	call ex_handler_\handler
+	jmp	default_return
+.endm
+
 default_return:
 	pop_regs
 	iretq
@@ -133,6 +154,7 @@ default_entry_no_ist	name=hv		handler=hypervisor_injection	error_code=0	vector=2
 
 // #VC VMM Communication Exception (Vector 29)
 default_entry_no_ist	name=vc		handler=vmm_communication	error_code=1	vector=29
+vc_entry               	name=vc		handler=vmm_communication	error_code=1	vector=29
 
 // #SX Security Exception (Vector 30)
 default_entry_no_ist	name=sx		handler=panic			error_code=1	vector=30

--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -45,6 +45,10 @@ extern "C" {
     fn asm_entry_sx();
 }
 
+extern "C" {
+    fn asm_entry_ist_vc();
+}
+
 fn init_ist_vectors() {
     idt_mut().set_entry(
         DF_VECTOR,
@@ -56,7 +60,7 @@ fn init_ist_vectors() {
     );
     idt_mut().set_entry(
         VC_VECTOR,
-        IdtEntry::ist_entry(asm_entry_vc, IST_VC.try_into().unwrap()),
+        IdtEntry::ist_entry(asm_entry_ist_vc, IST_VC.try_into().unwrap()),
     );
 }
 

--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -7,7 +7,7 @@
 use super::super::control_regs::read_cr2;
 use super::super::extable::handle_exception_table;
 use super::super::percpu::this_cpu;
-use super::super::tss::IST_DF;
+use super::super::tss::{IST_DB, IST_DF, IST_VC};
 use super::super::vc::handle_vc_exception;
 use super::common::PF_ERROR_WRITE;
 use super::common::{
@@ -49,6 +49,14 @@ fn init_ist_vectors() {
     idt_mut().set_entry(
         DF_VECTOR,
         IdtEntry::ist_entry(asm_entry_df, IST_DF.try_into().unwrap()),
+    );
+    idt_mut().set_entry(
+        DB_VECTOR,
+        IdtEntry::ist_entry(asm_entry_db, IST_DB.try_into().unwrap()),
+    );
+    idt_mut().set_entry(
+        VC_VECTOR,
+        IdtEntry::ist_entry(asm_entry_vc, IST_VC.try_into().unwrap()),
     );
 }
 

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -396,6 +396,10 @@ impl PerCpu {
         self.ist.double_fault_stack.unwrap().end()
     }
 
+    pub fn get_vc_stack_bounds(&self) -> Option<MemoryRegion<VirtAddr>> {
+        self.ist.vmm_comm_stack
+    }
+
     fn setup_tss(&mut self) {
         self.tss.ist_stacks[IST_DF] = self.ist.double_fault_stack.unwrap().end();
         self.tss.ist_stacks[IST_DB] = self.ist.debug_stack.unwrap().end();

--- a/kernel/src/cpu/registers.rs
+++ b/kernel/src/cpu/registers.rs
@@ -4,6 +4,8 @@
 //
 // Author: Roy Hopkins <rhopkins@suse.de>
 
+use super::X86ExceptionContext;
+
 #[repr(C, packed)]
 #[derive(Default, Debug, Clone, Copy)]
 pub struct X86GeneralRegs {
@@ -43,4 +45,14 @@ pub struct X86InterruptFrame {
     pub flags: usize,
     pub rsp: usize,
     pub ss: usize,
+}
+
+/// Indicates if the exception related to ctx was raised from user-mode.
+///
+/// # Returns:
+///
+/// [`true`] if the exception context ctx was raised from uer-mode.
+/// [`false`] otherwise.
+pub fn from_user(ctx: &X86ExceptionContext) -> bool {
+    (ctx.frame.cs & 3) != 0
 }

--- a/kernel/src/cpu/tss.rs
+++ b/kernel/src/cpu/tss.rs
@@ -10,6 +10,8 @@ use crate::address::VirtAddr;
 // IST offsets
 pub const _IST_INVALID: usize = 0;
 pub const IST_DF: usize = 1;
+pub const IST_DB: usize = 2;
+pub const IST_VC: usize = 3;
 
 #[derive(Debug, Default, Clone, Copy)]
 #[repr(C, packed)]

--- a/kernel/src/cpu/vc.rs
+++ b/kernel/src/cpu/vc.rs
@@ -90,12 +90,10 @@ pub fn stage2_handle_vc_exception(ctx: &mut X86ExceptionContext) {
     let err = ctx.error_code;
     let rip = ctx.frame.rip;
 
-    /*
-     * To handle NAE events, we're supposed to reset the VALID_BITMAP field of the GHCB.
-     * This is currently only relevant for IOIO handling. This field is currently reset in
-     * the ioio_{in,ou} methods but it would be better to move the reset out of the different
-     * handlers.
-     */
+    // To handle NAE events, we're supposed to reset the VALID_BITMAP field of the GHCB.
+    // This is currently only relevant for IOIO handling. This field is currently reset in
+    // the ioio_{in,ou} methods but it would be better to move the reset out of the different
+    // handlers.
     let mut ghcb = current_ghcb();
 
     let insn = vc_decode_insn(ctx).expect("Could not decode instructions");
@@ -120,12 +118,10 @@ pub fn handle_vc_exception(ctx: &mut X86ExceptionContext) {
     let error_code = ctx.error_code;
     let rip = ctx.frame.rip;
 
-    /*
-     * To handle NAE events, we're supposed to reset the VALID_BITMAP field of the GHCB.
-     * This is currently only relevant for IOIO handling. This field is currently reset in
-     * the ioio_{in,ou} methods but it would be better to move the reset out of the different
-     * handlers.
-     */
+    // To handle NAE events, we're supposed to reset the VALID_BITMAP field of the GHCB.
+    // This is currently only relevant for IOIO handling. This field is currently reset in
+    // the ioio_{in,ou} methods but it would be better to move the reset out of the different
+    // handlers.
     let mut ghcb = current_ghcb();
 
     let insn = vc_decode_insn(ctx).expect("Could not decode instruction");
@@ -151,15 +147,13 @@ pub fn handle_vc_exception(ctx: &mut X86ExceptionContext) {
 }
 
 fn handle_cpuid(ctx: &mut X86ExceptionContext) -> Result<(), SvsmError> {
-    /*
-     * Section 2.3.1 GHCB MSR Protocol in SEV-ES Guest-Hypervisor Communication Block
-     * Standardization Rev. 2.02.
-     * For SEV-ES/SEV-SNP, we can use the CPUID table already defined and populated with
-     * firmware information.
-     * We choose for now not to call the hypervisor to perform CPUID, since it's no trusted.
-     * Since GHCB is not needed to handle CPUID with the firmware table, we can call the handler
-     * very soon in stage 2.
-     */
+    // Section 2.3.1 GHCB MSR Protocol in SEV-ES Guest-Hypervisor Communication Block
+    // Standardization Rev. 2.02.
+    // For SEV-ES/SEV-SNP, we can use the CPUID table already defined and populated with
+    // firmware information.
+    // We choose for now not to call the hypervisor to perform CPUID, since it's no trusted.
+    // Since GHCB is not needed to handle CPUID with the firmware table, we can call the handler
+    // very soon in stage 2.
 
     snp_cpuid(ctx)
 }

--- a/kernel/src/mm/address_space.rs
+++ b/kernel/src/mm/address_space.rs
@@ -129,6 +129,12 @@ pub const SVSM_STACKS_IST_BASE: VirtAddr = SVSM_STACKS_INIT_TASK.const_add(STACK
 /// DoubleFault IST stack base address
 pub const SVSM_STACK_IST_DF_BASE: VirtAddr = SVSM_STACKS_IST_BASE;
 
+/// Debug IST stack base address
+pub const SVSM_STACK_IST_DB_BASE: VirtAddr = SVSM_STACKS_IST_BASE.const_add(STACK_TOTAL_SIZE);
+
+/// VMM Communication Exception IST stack base address
+pub const SVSM_STACK_IST_VC_BASE: VirtAddr = SVSM_STACKS_IST_BASE.const_add(2 * STACK_TOTAL_SIZE);
+
 /// Base Address for temporary mappings - used by page-table guards
 pub const SVSM_PERCPU_TEMP_BASE: VirtAddr = SVSM_PERCPU_BASE.const_add(SIZE_LEVEL2);
 


### PR DESCRIPTION
Making #VC handler working on IST stack is cleaner. However, it requires to properly handle side-effects, like the handling of nested #VC.

This PR:
 * makes #VC and #DB IST
 * add a few methods to easily find if a given address is on #VC IST stack memory region
 * handle nested IST #VC
 * makes a few comments in the VC code Rust idiomatic.

A few interrogations I would like to solve before merging:
 * please double-check that the [addresses](https://github.com/coconut-svsm/svsm/blob/f90083200b6576bc8934c4265ae0db88cfdfbe2c/kernel/src/mm/address_space.rs#L132) created for IST stacks are correct
 * is making #DB IST stricly necessary to make #VC IST?