### PR TITLE
console: Initialize serial port

### DIFF
--- a/kernel/src/debug/gdbstub.rs
+++ b/kernel/src/debug/gdbstub.rs
@@ -46,6 +46,7 @@ pub mod svsm_gdbstub {
 
     pub fn gdbstub_start() -> Result<(), u64> {
         unsafe {
+            GDB_SERIAL.init();
             let mut target = GdbStubTarget::new();
             let gdb = GdbStubBuilder::new(GdbStubConnection::new())
                 .with_packet_buffer(&mut PACKET_BUFFER)

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -114,6 +114,7 @@ fn setup_env(config: &SvsmConfig<'_>) {
             port: config.debug_serial_port(),
         })
         .expect("console serial output already configured");
+    (*CONSOLE_SERIAL).init();
 
     WRITER.lock().set(&*CONSOLE_SERIAL);
     init_console();

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -354,6 +354,7 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
             port: debug_serial_port,
         })
         .expect("console serial output already configured");
+    (*CONSOLE_SERIAL).init();
 
     WRITER.lock().set(&*CONSOLE_SERIAL);
     init_console();


### PR DESCRIPTION
Previously SVSM did not call the `init()` of serial port, thus did not set up the serial port. It worked fine with QEMU because QEMU's default serial port config complies with SVSM's usage. Google's hypervisor has different defaults, so it is necessary to initialize it.

Fix the problem by actually calling the `init()` at proper location.

Original patch by: Zixuan Wang <zxwang42@gmail.com>
Signed-off-by: Adam Dunlap <acdunlap@google.com>