### PR TITLE
acpi: Allow firmware path configuration

### DIFF
--- a/Documentation/INSTALL.md
+++ b/Documentation/INSTALL.md
@@ -224,6 +224,16 @@ Unit tests can be run inside the SVSM by
 $ QEMU=/path/to/qemu OVMF=/path/to/firmware/ make test-in-svsm
 ```
 
+Different (non-QEMU) hypervisors may provide the ACPI tables and ACPI RSDP at
+different paths. If this is the case, they can be provided as environment
+variables, e.g.
+```
+$ ACPI_RSDP_PATH=path/to/acpi/rsdp ACPI_TABLES_PATH=path/to/acpi/tables FW_FILE=/path/to/firmware/OVMF.fd make
+```
+This should only be necessary if using an alternate hypervisor and if SVSM panics
+with an error such as `Failed to load ACPI tables: FwCfg(FileNotFound)`. The default
+values are "etc/acpi/rsdp" and "etc/acpi/tables", respectively.
+
 Putting it all together
 -----------------------
 

--- a/kernel/src/acpi/tables.rs
+++ b/kernel/src/acpi/tables.rs
@@ -43,16 +43,16 @@ impl RSDPDesc {
     ///
     fn from_fwcfg(fw_cfg: &FwCfg<'_>) -> Result<Self, SvsmError> {
         let mut buf = mem::MaybeUninit::<Self>::uninit();
-        let file = fw_cfg.file_selector("etc/acpi/rsdp")?;
-        let size = file.size() as usize;
+        let path = option_env!("ACPI_RSDP_PATH").unwrap_or("etc/acpi/rsdp");
+        let file = fw_cfg.file_selector(path)?;
 
-        if size != mem::size_of::<Self>() {
+        if (file.size() as usize) < mem::size_of::<Self>() {
             return Err(SvsmError::Acpi);
         }
 
         fw_cfg.select(file.selector());
         let ptr = buf.as_mut_ptr().cast::<u8>();
-        for i in 0..size {
+        for i in 0..mem::size_of::<Self>() {
             let byte: u8 = fw_cfg.read_le();
             unsafe { ptr.add(i).write(byte) };
         }
@@ -283,7 +283,8 @@ impl ACPITableBuffer {
     ///
     /// A new [`ACPITableBuffer`] instance containing ACPI tables and their metadata.
     fn from_fwcfg(fw_cfg: &FwCfg<'_>) -> Result<Self, SvsmError> {
-        let file = fw_cfg.file_selector("etc/acpi/tables")?;
+        let path = option_env!("ACPI_TABLES_PATH").unwrap_or("etc/acpi/tables");
+        let file = fw_cfg.file_selector(path)?;
         let size = file.size() as usize;
 
         let mut buf = Vec::<u8>::new();


### PR DESCRIPTION
The Google hypervisor uses ACPI tables that are at a different path. The RSDP table also has extra information tacked onto the end. Allow passing the paths to these tables as environment variables and allow the RSDP table to be larger than expected.