### PR TITLE
repo: apply cargo fmt to doctests

### DIFF
--- a/kernel/src/acpi/tables.rs
+++ b/kernel/src/acpi/tables.rs
@@ -40,7 +40,6 @@ impl RSDPDesc {
     /// # Returns
     ///
     /// A [`Result`] containing the [`RSDPDesc`] if successful, or an [`SvsmError`] on failure.
-    ///
     fn from_fwcfg(fw_cfg: &FwCfg<'_>) -> Result<Self, SvsmError> {
         let mut buf = mem::MaybeUninit::<Self>::uninit();
         let file = fw_cfg.file_selector("etc/acpi/rsdp")?;
@@ -474,7 +473,7 @@ pub struct ACPICPUInfo {
 ///         for info in cpu_info {
 ///             // You can print id (info.apic_id) and whether it is enabled (info.enabled)
 ///         }
-///     },
+///     }
 ///     Err(err) => {
 ///         // Print error
 ///     }

--- a/kernel/src/elf/mod.rs
+++ b/kernel/src/elf/mod.rs
@@ -26,8 +26,8 @@ use core::mem;
 /// or the `format!` macro, like this:
 ///
 /// ```rust
-/// use svsm::error::SvsmError;
 /// use svsm::elf::ElfError;
+/// use svsm::error::SvsmError;
 ///
 /// let error = ElfError::InvalidAddressRange;
 /// let error_message = error.to_string();
@@ -203,7 +203,6 @@ pub type Elf64char = u8;
 /// Represents a 64-bit ELF virtual address range.
 ///
 /// In mathematical notation, the range is [vaddr_begin, vaddr_end)
-///
 #[derive(PartialEq, Eq, Debug, Default, Clone, Copy)]
 pub struct Elf64AddrRange {
     pub vaddr_begin: Elf64Addr,
@@ -217,7 +216,7 @@ impl Elf64AddrRange {
     /// # Examples
     ///
     /// ```rust
-    /// use svsm::elf::{Elf64AddrRange, Elf64Addr};
+    /// use svsm::elf::{Elf64Addr, Elf64AddrRange};
     ///
     /// let range = Elf64AddrRange {
     ///     vaddr_begin: 0x1000,
@@ -236,7 +235,7 @@ impl Elf64AddrRange {
     /// # Examples
     ///
     /// ```rust
-    /// use svsm::elf::{Elf64AddrRange, Elf64Addr};
+    /// use svsm::elf::{Elf64Addr, Elf64AddrRange};
     ///
     /// let range1 = Elf64AddrRange {
     ///     vaddr_begin: 0x1000,
@@ -266,7 +265,7 @@ impl TryFrom<(Elf64Addr, Elf64Xword)> for Elf64AddrRange {
     /// # Examples
     ///
     /// ```rust
-    /// use svsm::elf::{Elf64AddrRange, Elf64Addr, Elf64Xword};
+    /// use svsm::elf::{Elf64Addr, Elf64AddrRange, Elf64Xword};
     ///
     /// let vaddr_begin = 0x1000;
     /// let size = 0x100;
@@ -306,11 +305,17 @@ impl TryFrom<(Elf64Addr, Elf64Xword)> for Elf64AddrRange {
 /// # Examples
 ///
 /// ```rust
-/// use svsm::elf::Elf64AddrRange;
 /// use core::cmp::Ordering;
+/// use svsm::elf::Elf64AddrRange;
 ///
-/// let range1 = Elf64AddrRange { vaddr_begin: 0x1000, vaddr_end: 0x1100 };
-/// let range2 = Elf64AddrRange { vaddr_begin: 0x1100, vaddr_end: 0x1200 };
+/// let range1 = Elf64AddrRange {
+///     vaddr_begin: 0x1000,
+///     vaddr_end: 0x1100,
+/// };
+/// let range2 = Elf64AddrRange {
+///     vaddr_begin: 0x1100,
+///     vaddr_end: 0x1200,
+/// };
 ///
 /// assert_eq!(range1.partial_cmp(&range2), Some(Ordering::Less));
 /// ```
@@ -347,7 +352,6 @@ impl TryFrom<(Elf64Off, Elf64Xword)> for Elf64FileRange {
     ///
     /// Returns an [`ElfError::InvalidFileRange`] if the calculation of `offset_end`
     /// results in an invalid file range.
-    ///
     fn try_from(value: (Elf64Off, Elf64Xword)) -> Result<Self, Self::Error> {
         let offset_begin = usize::try_from(value.0).map_err(|_| ElfError::InvalidFileRange)?;
         let size = usize::try_from(value.1).map_err(|_| ElfError::InvalidFileRange)?;
@@ -386,7 +390,6 @@ impl<'a> Elf64File<'a> {
     /// # Errors
     ///
     /// Returns an [`ElfError`] if there are issues parsing the ELF file.
-    ///
     pub fn read(elf_file_buf: &'a [u8]) -> Result<Self, ElfError> {
         let mut elf_hdr = Elf64Hdr::read(elf_file_buf)?;
 
@@ -736,7 +739,6 @@ impl<'a> Elf64File<'a> {
     /// * If the file offset calculations result in an invalid file range.
     /// * If the virtual address range extends beyond the loaded segment's file content,
     ///   indicating an unbacked virtual address range.
-    ///
     fn map_vaddr_to_file_off(
         &self,
         vaddr_begin: Elf64Addr,
@@ -813,7 +815,6 @@ impl<'a> Elf64File<'a> {
     ///   a reference to the corresponding slice of bytes from the ELF file buffer.
     /// - [`Err<ElfError>`]: If an error occurs during mapping, such as an unmapped or unbacked
     ///   virtual address range, returns an [`ElfError`].
-    ///
     fn map_vaddr_to_file_buf(
         &self,
         vaddr_begin: Elf64Addr,
@@ -855,7 +856,6 @@ impl<'a> Elf64File<'a> {
     /// # Returns
     ///
     /// - [`Elf64Off`]: The alignment offset for the image's load address.
-    ///
     fn image_load_align_offset(&self) -> Elf64Off {
         if self.max_load_segment_align == 0 {
             return 0;
@@ -907,7 +907,6 @@ impl<'a> Elf64File<'a> {
     /// # Returns
     ///
     /// An [`Elf64ImageLoadSegmentIterator`] over the loaded image segments.
-    ///
     pub fn image_load_segment_iter(
         &'a self,
         image_load_addr: Elf64Addr,
@@ -941,7 +940,6 @@ impl<'a> Elf64File<'a> {
     ///   returns [`None`].
     /// - [`Err<ElfError>`]: If an error occurs while processing relocations, returns an
     ///   [`ElfError`].
-    ///
     pub fn apply_dyn_relas<RP: Elf64RelocProcessor>(
         &'a self,
         rela_proc: RP,
@@ -996,7 +994,6 @@ impl<'a> Elf64File<'a> {
     /// # Returns
     ///
     /// The adjusted entry point virtual address.
-    ///
     pub fn get_entry(&self, image_load_addr: Elf64Addr) -> Elf64Addr {
         self.elf_hdr
             .e_entry
@@ -1096,7 +1093,6 @@ impl Elf64Hdr {
     /// - [`ElfError::UnsupportedVersion`]: The version of the ELF file is not supported.
     /// - [`ElfError::UnsupportedOsAbi`]: The ELF file uses an unsupported OS/ABI.
     /// - Other errors specific to reading and parsing the header fields.
-    ///
     fn read(buf: &[u8]) -> Result<Self, ElfError> {
         // Examine the e_ident[] magic.
         if buf.len() < 16 {

--- a/kernel/src/locking/rwlock.rs
+++ b/kernel/src/locking/rwlock.rs
@@ -98,7 +98,6 @@ unsafe impl<T: Send + Sync> Sync for RWLock<T> {}
 /// A tuple containing two 32-bit unsigned integer values. The first
 /// element of the tuple is the lower 32 bits of input value, and the
 /// second is the upper 32 bits.
-///
 #[inline]
 fn split_val(val: u64) -> (u64, u64) {
     (val & 0xffff_ffffu64, val >> 32)
@@ -117,7 +116,6 @@ fn split_val(val: u64) -> (u64, u64) {
 /// # Returns
 ///
 /// A 64-bit value representing the combined state of readers and writers in the RWLock.
-///
 #[inline]
 fn compose_val(readers: u64, writers: u64) -> u64 {
     (readers & 0xffff_ffffu64) | (writers << 32)
@@ -126,7 +124,6 @@ fn compose_val(readers: u64, writers: u64) -> u64 {
 /// A reader-writer lock that allows multiple readers or a single writer
 /// to access the protected data. [`RWLock`] provides exclusive access for
 /// writers and shared access for readers, for efficient synchronization.
-///
 impl<T> RWLock<T> {
     /// Creates a new [`RWLock`] instance with the provided initial data.
     ///
@@ -165,7 +162,6 @@ impl<T> RWLock<T> {
     ///
     /// A 64-bit value representing the current state of the [`RWLock`],
     /// including the count of readers and writers.
-    ///
     #[inline]
     fn wait_for_writers(&self) -> u64 {
         loop {
@@ -186,7 +182,6 @@ impl<T> RWLock<T> {
     ///
     /// A 64-bit value representing the current state of the [`RWLock`],
     /// including the count of readers and writers.
-    ///
     #[inline]
     fn wait_for_readers(&self) -> u64 {
         loop {
@@ -205,7 +200,6 @@ impl<T> RWLock<T> {
     /// # Returns
     ///
     /// A [`ReadLockGuard`] that provides read access to the protected data.
-    ///
     pub fn lock_read(&self) -> ReadLockGuard<'_, T> {
         loop {
             let val = self.wait_for_writers();
@@ -234,7 +228,6 @@ impl<T> RWLock<T> {
     /// # Returns
     ///
     /// A [`WriteLockGuard`] that provides write access to the protected data.
-    ///
     pub fn lock_write(&self) -> WriteLockGuard<'_, T> {
         // Waiting for current writer to finish
         loop {

--- a/kernel/src/mm/vm/mapping/api.rs
+++ b/kernel/src/mm/vm/mapping/api.rs
@@ -126,7 +126,6 @@ pub trait VirtualMapping: core::fmt::Debug {
     ///
     /// * 'write' - `true` if the fault was due to a write to the memory
     ///              location, or 'false' if the fault was due to a read.
-    ///
     fn handle_page_fault(
         &mut self,
         _vmr: &VMR,

--- a/kernel/src/utils/immut_after_init.rs
+++ b/kernel/src/utils/immut_after_init.rs
@@ -46,7 +46,7 @@ pub enum ImmutAfterInitError {
 /// initialized at runtime:
 /// ```
 /// # use svsm::utils::immut_after_init::ImmutAfterInitCell;
-/// static X : ImmutAfterInitCell<i32> = ImmutAfterInitCell::uninit();
+/// static X: ImmutAfterInitCell<i32> = ImmutAfterInitCell::uninit();
 /// pub fn main() {
 ///     unsafe { X.init(&123) };
 ///     assert_eq!(*X, 123);
@@ -58,14 +58,13 @@ pub enum ImmutAfterInitError {
 /// already:
 /// ```
 /// # use svsm::utils::immut_after_init::ImmutAfterInitCell;
-/// static X : ImmutAfterInitCell<i32> = ImmutAfterInitCell::new(0);
+/// static X: ImmutAfterInitCell<i32> = ImmutAfterInitCell::new(0);
 /// pub fn main() {
 ///     assert_eq!(*X, 0);
 ///     unsafe { X.reinit(&123) };
 ///     assert_eq!(*X, 123);
 /// }
 /// ```
-///
 #[derive(Debug)]
 pub struct ImmutAfterInitCell<T> {
     #[doc(hidden)]
@@ -174,7 +173,6 @@ unsafe impl<T> Sync for ImmutAfterInitCell<T> {}
 
 /// A reference to a memory location which is effectively immutable after
 /// initalization code has run.
-///
 
 /// A `ImmutAfterInitRef` can either get initialized statically at link time or
 /// once from initialization code, basically following the protocol of a
@@ -185,8 +183,8 @@ unsafe impl<T> Sync for ImmutAfterInitCell<T> {}
 /// `ImmutAfterInitCell`'s contents,
 /// ```
 /// # use svsm::utils::immut_after_init::{ImmutAfterInitCell, ImmutAfterInitRef};
-/// static X : ImmutAfterInitCell<i32> = ImmutAfterInitCell::uninit();
-/// static RX : ImmutAfterInitRef<'_, i32> = ImmutAfterInitRef::uninit();
+/// static X: ImmutAfterInitCell<i32> = ImmutAfterInitCell::uninit();
+/// static RX: ImmutAfterInitRef<'_, i32> = ImmutAfterInitRef::uninit();
 /// fn main() {
 ///     unsafe { X.init(&123) };
 ///     unsafe { RX.init_from_cell(&X) };
@@ -196,8 +194,8 @@ unsafe impl<T> Sync for ImmutAfterInitCell<T> {}
 /// or to plain value directly:
 /// ```
 /// # use svsm::utils::immut_after_init::ImmutAfterInitRef;
-/// static X : i32 = 123;
-/// static RX : ImmutAfterInitRef<'_, i32> = ImmutAfterInitRef::uninit();
+/// static X: i32 = 123;
+/// static RX: ImmutAfterInitRef<'_, i32> = ImmutAfterInitRef::uninit();
 /// fn main() {
 ///     unsafe { RX.init_from_ref(&X) };
 ///     assert_eq!(*RX, 123);

--- a/kernel/src/utils/memory_region.rs
+++ b/kernel/src/utils/memory_region.rs
@@ -157,7 +157,7 @@ where
     /// # use svsm::utils::MemoryRegion;
     /// let r1 = MemoryRegion::new(VirtAddr::from(0xffffff0000u64), PAGE_SIZE);
     /// let r2 = MemoryRegion::new(VirtAddr::from(0xffffff1000u64), PAGE_SIZE);
-    /// let r3  = r1.merge(&r2);
+    /// let r3 = r1.merge(&r2);
     /// assert_eq!(r3.start(), r1.start());
     /// assert_eq!(r3.len(), r1.len() + r2.len());
     /// assert_eq!(r3.end(), r2.end());


### PR DESCRIPTION
Using cargo fmt in doctests is a nightly feature, so we don't use it in CI. Thus, apply changes manually.