### PR TITLE
kernel/cpu: Remove unnecessary mut

### DIFF
--- a/kernel/src/cpu/vc.rs
+++ b/kernel/src/cpu/vc.rs
@@ -237,7 +237,7 @@ fn handle_ioio(
     }
 }
 
-fn vc_decode_insn(ctx: &mut X86ExceptionContext) -> Result<Instruction, SvsmError> {
+fn vc_decode_insn(ctx: &X86ExceptionContext) -> Result<Instruction, SvsmError> {
     if !vc_decoding_needed(ctx.error_code) {
         return Ok(Instruction::default());
     }


### PR DESCRIPTION
This function does not require the context to be mutable, so the `mut` keyword can be removed.  This resolves a clippy warning.