### PR TITLE
Makefile: run clippy on fuzzing harnesses and tests & other improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,8 +122,10 @@ bin/svsm-test.bin: bin/stage1-test
 	objcopy -O binary $< $@
 
 clippy:
-	cargo clippy --workspace --exclude igvmbuilder --exclude svsm-fuzz --all-features -- -D warnings
-	cargo clippy --workspace --all-features --exclude svsm --target=x86_64-unknown-linux-gnu -- -D warnings
+	cargo clippy --workspace --all-features --exclude svsm-fuzz --exclude igvmbuilder -- -D warnings
+	cargo clippy --workspace --all-features --exclude svsm-fuzz --exclude svsm --target=x86_64-unknown-linux-gnu -- -D warnings
+	RUSTFLAGS="--cfg fuzzing" cargo clippy --package svsm-fuzz --all-features --target=x86_64-unknown-linux-gnu -- -D warnings
+	cargo clippy --workspace --all-features --tests --target=x86_64-unknown-linux-gnu -- -D warnings
 
 clean:
 	cargo clean

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-svsm = { workspace = true, features = ["fuzzing-hooks"] }
+svsm.workspace = true
 
 arbitrary = { workspace = true, features = ["derive"] }
 libfuzzer-sys.workspace = true

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -37,7 +37,6 @@ test.workspace = true
 [features]
 default = []
 enable-gdb = ["dep:gdbstub", "dep:gdbstub_arch"]
-fuzzing-hooks = []
 
 [dev-dependencies]
 memoffset.workspace = true

--- a/kernel/src/acpi/tables.rs
+++ b/kernel/src/acpi/tables.rs
@@ -11,7 +11,6 @@ use crate::fw_cfg::FwCfg;
 use crate::string::FixedString;
 use alloc::vec::Vec;
 use core::mem;
-use log;
 
 /// ACPI Root System Description Pointer (RSDP)
 /// used by ACPI programming interface

--- a/kernel/src/console.rs
+++ b/kernel/src/console.rs
@@ -8,7 +8,6 @@ use crate::locking::SpinLock;
 use crate::serial::{Terminal, DEFAULT_SERIAL_PORT};
 use crate::utils::immut_after_init::ImmutAfterInitCell;
 use core::fmt;
-use log;
 
 #[derive(Clone, Copy)]
 pub struct Console {

--- a/kernel/src/cpu/cpuid.rs
+++ b/kernel/src/cpu/cpuid.rs
@@ -6,7 +6,6 @@
 
 use crate::utils::immut_after_init::ImmutAfterInitRef;
 use cpuarch::snp_cpuid::SnpCpuidTable;
-use log;
 
 static CPUID_PAGE: ImmutAfterInitRef<'_, SnpCpuidTable> = ImmutAfterInitRef::uninit();
 

--- a/kernel/src/fs/filesystem.rs
+++ b/kernel/src/fs/filesystem.rs
@@ -178,7 +178,7 @@ impl SvsmFs {
         self.root = Some(root.clone());
     }
 
-    #[cfg(all(any(test, feature = "fuzzing-hooks"), not(test_in_svsm)))]
+    #[cfg(all(any(test, fuzzing), not(test_in_svsm)))]
     fn uninitialize(&mut self) {
         self.root = None;
     }
@@ -212,12 +212,12 @@ pub fn initialize_fs() {
     FS_ROOT.lock_write().initialize(&root_dir);
 }
 
-#[cfg(any(test, feature = "fuzzing-hooks"))]
+#[cfg(any(test, fuzzing))]
 #[cfg_attr(test_in_svsm, derive(Clone, Copy))]
 #[derive(Debug)]
 pub struct TestFileSystemGuard;
 
-#[cfg(any(test, feature = "fuzzing-hooks"))]
+#[cfg(any(test, fuzzing))]
 impl TestFileSystemGuard {
     /// Create a test filesystem.
     ///
@@ -238,7 +238,7 @@ impl TestFileSystemGuard {
     }
 }
 
-#[cfg(all(any(test, feature = "fuzzing-hooks"), not(test_in_svsm)))]
+#[cfg(all(any(test, fuzzing), not(test_in_svsm)))]
 impl Drop for TestFileSystemGuard {
     fn drop(&mut self) {
         // Uninitialize the filesystem only if running in userspace.

--- a/kernel/src/mm/alloc.rs
+++ b/kernel/src/mm/alloc.rs
@@ -13,7 +13,6 @@ use crate::utils::{align_down, align_up, zero_mem_region};
 use core::alloc::{GlobalAlloc, Layout};
 use core::mem::size_of;
 use core::ptr;
-use log;
 
 #[cfg(any(test, feature = "fuzzing-hooks"))]
 use crate::locking::LockGuard;

--- a/kernel/src/mm/alloc.rs
+++ b/kernel/src/mm/alloc.rs
@@ -14,7 +14,7 @@ use core::alloc::{GlobalAlloc, Layout};
 use core::mem::size_of;
 use core::ptr;
 
-#[cfg(any(test, feature = "fuzzing-hooks"))]
+#[cfg(any(test, fuzzing))]
 use crate::locking::LockGuard;
 
 /// Represents possible errors that can occur during memory allocation.
@@ -1495,7 +1495,7 @@ impl SvsmAllocator {
 
     /// Resets the internal state. This is equivalent to reassigning `self`
     /// with a newly created [`SvsmAllocator`] with `Self::new()`.
-    #[cfg(all(not(test_in_svsm), any(test, feature = "fuzzing-hooks")))]
+    #[cfg(all(not(test_in_svsm), any(test, fuzzing)))]
     fn reset(&self) {
         *self.slabs[0].lock() = Slab::new(Self::MIN_SLAB_SIZE);
         *self.slabs[1].lock() = Slab::new(Self::MIN_SLAB_SIZE * 2);
@@ -1575,7 +1575,7 @@ pub fn root_mem_init(pstart: PhysAddr, vstart: VirtAddr, page_count: usize) {
         .expect("Failed to initialize SLAB_PAGE_SLAB");
 }
 
-#[cfg(any(test, feature = "fuzzing-hooks"))]
+#[cfg(any(test, fuzzing))]
 /// A global lock on global memory. Should only be acquired via
 /// [`TestRootMem::setup()`].
 static TEST_ROOT_MEM_LOCK: SpinLock<()> = SpinLock::new(());
@@ -1584,12 +1584,12 @@ static TEST_ROOT_MEM_LOCK: SpinLock<()> = SpinLock::new(());
 pub const DEFAULT_TEST_MEMORY_SIZE: usize = 16usize * 1024 * 1024;
 
 /// A dummy struct to acquire a lock over global memory for tests.
-#[cfg(any(test, feature = "fuzzing-hooks"))]
+#[cfg(any(test, fuzzing))]
 #[derive(Debug)]
 #[allow(dead_code)]
 pub struct TestRootMem<'a>(LockGuard<'a, ()>);
 
-#[cfg(any(test, feature = "fuzzing-hooks"))]
+#[cfg(any(test, fuzzing))]
 impl TestRootMem<'_> {
     #[cfg(test_in_svsm)]
     /// Sets up a test environment, returning a guard to ensure memory is
@@ -1637,7 +1637,7 @@ impl TestRootMem<'_> {
     }
 }
 
-#[cfg(all(not(test_in_svsm), any(test, feature = "fuzzing-hooks")))]
+#[cfg(all(not(test_in_svsm), any(test, fuzzing)))]
 impl Drop for TestRootMem<'_> {
     /// If running tests in userspace, destroy root memory before
     /// dropping the lock over it.

--- a/kernel/src/mm/memory.rs
+++ b/kernel/src/mm/memory.rs
@@ -14,7 +14,6 @@ use crate::locking::RWLock;
 use crate::utils::MemoryRegion;
 use alloc::vec::Vec;
 use bootlib::kernel_launch::KernelLaunchInfo;
-use log;
 
 use super::pagetable::LAUNCH_VMSA_ADDR;
 

--- a/kernel/src/sev/status.rs
+++ b/kernel/src/sev/status.rs
@@ -8,7 +8,6 @@ use crate::cpu::msr::{read_msr, SEV_STATUS};
 use crate::utils::immut_after_init::ImmutAfterInitCell;
 use bitflags::bitflags;
 use core::fmt::{self, Write};
-use log;
 
 bitflags! {
     #[derive(Copy, Clone, PartialEq, Eq)]

--- a/kernel/src/utils/bitmap_allocator.rs
+++ b/kernel/src/utils/bitmap_allocator.rs
@@ -18,7 +18,7 @@ pub trait BitmapAllocator {
     fn empty(&self) -> bool;
     fn capacity(&self) -> usize;
     fn used(&self) -> usize;
-    #[cfg(feature = "fuzzing-hooks")]
+    #[cfg(fuzzing)]
     fn max_align(&self) -> usize {
         (<Self as BitmapAllocator>::CAPACITY.ilog2() - 1) as usize
     }
@@ -36,7 +36,7 @@ impl BitmapAllocator64 {
         Self { bits: u64::MAX }
     }
 
-    #[cfg(feature = "fuzzing-hooks")]
+    #[cfg(fuzzing)]
     pub fn get_bits(&self) -> u64 {
         self.bits
     }
@@ -108,7 +108,7 @@ impl BitmapAllocatorTree<BitmapAllocator64> {
         }
     }
 
-    #[cfg(feature = "fuzzing-hooks")]
+    #[cfg(fuzzing)]
     pub fn get_child(&self, index: usize) -> BitmapAllocator64 {
         self.child[index]
     }

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -42,14 +42,7 @@ for file in `git diff --name-only --staged`; do
     fi
 done
 
-# Run clippy on SVSM kernel
-cargo clippy --workspace --exclude igvmbuilder --exclude svsm-fuzz --all-features -- -D warnings || exit 1
-# Run clippy on std-dependent packages
-cargo clippy --workspace --all-features --exclude svsm --exclude svsm-fuzz --target=x86_64-unknown-linux-gnu -- -D warnings || exit 1
-# Run clippy on fuzzing harnesses
-RUSTFLAGS="--cfg fuzzing" cargo clippy --package svsm-fuzz --all-features --target=x86_64-unknown-linux-gnu -- -D warnings || exit 1
-# Run clippy on tests
-cargo clippy --workspace --all-features --tests --target=x86_64-unknown-linux-gnu -- -D warnings || exit 1
+make clippy || exit 1
 
 exit $RET
 


### PR DESCRIPTION
* Remove unused imports
* Add missing clippy runs to Makefile + call into Makefile from pre-commit hook
* Remove unnecessary `fuzzing-hooks` feature.