### PR TITLE
igvmbuilder/stage2_stack: compile-time check stage 2 stack & remove needless allocation

### DIFF
--- a/igvmbuilder/src/igvm_builder.rs
+++ b/igvmbuilder/src/igvm_builder.rs
@@ -322,7 +322,7 @@ impl IgvmBuilder {
             self.gpa_map.stage2_stack.get_start(),
             COMPATIBILITY_MASK,
             &mut self.directives,
-        )?;
+        );
 
         // Populate the empty region at the bottom of RAM.
         self.add_empty_pages(

--- a/igvmbuilder/src/stage2_stack.rs
+++ b/igvmbuilder/src/stage2_stack.rs
@@ -43,9 +43,9 @@ impl Stage2Stack {
         compatibility_mask: u32,
         directives: &mut Vec<IgvmDirectiveHeader>,
     ) {
-        let mut stage2_stack_data = self.as_bytes().to_vec();
+        let stage2_stack_data = self.as_bytes();
         let mut stage2_stack_page = vec![0u8; PAGE_SIZE_4K as usize - stage2_stack_data.len()];
-        stage2_stack_page.append(&mut stage2_stack_data);
+        stage2_stack_page.extend_from_slice(stage2_stack_data);
 
         directives.push(IgvmDirectiveHeader::PageData {
             gpa,


### PR DESCRIPTION
* Remove a runtime size check in favor of a compile-time check
* Remove a needless allocation of a `Vec<u8>`.