### PR TITLE
stage2: Include VTOM in the stage2 boot stack

### DIFF
--- a/bootlib/src/kernel_launch.rs
+++ b/bootlib/src/kernel_launch.rs
@@ -46,6 +46,8 @@ impl KernelLaunchInfo {
 #[derive(AsBytes, Default, Debug, Clone, Copy)]
 #[repr(C, packed)]
 pub struct Stage2LaunchInfo {
+    // VTOM must be the first field.
+    pub vtom: u64,
     pub kernel_elf_start: u32,
     pub kernel_elf_end: u32,
     pub kernel_fs_start: u32,

--- a/igvmbuilder/src/igvm_builder.rs
+++ b/igvmbuilder/src/igvm_builder.rs
@@ -318,7 +318,7 @@ impl IgvmBuilder {
         )?;
 
         // Populate the stage 2 stack.
-        let stage2_stack = Stage2Stack::new(&self.gpa_map);
+        let stage2_stack = Stage2Stack::new(&self.gpa_map, param_block.vtom);
         stage2_stack.add_directive(
             self.gpa_map.stage2_stack.get_start(),
             COMPATIBILITY_MASK,

--- a/igvmbuilder/src/stage2_stack.rs
+++ b/igvmbuilder/src/stage2_stack.rs
@@ -20,13 +20,14 @@ pub struct Stage2Stack {
 const _: () = assert!((size_of::<Stage2Stack>() as u64) <= PAGE_SIZE_4K);
 
 impl Stage2Stack {
-    pub fn new(gpa_map: &GpaMap) -> Self {
+    pub fn new(gpa_map: &GpaMap, vtom: u64) -> Self {
         let stage2_stack = Stage2LaunchInfo {
             kernel_elf_start: gpa_map.kernel_elf.get_start() as u32,
             kernel_elf_end: (gpa_map.kernel_elf.get_start() + gpa_map.kernel_elf.get_size()) as u32,
             kernel_fs_start: gpa_map.kernel_fs.get_start() as u32,
             kernel_fs_end: (gpa_map.kernel_fs.get_start() + gpa_map.kernel_fs.get_size()) as u32,
             igvm_params: gpa_map.igvm_param_block.get_start() as u32,
+            vtom,
             padding: 0,
         };
         Self { stage2_stack }

--- a/kernel/src/config.rs
+++ b/kernel/src/config.rs
@@ -172,11 +172,4 @@ impl SvsmConfig<'_> {
             SvsmConfig::IgvmConfig(igvm_params) => igvm_params.initialize_guest_vmsa(vmsa),
         }
     }
-
-    pub fn get_vtom(&self) -> u64 {
-        match self {
-            SvsmConfig::FirmwareConfig(_) => 0,
-            SvsmConfig::IgvmConfig(igvm_params) => igvm_params.get_vtom(),
-        }
-    }
 }

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -391,6 +391,9 @@ pub extern "C" fn svsm_main() {
     let config = if launch_info.igvm_params_virt_addr != 0 {
         let igvm_params = IgvmParams::new(VirtAddr::from(launch_info.igvm_params_virt_addr))
             .expect("Invalid IGVM parameters");
+        if (launch_info.vtom != 0) && (launch_info.vtom != igvm_params.get_vtom()) {
+            panic!("Launch VTOM does not match VTOM from IGVM parameters");
+        }
         SvsmConfig::IgvmConfig(igvm_params)
     } else {
         SvsmConfig::FirmwareConfig(FwCfg::new(&CONSOLE_IO))

--- a/stage1/stage1.S
+++ b/stage1/stage1.S
@@ -67,6 +67,10 @@ startup_32:
 	leal	kernel_elf(%ebp), %edi
 	pushl	%edi
 
+	/* Reserve space for VTOM */
+	pushl	%eax
+	pushl	%eax
+
 	/* Jump to stage 2 */
 	movl	$STAGE2_START, %eax
 	jmp	*%eax


### PR DESCRIPTION
This change includes the VTOM information in the boot stack because in certain circumstances, it may need to be available before the IGVM parameters are mapped.