### PR TITLE
elf/tests: remove unnecessary qualification

### DIFF
--- a/kernel/src/elf/mod.rs
+++ b/kernel/src/elf/mod.rs
@@ -2536,7 +2536,7 @@ mod tests {
 
         // Use the Elf64File::read method to create an Elf64File instance
         let res = Elf64File::read(&byte_data);
-        assert_eq!(res, Err(crate::elf::ElfError::InvalidPhdrSize));
+        assert_eq!(res, Err(ElfError::InvalidPhdrSize));
 
         // Construct an Elf64Hdr instance from the byte data
         let elf_hdr = Elf64Hdr::read(&byte_data);


### PR DESCRIPTION
Fix the following clippy warning on the nightly toolchain:

```
error: unnecessary qualification
    --> kernel/src/elf/mod.rs:2539:29
     |
2539 |         assert_eq!(res, Err(crate::elf::ElfError::InvalidPhdrSize));
     |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: requested on the command line with `-D unused-qualifications`
help: remove the unnecessary path segments
     |
2539 -         assert_eq!(res, Err(crate::elf::ElfError::InvalidPhdrSize));
2539 +         assert_eq!(res, Err(ElfError::InvalidPhdrSize));
     |
```