### PR TITLE
sev/ghcb Add #VC handler tests

### DIFF
--- a/kernel/src/cpu/msr.rs
+++ b/kernel/src/cpu/msr.rs
@@ -51,6 +51,30 @@ pub fn rdtsc() -> u64 {
     (eax as u64) | (edx as u64) << 32
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct RdtscpOut {
+    pub timestamp: u64,
+    pub pid: u32,
+}
+
+pub fn rdtscp() -> RdtscpOut {
+    let eax: u32;
+    let edx: u32;
+    let ecx: u32;
+
+    unsafe {
+        asm!("rdtsc",
+             out("eax") eax,
+             out("ecx") ecx,
+             out("edx") edx,
+             options(att_syntax, nomem, nostack));
+    }
+    RdtscpOut {
+        timestamp: (eax as u64) | (edx as u64) << 32,
+        pid: ecx,
+    }
+}
+
 pub fn read_flags() -> u64 {
     let rax: u64;
     unsafe {

--- a/kernel/src/cpu/vc.rs
+++ b/kernel/src/cpu/vc.rs
@@ -257,3 +257,133 @@ fn vc_decode_insn(ctx: &X86ExceptionContext) -> Result<Instruction, SvsmError> {
 fn vc_decoding_needed(error_code: usize) -> bool {
     !(SVM_EXIT_EXCP_BASE..=SVM_EXIT_LAST_EXCP).contains(&error_code)
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::cpu::percpu::this_cpu_mut;
+    use crate::sev::ghcb::GHCB;
+    use core::arch::asm;
+    use core::arch::x86_64::__cpuid_count;
+
+    #[test]
+    #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
+    fn test_has_memory_encryption_info_cpuid() {
+        const CPUID_EXTENDED_FUNCTION_INFO: u32 = 0x8000_0000;
+        const CPUID_MEMORY_ENCRYPTION_INFO: u32 = 0x8000_001F;
+        let extended_info = unsafe { __cpuid_count(CPUID_EXTENDED_FUNCTION_INFO, 0) };
+        assert!(extended_info.eax >= CPUID_MEMORY_ENCRYPTION_INFO);
+    }
+
+    #[test]
+    #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
+    fn test_has_amd_cpuid() {
+        const CPUID_VENDOR_INFO: u32 = 0;
+
+        let vendor_info = unsafe { __cpuid_count(CPUID_VENDOR_INFO, 0) };
+
+        let vendor_name_bytes = [vendor_info.ebx, vendor_info.edx, vendor_info.ecx]
+            .map(|v| v.to_le_bytes())
+            .concat();
+
+        assert_eq!(core::str::from_utf8(&vendor_name_bytes), Ok("AuthenticAMD"));
+    }
+
+    const GHCB_FILL_TEST_VALUE: u8 = b'1';
+
+    fn fill_ghcb_with_test_data() {
+        let ghcb = this_cpu_mut().ghcb_unsafe();
+        unsafe {
+            // The count param is 1 to only write one ghcb's worth of data
+            core::ptr::write_bytes(ghcb, GHCB_FILL_TEST_VALUE, 1);
+        }
+    }
+
+    fn verify_ghcb_was_altered() {
+        let ghcb = this_cpu_mut().ghcb_unsafe();
+        let ghcb_bytes =
+            unsafe { core::slice::from_raw_parts(ghcb.cast::<u8>(), core::mem::size_of::<GHCB>()) };
+        assert!(ghcb_bytes.iter().any(|v| *v != GHCB_FILL_TEST_VALUE));
+    }
+
+    // Calls `f` with an assertion that it ended up altering the ghcb.
+    fn verify_ghcb_gets_altered<R, F>(f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        fill_ghcb_with_test_data();
+        let result = f();
+        verify_ghcb_was_altered();
+        result
+    }
+
+    const TESTDEV_ECHO_LAST_PORT: u16 = 0xe0;
+
+    fn inb(port: u16) -> u8 {
+        unsafe {
+            let ret: u8;
+            asm!("inb %dx, %al", in("dx") port, out("al") ret, options(att_syntax));
+            ret
+        }
+    }
+
+    fn outb(port: u16, value: u8) {
+        unsafe { asm!("outb %al, %dx", in("al") value, in("dx") port, options(att_syntax)) }
+    }
+
+    fn inw(port: u16) -> u16 {
+        unsafe {
+            let ret: u16;
+            asm!("inw %dx, %ax", in("dx") port, out("ax") ret, options(att_syntax));
+            ret
+        }
+    }
+
+    fn outw(port: u16, value: u16) {
+        unsafe { asm!("outw %ax, %dx", in("ax") value, in("dx") port, options(att_syntax)) }
+    }
+
+    fn inl(port: u16) -> u32 {
+        unsafe {
+            let ret: u32;
+            asm!("inl %dx, %eax", in("dx") port, out("eax") ret, options(att_syntax));
+            ret
+        }
+    }
+
+    fn outl(port: u16, value: u32) {
+        unsafe { asm!("outl %eax, %dx", in("eax") value, in("dx") port, options(att_syntax)) }
+    }
+
+    #[test]
+    #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
+    fn test_port_io_8() {
+        const TEST_VAL: u8 = 0x12;
+        verify_ghcb_gets_altered(|| outb(TESTDEV_ECHO_LAST_PORT, TEST_VAL));
+        assert_eq!(
+            TEST_VAL,
+            verify_ghcb_gets_altered(|| inb(TESTDEV_ECHO_LAST_PORT))
+        );
+    }
+
+    #[test]
+    #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
+    fn test_port_io_16() {
+        const TEST_VAL: u16 = 0x4321;
+        verify_ghcb_gets_altered(|| outw(TESTDEV_ECHO_LAST_PORT, TEST_VAL));
+        assert_eq!(
+            TEST_VAL,
+            verify_ghcb_gets_altered(|| inw(TESTDEV_ECHO_LAST_PORT))
+        );
+    }
+
+    #[test]
+    #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
+    fn test_port_io_32() {
+        const TEST_VAL: u32 = 0xabcd1234;
+        verify_ghcb_gets_altered(|| outl(TESTDEV_ECHO_LAST_PORT, TEST_VAL));
+        assert_eq!(
+            TEST_VAL,
+            verify_ghcb_gets_altered(|| inl(TESTDEV_ECHO_LAST_PORT))
+        );
+    }
+}

--- a/kernel/src/sev/utils.rs
+++ b/kernel/src/sev/utils.rs
@@ -132,6 +132,38 @@ pub fn pvalidate(vaddr: VirtAddr, size: PageSize, valid: PvalidateOp) -> Result<
     }
 }
 
+/// Executes the vmmcall instruction.
+/// # Safety
+/// See cpu vendor documentation for what this can do.
+pub unsafe fn raw_vmmcall(eax: u32, ebx: u32, ecx: u32, edx: u32) -> i32 {
+    let new_eax;
+    asm!(
+            // bx register is reserved by llvm so it can't be passed in directly and must be
+            // restored
+            "xchg %rbx, {0:r}",
+            "vmmcall",
+            "xchg %rbx, {0:r}",
+            in(reg) ebx as u64,
+            inout("eax") eax => new_eax,
+            in("ecx") ecx,
+            in("edx") edx,
+            options(att_syntax));
+    new_eax
+}
+
+/// Sets the dr7 register to the given value
+/// # Safety
+/// See cpu vendor documentation for what this can do.
+pub unsafe fn set_dr7(new_val: u64) {
+    asm!("mov {0}, %dr7", in(reg) new_val, options(att_syntax));
+}
+
+pub fn get_dr7() -> u64 {
+    let out;
+    unsafe { asm!("mov %dr7, {0}", out(reg) out, options(att_syntax)) };
+    out
+}
+
 pub fn raw_vmgexit() {
     unsafe {
         asm!("rep; vmmcall", options(att_syntax));

--- a/scripts/launch_guest.sh
+++ b/scripts/launch_guest.sh
@@ -14,6 +14,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 C_BIT_POS=`$SCRIPT_DIR/../utils/cbit`
 DEBUG_SERIAL=""
 QEMU_EXIT_DEVICE=""
+QEMU_TEST_IO_DEVICE=""
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -38,6 +39,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     --unit-tests)
       QEMU_EXIT_DEVICE="-device isa-debug-exit,iobase=0xf4,iosize=0x04"
+      QEMU_TEST_IO_DEVICE="-device pc-testdev"
       shift
       ;;
     -*|--*)
@@ -110,6 +112,7 @@ $SUDO_CMD \
     -monitor none \
     -serial stdio \
     $DEBUG_SERIAL \
-    $QEMU_EXIT_DEVICE
+    $QEMU_EXIT_DEVICE \
+    $QEMU_TEST_IO_DEVICE
 
 stty intr ^C


### PR DESCRIPTION
Adds tests that make sure a \#VC exception is raised while executing various instructions and that the #VC handler properly handles them via the ghcb. Instructions tested are cpuid and port IO.

Looking for feedback on the following:

- Is the raw-cpuid dependency OK, or would it be better to just use inline asm or something else?
- What's a good location to put these? I chose ghcb.rs, but they might make more sense somewhere else.
- I have tests for other \#VC handler cases such as ones for msrs, dr7, wbinvd, rdtsc, mmio, and other IOIO instructions, but they fail since those cases aren't handled in the svsm handler. I could add these as \#\[should_panic\] if we think they might be useful later.
- I did not test these with qemu since it doesn't work on hardware I have. The IOIO tests rely on a "testdev" device that echos characters sent to a specific port. I'm pretty sure qemu has a compatible device, but it might need to be explicitly enabled.

@p4zuu please take a look.