### PR TITLE
Fix Hyper-V IGVM without firmware

### DIFF
--- a/igvmbuilder/src/gpa_map.rs
+++ b/igvmbuilder/src/gpa_map.rs
@@ -111,8 +111,15 @@ impl GpaMap {
                 1 << 20
             }
             Hypervisor::HyperV => {
-                // Load the kernel image after the firmware.
-                firmware_range.get_end()
+                // Load the kernel image after the firmware, but now lower than
+                // 1 MB.
+                let firmware_end = firmware_range.get_end();
+                let addr_1mb = 1 << 20;
+                if firmware_end < addr_1mb {
+                    addr_1mb
+                } else {
+                    firmware_end
+                }
             }
         };
         let kernel_elf = GpaRange::new(kernel_address, kernel_elf_len as u64)?;


### PR DESCRIPTION
In the Hyper-V configuration, the IGVM builder places the kernel image just above the firmware image.  If there is no firmware image, this results in the kernel image being placed at address zero.  This overlaps with where stage 2 is loaded, and that results in corruption of the kernel image and/or the IGVM parameter block depending on the extent of the collision.  Moving the kernel to a minimum address of 1 MB ensures that there is no collision.