### PR TITLE
Prevent use of ImmutAfterInit in the multithreaded environment

### DIFF
--- a/kernel/src/console.rs
+++ b/kernel/src/console.rs
@@ -52,7 +52,9 @@ pub static WRITER: SpinLock<Console> = SpinLock::new(Console {
 static CONSOLE_INITIALIZED: ImmutAfterInitCell<bool> = ImmutAfterInitCell::new(false);
 
 pub fn init_console() {
-    CONSOLE_INITIALIZED.reinit(&true);
+    CONSOLE_INITIALIZED
+        .reinit(&true)
+        .expect("could not reinit CONSOLE_INITIALIZED");
 }
 
 #[doc(hidden)]

--- a/kernel/src/cpu/smp.rs
+++ b/kernel/src/cpu/smp.rs
@@ -10,6 +10,7 @@ use crate::cpu::percpu::{this_cpu_mut, PerCpu};
 use crate::cpu::vmsa::init_svsm_vmsa;
 use crate::requests::{request_loop, request_processing_main};
 use crate::task::{create_kernel_task, schedule_init, TASK_FLAG_SHARE_PT};
+use crate::utils::immut_after_init::immut_after_init_set_multithreaded;
 
 fn start_cpu(apic_id: u32, vtom: u64) {
     unsafe {
@@ -44,6 +45,7 @@ fn start_cpu(apic_id: u32, vtom: u64) {
 }
 
 pub fn start_secondary_cpus(cpus: &[ACPICPUInfo], vtom: u64) {
+    immut_after_init_set_multithreaded();
     let mut count: usize = 0;
     for c in cpus.iter().filter(|c| c.apic_id != 0 && c.enabled) {
         log::info!("Launching AP with APIC-ID {}", c.apic_id);


### PR DESCRIPTION
The initialization of `ImmutAfterInitCell` objects (and, by extension, `ImmutAfterInitRef` objects) is designed specifically only to safe when the system is still in a single-threaded environment, because the intialization checks are not thread-safe.  This change ensures that no attempt is made to initialize or reinitialize any of these objects once the system has started multiple processors.  These checks are debug-only, like the checks on initialization state.