### PR TITLE
Ensure IGVM output is compatible with QEMU and calculate launch measurement

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --workspace --exclude igvmbuilder --exclude svsm-fuzz --all-features -- -D warnings
+          args: --workspace --exclude igvmbuilder --exclude igvmmeasure --exclude svsm-fuzz --all-features -- -D warnings
 
       - name: Clippy on std x86_64-unknown-linux-gnu
         uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,6 +317,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac-sha512"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ce1f4656bae589a3fab938f9f09bf58645b7ed01a2c5f8a3c238e01a4ef78a"
+
+[[package]]
 name = "igvm"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +360,17 @@ dependencies = [
  "igvm",
  "igvm_defs",
  "uuid",
+ "zerocopy 0.7.32",
+]
+
+[[package]]
+name = "igvmmeasure"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "hmac-sha512",
+ "igvm",
+ "igvm_defs",
  "zerocopy 0.7.32",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     # repo tooling
     "igvmbuilder",
+    "igvmmeasure",
     # binary targets
     "kernel",
     # fuzzing
@@ -24,6 +25,7 @@ bitflags = "2.4"
 clap = { version = "4.4.14", default-features = false}
 gdbstub = { version = "0.6.6", default-features = false }
 gdbstub_arch = { version = "0.2.4" }
+hmac-sha512 = "1.1.5"
 igvm_defs = { version = "0.1.3", default-features = false}
 igvm = { version = "0.1.3", default-features = false}
 intrusive-collections = "0.9.6"

--- a/Makefile
+++ b/Makefile
@@ -60,14 +60,17 @@ $(IGVMBUILDER):
 $(IGVMMEASURE):
 	cargo build ${CARGO_ARGS} --target=x86_64-unknown-linux-gnu -p igvmmeasure
 
-bin/coconut-qemu.igvm: $(IGVMBUILDER) bin/svsm-kernel.elf bin/stage2.bin ${FS_BIN}
+bin/coconut-qemu.igvm: $(IGVMBUILDER) $(IGVMMEASURE) bin/svsm-kernel.elf bin/stage2.bin ${FS_BIN}
 	$(IGVMBUILDER) --sort --output $@ --stage2 bin/stage2.bin --kernel bin/svsm-kernel.elf --filesystem ${FS_BIN} ${BUILD_FW} qemu
+	$(IGVMMEASURE) $@
 
-bin/coconut-hyperv.igvm: $(IGVMBUILDER) bin/svsm-kernel.elf bin/stage2.bin
+bin/coconut-hyperv.igvm: $(IGVMBUILDER)  $(IGVMMEASURE) bin/svsm-kernel.elf bin/stage2.bin
 	$(IGVMBUILDER) --sort --output $@ --stage2 bin/stage2.bin --kernel bin/svsm-kernel.elf --comport 3 hyper-v
+	$(IGVMMEASURE) $@
 
-bin/coconut-test-qemu.igvm: $(IGVMBUILDER) bin/test-kernel.elf bin/stage2.bin
+bin/coconut-test-qemu.igvm: $(IGVMBUILDER)  $(IGVMMEASURE) bin/test-kernel.elf bin/stage2.bin
 	$(IGVMBUILDER) --sort --output $@ --stage2 bin/stage2.bin --kernel bin/test-kernel.elf qemu
+	$(IGVMMEASURE) $@
 
 test:
 	cargo test --workspace --target=x86_64-unknown-linux-gnu

--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,12 @@ STAGE1_TEST_OBJS = stage1/stage1-test.o stage1/reset.o
 IGVM_FILES = bin/coconut-qemu.igvm bin/coconut-hyperv.igvm
 IGVMBUILDER = "target/x86_64-unknown-linux-gnu/${TARGET_PATH}/igvmbuilder"
 IGVMBIN = bin/igvmbld
+IGVMMEASURE = "target/x86_64-unknown-linux-gnu/${TARGET_PATH}/igvmmeasure"
+IGVMMEASUREBIN = bin/igvmmeasure
 
 all: bin/svsm.bin igvm
 
-igvm: $(IGVM_FILES) $(IGVMBIN)
+igvm: $(IGVM_FILES) $(IGVMBIN) $(IGVMMEASUREBIN)
 
 bin:
 	mkdir -v -p bin
@@ -49,8 +51,14 @@ bin:
 $(IGVMBIN): $(IGVMBUILDER) bin
 	cp -f $(IGVMBUILDER) $@
 
+$(IGVMMEASUREBIN): $(IGVMMEASURE) bin
+	cp -f $(IGVMMEASURE) $@
+
 $(IGVMBUILDER):
 	cargo build ${CARGO_ARGS} --target=x86_64-unknown-linux-gnu -p igvmbuilder
+
+$(IGVMMEASURE):
+	cargo build ${CARGO_ARGS} --target=x86_64-unknown-linux-gnu -p igvmmeasure
 
 bin/coconut-qemu.igvm: $(IGVMBUILDER) bin/svsm-kernel.elf bin/stage2.bin ${FS_BIN}
 	$(IGVMBUILDER) --sort --output $@ --stage2 bin/stage2.bin --kernel bin/svsm-kernel.elf --filesystem ${FS_BIN} ${BUILD_FW} qemu

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ bin/svsm.bin: bin/stage1
 	objcopy -O binary $< $@
 
 clippy:
-	cargo clippy --workspace --all-features --exclude svsm-fuzz --exclude igvmbuilder -- -D warnings
+	cargo clippy --workspace --all-features --exclude svsm-fuzz --exclude igvmbuilder --exclude igvmmeasure -- -D warnings
 	cargo clippy --workspace --all-features --exclude svsm-fuzz --exclude svsm --target=x86_64-unknown-linux-gnu -- -D warnings
 	RUSTFLAGS="--cfg fuzzing" cargo clippy --package svsm-fuzz --all-features --target=x86_64-unknown-linux-gnu -- -D warnings
 	cargo clippy --workspace --all-features --tests --target=x86_64-unknown-linux-gnu -- -D warnings

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ $(IGVMMEASURE):
 
 bin/coconut-qemu.igvm: $(IGVMBUILDER) $(IGVMMEASURE) bin/svsm-kernel.elf bin/stage2.bin ${FS_BIN}
 	$(IGVMBUILDER) --sort --output $@ --stage2 bin/stage2.bin --kernel bin/svsm-kernel.elf --filesystem ${FS_BIN} ${BUILD_FW} qemu
-	$(IGVMMEASURE) $@
+	$(IGVMMEASURE) --check-kvm $@
 
 bin/coconut-hyperv.igvm: $(IGVMBUILDER)  $(IGVMMEASURE) bin/svsm-kernel.elf bin/stage2.bin
 	$(IGVMBUILDER) --sort --output $@ --stage2 bin/stage2.bin --kernel bin/svsm-kernel.elf --comport 3 hyper-v

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ $(IGVMMEASURE):
 
 bin/coconut-qemu.igvm: $(IGVMBUILDER) $(IGVMMEASURE) bin/svsm-kernel.elf bin/stage2.bin ${FS_BIN}
 	$(IGVMBUILDER) --sort --output $@ --stage2 bin/stage2.bin --kernel bin/svsm-kernel.elf --filesystem ${FS_BIN} ${BUILD_FW} qemu
-	$(IGVMMEASURE) --check-kvm $@
+	$(IGVMMEASURE) --check-kvm --native-zero $@
 
 bin/coconut-hyperv.igvm: $(IGVMBUILDER)  $(IGVMMEASURE) bin/svsm-kernel.elf bin/stage2.bin
 	$(IGVMBUILDER) --sort --output $@ --stage2 bin/stage2.bin --kernel bin/svsm-kernel.elf --comport 3 hyper-v

--- a/igvmbuilder/src/gpa_map.rs
+++ b/igvmbuilder/src/gpa_map.rs
@@ -151,6 +151,14 @@ impl GpaMap {
             GpaRange::new(0, 0)?
         };
 
+        let vmsa = match options.hypervisor {
+            Hypervisor::Qemu => {
+                // VMSA address is currently hardcoded in kvm
+                GpaRange::new_page(0xFFFFFFFFF000)?
+            }
+            Hypervisor::HyperV => GpaRange::new_page(kernel.end - PAGE_SIZE_4K)?,
+        };
+
         let gpa_map = Self {
             low_memory: GpaRange::new(0, 0xf000)?,
             stage2_stack: GpaRange::new_page(0xf000)?,
@@ -166,7 +174,7 @@ impl GpaMap {
             guest_context,
             firmware: firmware_range,
             kernel,
-            vmsa: GpaRange::new_page(kernel.end - PAGE_SIZE_4K)?,
+            vmsa,
         };
         if options.verbose {
             println!("GPA Map: {gpa_map:#X?}");

--- a/igvmbuilder/src/vmsa.rs
+++ b/igvmbuilder/src/vmsa.rs
@@ -38,8 +38,8 @@ pub fn construct_vmsa(
     // EFER.SVME.
     vmsa.efer = 0x1000;
 
-    // CR0.PE | CR0.NE.
-    vmsa.cr0 = 0x21;
+    // CR0.PE | CR0.NE | CR0.ET.
+    vmsa.cr0 = 0x31;
 
     // CR4.MCE.
     vmsa.cr4 = 0x40;
@@ -57,6 +57,7 @@ pub fn construct_vmsa(
         vmsa.virtual_tom = vtom;
         features.set_vtom(true);
     }
+    features.set_debug_swap(true);
     vmsa.sev_features = features;
 
     Ok(IgvmDirectiveHeader::SnpVpContext {

--- a/igvmmeasure/.cargo/config.toml
+++ b/igvmmeasure/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "x86_64-unknown-linux-gnu"

--- a/igvmmeasure/Cargo.toml
+++ b/igvmmeasure/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "igvmmeasure"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { workspace = true, default-features = true, features = ["derive"] }
+igvm_defs.workspace = true
+igvm.workspace = true
+zerocopy.workspace = true
+hmac-sha512.workspace = true
+
+[lints]
+workspace = true

--- a/igvmmeasure/README.md
+++ b/igvmmeasure/README.md
@@ -47,5 +47,9 @@ build process if a non-conformant file is generated.
           Possible values:
           - sev-snp: Calculate the launch measurement for SEV-SNP
   -c, --check-kvm  Check that the IGVM file conforms to QEMU/KVM restrictions
+  -n, --native-zero
+          Determine how to pages that contain only zeroes in the IGVM file.
+          When true, zero pages are measured using the native zero page type if the underlying platform supports it.
+          When false, the page is measured as a normal page containing all zeros.
   -h, --help       Print help
 ```

--- a/igvmmeasure/README.md
+++ b/igvmmeasure/README.md
@@ -16,6 +16,18 @@ expected.
 Given an IGVM file, igvmmeasure parses the directives in the file and calculates
 the launch digest and outputs it as a hexadecimal string.
 
+## IGVM validation
+There are some restrictions on the contents of an IGVM file when using QEMU with
+KVM which impose some rules on the directives in the IGVM file. This is due to
+the way the initial guest state is passed from QEMU user mode to KVM in the
+kernel. Therefore, IGVM files for this virtualization stack must conform to
+these rules.
+
+Passing the `--check-kvm` option to igvmmeasure will result in some basic checks
+being performed on the directives in the file during the measurement process.
+This can be use to help diagnose measurement mismatches, or to abort the IGVM
+build process if a non-conformant file is generated.
+
 ## Usage
 `igvmmeasure [OPTIONS] <IGVM_FILE>`
 
@@ -34,5 +46,6 @@ the launch digest and outputs it as a hexadecimal string.
           [default: sev-snp]
           Possible values:
           - sev-snp: Calculate the launch measurement for SEV-SNP
+  -c, --check-kvm  Check that the IGVM file conforms to QEMU/KVM restrictions
   -h, --help       Print help
 ```

--- a/igvmmeasure/README.md
+++ b/igvmmeasure/README.md
@@ -51,5 +51,9 @@ build process if a non-conformant file is generated.
           Determine how to pages that contain only zeroes in the IGVM file.
           When true, zero pages are measured using the native zero page type if the underlying platform supports it.
           When false, the page is measured as a normal page containing all zeros.
+  -i, --ignore-idblock
+          If an ID block is present within the IGVM file then by default an error will be generated if the expected
+          measurement differs from the calculated measurement.
+          If this option is set then the expected measurement in the ID block is ignored.
   -h, --help       Print help
 ```

--- a/igvmmeasure/README.md
+++ b/igvmmeasure/README.md
@@ -1,0 +1,38 @@
+# igvmmeasure
+A tool to calculate the launch measurement for the directives in an IGVM file.
+
+When starting a guest configured using an IGVM file, the directives in the IGVM
+are use to populate initial guest memory and describe the initial guest state.
+This configuration is measured by the isolation technology, such as SEV-SNP or
+TDX and results in a launch digest that can be remotely verified using an
+attestation report.
+
+In order to ensure the integrity of a build that is packed in IGVM, it is
+necessary to be able to pre-calculate the measurement of the file to obtain the
+expected launch digest. This can then be compared with the actual launch
+measurement in the attestation report to ensure the initial guest state is as
+expected.
+
+Given an IGVM file, igvmmeasure parses the directives in the file and calculates
+the launch digest and outputs it as a hexadecimal string.
+
+## Usage
+`igvmmeasure [OPTIONS] <IGVM_FILE>`
+
+### Arguments:
+```
+  <IGVM_FILE>
+          The filename of the IGVM file to measure
+```
+
+### Options:
+```
+  -v, --verbose    Print verbose output
+  -b, --bare       Bare output only, consisting of just the digest as a hex string
+  -p, --platform <PLATFORM>
+          Platform to calculate the launch measurement for
+          [default: sev-snp]
+          Possible values:
+          - sev-snp: Calculate the launch measurement for SEV-SNP
+  -h, --help       Print help
+```

--- a/igvmmeasure/src/cmd_options.rs
+++ b/igvmmeasure/src/cmd_options.rs
@@ -27,6 +27,15 @@ pub struct CmdOptions {
     /// Platform to calculate the launch measurement for
     #[arg(short, long, value_enum, default_value_t = Platform::SevSnp)]
     pub platform: Platform,
+
+    /// Determine how to pages that contain only zeroes in the IGVM file.
+    ///
+    /// When true, zero pages are measured using the native zero page type
+    /// if the underlying platform supports it.
+    ///
+    /// When false, the page is measured as a normal page containing all zeros.
+    #[arg(short, long, default_value_t = false)]
+    pub native_zero: bool,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]

--- a/igvmmeasure/src/cmd_options.rs
+++ b/igvmmeasure/src/cmd_options.rs
@@ -36,6 +36,15 @@ pub struct CmdOptions {
     /// When false, the page is measured as a normal page containing all zeros.
     #[arg(short, long, default_value_t = false)]
     pub native_zero: bool,
+
+    /// If an ID block is present within the IGVM file then by default an
+    /// error will be generated if the expected measurement differs from
+    /// the calculated measurement.
+    ///
+    /// If this option is set then the expected measurement in the ID block
+    /// is ignored.
+    #[arg(short, long, default_value_t = false)]
+    pub ignore_idblock: bool,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]

--- a/igvmmeasure/src/cmd_options.rs
+++ b/igvmmeasure/src/cmd_options.rs
@@ -20,6 +20,10 @@ pub struct CmdOptions {
     #[arg(short, long, default_value_t = false)]
     pub bare: bool,
 
+    /// Check that the IGVM file conforms to QEMU/KVM restrictions
+    #[arg(short, long, default_value_t = false)]
+    pub check_kvm: bool,
+
     /// Platform to calculate the launch measurement for
     #[arg(short, long, value_enum, default_value_t = Platform::SevSnp)]
     pub platform: Platform,

--- a/igvmmeasure/src/cmd_options.rs
+++ b/igvmmeasure/src/cmd_options.rs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2024 SUSE LLC
+//
+// Author: Roy Hopkins <roy.hopkins@suse.com>
+
+use clap::{Parser, ValueEnum};
+
+#[derive(Parser, Debug)]
+pub struct CmdOptions {
+    /// The filename of the IGVM file to measure
+    #[arg()]
+    pub igvm_file: String,
+
+    /// Print verbose output
+    #[arg(short, long, default_value_t = false)]
+    pub verbose: bool,
+
+    /// Bare output only, consisting of just the digest as a hex string
+    #[arg(short, long, default_value_t = false)]
+    pub bare: bool,
+
+    /// Platform to calculate the launch measurement for
+    #[arg(short, long, value_enum, default_value_t = Platform::SevSnp)]
+    pub platform: Platform,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
+pub enum Platform {
+    /// Calculate the launch measurement for SEV-SNP
+    SevSnp,
+}

--- a/igvmmeasure/src/igvm_measure.rs
+++ b/igvmmeasure/src/igvm_measure.rs
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2024 SUSE LLC
+//
+// Author: Roy Hopkins <roy.hopkins@suse.com>
+
+use std::error::Error;
+use std::fs;
+
+use igvm::snp_defs::SevVmsa;
+use igvm::{IgvmDirectiveHeader, IgvmFile, IgvmPlatformHeader};
+use igvm_defs::{IgvmPageDataFlags, IgvmPageDataType, IgvmPlatformType, PAGE_SIZE_4K};
+use zerocopy::AsBytes;
+
+use crate::cmd_options::CmdOptions;
+use crate::page_info::PageInfo;
+
+#[derive(PartialEq)]
+enum SnpPageType {
+    None,
+    Normal,
+    Unmeasured,
+    Zero,
+    Secrets,
+    CpuId,
+    Vmsa,
+}
+
+impl std::fmt::Display for SnpPageType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                SnpPageType::None => "None",
+                SnpPageType::Normal => "Normal",
+                SnpPageType::Unmeasured => "Unmeasured",
+                SnpPageType::Zero => "Zero",
+                SnpPageType::Secrets => "Secrets",
+                SnpPageType::CpuId => "Cpuid",
+                SnpPageType::Vmsa => "VMSA",
+            }
+        )
+    }
+}
+
+pub struct IgvmMeasure<'a> {
+    options: &'a CmdOptions,
+    digest: [u8; 48],
+    last_page_type: SnpPageType,
+    last_gpa: u64,
+    last_next_gpa: u64,
+    last_len: u64,
+    compatibility_mask: u32,
+}
+
+const PAGE_SIZE_2M: u64 = 2 * 1024 * 1024;
+
+impl<'a> IgvmMeasure<'a> {
+    pub fn new(options: &'a CmdOptions) -> Self {
+        Self {
+            options,
+            digest: [0u8; 48],
+            last_page_type: SnpPageType::None,
+            last_gpa: 0,
+            last_next_gpa: 0,
+            last_len: 0,
+            compatibility_mask: 0,
+        }
+    }
+
+    fn find_compatibility_mask(&mut self, igvm: &IgvmFile) -> Result<(), Box<dyn Error>> {
+        for platform in igvm.platforms() {
+            let IgvmPlatformHeader::SupportedPlatform(platform) = platform;
+            match platform.platform_type {
+                IgvmPlatformType::SEV_SNP => {
+                    self.compatibility_mask = platform.compatibility_mask;
+                    return Ok(());
+                }
+                _ => continue,
+            }
+        }
+        Err("IGVM file is not compatible with the specified platform.".into())
+    }
+
+    pub fn measure(&mut self) -> Result<[u8; 48], Box<dyn Error>> {
+        let igvm_buffer = fs::read(&self.options.igvm_file).map_err(|e| {
+            eprintln!("Failed to open firmware file {}", self.options.igvm_file);
+            e
+        })?;
+        let igvm = IgvmFile::new_from_binary(igvm_buffer.as_bytes(), None)?;
+
+        self.find_compatibility_mask(&igvm)?;
+
+        for directive in igvm.directives() {
+            match directive {
+                IgvmDirectiveHeader::PageData {
+                    gpa,
+                    compatibility_mask,
+                    flags,
+                    data_type,
+                    data,
+                } => {
+                    if (*compatibility_mask & self.compatibility_mask) != 0 {
+                        self.measure_page(*gpa, flags, *data_type, data)?;
+                    }
+                }
+                IgvmDirectiveHeader::ParameterInsert(param) => {
+                    if (param.compatibility_mask & self.compatibility_mask) != 0 {
+                        self.measure_page(
+                            param.gpa,
+                            &IgvmPageDataFlags::new().with_unmeasured(true),
+                            IgvmPageDataType::NORMAL,
+                            &[],
+                        )?
+                    }
+                }
+                IgvmDirectiveHeader::SnpVpContext {
+                    gpa,
+                    compatibility_mask,
+                    vp_index: _vp_index,
+                    vmsa,
+                } => {
+                    if (*compatibility_mask & self.compatibility_mask) != 0 {
+                        self.measure_vmsa(*gpa, vmsa);
+                    }
+                }
+                _ => (),
+            }
+        }
+        self.log_page(SnpPageType::None, 0, 0);
+
+        Ok(self.digest)
+    }
+
+    fn log_page(&mut self, page_type: SnpPageType, gpa: u64, len: u64) {
+        if self.options.verbose {
+            if (page_type != self.last_page_type) || (gpa != self.last_next_gpa) {
+                if self.last_len > 0 {
+                    println!(
+                        "gpa {:#x} len {:#x} ({} page)",
+                        self.last_gpa, self.last_len, self.last_page_type
+                    );
+                }
+                self.last_len = len;
+                self.last_gpa = gpa;
+                self.last_next_gpa = gpa + len;
+                self.last_page_type = page_type;
+            } else {
+                self.last_len += len;
+                self.last_next_gpa += len;
+            }
+        }
+    }
+
+    fn measure_page(
+        &mut self,
+        gpa: u64,
+        flags: &IgvmPageDataFlags,
+        data_type: IgvmPageDataType,
+        data: &[u8],
+    ) -> Result<(), Box<dyn Error>> {
+        let page_len = if flags.is_2mb_page() {
+            PAGE_SIZE_2M
+        } else {
+            PAGE_SIZE_4K
+        };
+        assert!(data.is_empty() || data.len() == page_len as usize);
+
+        if data.is_empty() {
+            for page_offset in (0..page_len).step_by(PAGE_SIZE_4K as usize) {
+                self.measure_page_4k(gpa + page_offset, flags, data_type, &vec![]);
+            }
+        } else {
+            for (index, page_data) in data.chunks(PAGE_SIZE_4K as usize).enumerate() {
+                self.measure_page_4k(
+                    gpa + index as u64 * PAGE_SIZE_4K,
+                    flags,
+                    data_type,
+                    &page_data.to_vec(),
+                );
+            }
+        }
+        Ok(())
+    }
+
+    fn measure_page_4k(
+        &mut self,
+        gpa: u64,
+        flags: &IgvmPageDataFlags,
+        data_type: IgvmPageDataType,
+        data: &Vec<u8>,
+    ) {
+        let page_info = match data_type {
+            IgvmPageDataType::NORMAL => {
+                if flags.unmeasured() {
+                    self.log_page(SnpPageType::Unmeasured, gpa, PAGE_SIZE_4K);
+                    Some(PageInfo::new_unmeasured_page(self.digest, gpa))
+                } else if data.is_empty() {
+                    self.log_page(SnpPageType::Zero, gpa, PAGE_SIZE_4K);
+                    Some(PageInfo::new_zero_page(self.digest, gpa))
+                } else {
+                    self.log_page(SnpPageType::Normal, gpa, data.len() as u64);
+                    Some(PageInfo::new_normal_page(self.digest, gpa, data))
+                }
+            }
+            IgvmPageDataType::SECRETS => {
+                self.log_page(SnpPageType::Secrets, gpa, PAGE_SIZE_4K);
+                Some(PageInfo::new_secrets_page(self.digest, gpa))
+            }
+            IgvmPageDataType::CPUID_DATA => {
+                self.log_page(SnpPageType::CpuId, gpa, PAGE_SIZE_4K);
+                Some(PageInfo::new_cpuid_page(self.digest, gpa))
+            }
+            IgvmPageDataType::CPUID_XF => {
+                self.log_page(SnpPageType::CpuId, gpa, PAGE_SIZE_4K);
+                Some(PageInfo::new_cpuid_page(self.digest, gpa))
+            }
+            _ => None,
+        };
+        if let Some(page_info) = page_info {
+            self.digest = page_info.update_hash();
+        }
+    }
+
+    fn measure_vmsa(&mut self, gpa: u64, vmsa: &SevVmsa) {
+        let mut vmsa_page = vmsa.as_bytes().to_vec();
+        vmsa_page.resize(PAGE_SIZE_4K as usize, 0);
+        self.log_page(SnpPageType::Vmsa, gpa, PAGE_SIZE_4K);
+        let page_info = PageInfo::new_vmsa_page(self.digest, gpa, &vmsa_page);
+        self.digest = page_info.update_hash();
+    }
+}

--- a/igvmmeasure/src/igvm_measure.rs
+++ b/igvmmeasure/src/igvm_measure.rs
@@ -269,8 +269,17 @@ impl<'a> IgvmMeasure<'a> {
                     self.log_page(SnpPageType::Unmeasured, gpa, PAGE_SIZE_4K);
                     Some(PageInfo::new_unmeasured_page(self.digest, gpa))
                 } else if data.is_empty() {
-                    self.log_page(SnpPageType::Zero, gpa, PAGE_SIZE_4K);
-                    Some(PageInfo::new_zero_page(self.digest, gpa))
+                    if self.options.native_zero {
+                        self.log_page(SnpPageType::Zero, gpa, PAGE_SIZE_4K);
+                        Some(PageInfo::new_zero_page(self.digest, gpa))
+                    } else {
+                        self.log_page(SnpPageType::Normal, gpa, PAGE_SIZE_4K);
+                        Some(PageInfo::new_normal_page(
+                            self.digest,
+                            gpa,
+                            &vec![0u8; PAGE_SIZE_4K as usize],
+                        ))
+                    }
                 } else {
                     self.log_page(SnpPageType::Normal, gpa, data.len() as u64);
                     Some(PageInfo::new_normal_page(self.digest, gpa, data))

--- a/igvmmeasure/src/main.rs
+++ b/igvmmeasure/src/main.rs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2024 SUSE LLC
+//
+// Author: Roy Hopkins <roy.hopkins@suse.com>
+
+use std::error::Error;
+
+use clap::Parser;
+use cmd_options::CmdOptions;
+use igvm_measure::IgvmMeasure;
+
+mod cmd_options;
+mod igvm_measure;
+mod page_info;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let options = CmdOptions::parse();
+    let mut igvm = IgvmMeasure::new(&options);
+    let digest = igvm.measure()?;
+
+    if !options.bare {
+        println!(
+            "\n==============================================================================================================="
+        );
+        print!("igvmmeasure '{}'\nLaunch Digest: ", options.igvm_file);
+    }
+
+    digest.iter().for_each(|val| print!("{:02X}", val));
+    println!();
+
+    if !options.bare {
+        println!(
+            "===============================================================================================================\n"
+        );
+    }
+
+    Ok(())
+}

--- a/igvmmeasure/src/main.rs
+++ b/igvmmeasure/src/main.rs
@@ -35,5 +35,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         );
     }
 
+    if !options.ignore_idblock {
+        igvm.check_id_block()?;
+    }
+
     Ok(())
 }

--- a/igvmmeasure/src/page_info.rs
+++ b/igvmmeasure/src/page_info.rs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 SUSE LLC
+//
+// Author: Roy Hopkins <roy.hopkins@suse.com>
+
+use hmac_sha512::sha384::Hash;
+use zerocopy::AsBytes;
+
+#[repr(u8)]
+#[derive(AsBytes, Debug, Copy, Clone)]
+pub enum PageType {
+    Normal = 1,
+    Vmsa = 2,
+    Zero = 3,
+    Unmeasured = 4,
+    Secrets = 5,
+    Cpuid = 6,
+}
+
+#[repr(C, packed)]
+#[derive(AsBytes, Debug)]
+pub struct PageInfo {
+    digest_cur: [u8; 48],
+    contents: [u8; 48],
+    length: u16,
+    page_type: PageType,
+    imi_page: u8,
+    reserved: u8,
+    vmpl1_perms: u8,
+    vmpl2_perms: u8,
+    vmpl3_perms: u8,
+    gpa: u64,
+}
+
+impl PageInfo {
+    pub fn new_normal_page(digest_cur: [u8; 48], gpa: u64, data: &Vec<u8>) -> Self {
+        Self {
+            digest_cur,
+            contents: Hash::hash(data),
+            length: 0x70,
+            page_type: PageType::Normal,
+            imi_page: 0,
+            reserved: 0,
+            vmpl1_perms: 0,
+            vmpl2_perms: 0,
+            vmpl3_perms: 0,
+            gpa,
+        }
+    }
+
+    pub fn new_vmsa_page(digest_cur: [u8; 48], gpa: u64, data: &Vec<u8>) -> Self {
+        Self {
+            digest_cur,
+            contents: Hash::hash(data),
+            length: 0x70,
+            page_type: PageType::Vmsa,
+            imi_page: 0,
+            reserved: 0,
+            vmpl1_perms: 0,
+            vmpl2_perms: 0,
+            vmpl3_perms: 0,
+            gpa,
+        }
+    }
+
+    pub fn new_zero_page(digest_cur: [u8; 48], gpa: u64) -> Self {
+        Self::internal_new_unmeasured_page(digest_cur, gpa, PageType::Zero)
+    }
+
+    pub fn new_unmeasured_page(digest_cur: [u8; 48], gpa: u64) -> Self {
+        Self::internal_new_unmeasured_page(digest_cur, gpa, PageType::Unmeasured)
+    }
+
+    pub fn new_secrets_page(digest_cur: [u8; 48], gpa: u64) -> Self {
+        Self::internal_new_unmeasured_page(digest_cur, gpa, PageType::Secrets)
+    }
+
+    pub fn new_cpuid_page(digest_cur: [u8; 48], gpa: u64) -> Self {
+        Self::internal_new_unmeasured_page(digest_cur, gpa, PageType::Cpuid)
+    }
+
+    fn internal_new_unmeasured_page(digest_cur: [u8; 48], gpa: u64, page_type: PageType) -> Self {
+        Self {
+            digest_cur,
+            contents: [0u8; 48],
+            length: 0x70,
+            page_type,
+            imi_page: 0,
+            reserved: 0,
+            vmpl1_perms: 0,
+            vmpl2_perms: 0,
+            vmpl3_perms: 0,
+            gpa,
+        }
+    }
+
+    pub fn update_hash(&self) -> [u8; 48] {
+        Hash::hash(self.as_bytes())
+    }
+}


### PR DESCRIPTION
This PR introduces a new tool `igvmmeasure` that parses an IGVM file and calculates the launch digest which should match the launch measurement included as part of the attestation report from the platform.

By introducing this tool, it created the opportunity to verify that the directives within the IGVM file produced by the build process are properly sent as initial guest state, exactly as described and in the correct order. It was found that there were some discrepancies between the current IGVM file and the QEMU loader/KVM launch process that resulted in a mismatch between the expected and actual digest.

The first two commits in this PR fix these issues which both relate to the VMSA then proceed to introduce the measurement tool and introduce it into the build. An option has also been added to the tool to catch these inconsistencies in future changes to the IGVM file, causing the build to abort if detected.

Note that in order to obtain a matching measurement, fixes are required on top of the existing coconut/qemu. I will be raising a new PR with these changes shortly.