### PR TITLE
cpu/vc: handle faults when fecthing instructions

### DIFF
--- a/kernel/src/cpu/insn.rs
+++ b/kernel/src/cpu/insn.rs
@@ -184,24 +184,6 @@ impl Instruction {
     }
 }
 
-/// Copy the instruction bytes where rip points to.
-///
-/// # Arguments
-///
-/// rip: instruction pointer as [`*const u8`].
-///
-/// # Returns
-///
-/// [`[u8; MAX_INSN_SIZE]`]: the 15-byte buffer where rip points to.
-///
-/// # Safety
-///
-///  The caller should validate that `rip` is set to a valid address
-///  and that the next [`MAX_INSN_SIZE`] bytes are within valid memory.
-pub unsafe fn insn_fetch(rip: *const u8) -> [u8; MAX_INSN_SIZE] {
-    rip.cast::<[u8; MAX_INSN_SIZE]>().read()
-}
-
 #[cfg(test)]
 mod tests {
     use super::{InsnBuffer, Instruction, MAX_INSN_SIZE};

--- a/kernel/src/mm/guestmem.rs
+++ b/kernel/src/mm/guestmem.rs
@@ -248,4 +248,25 @@ mod tests {
 
         assert_eq!(test_buffer[0], data_to_write);
     }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "inline assembly")]
+    fn test_read_15_bytes_valid_address() {
+        let test_buffer = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14];
+        let test_addr = VirtAddr::from(test_buffer.as_ptr());
+        let ptr: GuestPtr<[u8; 15]> = GuestPtr::new(test_addr);
+        let result = ptr.read().unwrap();
+
+        assert_eq!(result, test_buffer);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "inline assembly")]
+    #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
+    fn test_read_invalid_address() {
+        let ptr: GuestPtr<u8> = GuestPtr::new(VirtAddr::new(0xDEAD_BEEF));
+
+        let err = ptr.read();
+        assert!(err.is_err());
+    }
 }


### PR DESCRIPTION
Faults can happen in the #VC handler if the exception context RIP (more generally the [RIP; RIP+15] array) doesn't belong to a mapped page.

To handle these faults, we can rely on GuestPtr::read() that uses the exception table if a fault occurs.

This touches the #VC handler, so I would wait for #288 to be merged to correctly test this PR.