### PR TITLE
cpu/vc: improve error handling

### DIFF
--- a/kernel/src/cpu/idt/stage2.rs
+++ b/kernel/src/cpu/idt/stage2.rs
@@ -39,7 +39,7 @@ pub extern "C" fn stage2_generic_idt_handler(ctx: &mut X86ExceptionContext) {
                 rip, rsp, cr2
             );
         }
-        VC_VECTOR => stage2_handle_vc_exception(ctx),
+        VC_VECTOR => stage2_handle_vc_exception(ctx).expect("Failed to handle #VC"),
         HV_VECTOR =>
             // #HV does not require processing during stage 2 and can be
         // completely ignored.
@@ -69,7 +69,7 @@ pub extern "C" fn stage2_generic_idt_handler_no_ghcb(ctx: &mut X86ExceptionConte
                 rip, rsp, cr2
             );
         }
-        VC_VECTOR => stage2_handle_vc_exception_no_ghcb(ctx),
+        VC_VECTOR => stage2_handle_vc_exception_no_ghcb(ctx).expect("Failed to handle #VC"),
         _ => {
             let err = ctx.error_code;
             let vec = ctx.vector;

--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -154,7 +154,7 @@ extern "C" fn ex_handler_hypervisor_injection(_ctx: &mut X86ExceptionContext) {
 // VMM Communication handler
 #[no_mangle]
 extern "C" fn ex_handler_vmm_communication(ctx: &mut X86ExceptionContext) {
-    handle_vc_exception(ctx);
+    handle_vc_exception(ctx).expect("Failed to handle #VC");
 }
 
 #[no_mangle]


### PR DESCRIPTION
Remove calls to `Result::expect()` in the VC code and return errors so that they can be handled by callers.

`VcError` is already implemented, so use the already existing type. Introduce `VcError::new()` to improve ergonomics when creating a new error.