### PR TITLE
kernel: Change the location of the VMSA page

### DIFF
--- a/bootlib/src/kernel_launch.rs
+++ b/bootlib/src/kernel_launch.rs
@@ -14,6 +14,7 @@ pub struct KernelLaunchInfo {
     /// Exclusive end of the kernel in physical memory.
     pub kernel_region_phys_end: u64,
     pub heap_area_phys_start: u64, // Start of trailing heap area within the physical memory region.
+    pub heap_area_size: u64,
     pub kernel_region_virt_start: u64,
     pub heap_area_virt_start: u64, // Start of virtual heap area mapping.
     pub kernel_elf_stage2_virt_start: u64, // Virtual address of kernel ELF in Stage2 mapping.
@@ -31,12 +32,8 @@ pub struct KernelLaunchInfo {
 }
 
 impl KernelLaunchInfo {
-    pub fn heap_area_size(&self) -> u64 {
-        self.kernel_region_phys_end - self.heap_area_phys_start
-    }
-
     pub fn heap_area_virt_end(&self) -> u64 {
-        self.heap_area_virt_start + self.heap_area_size()
+        self.heap_area_virt_start + self.heap_area_size
     }
 }
 

--- a/igvmbuilder/src/gpa_map.rs
+++ b/igvmbuilder/src/gpa_map.rs
@@ -166,7 +166,7 @@ impl GpaMap {
             guest_context,
             firmware: firmware_range,
             kernel,
-            vmsa: GpaRange::new_page(kernel.start)?,
+            vmsa: GpaRange::new_page(kernel.end - PAGE_SIZE_4K)?,
         };
         if options.verbose {
             println!("GPA Map: {gpa_map:#X?}");

--- a/kernel/src/config.rs
+++ b/kernel/src/config.rs
@@ -95,6 +95,12 @@ impl SvsmConfig<'_> {
             SvsmConfig::IgvmConfig(igvm_params) => igvm_params.get_memory_regions(),
         }
     }
+    pub fn reserved_kernel_area_size(&self) -> usize {
+        match self {
+            SvsmConfig::FirmwareConfig(_) => 0,
+            SvsmConfig::IgvmConfig(igvm_params) => igvm_params.reserved_kernel_area_size(),
+        }
+    }
     pub fn load_cpu_info(&self) -> Result<Vec<ACPICPUInfo>, SvsmError> {
         match self {
             SvsmConfig::FirmwareConfig(fw_cfg) => load_acpi_cpu_info(fw_cfg),

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -236,7 +236,7 @@ pub fn memory_init(launch_info: &KernelLaunchInfo) {
     root_mem_init(
         PhysAddr::from(launch_info.heap_area_phys_start),
         VirtAddr::from(launch_info.heap_area_virt_start),
-        launch_info.heap_area_size() as usize / PAGE_SIZE,
+        launch_info.heap_area_size as usize / PAGE_SIZE,
     );
 }
 

--- a/kernel/src/svsm_paging.rs
+++ b/kernel/src/svsm_paging.rs
@@ -47,10 +47,6 @@ pub fn init_page_table(
     // The memory backing the kernel ELF segments gets allocated back to back
     // from the physical memory region by the Stage2 loader.
     let mut phys = PhysAddr::from(launch_info.kernel_region_phys_start);
-    if let Some(ref igvm_params) = igvm_param_info.igvm_params {
-        phys = phys + igvm_params.reserved_kernel_area_size();
-    }
-
     for segment in kernel_elf.image_load_segment_iter(launch_info.kernel_region_virt_start) {
         let vaddr_start = VirtAddr::from(segment.vaddr_range.vaddr_begin);
         let vaddr_end = VirtAddr::from(segment.vaddr_range.vaddr_end);
@@ -87,7 +83,7 @@ pub fn init_page_table(
     // Map subsequent heap area.
     let heap_vregion = MemoryRegion::new(
         VirtAddr::from(launch_info.heap_area_virt_start),
-        launch_info.heap_area_size() as usize,
+        launch_info.heap_area_size as usize,
     );
     pgtable
         .map_region(


### PR DESCRIPTION
Certain hypervisors today impose a restriction that a VMSA page cannot be aligned to a 2 MB boundary.  This change adjusts the layout of the SVSM physical memory block so the VMSA is located at the top, not the base.