### PR TITLE
stage2: Check for correct alignment of virtual offset

### DIFF
--- a/kernel/src/utils/mod.rs
+++ b/kernel/src/utils/mod.rs
@@ -10,4 +10,6 @@ pub mod memory_region;
 pub mod util;
 
 pub use memory_region::MemoryRegion;
-pub use util::{align_down, align_up, halt, overlap, page_align_up, page_offset, zero_mem_region};
+pub use util::{
+    align_down, align_up, halt, is_aligned, overlap, page_align_up, page_offset, zero_mem_region,
+};

--- a/kernel/src/utils/util.rs
+++ b/kernel/src/utils/util.rs
@@ -24,6 +24,13 @@ where
     addr & !(align - T::from(1u8))
 }
 
+pub fn is_aligned<T>(addr: T, align: T) -> bool
+where
+    T: Sub<Output = T> + BitAnd<Output = T> + PartialEq + From<u32>,
+{
+    (addr & (align - T::from(1))) == T::from(0)
+}
+
 pub fn halt() {
     unsafe {
         asm!("hlt", options(att_syntax));


### PR DESCRIPTION
Add a check to make sure that the offset between the physical addresses and the virtual mapping is aligned to 2MiB.