### PR TITLE
kernel/gdbstub.rs: Allow mutable reference to mutable static

### DIFF
--- a/kernel/src/debug/gdbstub.rs
+++ b/kernel/src/debug/gdbstub.rs
@@ -48,6 +48,7 @@ pub mod svsm_gdbstub {
         unsafe {
             GDB_SERIAL.init();
             let mut target = GdbStubTarget::new();
+            #[allow(static_mut_refs)]
             let gdb = GdbStubBuilder::new(GdbStubConnection::new())
                 .with_packet_buffer(&mut PACKET_BUFFER)
                 .build()


### PR DESCRIPTION
The latest cargo release v1.77.0 is generating a warning for the "&mut PACKET_BUFFER", failing our github CI.

```
error: creating a mutable reference to mutable static is discouraged
  --> kernel/src/debug/gdbstub.rs:52:37
   |
52 |                 .with_packet_buffer(&mut PACKET_BUFFER)
   |                                     ^^^^^^^^^^^^^^^^^^ mutable reference to mutable static
```

Although it says that creating a mutable reference to mutable static is discouraged, this is the only place we use the PACKET_BUFFER variable and so it seems safe.

This PR overrides "-D warnings" by adding
"#[allow(static_mut_refs)]". That will force us to update our installed cargo to latest, otherwise, an error message like "unknown lint" will be printed.