### PR TITLE
Revert "mm/pagetable: add module-level error handling"

### DIFF
--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -8,7 +8,6 @@ use crate::cpu::vc::VcError;
 use crate::fs::FsError;
 use crate::fw_cfg::FwCfgError;
 use crate::mm::alloc::AllocError;
-use crate::mm::pagetable::PageTableError;
 use crate::sev::ghcb::GhcbError;
 use crate::sev::msr_protocol::GhcbMsrError;
 use crate::sev::SevSnpError;
@@ -49,6 +48,4 @@ pub enum SvsmError {
     Task(TaskError),
     // Errors from #VC handler
     Vc(VcError),
-    // Page table errors
-    PageTable(PageTableError),
 }

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -97,7 +97,7 @@ fn setup_env(config: &SvsmConfig<'_>, launch_info: &Stage2LaunchInfo) {
         PhysAddr::null(),
     );
     register_cpuid_table(unsafe { &CPUID_PAGE });
-    paging_init_early(launch_info.vtom).expect("Could not configure early paging");
+    paging_init_early(launch_info.vtom);
 
     // Bring up the GCHB for use from the SVSMIOPort console.
     verify_ghcb_version();

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -319,7 +319,7 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
         Err(e) => panic!("error reading kernel ELF: {}", e),
     };
 
-    paging_init(li.vtom).expect("Could not configure paging");
+    paging_init(li.vtom);
     init_page_table(&launch_info, &kernel_elf).expect("Could not initialize the page table");
 
     // SAFETY: this PerCpu has just been allocated and no other CPUs have been


### PR DESCRIPTION
This reverts commit 55b350a81a9156bad55da6f6e0799ae3755c5bce.

Latest upstream branch did not boot anymore beyond stage2. Bisection pointed to above commit and reverting it fixes the issue. It is quite possible the above commit uncovered another issue, but for now keep things booting and revert it until the underlying issue has been fixed.