### PR TITLE
svsm: improve error handling during firmware configuration

### DIFF
--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -34,6 +34,8 @@ pub enum SvsmError {
     MissingVMSA,
     // There is no CAA
     MissingCAA,
+    // There is no secrets page
+    MissingSecrets,
     // Invalid address, usually provided by the guest
     InvalidAddress,
     // Errors related to firmware parsing

--- a/kernel/src/fw_meta.rs
+++ b/kernel/src/fw_meta.rs
@@ -450,7 +450,8 @@ pub fn validate_fw_memory(
     let kernel_region = new_kernel_region(launch_info);
     for region in regions.iter() {
         if region.overlap(&kernel_region) {
-            panic!("FwMeta region ovelaps with kernel");
+            log::error!("FwMeta region ovelaps with kernel");
+            return Err(SvsmError::Firmware);
         }
     }
 


### PR DESCRIPTION
Return errors from leaf functions and panic at the callers in `svsm_main()`. While we are at it, handle these errors with `Result::expect()`, which will print the originating `SvsmError`.