### PR TITLE
cpu/vc: improve instruction decoder + handle more `IN` / `OUT` instructions + handle `RDMSR` / `WRMSR` + add SVSM discovery support

### DIFF
--- a/fuzz/fuzz_targets/insn.rs
+++ b/fuzz/fuzz_targets/insn.rs
@@ -11,7 +11,7 @@ fuzz_target!(|input: &[u8]| -> Corpus {
     let mut data = [0u8; MAX_INSN_SIZE];
     data.copy_from_slice(input);
 
-    let mut insn = Instruction::new(data);
+    let insn = Instruction::new(data);
     let _ = core::hint::black_box(insn.decode());
 
     Corpus::Keep

--- a/kernel/src/cpu/insn.rs
+++ b/kernel/src/cpu/insn.rs
@@ -58,6 +58,8 @@ pub enum DecodedInsn {
     Outl(Operand),
     Outb(Operand),
     Outw(Operand),
+    Wrmsr,
+    Rdmsr,
 }
 
 impl DecodedInsn {
@@ -76,6 +78,7 @@ impl DecodedInsn {
             Self::Outb(Operand::Imm(..)) => 2,
             Self::Outw(Operand::Imm(..)) => 3,
             Self::Outl(Operand::Imm(..)) => 2,
+            Self::Wrmsr | Self::Rdmsr => 2,
         }
     }
 }
@@ -117,11 +120,12 @@ impl Instruction {
                 0xEF => return Ok(DecodedInsn::Outw(Operand::rdx())),
                 _ => (),
             },
-            0x0F => {
-                if self.0[1] == 0xA2 {
-                    return Ok(DecodedInsn::Cpuid);
-                }
-            }
+            0x0F => match self.0[1] {
+                0x30 => return Ok(DecodedInsn::Wrmsr),
+                0x32 => return Ok(DecodedInsn::Rdmsr),
+                0xA2 => return Ok(DecodedInsn::Cpuid),
+                _ => (),
+            },
             _ => (),
         }
 

--- a/kernel/src/cpu/vc.rs
+++ b/kernel/src/cpu/vc.rs
@@ -9,7 +9,7 @@ use super::insn::MAX_INSN_SIZE;
 use crate::address::VirtAddr;
 use crate::cpu::cpuid::{cpuid_table_raw, CpuidLeaf};
 use crate::cpu::ghcb::current_ghcb;
-use crate::cpu::insn::{DecodedInsn, Instruction, Operand, Register};
+use crate::cpu::insn::{DecodedInsn, Immediate, Instruction, Operand, Register};
 use crate::debug::gdbstub::svsm_gdbstub::handle_debug_exception;
 use crate::error::SvsmError;
 use crate::mm::GuestPtr;
@@ -176,7 +176,10 @@ fn ioio_get_port(source: Operand, ctx: &X86ExceptionContext) -> u16 {
     match source {
         Operand::Reg(Register::Rdx) => ctx.regs.rdx as u16,
         Operand::Reg(..) => unreachable!("Port value is always in DX"),
-        _ => todo!(),
+        Operand::Imm(imm) => match imm {
+            Immediate::U8(val) => val as u16,
+            _ => unreachable!("Port value in immediate is always 1 byte"),
+        },
     }
 }
 
@@ -423,8 +426,7 @@ mod tests {
     }
 
     #[test]
-    // #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
-    #[ignore = "Currently unhandled by #VC handler"]
+    #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn test_port_io_8_hardcoded() {
         const TEST_VAL: u8 = 0x12;
         verify_ghcb_gets_altered(|| outb_to_testdev_echo(TEST_VAL));
@@ -432,8 +434,7 @@ mod tests {
     }
 
     #[test]
-    // #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
-    #[ignore = "Currently unhandled by #VC handler"]
+    #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn test_port_io_16_hardcoded() {
         const TEST_VAL: u16 = 0x4321;
         verify_ghcb_gets_altered(|| outw_to_testdev_echo(TEST_VAL));
@@ -441,8 +442,7 @@ mod tests {
     }
 
     #[test]
-    // #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
-    #[ignore = "Currently unhandled by #VC handler"]
+    #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn test_port_io_32_hardcoded() {
         const TEST_VAL: u32 = 0xabcd1234;
         verify_ghcb_gets_altered(|| outl_to_testdev_echo(TEST_VAL));

--- a/kernel/src/cpu/vc.rs
+++ b/kernel/src/cpu/vc.rs
@@ -509,13 +509,12 @@ mod tests {
     }
 
     #[test]
-    // #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
-    #[ignore = "Currently unhandled by #VC handler"]
+    #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn test_sev_snp_enablement_msr() {
-        const MSR_SEV_STATUS: u32 = 0b10;
-        const MSR_SEV_STATUS_SEV_SNP_ENABLED: u64 = 0b100;
+        const MSR_SEV_STATUS: u32 = 0xc0010131;
+        const MSR_SEV_STATUS_SEV_SNP_ENABLED: u64 = 0b10;
 
-        let sev_status = verify_ghcb_gets_altered(|| read_msr(MSR_SEV_STATUS));
+        let sev_status = read_msr(MSR_SEV_STATUS);
         assert_ne!(sev_status & MSR_SEV_STATUS_SEV_SNP_ENABLED, 0);
     }
 

--- a/kernel/src/cpu/vc.rs
+++ b/kernel/src/cpu/vc.rs
@@ -91,12 +91,10 @@ pub fn stage2_handle_vc_exception_no_ghcb(ctx: &mut X86ExceptionContext) -> Resu
 pub fn stage2_handle_vc_exception(ctx: &mut X86ExceptionContext) -> Result<(), SvsmError> {
     let err = ctx.error_code;
 
-    /*
-     * To handle NAE events, we're supposed to reset the VALID_BITMAP field of the GHCB.
-     * This is currently only relevant for IOIO handling. This field is currently reset in
-     * the ioio_{in,ou} methods but it would be better to move the reset out of the different
-     * handlers.
-     */
+    // To handle NAE events, we're supposed to reset the VALID_BITMAP field of the GHCB.
+    // This is currently only relevant for IOIO handling. This field is currently reset in
+    // the ioio_{in,ou} methods but it would be better to move the reset out of the different
+    // handlers.
     let mut ghcb = current_ghcb();
 
     let insn = vc_decode_insn(ctx)?;
@@ -114,12 +112,10 @@ pub fn stage2_handle_vc_exception(ctx: &mut X86ExceptionContext) -> Result<(), S
 pub fn handle_vc_exception(ctx: &mut X86ExceptionContext) -> Result<(), SvsmError> {
     let error_code = ctx.error_code;
 
-    /*
-     * To handle NAE events, we're supposed to reset the VALID_BITMAP field of the GHCB.
-     * This is currently only relevant for IOIO handling. This field is currently reset in
-     * the ioio_{in,ou} methods but it would be better to move the reset out of the different
-     * handlers.
-     */
+    // To handle NAE events, we're supposed to reset the VALID_BITMAP field of the GHCB.
+    // This is currently only relevant for IOIO handling. This field is currently reset in
+    // the ioio_{in,ou} methods but it would be better to move the reset out of the different
+    // handlers.
     let mut ghcb = current_ghcb();
 
     let insn = vc_decode_insn(ctx)?;
@@ -142,16 +138,13 @@ pub fn handle_vc_exception(ctx: &mut X86ExceptionContext) -> Result<(), SvsmErro
 }
 
 fn handle_cpuid(ctx: &mut X86ExceptionContext) -> Result<(), SvsmError> {
-    /*
-     * Section 2.3.1 GHCB MSR Protocol in SEV-ES Guest-Hypervisor Communication Block
-     * Standardization Rev. 2.02.
-     * For SEV-ES/SEV-SNP, we can use the CPUID table already defined and populated with
-     * firmware information.
-     * We choose for now not to call the hypervisor to perform CPUID, since it's no trusted.
-     * Since GHCB is not needed to handle CPUID with the firmware table, we can call the handler
-     * very soon in stage 2.
-     */
-
+    // Section 2.3.1 GHCB MSR Protocol in SEV-ES Guest-Hypervisor Communication Block
+    // Standardization Rev. 2.02.
+    // For SEV-ES/SEV-SNP, we can use the CPUID table already defined and populated with
+    // firmware information.
+    // We choose for now not to call the hypervisor to perform CPUID, since it's no trusted.
+    // Since GHCB is not needed to handle CPUID with the firmware table, we can call the handler
+    // very soon in stage 2.
     snp_cpuid(ctx)
 }
 


### PR DESCRIPTION
* Simplify the instruction decoder and its API.
* Decode remaining `IN` / `OUT` instruction cases and enable related #VC tests.
* Handle `SVM_EXIT_MSR` in the #VC handler and enable related #VC tests.
* Support SVSM discovery via MSR for post-boot services.
* Support SVSM discovery via CPUID for post-boot services.

This works towards a more complete implementation of #14 