### PR TITLE
kernel/cpu: overhaul per-CPU borrow checking

### DIFF
--- a/kernel/src/cpu/ghcb.rs
+++ b/kernel/src/cpu/ghcb.rs
@@ -31,8 +31,7 @@ pub fn current_ghcb() -> GHCBRef {
     // FIXME - Add borrow checking to GHCB references.
     unsafe {
         let cpu_unsafe = &*this_cpu_unsafe();
-        let cpu = cpu_unsafe.mut_cpu_ptr().as_mut().unwrap();
-        let ghcb = cpu.ghcb_unsafe();
+        let ghcb = cpu_unsafe.ghcb_unsafe();
         GHCBRef { ghcb }
     }
 }

--- a/kernel/src/cpu/ghcb.rs
+++ b/kernel/src/cpu/ghcb.rs
@@ -30,8 +30,8 @@ impl DerefMut for GHCBRef {
 pub fn current_ghcb() -> GHCBRef {
     // FIXME - Add borrow checking to GHCB references.
     unsafe {
-        let cpu_ptr = this_cpu_unsafe();
-        let cpu = &mut *cpu_ptr;
+        let cpu_unsafe = &*this_cpu_unsafe();
+        let cpu = cpu_unsafe.mut_cpu_ptr().as_mut().unwrap();
         let ghcb = cpu.ghcb_unsafe();
         GHCBRef { ghcb }
     }

--- a/kernel/src/cpu/smp.rs
+++ b/kernel/src/cpu/smp.rs
@@ -13,35 +13,34 @@ use crate::task::{create_kernel_task, schedule_init, TASK_FLAG_SHARE_PT};
 use crate::utils::immut_after_init::immut_after_init_set_multithreaded;
 
 fn start_cpu(apic_id: u32, vtom: u64) {
-    unsafe {
-        let start_rip: u64 = (start_ap as *const u8) as u64;
-        let percpu = PerCpu::alloc(apic_id)
-            .expect("Failed to allocate AP per-cpu data")
-            .as_mut()
-            .unwrap();
+    let start_rip: u64 = (start_ap as *const u8) as u64;
+    let mut percpu = PerCpu::alloc(apic_id).expect("Failed to allocate AP per-cpu data");
 
-        percpu.setup().expect("Failed to setup AP per-cpu area");
-        percpu
-            .alloc_svsm_vmsa()
-            .expect("Failed to allocate AP SVSM VMSA");
+    percpu.setup().expect("Failed to setup AP per-cpu area");
+    percpu
+        .alloc_svsm_vmsa()
+        .expect("Failed to allocate AP SVSM VMSA");
 
-        let mut vmsa = percpu.get_svsm_vmsa().unwrap();
-        init_svsm_vmsa(vmsa.vmsa(), vtom);
-        percpu.prepare_svsm_vmsa(start_rip);
+    let mut vmsa = percpu.get_svsm_vmsa().unwrap();
+    init_svsm_vmsa(vmsa.vmsa(), vtom);
+    percpu.prepare_svsm_vmsa(start_rip);
 
-        let sev_features = vmsa.vmsa().sev_features;
-        let vmsa_pa = vmsa.paddr;
+    let sev_features = vmsa.vmsa().sev_features;
+    let vmsa_pa = vmsa.paddr;
 
-        let percpu_shared = (*percpu.cpu_unsafe()).shared();
+    let percpu_shared = unsafe { (*percpu.cpu_unsafe()).shared() };
 
-        vmsa.vmsa().enable();
-        current_ghcb()
-            .ap_create(vmsa_pa, apic_id.into(), 0, sev_features)
-            .expect("Failed to launch secondary CPU");
-        loop {
-            if percpu_shared.is_online() {
-                break;
-            }
+    // Drop the reference to the target CPU so it does not observe a borrow
+    // conflict when it starts running.
+    drop(percpu);
+
+    vmsa.vmsa().enable();
+    current_ghcb()
+        .ap_create(vmsa_pa, apic_id.into(), 0, sev_features)
+        .expect("Failed to launch secondary CPU");
+    loop {
+        if percpu_shared.is_online() {
+            break;
         }
     }
 }

--- a/kernel/src/cpu/smp.rs
+++ b/kernel/src/cpu/smp.rs
@@ -32,7 +32,7 @@ fn start_cpu(apic_id: u32, vtom: u64) {
         let sev_features = vmsa.vmsa().sev_features;
         let vmsa_pa = vmsa.paddr;
 
-        let percpu_shared = percpu.shared();
+        let percpu_shared = (*percpu.cpu_unsafe()).shared();
 
         vmsa.vmsa().enable();
         current_ghcb()

--- a/kernel/src/protocols/core.rs
+++ b/kernel/src/protocols/core.rs
@@ -6,7 +6,7 @@
 
 use crate::address::{Address, PhysAddr, VirtAddr};
 use crate::cpu::flush_tlb_global_sync;
-use crate::cpu::percpu::{this_cpu_mut, PERCPU_AREAS, PERCPU_VMSAS};
+use crate::cpu::percpu::{this_cpu_shared, PERCPU_AREAS, PERCPU_VMSAS};
 use crate::cpu::vmsa::{vmsa_mut_ref_from_vaddr, vmsa_ref_from_vaddr};
 use crate::error::SvsmError;
 use crate::mm::virtualrange::{VIRT_ALIGN_2M, VIRT_ALIGN_4K};
@@ -344,7 +344,7 @@ fn core_remap_ca(params: &RequestParams) -> Result<(), SvsmReqError> {
     let pending = GuestPtr::<SvsmCaa>::new(vaddr);
     pending.write(SvsmCaa::zeroed())?;
 
-    this_cpu_mut().shared.update_guest_caa(gpa);
+    this_cpu_shared().update_guest_caa(gpa);
 
     Ok(())
 }

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -60,19 +60,16 @@ fn setup_stage2_allocator() {
 }
 
 fn init_percpu() {
-    unsafe {
-        let bsp_percpu = PerCpu::alloc(0)
-            .expect("Failed to allocate BSP per-cpu data")
-            .as_mut()
-            .unwrap();
+    let mut bsp_percpu = PerCpu::alloc(0).expect("Failed to allocate BSP per-cpu data");
 
+    unsafe {
         bsp_percpu.set_pgtable(PageTableRef::shared(addr_of_mut!(pgtable)));
-        bsp_percpu
-            .map_self_stage2()
-            .expect("Failed to map per-cpu area");
-        bsp_percpu.setup_ghcb().expect("Failed to setup BSP GHCB");
-        bsp_percpu.register_ghcb().expect("Failed to register GHCB");
     }
+    bsp_percpu
+        .map_self_stage2()
+        .expect("Failed to map per-cpu area");
+    bsp_percpu.setup_ghcb().expect("Failed to setup BSP GHCB");
+    bsp_percpu.register_ghcb().expect("Failed to register GHCB");
 }
 
 fn shutdown_percpu() {

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -26,7 +26,7 @@ use svsm::cpu::gdt;
 use svsm::cpu::ghcb::current_ghcb;
 use svsm::cpu::idt::svsm::{early_idt_init, idt_init};
 use svsm::cpu::percpu::PerCpu;
-use svsm::cpu::percpu::{this_cpu, this_cpu_mut};
+use svsm::cpu::percpu::{this_cpu, this_cpu_mut, this_cpu_shared};
 use svsm::cpu::smp::start_secondary_cpus;
 use svsm::debug::gdbstub::svsm_gdbstub::{debug_break, gdbstub_start};
 use svsm::debug::stacktrace::print_stack;
@@ -166,14 +166,11 @@ fn copy_tables_to_fw(fw_meta: &SevFWMetaData) -> Result<(), SvsmError> {
 }
 
 fn prepare_fw_launch(fw_meta: &SevFWMetaData) -> Result<(), SvsmError> {
-    let mut cpu = this_cpu_mut();
-
     if let Some(caa) = fw_meta.caa_page {
-        cpu.shared.update_guest_caa(caa);
+        this_cpu_shared().update_guest_caa(caa);
     }
 
-    cpu.alloc_guest_vmsa()?;
-    drop(cpu);
+    this_cpu_mut().alloc_guest_vmsa()?;
     update_mappings()?;
 
     Ok(())

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -26,7 +26,7 @@ use svsm::cpu::gdt;
 use svsm::cpu::ghcb::current_ghcb;
 use svsm::cpu::idt::svsm::{early_idt_init, idt_init};
 use svsm::cpu::percpu::PerCpu;
-use svsm::cpu::percpu::{this_cpu, this_cpu_mut, this_cpu_shared};
+use svsm::cpu::percpu::{this_cpu, this_cpu_mut, this_cpu_shared, this_cpu_unsafe};
 use svsm::cpu::smp::start_secondary_cpus;
 use svsm::debug::gdbstub::svsm_gdbstub::{debug_break, gdbstub_start};
 use svsm::debug::stacktrace::print_stack;
@@ -358,7 +358,10 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
 
     boot_stack_info();
 
-    let bp = this_cpu().get_top_of_stack();
+    let bp = unsafe {
+        let cpu_unsafe = &*this_cpu_unsafe();
+        cpu_unsafe.get_top_of_stack()
+    };
 
     log::info!("BSP Runtime stack starts @ {:#018x}", bp);
 

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -317,12 +317,7 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
     // brought up, thus it cannot be aliased and we can get a mutable
     // reference to it. We trust PerCpu::alloc() to return a valid and
     // aligned pointer.
-    let bsp_percpu = unsafe {
-        PerCpu::alloc(0)
-            .expect("Failed to allocate BSP per-cpu data")
-            .as_mut()
-            .unwrap()
-    };
+    let mut bsp_percpu = PerCpu::alloc(0).expect("Failed to allocate BSP per-cpu data");
 
     bsp_percpu
         .setup()
@@ -336,6 +331,8 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
     bsp_percpu
         .setup_idle_task(svsm_main)
         .expect("Failed to allocate idle task for BSP");
+
+    drop(bsp_percpu);
 
     idt_init();
 


### PR DESCRIPTION
This PR changes the implementation of CPU borrow checking in two important ways.  First, it uses `RefCell` instead of a custom implementation of borrow checking - this is valuable because it relies on core common code.  Second, borrow checking is now performed in all builds, not just debug builds - this is important because the memory safety guarantees made by Rust are intended to apply in all cases, in all code paths, not just those code paths that were validated using debug builds.

The contents of `PerCpu` have been refactored to enforce meaningful borrow checking according to a specific set of principles.
- In general, *all* references to a structure must enforce borrow checking rules to prevent conflicts between shared and mutable references.
- When references are synthesized from global constants (and thus the compiler cannot correctly check borrowed references), borrow checking must be performed dynamically.
- Borrow checking can safely be avoided if, and only if, references to a structure can only be issued as shared references, because no borrow conflict can arise when no mutable references are possible.
- If an object cannot adhere to these borrow checking rules, because of some runtime condition that could require access to object fields in violation of the borrow rules, references to the object must be made using raw pointers.  This requires the use of unsafe code by any logic that has to reach in, and should thus prompt careful justification that any non-compliant reference is actually correct and appropriate.