### PR TITLE
Support execution in user-mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,6 +834,7 @@ dependencies = [
  "libmstpm",
  "log",
  "packit",
+ "syscall",
  "test",
 ]
 
@@ -867,6 +868,10 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "syscall"
+version = "0.1.0"
 
 [[package]]
 name = "test"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ members = [
     "elf",
     # Microsoft TPM library
     "libmstpm",
+    # syscall interface definitions
+    "syscall",
 ]
 
 
@@ -23,6 +25,7 @@ test = { path = "test" }
 svsm = { path = "kernel" }
 elf = { path = "elf" }
 libmstpm = { path = "libmstpm" }
+syscall = { path = "syscall" }
 
 # crates.io
 aes-gcm = { version = "0.10.3", default-features = false }

--- a/elf/src/load_segments.rs
+++ b/elf/src/load_segments.rs
@@ -11,6 +11,7 @@ extern crate alloc;
 use super::types::*;
 use super::Elf64AddrRange;
 use super::Elf64File;
+use super::Elf64FileRange;
 use super::Elf64PhdrFlags;
 use super::ElfError;
 use alloc::vec::Vec;
@@ -146,6 +147,8 @@ pub struct Elf64ImageLoadVaddrAllocInfo {
 pub struct Elf64ImageLoadSegment<'a> {
     /// The virtual address (vaddr) range covering by this segment
     pub vaddr_range: Elf64AddrRange,
+    /// The range in the ELF file covering this segment
+    pub file_range: Elf64FileRange,
     /// The contents of the segment in the ELF file
     pub file_contents: &'a [u8],
     /// Flags associated with this segment
@@ -193,6 +196,7 @@ impl<'a> Iterator for Elf64ImageLoadSegmentIterator<'a> {
 
         Some(Elf64ImageLoadSegment {
             vaddr_range,
+            file_range,
             file_contents,
             flags: phdr.p_flags,
         })

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -21,6 +21,7 @@ doctest = true
 bootlib.workspace = true
 cpuarch.workspace = true
 elf.workspace = true
+syscall.workspace = true
 
 aes-gcm = { workspace = true, features = ["aes", "alloc"] }
 bitflags.workspace = true

--- a/kernel/src/address.rs
+++ b/kernel/src/address.rs
@@ -212,6 +212,11 @@ impl VirtAddr {
         Self(sign_extend(addr))
     }
 
+    /// Returns the index into page-table pages of given levels.
+    pub const fn to_pgtbl_idx<const L: usize>(&self) -> usize {
+        (self.0 >> (12 + L * 9)) & 0x1ffusize
+    }
+
     #[inline]
     pub fn as_ptr<T>(&self) -> *const T {
         self.0 as *const T

--- a/kernel/src/address.rs
+++ b/kernel/src/address.rs
@@ -8,6 +8,8 @@ use crate::types::{PAGE_SHIFT, PAGE_SIZE};
 use core::fmt;
 use core::ops;
 
+use core::slice;
+
 // The backing type to represent an address;
 type InnerAddr = usize;
 
@@ -250,6 +252,24 @@ impl VirtAddr {
 
     pub const fn const_add(&self, offset: usize) -> Self {
         VirtAddr::new(self.0 + offset)
+    }
+
+    /// Converts the `VirtAddr` to a slice of a given type
+    ///
+    /// # Arguments:
+    ///
+    /// * `len` - Number of elements of type `T` in the slice
+    ///
+    /// # Returns
+    ///
+    /// Slice with `len` elements of type `T`
+    ///
+    /// # Safety
+    ///
+    /// All Safety requirements from [`core::slice::from_raw_parts`] for the
+    /// data pointed to by the `VirtAddr` apply here as well.
+    pub unsafe fn to_slice<T>(&self, len: usize) -> &[T] {
+        slice::from_raw_parts::<T>(self.as_ptr::<T>(), len)
     }
 }
 

--- a/kernel/src/cpu/gdt.rs
+++ b/kernel/src/cpu/gdt.rs
@@ -41,6 +41,14 @@ impl GDTEntry {
     pub const fn data_64_kernel() -> Self {
         Self(0x00cf92000000ffffu64)
     }
+
+    pub const fn code_64_user() -> Self {
+        Self(0x00affb000000ffffu64)
+    }
+
+    pub const fn data_64_user() -> Self {
+        Self(0x00cff2000000ffffu64)
+    }
 }
 
 const GDT_SIZE: u16 = 8;
@@ -57,8 +65,8 @@ impl GDT {
                 GDTEntry::null(),
                 GDTEntry::code_64_kernel(),
                 GDTEntry::data_64_kernel(),
-                GDTEntry::null(),
-                GDTEntry::null(),
+                GDTEntry::code_64_user(),
+                GDTEntry::data_64_user(),
                 GDTEntry::null(),
                 GDTEntry::null(),
                 GDTEntry::null(),

--- a/kernel/src/cpu/idt/common.rs
+++ b/kernel/src/cpu/idt/common.rs
@@ -47,6 +47,10 @@ pub struct X86ExceptionContext {
     pub frame: X86InterruptFrame,
 }
 
+pub fn user_mode(ctxt: &X86ExceptionContext) -> bool {
+    (ctxt.frame.cs & 3) == 3
+}
+
 #[derive(Copy, Clone, Default, Debug)]
 #[repr(C, packed)]
 pub struct IdtEntry {

--- a/kernel/src/cpu/idt/entry.S
+++ b/kernel/src/cpu/idt/entry.S
@@ -145,3 +145,6 @@ default_entry_no_ist	name=vc		handler=vmm_communication	error_code=1	vector=29
 
 // #SX Security Exception (Vector 30)
 default_entry_no_ist	name=sx		handler=panic			error_code=1	vector=30
+
+// INT 0x80 system call handler
+default_entry_no_ist	name=int80	handler=system_call		error_code=0	vector=0x80

--- a/kernel/src/cpu/idt/entry.S
+++ b/kernel/src/cpu/idt/entry.S
@@ -58,9 +58,18 @@ asm_entry_\name:
 	jmp	default_return
 .endm
 
+.globl default_return
 default_return:
+	testb	$3, 18*8(%rsp) // Check CS in exception frame
+	jnz return_user
 	pop_regs
+default_iret:
 	iretq
+
+return_user:
+	// Put user-mode specific return code here
+	pop_regs
+	jmp default_iret
 
 // #DE Divide-by-Zero-Error Exception (Vector 0)
 default_entry_no_ist	name=de		handler=panic			error_code=0	vector=0

--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -24,6 +24,7 @@ use crate::syscall::*;
 use syscall::*;
 
 extern "C" {
+    pub fn default_return();
     fn asm_entry_de();
     fn asm_entry_db();
     fn asm_entry_nmi();

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -708,6 +708,10 @@ impl PerCpu {
     pub fn runqueue(&self) -> &RWLock<RunQueue> {
         &self.runqueue
     }
+
+    pub fn current_task(&self) -> TaskPointer {
+        self.runqueue.lock_read().current_task()
+    }
 }
 
 pub fn this_cpu_unsafe() -> *mut PerCpuUnsafe {

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -26,9 +26,7 @@ use crate::mm::{
 use crate::sev::ghcb::GHCB;
 use crate::sev::utils::RMPFlags;
 use crate::sev::vmsa::allocate_new_vmsa;
-use crate::task::{
-    schedule, schedule_task, RunQueue, Task, TaskPointer, WaitQueue, TASK_FLAG_SHARE_PT,
-};
+use crate::task::{schedule, schedule_task, RunQueue, Task, TaskPointer, WaitQueue};
 use crate::types::{PAGE_SHIFT, PAGE_SHIFT_2M, PAGE_SIZE, PAGE_SIZE_2M, SVSM_TR_FLAGS, SVSM_TSS};
 use crate::utils::MemoryRegion;
 use alloc::sync::Arc;
@@ -522,7 +520,7 @@ impl PerCpu {
     }
 
     pub fn setup_idle_task(&mut self, entry: extern "C" fn()) -> Result<(), SvsmError> {
-        let idle_task = Task::create(self, entry, TASK_FLAG_SHARE_PT)?;
+        let idle_task = Task::create(self, entry)?;
         self.runqueue.lock_read().set_idle_task(idle_task);
         Ok(())
     }

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -712,6 +712,10 @@ impl PerCpu {
     pub fn current_task(&self) -> TaskPointer {
         self.runqueue.lock_read().current_task()
     }
+
+    pub fn set_tss_rsp0(&mut self, addr: VirtAddr) {
+        self.tss.stacks[0] = addr;
+    }
 }
 
 pub fn this_cpu_unsafe() -> *mut PerCpuUnsafe {

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -386,8 +386,7 @@ impl PerCpu {
 
     fn allocate_page_table(&mut self) -> Result<(), SvsmError> {
         self.vm_range.initialize()?;
-        let mut pgtable_ref = get_init_pgtable_locked().clone_shared()?;
-        self.vm_range.populate(&mut pgtable_ref);
+        let pgtable_ref = get_init_pgtable_locked().clone_shared()?;
         self.set_pgtable(pgtable_ref);
 
         Ok(())
@@ -482,6 +481,11 @@ impl PerCpu {
         Ok(())
     }
 
+    fn finish_page_table(&mut self) {
+        let mut pgtable = self.get_pgtable();
+        self.vm_range.populate(&mut pgtable);
+    }
+
     pub fn dump_vm_ranges(&self) {
         self.vm_range.dump_ranges();
     }
@@ -510,6 +514,8 @@ impl PerCpu {
 
         // Initialize allocator for temporary mappings
         self.virt_range_init();
+
+        self.finish_page_table();
 
         Ok(())
     }

--- a/kernel/src/cpu/smp.rs
+++ b/kernel/src/cpu/smp.rs
@@ -9,7 +9,7 @@ use crate::cpu::ghcb::current_ghcb;
 use crate::cpu::percpu::{this_cpu_mut, this_cpu_shared, PerCpu};
 use crate::cpu::vmsa::init_svsm_vmsa;
 use crate::requests::{request_loop, request_processing_main};
-use crate::task::{create_kernel_task, schedule_init, TASK_FLAG_SHARE_PT};
+use crate::task::{create_kernel_task, schedule_init};
 use crate::utils::immut_after_init::immut_after_init_set_multithreaded;
 
 fn start_cpu(apic_id: u32, vtom: u64) {
@@ -77,8 +77,7 @@ fn start_ap() {
 
 #[no_mangle]
 pub extern "C" fn ap_request_loop() {
-    create_kernel_task(request_processing_main, TASK_FLAG_SHARE_PT)
-        .expect("Failed to launch request processing task");
+    create_kernel_task(request_processing_main).expect("Failed to launch request processing task");
     request_loop();
     panic!("Returned from request_loop!");
 }

--- a/kernel/src/fs/api.rs
+++ b/kernel/src/fs/api.rs
@@ -113,7 +113,20 @@ pub trait File: Debug + Send + Sync {
     ///
     /// size of the file in bytes.
     fn size(&self) -> usize;
-    fn mapping(&self, offset: usize) -> Option<PageRef>;
+
+    /// Get reference to backing pages of the file
+    ///
+    /// # Arguments
+    ///
+    /// - `offset`: offset to the requested page in bytes
+    ///
+    /// # Returns
+    ///
+    /// [`Option<PageRef>`]: An [`Option`] with the requested page reference.
+    /// `None` if the offset is not backed by a page.
+    fn mapping(&self, _offset: usize) -> Option<PageRef> {
+        None
+    }
 }
 
 /// Represents directory operations

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -34,6 +34,7 @@ pub mod sev;
 pub mod string;
 pub mod svsm_console;
 pub mod svsm_paging;
+pub mod syscall;
 pub mod task;
 pub mod types;
 pub mod utils;

--- a/kernel/src/mm/address_space.rs
+++ b/kernel/src/mm/address_space.rs
@@ -154,6 +154,16 @@ pub const SVSM_PERTASK_END: VirtAddr = SVSM_PERTASK_BASE.const_add(SIZE_LEVEL3);
 /// Kernel stack for a task
 pub const SVSM_PERTASK_STACK_BASE: VirtAddr = SVSM_PERTASK_BASE;
 
+//
+// User-space mapping constants
+//
+
+/// Start of user memory address range
+pub const USER_MEM_START: VirtAddr = VirtAddr::new(0);
+
+/// End of user memory address range
+pub const USER_MEM_END: VirtAddr = USER_MEM_START.const_add(256 * SIZE_LEVEL3);
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/kernel/src/mm/alloc.rs
+++ b/kernel/src/mm/alloc.rs
@@ -917,6 +917,19 @@ impl PageRef {
     pub fn phys_addr(&self) -> PhysAddr {
         self.phys_addr
     }
+
+    pub fn try_copy_page(&self) -> Result<Self, SvsmError> {
+        let virt_addr = allocate_file_page()?;
+        unsafe {
+            let src = self.virt_addr.as_ptr::<[u8; PAGE_SIZE]>();
+            let dst = virt_addr.as_mut_ptr::<[u8; PAGE_SIZE]>();
+            ptr::copy_nonoverlapping(src, dst, 1);
+        }
+        Ok(PageRef {
+            virt_addr,
+            phys_addr: virt_to_phys(virt_addr),
+        })
+    }
 }
 
 impl AsRef<[u8; PAGE_SIZE]> for PageRef {

--- a/kernel/src/mm/mappings.rs
+++ b/kernel/src/mm/mappings.rs
@@ -52,7 +52,10 @@ pub fn create_file_mapping(
     Ok(Arc::new(Mapping::new(file_mapping)))
 }
 
-pub fn create_anon_mapping(size: usize) -> Result<Arc<Mapping>, SvsmError> {
-    let alloc = VMalloc::new(size)?;
+pub fn create_anon_mapping(
+    size: usize,
+    flags: VMFileMappingFlags,
+) -> Result<Arc<Mapping>, SvsmError> {
+    let alloc = VMalloc::new(size, flags)?;
     Ok(Arc::new(Mapping::new(alloc)))
 }

--- a/kernel/src/mm/mappings.rs
+++ b/kernel/src/mm/mappings.rs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2024 SUSE LLC
+//
+// Author: Joerg Roedel <jroedel@suse.de>
+
+use crate::error::SvsmError;
+use crate::fs::FileHandle;
+use crate::mm::vm::{Mapping, VMFileMapping, VMFileMappingFlags, VMalloc};
+
+extern crate alloc;
+use alloc::sync::Arc;
+
+pub fn create_file_mapping(
+    file: &FileHandle,
+    offset: usize,
+    size: usize,
+    flags: VMFileMappingFlags,
+) -> Result<Arc<Mapping>, SvsmError> {
+    let file_mapping = VMFileMapping::new(file, offset, size, flags)?;
+    Ok(Arc::new(Mapping::new(file_mapping)))
+}
+
+pub fn create_anon_mapping(size: usize) -> Result<Arc<Mapping>, SvsmError> {
+    let alloc = VMalloc::new(size)?;
+    Ok(Arc::new(Mapping::new(alloc)))
+}

--- a/kernel/src/mm/mappings.rs
+++ b/kernel/src/mm/mappings.rs
@@ -8,6 +8,7 @@ use crate::address::VirtAddr;
 use crate::error::SvsmError;
 use crate::fs::FileHandle;
 use crate::mm::vm::{Mapping, VMFileMapping, VMFileMappingFlags, VMalloc, VMR};
+use crate::task::current_task;
 
 use core::ops::Deref;
 
@@ -58,4 +59,32 @@ pub fn create_anon_mapping(
 ) -> Result<Arc<Mapping>, SvsmError> {
     let alloc = VMalloc::new(size, flags)?;
     Ok(Arc::new(Mapping::new(alloc)))
+}
+
+pub fn mmap_user(
+    addr: VirtAddr,
+    file: Option<&FileHandle>,
+    offset: usize,
+    size: usize,
+    flags: VMFileMappingFlags,
+) -> Result<VirtAddr, SvsmError> {
+    current_task().mmap_user(addr, file, offset, size, flags)
+}
+
+pub fn mmap_kernel(
+    addr: VirtAddr,
+    file: Option<&FileHandle>,
+    offset: usize,
+    size: usize,
+    flags: VMFileMappingFlags,
+) -> Result<VirtAddr, SvsmError> {
+    current_task().mmap_kernel(addr, file, offset, size, flags)
+}
+
+pub fn munmap_user(addr: VirtAddr) -> Result<(), SvsmError> {
+    current_task().munmap_user(addr)
+}
+
+pub fn munmap_kernel(addr: VirtAddr) -> Result<(), SvsmError> {
+    current_task().munmap_kernel(addr)
 }

--- a/kernel/src/mm/mod.rs
+++ b/kernel/src/mm/mod.rs
@@ -25,3 +25,5 @@ pub use ptguards::*;
 pub use pagetable::PageTablePart;
 
 pub use alloc::{allocate_file_page, allocate_file_page_ref, PageRef};
+
+pub use mappings::VMMappingGuard;

--- a/kernel/src/mm/mod.rs
+++ b/kernel/src/mm/mod.rs
@@ -26,4 +26,4 @@ pub use pagetable::PageTablePart;
 
 pub use alloc::{allocate_file_page, allocate_file_page_ref, PageRef};
 
-pub use mappings::VMMappingGuard;
+pub use mappings::{mmap_kernel, mmap_user, munmap_kernel, munmap_user, VMMappingGuard};

--- a/kernel/src/mm/mod.rs
+++ b/kernel/src/mm/mod.rs
@@ -7,6 +7,7 @@
 pub mod address_space;
 pub mod alloc;
 pub mod guestmem;
+pub mod mappings;
 pub mod memory;
 pub mod page_visibility;
 pub mod pagetable;

--- a/kernel/src/mm/pagetable.rs
+++ b/kernel/src/mm/pagetable.rs
@@ -280,7 +280,8 @@ impl PageTable {
     }
 
     pub fn index<const L: usize>(vaddr: VirtAddr) -> usize {
-        vaddr.bits() >> (12 + L * 9) & 0x1ff
+        vaddr.to_pgtbl_idx::<L>()
+        //vaddr.bits() >> (12 + L * 9) & 0x1ff
     }
 
     fn entry_to_pagetable(entry: PTEntry) -> Option<&'static mut PTPage> {

--- a/kernel/src/mm/pagetable.rs
+++ b/kernel/src/mm/pagetable.rs
@@ -137,7 +137,7 @@ fn strip_confidentiality_bits(paddr: PhysAddr) -> PhysAddr {
 }
 
 bitflags! {
-    #[derive(Copy, Clone, Debug)]
+    #[derive(Copy, Clone, Debug, Default)]
     pub struct PTEntryFlags: u64 {
         const PRESENT       = 1 << 0;
         const WRITABLE      = 1 << 1;

--- a/kernel/src/mm/pagetable.rs
+++ b/kernel/src/mm/pagetable.rs
@@ -693,16 +693,17 @@ impl PageTable {
     }
 
     pub fn populate_pgtbl_part(&mut self, part: &PageTablePart) {
-        let idx = part.index();
-        let paddr = part.address();
-        let flags = PTEntryFlags::PRESENT
-            | PTEntryFlags::WRITABLE
-            | PTEntryFlags::USER
-            | PTEntryFlags::ACCESSED;
-        let entry = &mut self.root[idx];
-        // The C bit is not required here because all page table fetches are
-        // made as C=1.
-        entry.set(paddr, flags);
+        if let Some(paddr) = part.address() {
+            let idx = part.index();
+            let flags = PTEntryFlags::PRESENT
+                | PTEntryFlags::WRITABLE
+                | PTEntryFlags::USER
+                | PTEntryFlags::ACCESSED;
+            let entry = &mut self.root[idx];
+            // The C bit is not required here because all page table fetches are
+            // made as C=1.
+            entry.set(paddr, flags);
+        }
     }
 }
 
@@ -953,7 +954,7 @@ impl Drop for RawPageTablePart {
 #[derive(Debug)]
 pub struct PageTablePart {
     /// The root of the page-table sub-tree
-    raw: Box<RawPageTablePart>,
+    raw: Option<Box<RawPageTablePart>>,
     /// The top-level index this PageTablePart is populated at
     idx: usize,
 }
@@ -970,9 +971,25 @@ impl PageTablePart {
     /// A new instance of PageTablePart
     pub fn new(start: VirtAddr) -> Self {
         PageTablePart {
-            raw: Box::<RawPageTablePart>::default(),
+            raw: None,
             idx: PageTable::index::<3>(start),
         }
+    }
+
+    pub fn alloc(&mut self) {
+        self.get_or_init_mut();
+    }
+
+    fn get_or_init_mut(&mut self) -> &mut RawPageTablePart {
+        self.raw.get_or_insert_with(Box::default)
+    }
+
+    fn get_mut(&mut self) -> Option<&mut RawPageTablePart> {
+        self.raw.as_deref_mut()
+    }
+
+    fn get(&self) -> Option<&RawPageTablePart> {
+        self.raw.as_deref()
     }
 
     /// Request PageTable index to populate this instance to
@@ -990,8 +1007,8 @@ impl PageTablePart {
     /// # Returns
     ///
     /// Physical base address of the page-table sub-tree
-    pub fn address(&self) -> PhysAddr {
-        self.raw.address()
+    pub fn address(&self) -> Option<PhysAddr> {
+        self.get().map(|p| p.address())
     }
 
     /// Map a 4KiB page in the page table sub-tree
@@ -1021,7 +1038,7 @@ impl PageTablePart {
     ) -> Result<(), SvsmError> {
         assert!(PageTable::index::<3>(vaddr) == self.idx);
 
-        self.raw.map_4k(vaddr, paddr, flags, shared)
+        self.get_or_init_mut().map_4k(vaddr, paddr, flags, shared)
     }
 
     /// Unmaps a 4KiB page from the page table sub-tree
@@ -1040,7 +1057,7 @@ impl PageTablePart {
     pub fn unmap_4k(&mut self, vaddr: VirtAddr) -> Option<PTEntry> {
         assert!(PageTable::index::<3>(vaddr) == self.idx);
 
-        self.raw.unmap_4k(vaddr)
+        self.get_mut().and_then(|r| r.unmap_4k(vaddr))
     }
 
     /// Map a 2MiB page in the page table sub-tree
@@ -1070,7 +1087,7 @@ impl PageTablePart {
     ) -> Result<(), SvsmError> {
         assert!(PageTable::index::<3>(vaddr) == self.idx);
 
-        self.raw.map_2m(vaddr, paddr, flags, shared)
+        self.get_or_init_mut().map_2m(vaddr, paddr, flags, shared)
     }
 
     /// Unmaps a 2MiB page from the page table sub-tree
@@ -1089,6 +1106,6 @@ impl PageTablePart {
     pub fn unmap_2m(&mut self, vaddr: VirtAddr) -> Option<PTEntry> {
         assert!(PageTable::index::<3>(vaddr) == self.idx);
 
-        self.raw.unmap_2m(vaddr)
+        self.get_mut().and_then(|r| r.unmap_2m(vaddr))
     }
 }

--- a/kernel/src/mm/vm/mapping/file_mapping.rs
+++ b/kernel/src/mm/vm/mapping/file_mapping.rs
@@ -66,7 +66,7 @@ impl VMFileMapping {
     ///
     /// Initialized mapping on success, Err(SvsmError::Mem) on error
     pub fn new(
-        file: FileHandle,
+        file: &FileHandle,
         offset: usize,
         size: usize,
         flags: VMFileMappingFlags,
@@ -196,7 +196,7 @@ mod tests {
         let _test_fs = TestFileSystemGuard::setup();
 
         let (fh, name) = create_512b_test_file();
-        let vm = VMFileMapping::new(fh, 0, 512, VMFileMappingFlags::Read)
+        let vm = VMFileMapping::new(&fh, 0, 512, VMFileMappingFlags::Read)
             .expect("Failed to create new VMFileMapping");
         assert_eq!(vm.mapping_size(), PAGE_SIZE);
         assert!(vm.flags.contains(VMFileMappingFlags::Read));
@@ -214,7 +214,7 @@ mod tests {
 
         let (fh, name) = create_16k_test_file();
         let fh2 = open(name).unwrap();
-        let vm = VMFileMapping::new(fh, offset, fh2.size() - offset, VMFileMappingFlags::Read);
+        let vm = VMFileMapping::new(&fh, offset, fh2.size() - offset, VMFileMappingFlags::Read);
         assert!(vm.is_err());
         unlink(name).unwrap();
     }
@@ -226,7 +226,7 @@ mod tests {
 
         let (fh, name) = create_16k_test_file();
         let fh2 = open(name).unwrap();
-        let vm = VMFileMapping::new(fh, 0, fh2.size() + 1, VMFileMappingFlags::Read);
+        let vm = VMFileMapping::new(&fh, 0, fh2.size() + 1, VMFileMappingFlags::Read);
         assert!(vm.is_err());
         unlink(name).unwrap();
     }
@@ -238,7 +238,7 @@ mod tests {
 
         let (fh, name) = create_16k_test_file();
         let fh2 = open(name).unwrap();
-        let vm = VMFileMapping::new(fh, PAGE_SIZE, fh2.size(), VMFileMappingFlags::Read);
+        let vm = VMFileMapping::new(&fh, PAGE_SIZE, fh2.size(), VMFileMappingFlags::Read);
         assert!(vm.is_err());
         unlink(name).unwrap();
     }
@@ -248,7 +248,8 @@ mod tests {
         let _test_fs = TestFileSystemGuard::setup();
 
         let (fh, name) = create_512b_test_file();
-        let vm = VMFileMapping::new(fh, 0, 512, flags).expect("Failed to create new VMFileMapping");
+        let vm =
+            VMFileMapping::new(&fh, 0, 512, flags).expect("Failed to create new VMFileMapping");
 
         let res = vm
             .map(0)
@@ -270,7 +271,7 @@ mod tests {
 
         let (fh, name) = create_16k_test_file();
         let fh2 = open(name).unwrap();
-        let vm = VMFileMapping::new(fh, 0, fh2.size(), flags)
+        let vm = VMFileMapping::new(&fh, 0, fh2.size(), flags)
             .expect("Failed to create new VMFileMapping");
 
         for i in 0..4 {
@@ -294,7 +295,7 @@ mod tests {
 
         let (fh, name) = create_5000b_test_file();
         let fh2 = open(name).unwrap();
-        let vm = VMFileMapping::new(fh, 0, fh2.size(), flags)
+        let vm = VMFileMapping::new(&fh, 0, fh2.size(), flags)
             .expect("Failed to create new VMFileMapping");
 
         assert_eq!(vm.mapping_size(), PAGE_SIZE * 2);
@@ -321,7 +322,7 @@ mod tests {
 
         let (fh, name) = create_16k_test_file();
         let fh2 = open(name).unwrap();
-        let vm = VMFileMapping::new(fh, 2 * PAGE_SIZE, PAGE_SIZE, flags)
+        let vm = VMFileMapping::new(&fh, 2 * PAGE_SIZE, PAGE_SIZE, flags)
             .expect("Failed to create new VMFileMapping");
 
         assert_eq!(vm.mapping_size(), PAGE_SIZE);

--- a/kernel/src/mm/vm/mapping/file_mapping.rs
+++ b/kernel/src/mm/vm/mapping/file_mapping.rs
@@ -31,6 +31,8 @@ bitflags! {
         const Execute = 1 << 2;
         // Map private copies of file pages
         const Private = 1 << 3;
+        // Map at a fixed address
+        const Fixed = 1 << 4;
     }
 }
 

--- a/kernel/src/mm/vm/mapping/mod.rs
+++ b/kernel/src/mm/vm/mapping/mod.rs
@@ -13,7 +13,7 @@ pub mod reserved;
 pub mod vmalloc;
 
 pub use api::{Mapping, VMMAdapter, VMPageFaultResolution, VirtualMapping, VMM};
-pub use file_mapping::{VMFileMapping, VMFileMappingPermission};
+pub use file_mapping::{VMFileMapping, VMFileMappingFlags};
 pub use kernel_stack::VMKernelStack;
 pub use phys_mem::VMPhysMem;
 pub use rawalloc::RawAllocMapping;

--- a/kernel/src/mm/vm/mod.rs
+++ b/kernel/src/mm/vm/mod.rs
@@ -8,7 +8,7 @@ mod mapping;
 mod range;
 
 pub use mapping::{
-    Mapping, RawAllocMapping, VMFileMapping, VMFileMappingPermission, VMKernelStack, VMMAdapter,
+    Mapping, RawAllocMapping, VMFileMapping, VMFileMappingFlags, VMKernelStack, VMMAdapter,
     VMPhysMem, VMReserved, VMalloc, VirtualMapping, VMM,
 };
 pub use range::{VMRMapping, VMR, VMR_GRANULE};

--- a/kernel/src/mm/vm/range.rs
+++ b/kernel/src/mm/vm/range.rs
@@ -120,6 +120,16 @@ impl VMR {
         }
     }
 
+    pub fn populate_addr(&self, pgtbl: &mut PageTableRef, vaddr: VirtAddr) {
+        let start = VirtAddr::from(self.start_pfn << PAGE_SHIFT);
+        let end = VirtAddr::from(self.end_pfn << PAGE_SHIFT);
+        assert!(vaddr >= start && vaddr < end);
+
+        let idx = vaddr.to_pgtbl_idx::<3>() - start.to_pgtbl_idx::<3>();
+        let parts = self.pgtbl_parts.lock_read();
+        pgtbl.populate_pgtbl_part(&parts[idx]);
+    }
+
     /// Initialize this [`VMR`] by checking the `start` and `end` values and
     /// allocating the [`PageTablePart`]s required for the mappings.
     ///

--- a/kernel/src/mm/vm/range.rs
+++ b/kernel/src/mm/vm/range.rs
@@ -91,8 +91,9 @@ impl VMR {
     ///
     /// `Ok(())` on success, Err(SvsmError::Mem) on allocation error
     fn alloc_page_tables(&self) -> Result<(), SvsmError> {
-        let count = ((self.end_pfn - self.start_pfn) << PAGE_SHIFT) / VMR_GRANULE;
         let start = VirtAddr::from(self.start_pfn << PAGE_SHIFT);
+        let end = VirtAddr::from(self.end_pfn << PAGE_SHIFT);
+        let count = end.to_pgtbl_idx::<3>() - start.to_pgtbl_idx::<3>();
         let mut vec = self.pgtbl_parts.lock_write();
 
         for idx in 0..count {

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -47,6 +47,7 @@ use svsm::sev::utils::{rmp_adjust, RMPFlags};
 use svsm::sev::{init_hypervisor_ghcb_features, secrets_page, secrets_page_mut, sev_status_init};
 use svsm::svsm_console::SVSMIOPort;
 use svsm::svsm_paging::{init_page_table, invalidate_early_boot_memory};
+use svsm::task::exec_user;
 use svsm::task::{create_kernel_task, schedule_init};
 use svsm::types::{PageSize, GUEST_VMPL, PAGE_SIZE};
 use svsm::utils::{halt, immut_after_init::ImmutAfterInitCell, zero_mem_region};
@@ -454,6 +455,10 @@ pub extern "C" fn svsm_main() {
 
     #[cfg(test)]
     crate::test_main();
+
+    if exec_user("/init").is_err() {
+        log::info!("Failed to launch /init");
+    }
 
     request_loop();
 

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -47,7 +47,7 @@ use svsm::sev::utils::{rmp_adjust, RMPFlags};
 use svsm::sev::{init_hypervisor_ghcb_features, secrets_page, secrets_page_mut, sev_status_init};
 use svsm::svsm_console::SVSMIOPort;
 use svsm::svsm_paging::{init_page_table, invalidate_early_boot_memory};
-use svsm::task::{create_kernel_task, schedule_init, TASK_FLAG_SHARE_PT};
+use svsm::task::{create_kernel_task, schedule_init};
 use svsm::types::{PageSize, GUEST_VMPL, PAGE_SIZE};
 use svsm::utils::{halt, immut_after_init::ImmutAfterInitCell, zero_mem_region};
 #[cfg(all(feature = "mstpm", not(test)))]
@@ -450,8 +450,7 @@ pub extern "C" fn svsm_main() {
         }
     }
 
-    create_kernel_task(request_processing_main, TASK_FLAG_SHARE_PT)
-        .expect("Failed to launch request processing task");
+    create_kernel_task(request_processing_main).expect("Failed to launch request processing task");
 
     #[cfg(test)]
     crate::test_main();

--- a/kernel/src/syscall/handlers.rs
+++ b/kernel/src/syscall/handlers.rs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2024 SUSE LLC
+//
+// Author: Joerg Roedel <jroedel@suse.de>
+
+use crate::task::{current_task_terminated, schedule};
+
+pub fn sys_hello() -> usize {
+    log::info!("Hello, world! System call invoked from user-space.");
+    0
+}
+
+pub fn sys_exit() -> ! {
+    log::info!("Terminating current task");
+    unsafe {
+        current_task_terminated();
+    }
+    schedule();
+    panic!("schedule() returned in sys_exit()");
+}

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2024 SUSE LLC
+//
+// Author: Joerg Roedel <jroedel@suse.de>
+
+mod handlers;
+
+pub use handlers::*;

--- a/kernel/src/task/exec.rs
+++ b/kernel/src/task/exec.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2024 SUSE LLC
+//
+// Author: Joerg Roedel <jroedel@suse.de>
+
+use crate::address::{Address, VirtAddr};
+use crate::error::SvsmError;
+use crate::fs::open;
+use crate::mm::vm::VMFileMappingFlags;
+use crate::mm::USER_MEM_END;
+use crate::task::{create_user_task, current_task, schedule};
+use crate::types::PAGE_SIZE;
+use elf::{Elf64File, Elf64PhdrFlags};
+
+fn convert_elf_phdr_flags(flags: Elf64PhdrFlags) -> VMFileMappingFlags {
+    let mut vm_flags = VMFileMappingFlags::Fixed;
+
+    if flags.contains(Elf64PhdrFlags::WRITE) {
+        vm_flags |= VMFileMappingFlags::Write | VMFileMappingFlags::Private;
+    }
+
+    if flags.contains(Elf64PhdrFlags::EXECUTE) {
+        vm_flags |= VMFileMappingFlags::Execute;
+    }
+
+    vm_flags
+}
+
+pub fn exec_user(binary: &str) -> Result<(), SvsmError> {
+    let fh = open(binary)?;
+    let file_size = fh.size();
+
+    let task = current_task();
+    let vstart = task.mmap_kernel_guard(
+        VirtAddr::new(0),
+        Some(&fh),
+        0,
+        file_size,
+        VMFileMappingFlags::Read,
+    )?;
+    let buf = unsafe { vstart.to_slice::<u8>(file_size) };
+    let elf_bin = Elf64File::read(buf).map_err(|_| SvsmError::Mem)?;
+
+    let alloc_info = elf_bin.image_load_vaddr_alloc_info();
+    let virt_base = alloc_info.range.vaddr_begin;
+    let entry = elf_bin.get_entry(virt_base);
+
+    let task = create_user_task(entry.try_into().unwrap())?;
+
+    for seg in elf_bin.image_load_segment_iter(virt_base) {
+        let virt_start = VirtAddr::from(seg.vaddr_range.vaddr_begin);
+        let virt_end = VirtAddr::from(seg.vaddr_range.vaddr_end).align_up(PAGE_SIZE);
+        let file_offset = seg.file_range.offset_begin;
+        let len = virt_end - virt_start;
+        let flags = convert_elf_phdr_flags(seg.flags);
+
+        if !virt_start.is_aligned(PAGE_SIZE) {
+            return Err(SvsmError::Mem);
+        }
+
+        if file_offset > 0 {
+            task.mmap_user(virt_start, Some(&fh), file_offset, len, flags)?;
+        } else {
+            task.mmap_user(virt_start, None, 0, len, flags)?;
+        }
+    }
+
+    // Make sure the mapping is gone before calling schedule
+    drop(vstart);
+
+    // Setup 64k of task stack
+    let user_stack_size: usize = 64 * 1024;
+    let stack_flags: VMFileMappingFlags = VMFileMappingFlags::Fixed | VMFileMappingFlags::Write;
+    let stack_addr = USER_MEM_END - user_stack_size;
+    task.mmap_user(stack_addr, None, 0, user_stack_size, stack_flags)?;
+
+    schedule();
+
+    Ok(())
+}

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -9,8 +9,8 @@ mod tasks;
 mod waiting;
 
 pub use schedule::{
-    create_kernel_task, current_task_terminated, is_current_task, schedule, schedule_init,
-    schedule_task, RunQueue, TASKLIST,
+    create_kernel_task, current_task, current_task_terminated, is_current_task, schedule,
+    schedule_init, schedule_task, RunQueue, TASKLIST,
 };
 
 pub use tasks::{

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -9,7 +9,8 @@ mod tasks;
 mod waiting;
 
 pub use schedule::{
-    create_kernel_task, is_current_task, schedule, schedule_init, schedule_task, RunQueue, TASKLIST,
+    create_kernel_task, current_task_terminated, is_current_task, schedule, schedule_init,
+    schedule_task, RunQueue, TASKLIST,
 };
 
 pub use tasks::{

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -4,6 +4,7 @@
 //
 // Author: Roy Hopkins <rhopkins@suse.de>
 
+mod exec;
 mod schedule;
 mod tasks;
 mod waiting;
@@ -18,4 +19,5 @@ pub use tasks::{
     TaskState, INITIAL_TASK_ID, TASK_FLAG_SHARE_PT,
 };
 
+pub use exec::exec_user;
 pub use waiting::WaitQueue;

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -9,8 +9,8 @@ mod tasks;
 mod waiting;
 
 pub use schedule::{
-    create_kernel_task, current_task, current_task_terminated, is_current_task, schedule,
-    schedule_init, schedule_task, RunQueue, TASKLIST,
+    create_kernel_task, create_user_task, current_task, current_task_terminated, is_current_task,
+    schedule, schedule_init, schedule_task, RunQueue, TASKLIST,
 };
 
 pub use tasks::{

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -14,8 +14,8 @@ pub use schedule::{
 };
 
 pub use tasks::{
-    Task, TaskContext, TaskError, TaskListAdapter, TaskPointer, TaskRunListAdapter, TaskState,
-    INITIAL_TASK_ID, TASK_FLAG_SHARE_PT,
+    is_task_fault, Task, TaskContext, TaskError, TaskListAdapter, TaskPointer, TaskRunListAdapter,
+    TaskState, INITIAL_TASK_ID, TASK_FLAG_SHARE_PT,
 };
 
 pub use waiting::WaitQueue;

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -10,7 +10,7 @@ mod waiting;
 
 pub use schedule::{
     create_kernel_task, create_user_task, current_task, current_task_terminated, is_current_task,
-    schedule, schedule_init, schedule_task, RunQueue, TASKLIST,
+    schedule, schedule_init, schedule_task, terminate, RunQueue, TASKLIST,
 };
 
 pub use tasks::{

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -223,9 +223,9 @@ impl TaskList {
 
 pub static TASKLIST: SpinLock<TaskList> = SpinLock::new(TaskList::new());
 
-pub fn create_kernel_task(entry: extern "C" fn(), flags: u16) -> Result<TaskPointer, SvsmError> {
+pub fn create_kernel_task(entry: extern "C" fn()) -> Result<TaskPointer, SvsmError> {
     let mut cpu = this_cpu_mut();
-    let task = Task::create(&mut cpu, entry, flags)?;
+    let task = Task::create(&mut cpu, entry)?;
     TASKLIST.lock().list().push_back(task.clone());
 
     // Put task on the runqueue of this CPU

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -276,6 +276,14 @@ pub unsafe fn current_task_terminated() {
     TASKLIST.lock().terminate(task_node.clone());
 }
 
+pub fn terminate() {
+    // TODO: re-evaluate whether current_task_terminated() needs to be unsafe
+    unsafe {
+        current_task_terminated();
+    }
+    schedule();
+}
+
 // SAFETY: This function returns a raw pointer to a task. It is safe
 // because this function is only used in the task switch code, which also only
 // takes a single reference to the next and previous tasks. Also, this

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -237,6 +237,10 @@ pub fn create_kernel_task(entry: extern "C" fn()) -> Result<TaskPointer, SvsmErr
     Ok(task)
 }
 
+pub fn current_task() -> TaskPointer {
+    this_cpu().current_task()
+}
+
 /// Check to see if the task scheduled on the current processor has the given id
 pub fn is_current_task(id: u32) -> bool {
     match &this_cpu().runqueue().lock_read().current_task {

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -237,6 +237,18 @@ pub fn create_kernel_task(entry: extern "C" fn()) -> Result<TaskPointer, SvsmErr
     Ok(task)
 }
 
+pub fn create_user_task(user_entry: usize) -> Result<TaskPointer, SvsmError> {
+    let mut cpu = this_cpu_mut();
+    let task = Task::create_user(&mut cpu, user_entry)?;
+    TASKLIST.lock().list().push_back(task.clone());
+
+    // Put task on the runqueue of this CPU
+    cpu.runqueue().lock_write().handle_task(task.clone());
+    drop(cpu);
+
+    Ok(task)
+}
+
 pub fn current_task() -> TaskPointer {
     this_cpu().current_task()
 }

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -315,6 +315,8 @@ pub fn schedule() {
             this_cpu().populate_page_table(&mut pt);
         }
 
+        this_cpu_mut().set_tss_rsp0(next.stack_bounds.end());
+
         // Get task-pointers, consuming the Arcs and release their reference
         unsafe {
             let a = task_pointer(current);

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -247,9 +247,9 @@ pub fn is_current_task(id: u32) -> bool {
 
 /// Terminates the current task.
 ///
-/// # Panics
+/// # Safety
 ///
-/// Panics if there is no current task.
+/// This function must only be called after scheduling is initialized, otherwise it will panic.
 pub unsafe fn current_task_terminated() {
     let cpu = this_cpu();
     let mut rq = cpu.runqueue().lock_write();

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -113,7 +113,7 @@ impl TaskSchedState {
 pub struct Task {
     pub rsp: u64,
 
-    stack_bounds: MemoryRegion<VirtAddr>,
+    pub stack_bounds: MemoryRegion<VirtAddr>,
 
     /// Page table that is loaded when the task is scheduled
     pub page_table: SpinLock<PageTableRef>,

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -346,6 +346,20 @@ impl Task {
 
         Self::mmap_common(vmr, addr, file, offset, size, flags)
     }
+
+    pub fn munmap_kernel(&self, addr: VirtAddr) -> Result<(), SvsmError> {
+        self.vm_kernel_range.remove(addr)?;
+        Ok(())
+    }
+
+    pub fn munmap_user(&self, addr: VirtAddr) -> Result<(), SvsmError> {
+        if self.vm_user_range.is_none() {
+            return Err(SvsmError::Mem);
+        }
+
+        self.vm_user_range.as_ref().unwrap().remove(addr)?;
+        Ok(())
+    }
 }
 
 extern "C" fn task_exit() {

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -117,6 +117,9 @@ pub struct Task {
     /// Task virtual memory range for use at CPL 0
     vm_kernel_range: VMR,
 
+    /// Task virtual memory range for use at CPL 3 - None for kernel tasks
+    vm_user_range: Option<VMR>,
+
     /// State relevant for scheduler
     sched_state: RWLock<TaskSchedState>,
 
@@ -187,6 +190,7 @@ impl Task {
             stack_bounds: bounds,
             page_table: SpinLock::new(pgtable),
             vm_kernel_range,
+            vm_user_range: None,
             sched_state: RWLock::new(TaskSchedState {
                 idle_task: false,
                 state: TaskState::RUNNING,

--- a/syscall/Cargo.toml
+++ b/syscall/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "syscall"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/syscall/src/lib.rs
+++ b/syscall/src/lib.rs
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2024 SUSE LLC
+//
+// Author: Joerg Roedel <jroedel@suse.de>
+#![no_std]
+
+mod numbers;
+
+pub use numbers::*;

--- a/syscall/src/numbers.rs
+++ b/syscall/src/numbers.rs
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2024 SUSE LLC
+//
+// Author: Joerg Roedel <jroedel@suse.de>
+
+// SYSCALL numbers are not stable yet and just used for CPL-3 bringup
+
+pub const SYS_HELLO: u64 = 0;
+pub const SYS_EXIT: u64 = 1;


### PR DESCRIPTION
Here are changes to allow the SVSM to load ELF binaries from the RAM file-system and execute them in user-mode.

The changes itself are not very useful yet, as there are no syscalls implemented besides some needed for testing, but the PR contains all the heavy-lifting needed to:

- VMM changes to populate and manage a user address space
- Opening and parsing of ELF files
- Creating user tasks and set up the correct stack layout to get it into user-mode once the task is scheduled
- Segment setup and IDT/entry code changes needed for user-mode

The changes in this PR are the groundwork for running SVSM modules in user-space.