### PR TITLE
Extend IGVM measure tool to generate SEV-SNP ID blocks containing signed launch measurement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ stage1/stage1-test
 print-meta
 cbit
 .idea/
+testkeys/
 
 # local fuzzing artifacts
 **/fuzz/target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bitfield-struct"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,6 +134,15 @@ name = "bitflags"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bootlib"
@@ -209,6 +230,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "cpuarch"
 version = "0.1.0"
 
@@ -231,6 +258,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,6 +289,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,10 +311,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "elf"
 version = "0.1.0"
 dependencies = [
  "bitflags 2.4.2",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -299,6 +406,18 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -312,6 +431,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,6 +452,24 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "hmac-sha512"
@@ -378,6 +526,7 @@ dependencies = [
  "hmac-sha512",
  "igvm",
  "igvm_defs",
+ "p384",
  "zerocopy 0.7.32",
 ]
 
@@ -492,6 +641,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "p384"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
 name = "packit"
 version = "0.1.1"
 source = "git+https://github.com/coconut-svsm/packit#f31283ddc20ee2ad0d3ac7d91555535b457263ae"
@@ -506,10 +667,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "polyval"
@@ -521,6 +701,15 @@ dependencies = [
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -542,10 +731,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "range_map_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8edc89eaa583cf6bc4c6ef16a219f0a60d342ca3bf0eae793560038ac8af1795"
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
 
 [[package]]
 name = "static_assertions"
@@ -561,9 +814,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "svsm"
@@ -712,6 +965,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -818,3 +1077,9 @@ dependencies = [
  "quote",
  "syn 2.0.48",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ intrusive-collections = "0.9.6"
 libfuzzer-sys = "0.4"
 log = "0.4.17"
 memoffset = "0.9.0"
+p384 = { version = "0.13.0" }
 uuid = "1.6.1"
 # Add the derive feature by default because all crates use it.
 zerocopy = { version = "0.7.32", features = ["derive"] }

--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,8 @@ $(IGVMMEASURE):
 	cargo build ${CARGO_ARGS} --target=x86_64-unknown-linux-gnu -p igvmmeasure
 
 bin/coconut-qemu.igvm: $(IGVMBUILDER) $(IGVMMEASURE) bin/svsm-kernel.elf bin/stage2.bin ${FS_BIN}
-	$(IGVMBUILDER) --sort --output $@ --stage2 bin/stage2.bin --kernel bin/svsm-kernel.elf --filesystem ${FS_BIN} ${BUILD_FW} qemu
-	$(IGVMMEASURE) --check-kvm --native-zero $@ measure
+	$(IGVMBUILDER) --sort --policy 0x30000 --output $@ --stage2 bin/stage2.bin --kernel bin/svsm-kernel.elf --filesystem ${FS_BIN} ${BUILD_FW} qemu
+	$(IGVMMEASURE) --check-kvm $@ measure
 
 bin/coconut-hyperv.igvm: $(IGVMBUILDER)  $(IGVMMEASURE) bin/svsm-kernel.elf bin/stage2.bin
 	$(IGVMBUILDER) --sort --output $@ --stage2 bin/stage2.bin --kernel bin/svsm-kernel.elf --comport 3 hyper-v

--- a/Makefile
+++ b/Makefile
@@ -65,15 +65,15 @@ $(IGVMMEASURE):
 
 bin/coconut-qemu.igvm: $(IGVMBUILDER) $(IGVMMEASURE) bin/svsm-kernel.elf bin/stage2.bin ${FS_BIN}
 	$(IGVMBUILDER) --sort --output $@ --stage2 bin/stage2.bin --kernel bin/svsm-kernel.elf --filesystem ${FS_BIN} ${BUILD_FW} qemu
-	$(IGVMMEASURE) --check-kvm --native-zero $@
+	$(IGVMMEASURE) --check-kvm --native-zero $@ measure
 
 bin/coconut-hyperv.igvm: $(IGVMBUILDER)  $(IGVMMEASURE) bin/svsm-kernel.elf bin/stage2.bin
 	$(IGVMBUILDER) --sort --output $@ --stage2 bin/stage2.bin --kernel bin/svsm-kernel.elf --comport 3 hyper-v
-	$(IGVMMEASURE) $@
+	$(IGVMMEASURE) $@ measure
 
 bin/coconut-test-qemu.igvm: $(IGVMBUILDER)  $(IGVMMEASURE) bin/test-kernel.elf bin/stage2.bin
 	$(IGVMBUILDER) --sort --output $@ --stage2 bin/stage2.bin --kernel bin/test-kernel.elf qemu
-	$(IGVMMEASURE) $@
+	$(IGVMMEASURE) $@ measure
 
 test:
 	cargo test ${CARGO_ARGS} ${SVSM_ARGS_TEST} --workspace --target=x86_64-unknown-linux-gnu

--- a/igvmbuilder/README.md
+++ b/igvmbuilder/README.md
@@ -47,7 +47,6 @@ firmware - OVMF on QEMU and IGVM-based firmware on Hyper-V.
 
   -c, --comport <COMPORT>
           COM port to use for the SVSM console. Valid values are 1-4
-          
           [default: 1]
 
   -v, --verbose
@@ -55,7 +54,10 @@ firmware - OVMF on QEMU and IGVM-based firmware on Hyper-V.
 
   --sort
           Sort the IGVM Page directives by GPA from lowest to highest
-          
+
+--policy <POLICY>
+          A hex value containing the guest policy to apply. For example: 0x30000
+
   -h, --help
           Print help (see a summary with '-h')
 ```

--- a/igvmbuilder/src/cmd_options.rs
+++ b/igvmbuilder/src/cmd_options.rs
@@ -43,6 +43,10 @@ pub struct CmdOptions {
     /// Sort the IGVM Page directives by GPA from lowest to highest
     #[arg(long, default_value_t = false)]
     pub sort: bool,
+
+    /// A hex value containing the guest policy to apply. For example: 0x30000
+    #[arg(long)]
+    pub policy: Option<String>,
 }
 
 impl CmdOptions {

--- a/igvmmeasure/Cargo.toml
+++ b/igvmmeasure/Cargo.toml
@@ -5,10 +5,11 @@ edition = "2021"
 
 [dependencies]
 clap = { workspace = true, default-features = true, features = ["derive"] }
-igvm_defs.workspace = true
-igvm.workspace = true
-zerocopy.workspace = true
 hmac-sha512.workspace = true
+igvm.workspace = true
+igvm_defs.workspace = true
+p384.workspace = true
+zerocopy.workspace = true
 
 [lints]
 workspace = true

--- a/igvmmeasure/README.md
+++ b/igvmmeasure/README.md
@@ -1,5 +1,6 @@
 # igvmmeasure
-A tool to calculate the launch measurement for the directives in an IGVM file.
+A tool to calculate the launch measurement for the directives in an IGVM file
+and to optionally create a signed version of the IGVM file.
 
 When starting a guest configured using an IGVM file, the directives in the IGVM
 are use to populate initial guest memory and describe the initial guest state.
@@ -14,7 +15,10 @@ measurement in the attestation report to ensure the initial guest state is as
 expected.
 
 Given an IGVM file, igvmmeasure parses the directives in the file and calculates
-the launch digest and outputs it as a hexadecimal string.
+the launch digest. This can either be output as a hexadecimal string, or
+igvmmeasure can be used to create a signed IGVM file that contains directives
+that instruct an IGVM loader, such as the loader integrated into QEMU to provide
+a signed measurement to the platform which is then verified at guest launch.
 
 ## IGVM validation
 There are some restrictions on the contents of an IGVM file when using QEMU with
@@ -29,31 +33,95 @@ This can be use to help diagnose measurement mismatches, or to abort the IGVM
 build process if a non-conformant file is generated.
 
 ## Usage
-`igvmmeasure [OPTIONS] <IGVM_FILE>`
+`igvmmeasure [OPTIONS] <INPUT> <COMMAND>`
 
 ### Arguments:
 ```
-  <IGVM_FILE>
-          The filename of the IGVM file to measure
+  <INPUT>
+          The filename of the input IGVM file to measure
 ```
 
 ### Options:
 ```
-  -v, --verbose    Print verbose output
-  -b, --bare       Bare output only, consisting of just the digest as a hex string
-  -p, --platform <PLATFORM>
-          Platform to calculate the launch measurement for
-          [default: sev-snp]
-          Possible values:
-          - sev-snp: Calculate the launch measurement for SEV-SNP
-  -c, --check-kvm  Check that the IGVM file conforms to QEMU/KVM restrictions
-  -n, --native-zero
-          Determine how to pages that contain only zeroes in the IGVM file.
-          When true, zero pages are measured using the native zero page type if the underlying platform supports it.
-          When false, the page is measured as a normal page containing all zeros.
+  -v, --verbose              Print verbose output
+  -c, --check-kvm            Check that the IGVM file conforms to QEMU/KVM restrictions
+  -p, --platform <PLATFORM>  Platform to calculate the launch measurement for [default: sev-snp] [possible values: sev-snp]
+  -n, --native-zero          Determine how to pages that contain only zeroes in the IGVM file
+  -h, --help                 Print help (see more with '--help')
+```
+
+### Commands
+`igvmmeasure` can either measure and IGVM file and display the output in the
+console, or it can generate a measurement that is added as a signed ID block for
+SEV-SNP into a signed copy of the input IGVM file. The operation is selected via
+one of these commands:
+
+```
+  measure  Measure the input file and print the measurement to the console
+  sign     Measure the input file and generate a new output file containing a
+           signature suitable for the target platform. For SEV-SNP this
+           generates an IGVM_VHT_SNP_ID_BLOCK directive in the output file
+```
+
+Each command has its own specific options:
+```
+measure
   -i, --ignore-idblock
-          If an ID block is present within the IGVM file then by default an error will be generated if the expected
-          measurement differs from the calculated measurement.
-          If this option is set then the expected measurement in the ID block is ignored.
-  -h, --help       Print help
+          If an ID block is present within the IGVM file then by default an
+          error will be generated if the expected measurement differs from the
+          calculated measurement. If this option is set then the expected
+          measurement in the ID block is ignored.
+
+  -b, --bare
+          Bare output only, consisting of just the digest as a hex string
+
+sign
+      --output <OUTPUT>
+          Output filename of the signed IGVM file that will be created
+
+      --id-key <ID_KEY>
+          Filename of the private key that is used to sign the contents of the
+          ID block. For SEV-SNP platforms, this should be an ECDSA P-384 key.
+          You can create a key using:
+                $ openssl ecparam -name secp384r1 -genkey -noout -out
+
+      --author-key <AUTHOR_KEY>
+          Filename of the author private key that is used to sign the public
+          part of the id_key. For SEV-SNP platforms, this should be an ECDSA
+          P-384 key. You can create a key using:
+                $ openssl ecparam -name secp384r1 -genkey -noout -out
+
+        The author key is option. See the SEV-SNP documentation for more
+        information.
+```
+
+## Example signing process
+An IGVM file can be signed using igvmmeasure to generate an output file that
+contains a signed ID block for SEV-SNP.
+
+There are two of keys that are used during the signing process:
+
+### id-key
+The key that is used to sign the launch digest. The public portion of
+the key is stored in the IGVM file with the launch measurement and signature to
+allow the SEV-SNP platform to validate the expected measurement before checking
+the measurement matches that actual configuration of the guest.
+
+### author-key
+The key that is used to sign the public id-key. This allows the SEV-SNP platform
+to check the validity of the public key that is used to verify the launch
+measurement. The author-key is optional and is ignored by the platform if not
+provided.
+
+An id-key and author-key can be generated using openssl:
+
+```
+openssl ecparam -name secp384r1 -genkey -noout -out testkeys/id_key.pem
+openssl ecparam -name secp384r1 -genkey -noout -out testkeys/author_key.pem
+```
+
+Once the keys have been generated, the IGVM file can be signed:
+
+```
+igvmmeasure igvm_file sign --output igvm_file_signed --id-key testkeys/id_key.pem --author-key testkeys/author_key.pem
 ```

--- a/igvmmeasure/src/cmd_options.rs
+++ b/igvmmeasure/src/cmd_options.rs
@@ -4,24 +4,20 @@
 //
 // Author: Roy Hopkins <roy.hopkins@suse.com>
 
-use clap::{Parser, ValueEnum};
+use clap::{Parser, Subcommand, ValueEnum};
 
 #[derive(Parser, Debug)]
 pub struct CmdOptions {
-    /// The filename of the IGVM file to measure
+    /// The filename of the input IGVM file to measure
     #[arg()]
-    pub igvm_file: String,
+    pub input: String,
 
     /// Print verbose output
-    #[arg(short, long, default_value_t = false)]
+    #[arg(short, long)]
     pub verbose: bool,
 
-    /// Bare output only, consisting of just the digest as a hex string
-    #[arg(short, long, default_value_t = false)]
-    pub bare: bool,
-
     /// Check that the IGVM file conforms to QEMU/KVM restrictions
-    #[arg(short, long, default_value_t = false)]
+    #[arg(short, long)]
     pub check_kvm: bool,
 
     /// Platform to calculate the launch measurement for
@@ -34,17 +30,30 @@ pub struct CmdOptions {
     /// if the underlying platform supports it.
     ///
     /// When false, the page is measured as a normal page containing all zeros.
-    #[arg(short, long, default_value_t = false)]
+    #[arg(short, long)]
     pub native_zero: bool,
 
-    /// If an ID block is present within the IGVM file then by default an
-    /// error will be generated if the expected measurement differs from
-    /// the calculated measurement.
-    ///
-    /// If this option is set then the expected measurement in the ID block
-    /// is ignored.
-    #[arg(short, long, default_value_t = false)]
-    pub ignore_idblock: bool,
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Measure the input file and print the measurement to the console.
+    Measure {
+        /// If an ID block is present within the IGVM file then by default an
+        /// error will be generated if the expected measurement differs from
+        /// the calculated measurement.
+        ///
+        /// If this option is set then the expected measurement in the ID block
+        /// is ignored.
+        #[arg(short, long)]
+        ignore_idblock: bool,
+
+        /// Bare output only, consisting of just the digest as a hex string
+        #[arg(short, long)]
+        bare: bool,
+    },
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]

--- a/igvmmeasure/src/cmd_options.rs
+++ b/igvmmeasure/src/cmd_options.rs
@@ -54,6 +54,33 @@ pub enum Commands {
         #[arg(short, long)]
         bare: bool,
     },
+    /// Measure the input file and generate a new output file containing a
+    /// signature suitable for the target platform. For SEV-SNP this generates
+    /// an IGVM_VHT_SNP_ID_BLOCK directive in the output file.
+    Sign {
+        /// Output filename of the signed IGVM file that will be created.
+        #[arg(long)]
+        output: String,
+
+        /// Filename of the private key that is used to sign the contents of
+        /// the ID block. For SEV-SNP platforms, this should be an ECDSA P-384
+        /// key. You can create a key using:
+        ///
+        /// $ openssl ecparam -name secp384r1 -genkey -noout -out
+        #[arg(long)]
+        id_key: String,
+
+        /// Filename of the author private key that is used to sign the public
+        /// part of the id_key. For SEV-SNP platforms, this should be an ECDSA
+        /// P-384 key. You can create a key using:
+        ///
+        /// $ openssl ecparam -name secp384r1 -genkey -noout -out
+        ///
+        /// The author key is option. See the SEV-SNP documentation for more
+        /// information.
+        #[arg(long)]
+        author_key: Option<String>,
+    },
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]

--- a/igvmmeasure/src/id_block.rs
+++ b/igvmmeasure/src/id_block.rs
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 SUSE LLC
+//
+// Author: Roy Hopkins <roy.hopkins@suse.com>
+
+use std::error::Error;
+use std::fs;
+
+use igvm::{IgvmDirectiveHeader, IgvmFile};
+use igvm_defs::{
+    IgvmPlatformType, IGVM_VHS_SNP_ID_BLOCK_PUBLIC_KEY, IGVM_VHS_SNP_ID_BLOCK_SIGNATURE,
+};
+use p384::ecdsa::signature::Signer;
+use p384::ecdsa::{Signature, SigningKey};
+use p384::elliptic_curve::bigint::ArrayEncoding;
+use p384::{EncodedPoint, SecretKey};
+use zerocopy::{AsBytes, FromZeroes};
+
+use crate::igvm_measure::IgvmMeasure;
+use crate::utils::{get_compatibility_mask, get_policy};
+
+#[repr(C, packed)]
+#[derive(AsBytes, Clone, Copy, Debug)]
+pub struct SevIdBlock {
+    pub ld: [u8; 48],
+    pub family_id: [u8; 16],
+    pub image_id: [u8; 16],
+    pub version: u32,
+    pub guest_svn: u32,
+    pub policy: u64,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct SevIdBlockBuilder {
+    pub id_block: SevIdBlock,
+    compatibility_mask: u32,
+}
+
+impl SevIdBlockBuilder {
+    pub fn build(igvm: &IgvmFile, measure: &IgvmMeasure) -> Result<Self, Box<dyn Error>> {
+        let ld = measure.digest();
+        let compatibility_mask = get_compatibility_mask(igvm, IgvmPlatformType::SEV_SNP).ok_or(
+            String::from("IGVM file is not compatible with the specified platform."),
+        )?;
+        let policy = get_policy(igvm, compatibility_mask)
+            .ok_or(String::from("IGVM file does not contain a guest policy."))?;
+
+        Ok(Self {
+            compatibility_mask,
+            id_block: SevIdBlock {
+                ld,
+                family_id: Default::default(),
+                image_id: Default::default(),
+                version: 1,
+                guest_svn: Default::default(),
+                policy,
+            },
+        })
+    }
+
+    fn secret_key(key_file: &String) -> Result<SecretKey, Box<dyn Error>> {
+        let pem = fs::read_to_string(key_file)?;
+        Ok(SecretKey::from_sec1_pem(&pem)?)
+    }
+
+    pub fn gen_signature(
+        key_file: &String,
+        data: &[u8],
+    ) -> Result<Box<IGVM_VHS_SNP_ID_BLOCK_SIGNATURE>, Box<dyn Error>> {
+        let signing_key = SigningKey::from(&Self::secret_key(key_file)?);
+        let signature: Signature = signing_key.sign(data);
+
+        let r = signature.r().to_canonical().to_le_byte_array();
+        let s = signature.s().to_canonical().to_le_byte_array();
+
+        let mut result = IGVM_VHS_SNP_ID_BLOCK_SIGNATURE {
+            r_comp: [0u8; 72],
+            s_comp: [0u8; 72],
+        };
+        result.r_comp[..r.len()].copy_from_slice(&r);
+        result.s_comp[..s.len()].copy_from_slice(&s);
+
+        Ok(Box::new(result))
+    }
+
+    pub fn pub_key(
+        key_file: &String,
+    ) -> Result<Box<IGVM_VHS_SNP_ID_BLOCK_PUBLIC_KEY>, Box<dyn Error>> {
+        let secret_key = Self::secret_key(key_file)?;
+        let ep = EncodedPoint::from(secret_key.public_key());
+        let mut x = *ep.x().unwrap();
+        let mut y = *ep.y().unwrap();
+        x.reverse();
+        y.reverse();
+
+        let mut result = IGVM_VHS_SNP_ID_BLOCK_PUBLIC_KEY {
+            curve: 2,
+            reserved: 0,
+            qx: [0u8; 72],
+            qy: [0u8; 72],
+        };
+        result.qx[..x.len()].copy_from_slice(&x);
+        result.qy[..y.len()].copy_from_slice(&y);
+
+        Ok(Box::new(result))
+    }
+
+    pub fn sign(
+        &self,
+        key_file: &String,
+        author_key_file: &Option<String>,
+    ) -> Result<IgvmDirectiveHeader, Box<dyn Error>> {
+        let id_block_signature = Self::gen_signature(key_file, self.id_block.as_bytes())?;
+        let id_key = SevIdBlockBuilder::pub_key(key_file)?;
+
+        let (author_key_sig, author_pub_key) = if let Some(author_key) = author_key_file {
+            // The IGVM public key format includes an extra u32 reserved field that should
+            // not be measured according to the AMD SEV-SNP specification.
+            let mut id_key_field = vec![2u8, 0u8, 0u8, 0u8];
+            id_key_field.extend_from_slice(&id_key.qx);
+            id_key_field.extend_from_slice(&id_key.qy);
+            id_key_field.resize(0x404, 0);
+            (
+                Self::gen_signature(author_key, id_key_field.as_bytes())?,
+                Self::pub_key(author_key)?,
+            )
+        } else {
+            (
+                Box::new(IGVM_VHS_SNP_ID_BLOCK_SIGNATURE::new_zeroed()),
+                Box::new(IGVM_VHS_SNP_ID_BLOCK_PUBLIC_KEY::new_zeroed()),
+            )
+        };
+
+        Ok(IgvmDirectiveHeader::SnpIdBlock {
+            compatibility_mask: self.compatibility_mask,
+            author_key_enabled: if author_key_file.is_some() { 1 } else { 0 },
+            reserved: [0u8; 3],
+            ld: self.id_block.ld,
+            family_id: self.id_block.family_id,
+            image_id: self.id_block.image_id,
+            version: self.id_block.version,
+            guest_svn: self.id_block.guest_svn,
+            id_key_algorithm: 1,
+            author_key_algorithm: 1,
+            id_key_signature: id_block_signature,
+            id_public_key: id_key,
+            author_key_signature: author_key_sig,
+            author_public_key: author_pub_key,
+        })
+    }
+}

--- a/igvmmeasure/src/main.rs
+++ b/igvmmeasure/src/main.rs
@@ -5,38 +5,78 @@
 // Author: Roy Hopkins <roy.hopkins@suse.com>
 
 use std::error::Error;
+use std::fs;
 
 use clap::Parser;
-use cmd_options::CmdOptions;
+use cmd_options::{CmdOptions, Commands};
+use igvm::IgvmFile;
+use igvm_defs::IgvmPlatformType;
 use igvm_measure::IgvmMeasure;
+use utils::get_compatibility_mask;
+use zerocopy::AsBytes;
 
 mod cmd_options;
 mod igvm_measure;
 mod page_info;
+mod utils;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let options = CmdOptions::parse();
-    let mut igvm = IgvmMeasure::new(&options);
-    let digest = igvm.measure()?;
 
-    if !options.bare {
+    let igvm_buffer = fs::read(&options.input).map_err(|e| {
+        eprintln!("Failed to open firmware file {}", options.input);
+        e
+    })?;
+    let igvm = IgvmFile::new_from_binary(igvm_buffer.as_bytes(), None)?;
+    let compatibility_mask = get_compatibility_mask(&igvm, IgvmPlatformType::SEV_SNP).ok_or(
+        String::from("IGVM file is not compatible with the specified platform."),
+    )?;
+
+    let measure = IgvmMeasure::measure(
+        options.verbose,
+        options.check_kvm,
+        options.native_zero,
+        compatibility_mask,
+        &igvm,
+    )?;
+
+    match options.command {
+        Commands::Measure {
+            ignore_idblock,
+            bare,
+        } => measure_command(&options, ignore_idblock, bare, &measure)?,
+    }
+
+    Ok(())
+}
+
+fn measure_command(
+    options: &CmdOptions,
+    ignore_idblock: bool,
+    bare: bool,
+    measure: &IgvmMeasure,
+) -> Result<(), Box<dyn Error>> {
+    if !bare {
         println!(
             "\n==============================================================================================================="
         );
-        print!("igvmmeasure '{}'\nLaunch Digest: ", options.igvm_file);
+        print!("igvmmeasure '{}'\nLaunch Digest: ", options.input);
     }
 
-    digest.iter().for_each(|val| print!("{:02X}", val));
+    measure
+        .digest()
+        .iter()
+        .for_each(|val| print!("{:02X}", val));
     println!();
 
-    if !options.bare {
+    if !bare {
         println!(
             "===============================================================================================================\n"
         );
     }
 
-    if !options.ignore_idblock {
-        igvm.check_id_block()?;
+    if !ignore_idblock {
+        measure.check_id_block()?;
     }
 
     Ok(())

--- a/igvmmeasure/src/page_info.rs
+++ b/igvmmeasure/src/page_info.rs
@@ -19,7 +19,7 @@ pub enum PageType {
 }
 
 #[repr(C, packed)]
-#[derive(AsBytes, Debug)]
+#[derive(AsBytes, Debug, Copy, Clone)]
 pub struct PageInfo {
     digest_cur: [u8; 48],
     contents: [u8; 48],

--- a/igvmmeasure/src/utils.rs
+++ b/igvmmeasure/src/utils.rs
@@ -7,6 +7,22 @@
 use igvm::{IgvmFile, IgvmPlatformHeader};
 use igvm_defs::IgvmPlatformType;
 
+pub fn get_policy(igvm: &IgvmFile, compatibility_mask: u32) -> Option<u64> {
+    let mut policy: Option<u64> = None;
+    for init in igvm.initializations() {
+        if let igvm::IgvmInitializationHeader::GuestPolicy {
+            policy: guest_policy,
+            compatibility_mask: guest_cm,
+        } = init
+        {
+            if (compatibility_mask & guest_cm) != 0 {
+                policy = Some(*guest_policy);
+                break;
+            }
+        }
+    }
+    policy
+}
 
 pub fn get_compatibility_mask(igvm: &IgvmFile, platform: IgvmPlatformType) -> Option<u32> {
     let mut compatibility_mask: Option<u32> = None;

--- a/igvmmeasure/src/utils.rs
+++ b/igvmmeasure/src/utils.rs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2024 SUSE LLC
+//
+// Author: Roy Hopkins <roy.hopkins@suse.com>
+
+use igvm::{IgvmFile, IgvmPlatformHeader};
+use igvm_defs::IgvmPlatformType;
+
+
+pub fn get_compatibility_mask(igvm: &IgvmFile, platform: IgvmPlatformType) -> Option<u32> {
+    let mut compatibility_mask: Option<u32> = None;
+    for pl in igvm.platforms() {
+        let IgvmPlatformHeader::SupportedPlatform(supported) = pl;
+        if supported.platform_type == platform {
+            compatibility_mask = Some(supported.compatibility_mask);
+            break;
+        }
+    }
+    compatibility_mask
+}

--- a/scripts/gen_igvm_signing_keys.sh
+++ b/scripts/gen_igvm_signing_keys.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# Copyright (c) 2024 SUSE LLC
+#
+# Author: Roy Hopkins <roy.hopkins@suse.com>
+#
+# Generate keys for testing that can be used for signing an IGVM file
+set -e
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+mkdir -p $SCRIPT_DIR/../testkeys/
+openssl ecparam -name secp384r1 -genkey -noout -out $SCRIPT_DIR/../testkeys/id_key.pem
+openssl ecparam -name secp384r1 -genkey -noout -out $SCRIPT_DIR/../testkeys/author_key.pem

--- a/scripts/test_sign_qemu_igvm.sh
+++ b/scripts/test_sign_qemu_igvm.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# Copyright (c) 2024 SUSE LLC
+#
+# Author: Roy Hopkins <roy.hopkins@suse.com>
+#
+# Sign the QEMU IGVM file with test keys, generating
+# the test keys if they do not exist.
+set -e
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+SVSM_DIR=$SCRIPT_DIR/..
+
+# Generate the test keys if they do not already exist
+if [ ! -d $SVSM_DIR/testkeys ] || [ ! -f $SVSM_DIR/testkeys/id_key.pem ]; then
+    echo "Generating test keys"
+    $SCRIPT_DIR/gen_igvm_signing_keys.sh
+fi
+
+echo "Signing file: $SVSM_DIR/bin/coconut-qemu.igvm"
+$SVSM_DIR/bin/igvmmeasure $SVSM_DIR/bin/coconut-qemu.igvm sign --output bin/coconut-qemu-signed.igvm --id-key $SVSM_DIR/testkeys/id_key.pem --author-key $SVSM_DIR/testkeys/author_key.pem


### PR DESCRIPTION
The `igvmmeasure` tool was previously introduced to calculate and display the expected launch measurement for an IGVM file on a particular platform. The next progression is to embed that launch measurement into an SNP ID block so that an IGVM loader implementation on a hypervisor can provide this at guest startup to prevent launch if the IGVM file has been tampered with. This information also forms part of the attestation report and can be used to remotely verify the integrity of the initial guest state.

Generation of an ID block requires the launch measurement to be signed using a private key. Initial work on this PR involved reworking `igvmmeasure` into a separate library and executable so the ID block generation could be performed in `igvmbuilder`. However, this would require private keys to be available at build time. Therefore, `igvmmeasure` was left as a standalone executable and the signing functionality added to there.

An example workflow for securely signing an IGVM file consists of:

1. Building the IGVM file as normal using `make`.
2. Taking the IGVM output of the build and providing it to a secure signing server that has access to the required private keys.
3. Running `igvmmeasure` on the secure server to sign the IGVM file.
4. Returning the signed file to the build environment.

For testing or evaluating, the signing process can be performed using the two new scripts added by this PR. Basically by running this script to generate test keys and sign the QEMU IGVM binary:

```
scripts/test_sign_qemu_igvm.sh
```

A QEMU that supports ID blocks in the IGVM file is required to consume the signed IGVM file. This is currently in development and a link to the branch will be added to this PR when ready.