### PR TITLE
Makefile: Exclude default features when building stage2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ bin/meta.bin: utils/gen_meta utils/print-meta
 	./utils/gen_meta $@
 
 bin/stage2.bin: bin
-	cargo build ${CARGO_ARGS} ${SVSM_ARGS} --bin stage2
+	cargo build --manifest-path kernel/Cargo.toml ${CARGO_ARGS} --no-default-features --bin stage2
 	objcopy -O binary ${STAGE2_ELF} $@
 
 bin/svsm-kernel.elf: bin


### PR DESCRIPTION
The svsm module in kernel/ builds both the stage2 and kernel binaries. This can be configured with enable-gdb and mstpm features, both of which only apply to the kernel binary and not stage2. However the current Makefile enables the same features set for both binary builds.

The linker would normally remove the unused code generated for the features but, for mstpm the linker leaves a large amount of dead code in stage2. This causes the link to fail as stage2 does not link against libmstpm.

This commit changes the Makefile to remove all default features when building stage 2. In order to do this, it must run the cargo build directly on the kernel Cargo.toml.

This addresses https://github.com/coconut-svsm/svsm/issues/313