### PR TITLE
Fix SVSM boot crash when RELEASE=1

### DIFF
--- a/libmstpm/deps/openssl_svsm.conf
+++ b/libmstpm/deps/openssl_svsm.conf
@@ -11,7 +11,13 @@ my %targets = (
         CC              => "gcc",
         CFLAGS          => add(combine(picker(default => "-Wall",
                                           debug => "-g -O0",
-                                          release => "-O3"),
+                                          # When compiled with any optmization (e.g. -O1),
+                                          # the gcc generates code with instructions that are
+                                          # not supported at the SVSM level (e.g. the SSE pxor).
+                                          # That crashes the SVSM boot with an unhandled
+                                          # exception 6 (invalid opcode) usually in:
+                                          # vtpm_init()->libtpm:manufacture()->libcrypto:BN_CTX_new()
+                                          release => "-O0"),
                                    "-fPIE -m64 -nostdinc -nostdlib -static -fno-stack-protector")),
         bn_ops          => "SIXTY_FOUR_BIT_LONG",
         lib_cppflags    => add("-DL_ENDIAN -DNO_SYSLOG -DOPENSSL_SMALL_FOOTPRINT -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE"),


### PR DESCRIPTION
When OpenSSL is compiled with any optimization (e.g. -O1), the gcc generates code with instructions that are not supported at the SVSM level (e.g. the SSE pxor). That crashes the SVSM boot with an unhandled exception 6 (invalid opcode), usually in:
vtpm_init()->libtpm:manufacture()->libcrypto:BN_CTX_new(). For example:

[SVSM] Launching request-processing task on CPU 3
[SVSM] FW Meta Data
[SVSM]   CPUID Page   : 0x0080e000
[SVSM]   Secrets Page : 0x0080d000
[SVSM]   CAA Page     : 0x0080f000
[SVSM]   Pre-Validated Region 0x0000000000800000-0x0000000000809000
[SVSM]   Pre-Validated Region 0x000000000080a000-0x000000000080d000
[SVSM]   Pre-Validated Region 0x0000000000810000-0x0000000000820000
[SVSM] Validating 0x0000000000800000-0x0000000000809000
[SVSM] Validating 0x000000000080a000-0x0000000000820000
[SVSM] Flash region 0 at 0x00000000ffc00000 size 000000000000400000
[SVSM] ERROR: Panic: CPU[0] panicked at kernel/src/cpu/idt/svsm.rs:165:5:
Unhandled exception 6 RIP 0xffffff800002123f error code: 0x0000000000000000
[SVSM] ---BACKTRACE---:
[SVSM]   [0xffffff800010d4db]
[SVSM]   [0xffffff80000e979b]
[SVSM]   Invalid frame
[SVSM] ---END---

Dump of assembler code for function BN_CTX_new:
   0xffffff80000211d0 <+0>:	endbr64
   0xffffff80000211d4 <+4>:	push   %rbx
   0xffffff80000211d5 <+5>:	lea    0x116e3b(%rip),%rdi        # 0xffffff8000138017
   0xffffff80000211dc <+12>:	call   0xffffff8000000b30 <puts>
   0xffffff80000211e1 <+17>:	xor    %edx,%edx
   0xffffff80000211e3 <+19>:	mov    $0x40,%edi
   0xffffff80000211e8 <+24>:	lea    0x11e0ef(%rip),%rsi        # 0xffffff800013f2de
   0xffffff80000211ef <+31>:	call   0xffffff8000032bc0 <CRYPTO_zalloc>
   0xffffff80000211f4 <+36>:	test   %rax,%rax
   0xffffff80000211f7 <+39>:	jne    0xffffff8000021222 <BN_CTX_new+82>
   0xffffff80000211f9 <+41>:	lea    0x116e31(%rip),%rdi        # 0xffffff8000138031
   0xffffff8000021200 <+48>:	call   0xffffff8000000b30 <puts>
   0xffffff8000021205 <+53>:	xor    %r8d,%r8d
   0xffffff8000021208 <+56>:	xor    %ecx,%ecx
   0xffffff800002120a <+58>:	mov    $0x41,%edx
   0xffffff800002120f <+63>:	mov    $0x6a,%esi
   0xffffff8000021214 <+68>:	mov    $0x3,%edi
   0xffffff8000021219 <+73>:	call   0xffffff8000030a00 <ERR_put_error>
   0xffffff800002121e <+78>:	xor    %eax,%eax
   0xffffff8000021220 <+80>:	pop    %rbx
   0xffffff8000021221 <+81>:	ret
   0xffffff8000021222 <+82>:	lea    0x116e24(%rip),%rdi        # 0xffffff800013804d
   0xffffff8000021229 <+89>:	mov    %rax,%rbx
   0xffffff800002122c <+92>:	call   0xffffff8000000b30 <puts>
   0xffffff8000021231 <+97>:	lea    0x116e31(%rip),%rdi        # 0xffffff8000138069
   0xffffff8000021238 <+104>:	call   0xffffff8000000b30 <puts>
   0xffffff800002123d <+109>:	xor    %eax,%eax
=====>   0xffffff800002123f <+111>:	pxor   %xmm0,%xmm0    <=======
   0xffffff8000021243 <+115>:	lea    0x116e3d(%rip),%rdi        # 0xffffff8000138087
   0xffffff800002124a <+122>:	mov    %rax,0x10(%rbx)
   0xffffff800002124e <+126>:	movups %xmm0,(%rbx)
   0xffffff8000021251 <+129>:	call   0xffffff8000000b30 <puts>
   0xffffff8000021256 <+134>:	xor    %edx,%edx

We could pass "-mno-sse" in the OpenSSL CFLAGS, but that seems to cause another round of issues. Not to mention the fact that fmtfp() is using double, which does not seem be a good practice in embedded environements.

  crypto/bio/b_print.c: In function 'fmtfp':
  crypto/bio/b_print.c:587:46: error: SSE register return with SSE disabled
    587 |                     || (max > 0 && fvalue >= pow_10(max))) {
        |

So, for now, this PR mitigates the "unhandled exception 6" issue by building OpenSSL with -O0 for the release path.