### PR TITLE
Update URL to libmstpm/deps/ms-tpm-20-ref

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/openssl/openssl.git
 [submodule "libmstpm/deps/ms-tpm-20-ref"]
 	path = libmstpm/deps/ms-tpm-20-ref
-	url = https://github.com/microsoft/ms-tpm-20-ref.git
+	url = https://github.com/coconut-svsm/ms-tpm-20-ref.git

--- a/libmstpm/Makefile
+++ b/libmstpm/Makefile
@@ -113,7 +113,6 @@ MSTPM_CFLAGS += -I$(OPENSSL_DIR)/include
 # are not building the simulator.
 $(MSTPM_MAKEFILE):
 	(cd $(MSTPM_DIR) && \
-		sed -i '/^AX_PTHREAD/d' configure.ac && \
 		./bootstrap && \
 		./configure \
 			CFLAGS="${MSTPM_CFLAGS}" \
@@ -134,7 +133,6 @@ src/bindings.rs: deps/libmstpm.h $(LIBTPM)
 clean: $(OPENSSL_MAKEFILE) $(MSTPM_MAKEFILE)
 	make -C $(LIBCRT_DIR) clean
 	make -C $(OPENSSL_DIR) clean
-	sed -i '/^AX_PTHREAD/d' $(MSTPM_DIR)/configure.ac
 	make -C $(MSTPM_DIR) clean
 	rm -f libmstpm.a
 	rm -f src/bindings.rs


### PR DESCRIPTION
Point the TPM dependency to a COCONUT-specific fork of the Microsoft TPM reference implementation. The fork has some changes on-top of the upstream TPM library which are required in the SVSM environment.