### PR TITLE
kernel: Build test-kernel without TPM support

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -37,7 +37,7 @@ pub mod svsm_paging;
 pub mod task;
 pub mod types;
 pub mod utils;
-#[cfg(feature = "mstpm")]
+#[cfg(all(feature = "mstpm", not(test)))]
 pub mod vtpm;
 
 #[test]

--- a/kernel/src/protocols/mod.rs
+++ b/kernel/src/protocols/mod.rs
@@ -6,7 +6,7 @@
 
 pub mod core;
 pub mod errors;
-#[cfg(feature = "mstpm")]
+#[cfg(all(feature = "mstpm", not(test)))]
 pub mod vtpm;
 
 use cpuarch::vmsa::{GuestVMExit, VMSA};

--- a/kernel/src/requests.rs
+++ b/kernel/src/requests.rs
@@ -12,7 +12,7 @@ use crate::mm::GuestPtr;
 use crate::protocols::core::core_protocol_request;
 use crate::protocols::errors::{SvsmReqError, SvsmResultCode};
 
-#[cfg(feature = "mstpm")]
+#[cfg(all(feature = "mstpm", not(test)))]
 use crate::protocols::{vtpm::vtpm_protocol_request, SVSM_VTPM_PROTOCOL};
 use crate::protocols::{RequestParams, SVSM_CORE_PROTOCOL};
 use crate::types::GUEST_VMPL;
@@ -95,7 +95,7 @@ fn request_loop_once(
 
     match protocol {
         SVSM_CORE_PROTOCOL => core_protocol_request(request, params).map(|_| true),
-        #[cfg(feature = "mstpm")]
+        #[cfg(all(feature = "mstpm", not(test)))]
         SVSM_VTPM_PROTOCOL => vtpm_protocol_request(request, params).map(|_| true),
         _ => Err(SvsmReqError::unsupported_protocol()),
     }

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -50,7 +50,7 @@ use svsm::svsm_paging::{init_page_table, invalidate_early_boot_memory};
 use svsm::task::{create_kernel_task, schedule_init, TASK_FLAG_SHARE_PT};
 use svsm::types::{PageSize, GUEST_VMPL, PAGE_SIZE};
 use svsm::utils::{halt, immut_after_init::ImmutAfterInitCell, zero_mem_region};
-#[cfg(feature = "mstpm")]
+#[cfg(all(feature = "mstpm", not(test)))]
 use svsm::vtpm::vtpm_init;
 
 use svsm::mm::validate::{init_valid_bitmap_ptr, migrate_valid_bitmap};
@@ -427,7 +427,7 @@ pub extern "C" fn svsm_main() {
         prepare_fw_launch(fw_meta).expect("Failed to setup guest VMSA/CAA");
     }
 
-    #[cfg(feature = "mstpm")]
+    #[cfg(all(feature = "mstpm", not(test)))]
     vtpm_init().expect("vTPM failed to initialize");
 
     virt_log_usage();


### PR DESCRIPTION
Do not try to build the vTPM bindings into the test-in-svsm binary. This causes linker errors and there are not TPM tests yet anyway.