### PR TITLE
test: remove `memoffset` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,7 +833,6 @@ dependencies = [
  "intrusive-collections",
  "libmstpm",
  "log",
- "memoffset",
  "packit",
  "test",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ igvm = { version = "0.1.3", default-features = false}
 intrusive-collections = "0.9.6"
 libfuzzer-sys = "0.4"
 log = "0.4.17"
-memoffset = "0.9.0"
 p384 = { version = "0.13.0" }
 uuid = "1.6.1"
 # Add the derive feature by default because all crates use it.

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -42,7 +42,6 @@ enable-gdb = ["dep:gdbstub", "dep:gdbstub_arch"]
 mstpm = ["dep:libmstpm"]
 
 [dev-dependencies]
-memoffset.workspace = true
 
 [lints]
 workspace = true

--- a/kernel/src/greq/msg.rs
+++ b/kernel/src/greq/msg.rs
@@ -540,10 +540,9 @@ impl SnpGuestRequestExtData {
 mod tests {
     use super::*;
     use crate::mm::alloc::{TestRootMem, DEFAULT_TEST_MEMORY_SIZE};
-    use memoffset::offset_of;
+    use core::mem::offset_of;
 
     #[test]
-    #[cfg_attr(test_in_svsm, ignore = "offset_of")]
     fn test_snp_guest_request_hdr_offsets() {
         assert_eq!(offset_of!(SnpGuestRequestMsgHdr, authtag), 0);
         assert_eq!(offset_of!(SnpGuestRequestMsgHdr, msg_seqno), 0x20);
@@ -560,7 +559,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(test_in_svsm, ignore = "offset_of")]
     fn test_snp_guest_request_msg_offsets() {
         assert_eq!(offset_of!(SnpGuestRequestMsg, hdr), 0);
         assert_eq!(offset_of!(SnpGuestRequestMsg, pld), 0x60);

--- a/kernel/src/greq/pld_report.rs
+++ b/kernel/src/greq/pld_report.rs
@@ -195,10 +195,9 @@ const _: () = assert!(size_of::<AttestationReport>() <= u32::MAX as usize);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use memoffset::offset_of;
+    use core::mem::offset_of;
 
     #[test]
-    #[cfg_attr(test_in_svsm, ignore = "offset_of")]
     fn test_snp_report_request_offsets() {
         assert_eq!(offset_of!(SnpReportRequest, user_data), 0x0);
         assert_eq!(offset_of!(SnpReportRequest, vmpl), 0x40);
@@ -207,7 +206,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(test_in_svsm, ignore = "offset_of")]
     fn test_snp_report_response_offsets() {
         assert_eq!(offset_of!(SnpReportResponse, status), 0x0);
         assert_eq!(offset_of!(SnpReportResponse, report_size), 0x4);
@@ -216,7 +214,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(test_in_svsm, ignore = "offset_of")]
     fn test_ecdsa_p384_sha384_signature_offsets() {
         assert_eq!(offset_of!(Signature, r), 0x0);
         assert_eq!(offset_of!(Signature, s), 0x48);
@@ -224,7 +221,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(test_in_svsm, ignore = "offset_of")]
     fn test_attestation_report_offsets() {
         assert_eq!(offset_of!(AttestationReport, version), 0x0);
         assert_eq!(offset_of!(AttestationReport, guest_svn), 0x4);

--- a/scripts/test-in-svsm.sh
+++ b/scripts/test-in-svsm.sh
@@ -9,8 +9,4 @@ set -e
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-if [ "$QEMU" == "" ]; then
-	echo "Set QEMU environment variable to QEMU installation path" && exit 1
-fi
-
 $SCRIPT_DIR/launch_guest.sh --igvm $SCRIPT_DIR/../bin/coconut-test-qemu.igvm --unit-tests || true


### PR DESCRIPTION
As of Rust 1.77, the `core::mem::offset_of!()` macro is stable, which means we no longer need to use the `memoffset` crate in tests. The new  macro is also more efficient as it does not have excessive stack usage, which means we can enable the tests that make use of this macro inside the SVSM.

While we are at it, remove an unnecessary check in `scripts/test-in-svsm.sh`.