### PR TITLE
Support multiple platforms in the SVSM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,9 +479,9 @@ checksum = "e4ce1f4656bae589a3fab938f9f09bf58645b7ed01a2c5f8a3c238e01a4ef78a"
 
 [[package]]
 name = "igvm"
-version = "0.1.4"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b39ce99255103ed59ba094d96b76f02888b2d758bf8d3073db07b1639d84133"
+checksum = "7fc6f4b643ea7266268a6a0ce3c6e146679ea041a55577a51d8173c18ce0c89a"
 dependencies = [
  "bitfield-struct",
  "crc32fast",
@@ -496,9 +496,9 @@ dependencies = [
 
 [[package]]
 name = "igvm_defs"
-version = "0.1.3"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "757d494b41d5e46cfdc6b0dd8aeaf61f8f557a62b546dc4cb000a0d86d195b84"
+checksum = "1348f0e14c5d761c2185841c42ff6aed8ef6ea62a5aa1d28a1587d87ec4ab827"
 dependencies = [
  "bitfield-struct",
  "open-enum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ clap = { version = "4.4.14", default-features = false}
 gdbstub = { version = "0.6.6", default-features = false }
 gdbstub_arch = { version = "0.2.4" }
 hmac-sha512 = "1.1.5"
-igvm_defs = { version = "0.1.3", default-features = false}
-igvm = { version = "0.1.3", default-features = false}
+igvm_defs = { version = "0.1.9", default-features = false}
+igvm = { version = "0.1.9", default-features = false}
 intrusive-collections = "0.9.6"
 libfuzzer-sys = "0.4"
 log = "0.4.17"

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ bin/coconut-qemu.igvm: $(IGVMBUILDER) $(IGVMMEASURE) bin/svsm-kernel.elf bin/sta
 	$(IGVMMEASURE) --check-kvm $@ measure
 
 bin/coconut-hyperv.igvm: $(IGVMBUILDER)  $(IGVMMEASURE) bin/svsm-kernel.elf bin/stage2.bin
-	$(IGVMBUILDER) --sort --output $@ --stage2 bin/stage2.bin --kernel bin/svsm-kernel.elf --comport 3 hyper-v
+	$(IGVMBUILDER) --sort --output $@ --stage2 bin/stage2.bin --kernel bin/svsm-kernel.elf --comport 3 hyper-v --native
 	$(IGVMMEASURE) $@ measure
 
 bin/coconut-test-qemu.igvm: $(IGVMBUILDER)  $(IGVMMEASURE) bin/test-kernel.elf bin/stage2.bin

--- a/bootlib/src/kernel_launch.rs
+++ b/bootlib/src/kernel_launch.rs
@@ -48,10 +48,13 @@ impl KernelLaunchInfo {
 pub struct Stage2LaunchInfo {
     // VTOM must be the first field.
     pub vtom: u64,
+
+    // platform_type must be the second field.
+    pub platform_type: u32,
+
     pub kernel_elf_start: u32,
     pub kernel_elf_end: u32,
     pub kernel_fs_start: u32,
     pub kernel_fs_end: u32,
     pub igvm_params: u32,
-    pub padding: u32,
 }

--- a/bootlib/src/kernel_launch.rs
+++ b/bootlib/src/kernel_launch.rs
@@ -4,6 +4,8 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
+use crate::platform::SvsmPlatformType;
+
 use zerocopy::AsBytes;
 
 #[derive(Copy, Clone, Debug)]
@@ -29,6 +31,7 @@ pub struct KernelLaunchInfo {
     pub igvm_params_virt_addr: u64,
     pub vtom: u64,
     pub debug_serial_port: u16,
+    pub platform_type: SvsmPlatformType,
 }
 
 impl KernelLaunchInfo {

--- a/bootlib/src/lib.rs
+++ b/bootlib/src/lib.rs
@@ -12,3 +12,4 @@
 
 pub mod igvm_params;
 pub mod kernel_launch;
+pub mod platform;

--- a/bootlib/src/platform.rs
+++ b/bootlib/src/platform.rs
@@ -11,3 +11,19 @@ pub enum SvsmPlatformType {
     Native = 0,
     Snp = 1,
 }
+
+impl SvsmPlatformType {
+    pub fn as_u32(&self) -> u32 {
+        match self {
+            Self::Native => 0,
+            Self::Snp => 1,
+        }
+    }
+
+    pub fn from_u32(value: u32) -> Self {
+        match value {
+            1 => Self::Snp,
+            _ => Self::Native,
+        }
+    }
+}

--- a/bootlib/src/platform.rs
+++ b/bootlib/src/platform.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Jon Lange (jlange@microsoft.com)
+
+/// Defines the underlying platform type on which the SVSM will run.
+#[derive(Copy, Clone, Debug)]
+#[repr(C)]
+pub enum SvsmPlatformType {
+    Native = 0,
+    Snp = 1,
+}

--- a/igvmbuilder/src/cmd_options.rs
+++ b/igvmbuilder/src/cmd_options.rs
@@ -47,6 +47,10 @@ pub struct CmdOptions {
     /// A hex value containing the guest policy to apply. For example: 0x30000
     #[arg(long)]
     pub policy: Option<String>,
+
+    /// Include NATIVE platform target
+    #[arg(long, default_value_t = false)]
+    pub native: bool,
 }
 
 impl CmdOptions {

--- a/igvmbuilder/src/main.rs
+++ b/igvmbuilder/src/main.rs
@@ -15,6 +15,7 @@ mod gpa_map;
 mod igvm_builder;
 mod igvm_firmware;
 mod ovmf_firmware;
+mod platform;
 mod stage2_stack;
 mod vmsa;
 

--- a/igvmbuilder/src/platform.rs
+++ b/igvmbuilder/src/platform.rs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 Microsoft Corporation
+//
+// Author: Jon Lange <jlange@microsoft.com>
+
+use std::sync::atomic::{AtomicU32, Ordering};
+
+pub struct PlatformMask {
+    mask: AtomicU32,
+}
+
+impl PlatformMask {
+    pub const fn new() -> Self {
+        Self {
+            mask: AtomicU32::new(0),
+        }
+    }
+
+    pub fn get(&self) -> u32 {
+        self.mask.load(Ordering::Relaxed)
+    }
+
+    pub fn add(&self, add_mask: u32) {
+        self.mask.fetch_or(add_mask, Ordering::Relaxed);
+    }
+
+    pub fn contains(&self, test_mask: u32) -> bool {
+        (self.mask.load(Ordering::Relaxed) & test_mask) != 0
+    }
+}

--- a/igvmbuilder/src/vmsa.rs
+++ b/igvmbuilder/src/vmsa.rs
@@ -4,51 +4,110 @@
 //
 // Author: Roy Hopkins <roy.hopkins@suse.com>
 
-use std::error::Error;
 use std::mem::size_of;
 
 use igvm::snp_defs::{SevFeatures, SevVmsa};
 use igvm::IgvmDirectiveHeader;
+use igvm_defs::IgvmNativeVpContextX64;
 use zerocopy::FromZeroes;
 
 use crate::stage2_stack::Stage2Stack;
 
+pub fn construct_start_context() -> Box<IgvmNativeVpContextX64> {
+    let mut context_box = IgvmNativeVpContextX64::new_box_zeroed();
+    let context = context_box.as_mut();
+
+    // Establish CS as a 32-bit code selector.
+    context.code_attributes = 0xc09b;
+    context.code_limit = 0xffffffff;
+    context.code_selector = 0x08;
+
+    // Establish all data segments as generic data selectors.
+    context.data_attributes = 0xa093;
+    context.data_limit = 0xffffffff;
+    context.data_selector = 0x10;
+
+    // EFER.SVME.
+    context.efer = 0x1000;
+
+    // CR0.PE | CR0.NE | CR0.ET.
+    context.cr0 = 0x31;
+
+    // CR4.MCE.
+    context.cr4 = 0x40;
+
+    context.rflags = 2;
+    context.rip = 0x10000;
+    context.rsp = context.rip - size_of::<Stage2Stack>() as u64;
+
+    context_box
+}
+
+fn vmsa_convert_attributes(attributes: u16) -> u16 {
+    (attributes & 0xFF) | ((attributes >> 4) & 0xF00)
+}
+
 pub fn construct_vmsa(
+    context: &IgvmNativeVpContextX64,
     gpa_start: u64,
     vtom: u64,
     compatibility_mask: u32,
-) -> Result<IgvmDirectiveHeader, Box<dyn Error>> {
+) -> IgvmDirectiveHeader {
     let mut vmsa_box = SevVmsa::new_box_zeroed();
     let vmsa = vmsa_box.as_mut();
 
-    // Establish CS as a 32-bit code selector.
-    vmsa.cs.attrib = 0xc9b;
-    vmsa.cs.limit = 0xffffffff;
-    vmsa.cs.selector = 0x08;
+    // Copy GPRs.
+    vmsa.rax = context.rax;
+    vmsa.rcx = context.rcx;
+    vmsa.rdx = context.rdx;
+    vmsa.rbx = context.rbx;
+    vmsa.rsp = context.rsp;
+    vmsa.rbp = context.rbp;
+    vmsa.rsi = context.rsi;
+    vmsa.rdi = context.rdi;
+    vmsa.r8 = context.r8;
+    vmsa.r9 = context.r9;
+    vmsa.r10 = context.r10;
+    vmsa.r11 = context.r11;
+    vmsa.r12 = context.r12;
+    vmsa.r13 = context.r13;
+    vmsa.r14 = context.r14;
+    vmsa.r15 = context.r15;
 
-    // Establish all data segments as generic data selectors.
-    vmsa.ds.attrib = 0xa93;
-    vmsa.ds.limit = 0xffffffff;
-    vmsa.ds.selector = 0x10;
+    // Configure other initial state registers.
+    vmsa.rip = context.rip;
+    vmsa.rflags = context.rflags;
+
+    // Configure selectors.
+    vmsa.cs.selector = context.code_selector;
+    vmsa.cs.attrib = vmsa_convert_attributes(context.code_attributes);
+    vmsa.cs.base = context.code_base as u64;
+    vmsa.cs.limit = context.code_limit;
+
+    vmsa.ds.attrib = vmsa_convert_attributes(context.data_attributes);
+    vmsa.ds.limit = context.data_limit;
+    vmsa.ds.base = context.data_base as u64;
+    vmsa.ds.selector = context.data_selector;
     vmsa.ss = vmsa.ds;
     vmsa.es = vmsa.ds;
     vmsa.fs = vmsa.ds;
     vmsa.gs = vmsa.ds;
+    vmsa.gs.base = context.gs_base;
 
-    // EFER.SVME.
-    vmsa.efer = 0x1000;
+    vmsa.idtr.base = context.idtr_base;
+    vmsa.idtr.limit = context.idtr_size as u32;
+    vmsa.gdtr.base = context.gdtr_base;
+    vmsa.gdtr.limit = context.gdtr_size as u32;
 
-    // CR0.PE | CR0.NE | CR0.ET.
-    vmsa.cr0 = 0x31;
+    // Configure control registers.
+    vmsa.cr0 = context.cr0;
+    vmsa.cr3 = context.cr3;
+    vmsa.cr4 = context.cr4;
+    vmsa.efer = context.efer;
 
-    // CR4.MCE.
-    vmsa.cr4 = 0x40;
-
+    // Configure non-zero reset state.
     vmsa.pat = 0x0007040600070406;
     vmsa.xcr0 = 1;
-    vmsa.rflags = 2;
-    vmsa.rip = 0x10000;
-    vmsa.rsp = vmsa.rip - size_of::<Stage2Stack>() as u64;
 
     let mut features = SevFeatures::new();
     features.set_snp(true);
@@ -60,10 +119,10 @@ pub fn construct_vmsa(
     features.set_debug_swap(true);
     vmsa.sev_features = features;
 
-    Ok(IgvmDirectiveHeader::SnpVpContext {
+    IgvmDirectiveHeader::SnpVpContext {
         gpa: gpa_start,
         compatibility_mask,
         vp_index: 0,
         vmsa: vmsa_box,
-    })
+    }
 }

--- a/kernel/src/boot_stage2.rs
+++ b/kernel/src/boot_stage2.rs
@@ -109,6 +109,12 @@ global_asm!(
 
     get_pte_c_bit:
         /*
+         * Check if this is an SNP platform.  If not, there is no C bit.
+         */
+        cmpl $1, 8(%esi)
+        jnz .Lvtom
+
+        /*
          * Check that the SNP_Active bit in the SEV_STATUS MSR is set.
          */
         movl $0xc0010131, %ecx

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -27,6 +27,7 @@ pub mod io;
 pub mod kernel_region;
 pub mod locking;
 pub mod mm;
+pub mod platform;
 pub mod protocols;
 pub mod requests;
 pub mod serial;

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -4,10 +4,14 @@
 //
 // Author: Jon Lange <jlange@microsoft.com>
 
+use crate::address::{PhysAddr, VirtAddr};
 use crate::cpu::percpu::PerCpu;
+use crate::error::SvsmError;
 use crate::io::IOPort;
 use crate::platform::native::NativePlatform;
 use crate::platform::snp::SnpPlatform;
+use crate::types::PageSize;
+use crate::utils::MemoryRegion;
 
 use bootlib::platform::SvsmPlatformType;
 
@@ -40,6 +44,19 @@ pub trait SvsmPlatform {
 
     /// Obtains a console I/O port reference.
     fn get_console_io_port(&self) -> &'static dyn IOPort;
+
+    /// Performs a page state change between private and shared states.
+    fn page_state_change(
+        &self,
+        start: PhysAddr,
+        end: PhysAddr,
+        size: PageSize,
+        make_private: bool,
+    ) -> Result<(), SvsmError>;
+
+    /// Marks a page as valid or invalid as a private page.
+    fn pvalidate_range(&self, region: MemoryRegion<VirtAddr>, valid: bool)
+        -> Result<(), SvsmError>;
 }
 
 //FIXME - remove Copy trait

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -4,6 +4,7 @@
 //
 // Author: Jon Lange <jlange@microsoft.com>
 
+use crate::cpu::percpu::PerCpu;
 use crate::platform::native::NativePlatform;
 use crate::platform::snp::SnpPlatform;
 
@@ -32,6 +33,9 @@ pub trait SvsmPlatform {
 
     /// Determines the paging encryption masks for the current architecture.
     fn get_page_encryption_masks(&self, vtom: usize) -> PageEncryptionMasks;
+
+    /// Establishes state required for guest/host communication.
+    fn setup_guest_host_comm(&mut self, cpu: &mut PerCpu, is_bsp: bool);
 }
 
 //FIXME - remove Copy trait

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -12,6 +12,14 @@ use bootlib::platform::SvsmPlatformType;
 pub mod native;
 pub mod snp;
 
+#[derive(Clone, Copy, Debug)]
+pub struct PageEncryptionMasks {
+    pub private_pte_mask: usize,
+    pub shared_pte_mask: usize,
+    pub addr_mask_width: u32,
+    pub phys_addr_sizes: u32,
+}
+
 /// This defines a platform abstraction to permit the SVSM to run on different
 /// underlying architectures.
 pub trait SvsmPlatform {
@@ -21,6 +29,9 @@ pub trait SvsmPlatform {
     /// Performs initialization of the platform runtime environment after
     /// console logging has been initialized.
     fn env_setup_late(&mut self);
+
+    /// Determines the paging encryption masks for the current architecture.
+    fn get_page_encryption_masks(&self, vtom: usize) -> PageEncryptionMasks;
 }
 
 //FIXME - remove Copy trait

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -5,6 +5,7 @@
 // Author: Jon Lange <jlange@microsoft.com>
 
 use crate::cpu::percpu::PerCpu;
+use crate::io::IOPort;
 use crate::platform::native::NativePlatform;
 use crate::platform::snp::SnpPlatform;
 
@@ -36,6 +37,9 @@ pub trait SvsmPlatform {
 
     /// Establishes state required for guest/host communication.
     fn setup_guest_host_comm(&mut self, cpu: &mut PerCpu, is_bsp: bool);
+
+    /// Obtains a console I/O port reference.
+    fn get_console_io_port(&self) -> &'static dyn IOPort;
 }
 
 //FIXME - remove Copy trait

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Jon Lange <jlange@microsoft.com>
+
+use crate::platform::native::NativePlatform;
+use crate::platform::snp::SnpPlatform;
+
+use bootlib::platform::SvsmPlatformType;
+
+pub mod native;
+pub mod snp;
+
+/// This defines a platform abstraction to permit the SVSM to run on different
+/// underlying architectures.
+pub trait SvsmPlatform {
+    /// Performs basic early initialization of the runtime environment.
+    fn env_setup(&mut self);
+
+    /// Performs initialization of the platform runtime environment after
+    /// console logging has been initialized.
+    fn env_setup_late(&mut self);
+}
+
+//FIXME - remove Copy trait
+#[derive(Clone, Copy, Debug)]
+pub enum SvsmPlatformCell {
+    Snp(SnpPlatform),
+    Native(NativePlatform),
+}
+
+impl SvsmPlatformCell {
+    pub fn new(platform_type: SvsmPlatformType) -> Self {
+        match platform_type {
+            SvsmPlatformType::Native => SvsmPlatformCell::Native(NativePlatform::new()),
+            SvsmPlatformType::Snp => SvsmPlatformCell::Snp(SnpPlatform::new()),
+        }
+    }
+
+    pub fn as_mut_dyn_ref(&mut self) -> &mut dyn SvsmPlatform {
+        match self {
+            SvsmPlatformCell::Native(platform) => platform,
+            SvsmPlatformCell::Snp(platform) => platform,
+        }
+    }
+}

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -5,6 +5,7 @@
 // Author: Jon Lange <jlange@microsoft.com>
 
 use crate::cpu::cpuid::CpuidResult;
+use crate::cpu::percpu::PerCpu;
 use crate::platform::{PageEncryptionMasks, SvsmPlatform};
 
 #[derive(Clone, Copy, Debug)]
@@ -35,4 +36,6 @@ impl SvsmPlatform for NativePlatform {
             phys_addr_sizes: res.eax,
         }
     }
+
+    fn setup_guest_host_comm(&mut self, _cpu: &mut PerCpu, _is_bsp: bool) {}
 }

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -31,6 +31,15 @@ impl Default for NativePlatform {
 impl SvsmPlatform for NativePlatform {
     fn env_setup(&mut self) {}
     fn env_setup_late(&mut self) {}
+
+    fn setup_percpu(&self, _cpu: &mut PerCpu) -> Result<(), SvsmError> {
+        Ok(())
+    }
+
+    fn setup_percpu_current(&self, _cpu: &mut PerCpu) -> Result<(), SvsmError> {
+        Ok(())
+    }
+
     fn get_page_encryption_masks(&self, _vtom: usize) -> PageEncryptionMasks {
         // Find physical address size.
         let res = CpuidResult::get(0x80000008, 0);

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -4,7 +4,8 @@
 //
 // Author: Jon Lange <jlange@microsoft.com>
 
-use crate::platform::SvsmPlatform;
+use crate::cpu::cpuid::CpuidResult;
+use crate::platform::{PageEncryptionMasks, SvsmPlatform};
 
 #[derive(Clone, Copy, Debug)]
 pub struct NativePlatform {}
@@ -24,4 +25,14 @@ impl Default for NativePlatform {
 impl SvsmPlatform for NativePlatform {
     fn env_setup(&mut self) {}
     fn env_setup_late(&mut self) {}
+    fn get_page_encryption_masks(&self, _vtom: usize) -> PageEncryptionMasks {
+        // Find physical address size.
+        let res = CpuidResult::get(0x80000008, 0);
+        PageEncryptionMasks {
+            private_pte_mask: 0,
+            shared_pte_mask: 0,
+            addr_mask_width: 64,
+            phys_addr_sizes: res.eax,
+        }
+    }
 }

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Jon Lange <jlange@microsoft.com>
+
+use crate::platform::SvsmPlatform;
+
+#[derive(Clone, Copy, Debug)]
+pub struct NativePlatform {}
+
+impl NativePlatform {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for NativePlatform {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SvsmPlatform for NativePlatform {
+    fn env_setup(&mut self) {}
+    fn env_setup_late(&mut self) {}
+}

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -6,7 +6,11 @@
 
 use crate::cpu::cpuid::CpuidResult;
 use crate::cpu::percpu::PerCpu;
+use crate::platform::IOPort;
 use crate::platform::{PageEncryptionMasks, SvsmPlatform};
+use crate::svsm_console::NativeIOPort;
+
+static CONSOLE_IO: NativeIOPort = NativeIOPort::new();
 
 #[derive(Clone, Copy, Debug)]
 pub struct NativePlatform {}
@@ -38,4 +42,8 @@ impl SvsmPlatform for NativePlatform {
     }
 
     fn setup_guest_host_comm(&mut self, _cpu: &mut PerCpu, _is_bsp: bool) {}
+
+    fn get_console_io_port(&self) -> &'static dyn IOPort {
+        &CONSOLE_IO
+    }
 }

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -6,9 +6,10 @@
 
 use crate::cpu::cpuid::CpuidResult;
 use crate::cpu::percpu::PerCpu;
-use crate::platform::IOPort;
-use crate::platform::{PageEncryptionMasks, SvsmPlatform};
+use crate::platform::{IOPort, PageEncryptionMasks, PhysAddr, SvsmError, SvsmPlatform, VirtAddr};
 use crate::svsm_console::NativeIOPort;
+use crate::types::PageSize;
+use crate::utils::MemoryRegion;
 
 static CONSOLE_IO: NativeIOPort = NativeIOPort::new();
 
@@ -45,5 +46,23 @@ impl SvsmPlatform for NativePlatform {
 
     fn get_console_io_port(&self) -> &'static dyn IOPort {
         &CONSOLE_IO
+    }
+
+    fn page_state_change(
+        &self,
+        _start: PhysAddr,
+        _end: PhysAddr,
+        _size: PageSize,
+        _make_private: bool,
+    ) -> Result<(), SvsmError> {
+        Ok(())
+    }
+
+    fn pvalidate_range(
+        &self,
+        _region: MemoryRegion<VirtAddr>,
+        _valid: bool,
+    ) -> Result<(), SvsmError> {
+        Ok(())
     }
 }

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -4,7 +4,9 @@
 //
 // Author: Jon Lange <jlange@microsoft.com>
 
-use crate::platform::SvsmPlatform;
+use crate::cpu::cpuid::cpuid_table;
+use crate::platform::{PageEncryptionMasks, SvsmPlatform};
+use crate::sev::status::vtom_enabled;
 use crate::sev::{sev_status_init, sev_status_verify};
 
 #[derive(Clone, Copy, Debug)]
@@ -29,5 +31,29 @@ impl SvsmPlatform for SnpPlatform {
 
     fn env_setup_late(&mut self) {
         sev_status_verify();
+    }
+
+    fn get_page_encryption_masks(&self, vtom: usize) -> PageEncryptionMasks {
+        // Find physical address size.
+        let res =
+            cpuid_table(0x80000008).expect("Can not get physical address size from CPUID table");
+        if vtom_enabled() {
+            PageEncryptionMasks {
+                private_pte_mask: 0,
+                shared_pte_mask: vtom,
+                addr_mask_width: vtom.leading_zeros(),
+                phys_addr_sizes: res.eax,
+            }
+        } else {
+            // Find C-bit position.
+            let res = cpuid_table(0x8000001f).expect("Can not get C-Bit position from CPUID table");
+            let c_bit = res.ebx & 0x3f;
+            PageEncryptionMasks {
+                private_pte_mask: 1 << c_bit,
+                shared_pte_mask: 0,
+                addr_mask_width: c_bit,
+                phys_addr_sizes: res.eax,
+            }
+        }
     }
 }

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -43,6 +43,15 @@ impl SvsmPlatform for SnpPlatform {
         sev_status_verify();
     }
 
+    fn setup_percpu(&self, cpu: &mut PerCpu) -> Result<(), SvsmError> {
+        // Setup GHCB
+        cpu.setup_ghcb()
+    }
+
+    fn setup_percpu_current(&self, cpu: &mut PerCpu) -> Result<(), SvsmError> {
+        cpu.register_ghcb()
+    }
+
     fn get_page_encryption_masks(&self, vtom: usize) -> PageEncryptionMasks {
         // Find physical address size.
         let res =

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Jon Lange <jlange@microsoft.com>
+
+use crate::platform::SvsmPlatform;
+use crate::sev::{sev_status_init, sev_status_verify};
+
+#[derive(Clone, Copy, Debug)]
+pub struct SnpPlatform {}
+
+impl SnpPlatform {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for SnpPlatform {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SvsmPlatform for SnpPlatform {
+    fn env_setup(&mut self) {
+        sev_status_init();
+    }
+
+    fn env_setup_late(&mut self) {
+        sev_status_verify();
+    }
+}

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -6,10 +6,14 @@
 
 use crate::cpu::cpuid::cpuid_table;
 use crate::cpu::percpu::PerCpu;
+use crate::io::IOPort;
 use crate::platform::{PageEncryptionMasks, SvsmPlatform};
 use crate::sev::msr_protocol::verify_ghcb_version;
 use crate::sev::status::vtom_enabled;
 use crate::sev::{sev_status_init, sev_status_verify};
+use crate::svsm_console::SVSMIOPort;
+
+static CONSOLE_IO: SVSMIOPort = SVSMIOPort::new();
 
 #[derive(Clone, Copy, Debug)]
 pub struct SnpPlatform {}
@@ -72,5 +76,9 @@ impl SvsmPlatform for SnpPlatform {
             }
         });
         cpu.register_ghcb().expect("Failed to register GHCB");
+    }
+
+    fn get_console_io_port(&self) -> &'static dyn IOPort {
+        &CONSOLE_IO
     }
 }

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -165,7 +165,7 @@ pub extern "C" fn stage2_main(launch_info: &Stage2LaunchInfo) {
     let kernel_elf_start: PhysAddr = PhysAddr::from(launch_info.kernel_elf_start as u64);
     let kernel_elf_end: PhysAddr = PhysAddr::from(launch_info.kernel_elf_end as u64);
 
-    let platform_type = SvsmPlatformType::Snp;
+    let platform_type = SvsmPlatformType::from_u32(launch_info.platform_type);
     let mut platform_cell = SvsmPlatformCell::new(platform_type);
     let platform = platform_cell.as_mut_dyn_ref();
 

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -99,7 +99,7 @@ fn setup_env(
         PhysAddr::null(),
     );
     register_cpuid_table(unsafe { &CPUID_PAGE });
-    paging_init_early(launch_info.vtom);
+    paging_init_early(platform, launch_info.vtom);
 
     // Bring up the GCHB for use from the SVSMIOPort console.
     verify_ghcb_version();

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -41,7 +41,7 @@ use svsm::mm::memory::init_memory_map;
 use svsm::mm::pagetable::paging_init;
 use svsm::mm::virtualrange::virt_log_usage;
 use svsm::mm::{init_kernel_mapping_info, PerCPUPageMappingGuard};
-use svsm::platform::SvsmPlatformCell;
+use svsm::platform::{SvsmPlatformCell, SVSM_PLATFORM};
 use svsm::requests::{request_loop, request_processing_main, update_mappings};
 use svsm::serial::SerialPort;
 use svsm::sev::utils::{rmp_adjust, RMPFlags};
@@ -337,10 +337,10 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
     let mut bsp_percpu = PerCpu::alloc(0).expect("Failed to allocate BSP per-cpu data");
 
     bsp_percpu
-        .setup()
+        .setup(platform)
         .expect("Failed to setup BSP per-cpu area");
     bsp_percpu
-        .setup_on_cpu()
+        .setup_on_cpu(platform)
         .expect("Failed to run percpu.setup_on_cpu()");
     bsp_percpu.load();
 
@@ -379,6 +379,10 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
 
     log::info!("BSP Runtime stack starts @ {:#018x}", bp);
 
+    SVSM_PLATFORM
+        .init(&platform_cell)
+        .expect("Failed to initialize SVSM platform object");
+
     schedule_init();
 
     panic!("SVSM entry point terminated unexpectedly");
@@ -386,6 +390,8 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
 
 #[no_mangle]
 pub extern "C" fn svsm_main() {
+    let platform = SVSM_PLATFORM.as_dyn_ref();
+
     // If required, the GDB stub can be started earlier, just after the console
     // is initialised in svsm_start() above.
     gdbstub_start().expect("Could not start GDB stub");
@@ -428,7 +434,7 @@ pub extern "C" fn svsm_main() {
 
     log::info!("{} CPU(s) present", nr_cpus);
 
-    start_secondary_cpus(&cpus, launch_info.vtom);
+    start_secondary_cpus(platform, &cpus, launch_info.vtom);
 
     let fw_metadata = config.get_fw_metadata();
     if let Some(ref fw_meta) = fw_metadata {

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -41,6 +41,7 @@ use svsm::mm::memory::init_memory_map;
 use svsm::mm::pagetable::paging_init;
 use svsm::mm::virtualrange::virt_log_usage;
 use svsm::mm::{init_kernel_mapping_info, PerCPUPageMappingGuard};
+use svsm::platform::SvsmPlatformCell;
 use svsm::requests::{request_loop, request_processing_main, update_mappings};
 use svsm::serial::SerialPort;
 use svsm::sev::utils::{rmp_adjust, RMPFlags};
@@ -294,6 +295,9 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
     LAUNCH_INFO
         .init(li)
         .expect("Already initialized launch info");
+
+    let mut platform_cell = SvsmPlatformCell::new(li.platform_type);
+    let _platform = platform_cell.as_mut_dyn_ref();
 
     init_cpuid_table(VirtAddr::from(launch_info.cpuid_page));
     dump_cpuid_table();

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -297,7 +297,7 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
         .expect("Already initialized launch info");
 
     let mut platform_cell = SvsmPlatformCell::new(li.platform_type);
-    let _platform = platform_cell.as_mut_dyn_ref();
+    let platform = platform_cell.as_mut_dyn_ref();
 
     init_cpuid_table(VirtAddr::from(launch_info.cpuid_page));
     dump_cpuid_table();
@@ -327,7 +327,7 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
         Err(e) => panic!("error reading kernel ELF: {}", e),
     };
 
-    paging_init(li.vtom);
+    paging_init(platform, li.vtom);
     init_page_table(&launch_info, &kernel_elf).expect("Could not initialize the page table");
 
     // SAFETY: this PerCpu has just been allocated and no other CPUs have been

--- a/stage1/stage1.S
+++ b/stage1/stage1.S
@@ -53,7 +53,6 @@ startup_32:
 	/* Write startup information to stage2 stack */
 	xorl 	%eax, %eax
 	pushl	%eax
-	pushl	%eax
 
 	leal	kernel_fs_bin_end(%ebp), %edi
 	pushl	%edi
@@ -66,6 +65,9 @@ startup_32:
 
 	leal	kernel_elf(%ebp), %edi
 	pushl	%edi
+
+	/* Push the value 1 to indicate SNP */
+	pushl	$1
 
 	/* Reserve space for VTOM */
 	pushl	%eax


### PR DESCRIPTION
This change defines a platform abstraction to permit the SVSM to execute correctly on multiple platform types.  The first additional platform type is the "native" platform, meaning a VM that is not isolated with SNP, which runs as a native VM type on its host.  This change is only sufficient to boot the SVSM on a native platform through stage 2 into the kernel, and additional native support will be added in the future.