### PR TITLE
kernel/build.rs: run build if linker scripts changed

### DIFF
--- a/kernel/build.rs
+++ b/kernel/build.rs
@@ -34,4 +34,7 @@ fn main() {
         println!("cargo:rustc-link-arg=-Tkernel/src/svsm.lds");
         println!("cargo:rustc-link-arg=-no-pie");
     }
+
+    println!("cargo:rerun-if-changed=kernel/src/stage2.lds");
+    println!("cargo:rerun-if-changed=kernel/src/svsm.lds");
 }


### PR DESCRIPTION
Currently, running `make` after changing a linker script does not run a new build, which is counterintuitive. Let cargo now that if at least one of the linker scripts changes, we want to build the kernel again.