### PR TITLE
docs: Document page tables, visibility, per-CPU guards

### DIFF
--- a/kernel/src/mm/page_visibility.rs
+++ b/kernel/src/mm/page_visibility.rs
@@ -16,6 +16,12 @@ use crate::platform::{PageStateChangeOp, SVSM_PLATFORM};
 use crate::types::{PageSize, PAGE_SIZE};
 use crate::utils::MemoryRegion;
 
+/// Makes a virtual page shared by revoking its validation, updating the
+/// page state, and modifying the page tables accordingly.
+///
+/// # Arguments
+///
+/// * `vaddr` - The virtual address of the page to be made shared.
 pub fn make_page_shared(vaddr: VirtAddr) -> Result<(), SvsmError> {
     let platform = SVSM_PLATFORM.as_dyn_ref();
 
@@ -43,6 +49,12 @@ pub fn make_page_shared(vaddr: VirtAddr) -> Result<(), SvsmError> {
     Ok(())
 }
 
+/// Makes a virtual page private by updating the page tables, modifying the
+/// page state, and revalidating the page.
+///
+/// # Arguments
+///
+/// * `vaddr` - The virtual address of the page to be made private.
 pub fn make_page_private(vaddr: VirtAddr) -> Result<(), SvsmError> {
     // Update the page tables to map the page as private.
     this_cpu_mut().get_pgtable().set_encrypted_4k(vaddr)?;

--- a/kernel/src/mm/ptguards.rs
+++ b/kernel/src/mm/ptguards.rs
@@ -16,6 +16,7 @@ use crate::types::{PAGE_SIZE, PAGE_SIZE_2M};
 
 use crate::utils::MemoryRegion;
 
+/// Guard for a per-CPU page mapping to ensure adequate cleanup if drop.
 #[derive(Debug)]
 #[must_use = "if unused the mapping will immediately be unmapped"]
 pub struct PerCPUPageMappingGuard {
@@ -24,6 +25,24 @@ pub struct PerCPUPageMappingGuard {
 }
 
 impl PerCPUPageMappingGuard {
+    /// Creates a new [`PerCPUPageMappingGuard`] for the specified physical
+    /// address range and alignment.
+    ///
+    /// # Arguments
+    ///
+    /// * `paddr_start` - The starting physical address of the range.
+    /// * `paddr_end` - The ending physical address of the range.
+    /// * `alignment` - The desired alignment for the mapping.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing the [`PerCPUPageMappingGuard`] if successful,
+    /// or an `SvsmError` if an error occurs.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either `paddr_start`, the size, or `paddr_end`, are not
+    /// aligned.
     pub fn create(
         paddr_start: PhysAddr,
         paddr_end: PhysAddr,
@@ -66,10 +85,13 @@ impl PerCPUPageMappingGuard {
         })
     }
 
+    /// Creates a new [`PerCPUPageMappingGuard`] for a 4KB page at the
+    /// specified physical address, or an `SvsmError` if an error occurs.
     pub fn create_4k(paddr: PhysAddr) -> Result<Self, SvsmError> {
         Self::create(paddr, paddr + PAGE_SIZE, 0)
     }
 
+    /// Returns the virtual address associated with the guard.
     pub fn virt_addr(&self) -> VirtAddr {
         self.mapping.start()
     }


### PR DESCRIPTION
Document memory management of page tables, page visibility and per-CPU mapping guards. This is related to issue https://github.com/coconut-svsm/svsm/issues/74 Document COCONUT-SVSM and continues the mm documentation efforts that started with the merged https://github.com/coconut-svsm/svsm/pull/243. For the purpose of that issue, I will consider the memory subsystem sufficiently documented after this PR (even if not every single detail has been documented) and would like to shift focus to documenting `protocols`.