### PR TITLE
console, serial: multiple cleanups

### DIFF
--- a/kernel/src/console.rs
+++ b/kernel/src/console.rs
@@ -11,23 +11,20 @@ use core::fmt;
 
 #[derive(Clone, Copy)]
 pub struct Console {
-    writer: Option<&'static dyn Terminal>,
+    writer: &'static dyn Terminal,
 }
 
 impl Console {
     pub fn set(&mut self, w: &'static dyn Terminal) {
-        self.writer = Some(w);
+        self.writer = w;
     }
 }
 
 impl fmt::Write for Console {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        if let Some(writer) = self.writer {
-            for ch in s.bytes() {
-                writer.put_byte(ch);
-            }
+        for ch in s.bytes() {
+            self.writer.put_byte(ch);
         }
-
         Ok(())
     }
 }
@@ -35,19 +32,13 @@ impl fmt::Write for Console {
 impl fmt::Debug for Console {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Console")
-            .field(
-                "writer",
-                &format_args!(
-                    "{:?}",
-                    self.writer.as_ref().map(|writer| writer as *const _)
-                ),
-            )
+            .field("writer", &format_args!("{:?}", self.writer as *const _,))
             .finish()
     }
 }
 
 pub static WRITER: SpinLock<Console> = SpinLock::new(Console {
-    writer: Some(&DEFAULT_SERIAL_PORT),
+    writer: &DEFAULT_SERIAL_PORT,
 });
 static CONSOLE_INITIALIZED: ImmutAfterInitCell<bool> = ImmutAfterInitCell::new(false);
 

--- a/kernel/src/console.rs
+++ b/kernel/src/console.rs
@@ -113,11 +113,8 @@ impl log::Log for ConsoleLogger {
 
 static CONSOLE_LOGGER: ImmutAfterInitCell<ConsoleLogger> = ImmutAfterInitCell::uninit();
 
-pub fn install_console_logger(component: &'static str) {
-    let logger = ConsoleLogger::new(component);
-    CONSOLE_LOGGER
-        .init(&logger)
-        .expect("Already initialized console logger");
+pub fn install_console_logger(component: &'static str) -> ImmutAfterInitResult<()> {
+    CONSOLE_LOGGER.init(&ConsoleLogger::new(component))?;
 
     if let Err(e) = log::set_logger(&*CONSOLE_LOGGER) {
         // Failed to install the ConsoleLogger, presumably because something had
@@ -131,6 +128,7 @@ pub fn install_console_logger(component: &'static str) {
 
     // Log levels are to be configured via the log's library feature configuration.
     log::set_max_level(log::LevelFilter::Trace);
+    Ok(())
 }
 
 #[macro_export]

--- a/kernel/src/debug/gdbstub.rs
+++ b/kernel/src/debug/gdbstub.rs
@@ -174,10 +174,7 @@ pub mod svsm_gdbstub {
     static GDB_INITIALISED: AtomicBool = AtomicBool::new(false);
     static GDB_STATE: SpinLock<Option<SvsmGdbStub<'_>>> = SpinLock::new(None);
     static GDB_IO: SVSMIOPort = SVSMIOPort::new();
-    static mut GDB_SERIAL: SerialPort<'_> = SerialPort {
-        driver: &GDB_IO,
-        port: 0x2f8,
-    };
+    static mut GDB_SERIAL: SerialPort<'_> = SerialPort::new(&GDB_IO, 0x2f8);
     static mut PACKET_BUFFER: [u8; 4096] = [0; 4096];
     // Allocate the GDB stack as an array of u64's to ensure 8 byte alignment of the stack.
     static mut GDB_STACK: [u64; 8192] = [0; 8192];

--- a/kernel/src/serial.rs
+++ b/kernel/src/serial.rs
@@ -34,12 +34,12 @@ pub trait Terminal: Sync {
 
 #[derive(Debug, Copy, Clone)]
 pub struct SerialPort<'a> {
-    pub driver: &'a dyn IOPort,
-    pub port: u16,
+    driver: &'a dyn IOPort,
+    port: u16,
 }
 
 impl<'a> SerialPort<'a> {
-    pub fn new(driver: &'a dyn IOPort, p: u16) -> Self {
+    pub const fn new(driver: &'a dyn IOPort, p: u16) -> Self {
         SerialPort { driver, port: p }
     }
 
@@ -89,7 +89,4 @@ impl Terminal for SerialPort<'_> {
     }
 }
 
-pub static DEFAULT_SERIAL_PORT: SerialPort<'_> = SerialPort {
-    driver: &DEFAULT_IO_DRIVER,
-    port: SERIAL_PORT,
-};
+pub static DEFAULT_SERIAL_PORT: SerialPort<'_> = SerialPort::new(&DEFAULT_IO_DRIVER, SERIAL_PORT);

--- a/kernel/src/serial.rs
+++ b/kernel/src/serial.rs
@@ -45,45 +45,47 @@ impl<'a> SerialPort<'a> {
 
     pub fn init(&self) {
         let divisor: u32 = 115200 / BAUD;
-        let driver = &self.driver;
-        let port = self.port;
 
-        driver.outb(port + LCR, 0x3); // 8n1
-        driver.outb(port + IER, 0); // No Interrupt
-        driver.outb(port + FCR, 0); // No FIFO
-        driver.outb(port + MCR, 0x3); // DTR + RTS
+        self.outb(LCR, 0x3); // 8n1
+        self.outb(IER, 0x0); // No Interrupt
+        self.outb(FCR, 0x0); // No FIFO
+        self.outb(MCR, 0x3); // DTR + RTS
 
-        let c = driver.inb(port + LCR);
-        driver.outb(port + LCR, c | DLAB);
-        driver.outb(port + DLL, (divisor & 0xff) as u8);
-        driver.outb(port + DLH, ((divisor >> 8) & 0xff) as u8);
-        driver.outb(port + LCR, c & !DLAB);
+        let c = self.inb(LCR);
+        self.outb(LCR, c | DLAB);
+        self.outb(DLL, (divisor & 0xff) as u8);
+        self.outb(DLH, ((divisor >> 8) & 0xff) as u8);
+        self.outb(LCR, c & !DLAB);
+    }
+
+    #[inline]
+    fn inb(&self, port: u16) -> u8 {
+        self.driver.inb(self.port + port)
+    }
+
+    #[inline]
+    fn outb(&self, port: u16, val: u8) {
+        self.driver.outb(self.port + port, val);
     }
 }
 
 impl Terminal for SerialPort<'_> {
     fn put_byte(&self, ch: u8) {
-        let driver = &self.driver;
-        let port = self.port;
-
         loop {
-            let xmt = driver.inb(port + LSR);
+            let xmt = self.inb(LSR);
             if (xmt & XMTRDY) == XMTRDY {
                 break;
             }
         }
 
-        driver.outb(port + TXR, ch)
+        self.outb(TXR, ch)
     }
 
     fn get_byte(&self) -> u8 {
-        let driver = &self.driver;
-        let port = self.port;
-
         loop {
-            let rcv = driver.inb(port + LSR);
+            let rcv = self.inb(LSR);
             if (rcv & RCVRDY) == RCVRDY {
-                return driver.inb(port);
+                return self.inb(0);
             }
         }
     }

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -101,10 +101,10 @@ fn setup_env(
     early_idt_init();
 
     CONSOLE_SERIAL
-        .init(&SerialPort {
-            driver: platform.get_console_io_port(),
-            port: config.debug_serial_port(),
-        })
+        .init(&SerialPort::new(
+            platform.get_console_io_port(),
+            config.debug_serial_port(),
+        ))
         .expect("console serial output already configured");
     (*CONSOLE_SERIAL).init();
 

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -18,7 +18,7 @@ use core::slice;
 use cpuarch::snp_cpuid::SnpCpuidTable;
 use svsm::address::{Address, PhysAddr, VirtAddr};
 use svsm::config::SvsmConfig;
-use svsm::console::{init_console, install_console_logger, WRITER};
+use svsm::console::{init_console, install_console_logger};
 use svsm::cpu::cpuid::{dump_cpuid_table, register_cpuid_table};
 use svsm::cpu::gdt;
 use svsm::cpu::idt::stage2::{early_idt_init, early_idt_init_no_ghcb};
@@ -107,9 +107,7 @@ fn setup_env(
         ))
         .expect("console serial output already configured");
     (*CONSOLE_SERIAL).init();
-
-    WRITER.lock().set(&*CONSOLE_SERIAL);
-    init_console();
+    init_console(&*CONSOLE_SERIAL).expect("Console writer already initialized");
 
     // Console is fully working now and any unsupported configuration can be
     // properly reported.

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -84,7 +84,7 @@ fn setup_env(
     early_idt_init_no_ghcb();
     platform.env_setup();
 
-    install_console_logger("Stage2");
+    install_console_logger("Stage2").expect("Console logger already initialized");
     init_kernel_mapping_info(
         VirtAddr::null(),
         VirtAddr::from(640 * 1024usize),

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -18,7 +18,7 @@ use core::slice;
 use cpuarch::snp_cpuid::SnpCpuidTable;
 use svsm::address::{PhysAddr, VirtAddr};
 use svsm::config::SvsmConfig;
-use svsm::console::{init_console, install_console_logger, WRITER};
+use svsm::console::{init_console, install_console_logger};
 use svsm::cpu::control_regs::{cr0_init, cr4_init};
 use svsm::cpu::cpuid::{dump_cpuid_table, register_cpuid_table};
 use svsm::cpu::efer::efer_init;
@@ -358,8 +358,7 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
         .expect("console serial output already configured");
     (*CONSOLE_SERIAL).init();
 
-    WRITER.lock().set(&*CONSOLE_SERIAL);
-    init_console();
+    init_console(&*CONSOLE_SERIAL).expect("Console writer already initialized");
     install_console_logger("SVSM");
 
     log::info!("COCONUT Secure Virtual Machine Service Module (SVSM)");

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -354,10 +354,7 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
     idt_init();
 
     CONSOLE_SERIAL
-        .init(&SerialPort {
-            driver: &CONSOLE_IO,
-            port: debug_serial_port,
-        })
+        .init(&SerialPort::new(&CONSOLE_IO, debug_serial_port))
         .expect("console serial output already configured");
     (*CONSOLE_SERIAL).init();
 

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -359,7 +359,7 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
     (*CONSOLE_SERIAL).init();
 
     init_console(&*CONSOLE_SERIAL).expect("Console writer already initialized");
-    install_console_logger("SVSM");
+    install_console_logger("SVSM").expect("Console logger already initialized");
 
     log::info!("COCONUT Secure Virtual Machine Service Module (SVSM)");
 


### PR DESCRIPTION
* serial: make `SerialPort` fields private and use `SerialPort::new()` where needed.
* serial: add `SerialPort::{inb, outb}()` to simplify code.
* console: remove `Option` from `Console`, as it is always `Some`.
* console: initialize `WRITER` directly from `init_console()`
* console: return error from `install_console_logger()` instead of implicitly panicking.