### PR TITLE
Use `SvsmPlatform` page state change methods and other cleanups

### DIFF
--- a/kernel/src/fw_meta.rs
+++ b/kernel/src/fw_meta.rs
@@ -12,7 +12,7 @@ use crate::cpu::ghcb::current_ghcb;
 use crate::error::SvsmError;
 use crate::kernel_region::new_kernel_region;
 use crate::mm::PerCPUPageMappingGuard;
-use crate::sev::ghcb::PageStateChangeOp;
+use crate::platform::PageStateChangeOp;
 use crate::sev::{pvalidate, rmp_adjust, PvalidateOp, RMPFlags};
 use crate::types::{PageSize, PAGE_SIZE};
 use crate::utils::{zero_mem_region, MemoryRegion};
@@ -370,7 +370,7 @@ fn validate_fw_mem_region(
 
     if config.page_state_change_required() {
         current_ghcb()
-            .page_state_change(region, PageSize::Regular, PageStateChangeOp::PscPrivate)
+            .page_state_change(region, PageSize::Regular, PageStateChangeOp::Private)
             .expect("GHCB PSC call failed to validate firmware memory");
     }
 

--- a/kernel/src/fw_meta.rs
+++ b/kernel/src/fw_meta.rs
@@ -370,12 +370,7 @@ fn validate_fw_mem_region(
 
     if config.page_state_change_required() {
         current_ghcb()
-            .page_state_change(
-                pstart,
-                pend,
-                PageSize::Regular,
-                PageStateChangeOp::PscPrivate,
-            )
+            .page_state_change(region, PageSize::Regular, PageStateChangeOp::PscPrivate)
             .expect("GHCB PSC call failed to validate firmware memory");
     }
 

--- a/kernel/src/greq/msg.rs
+++ b/kernel/src/greq/msg.rs
@@ -24,8 +24,9 @@ use crate::{
     cpu::percpu::this_cpu_mut,
     crypto::aead::{Aes256Gcm, Aes256GcmTrait, AUTHTAG_SIZE, IV_SIZE},
     mm::virt_to_phys,
+    platform::PageStateChangeOp,
     protocols::errors::SvsmReqError,
-    sev::{ghcb::PageStateChangeOp, secrets_page::VMPCK_SIZE},
+    sev::secrets_page::VMPCK_SIZE,
     types::{PageSize, PAGE_SIZE},
     utils::MemoryRegion,
 };
@@ -250,7 +251,7 @@ impl SnpGuestRequestMsg {
             .page_state_change(
                 MemoryRegion::new(paddr, PAGE_SIZE),
                 PageSize::Regular,
-                PageStateChangeOp::PscShared,
+                PageStateChangeOp::Shared,
             )
             .map_err(|_| SvsmReqError::invalid_request())
     }
@@ -268,7 +269,7 @@ impl SnpGuestRequestMsg {
             .page_state_change(
                 MemoryRegion::new(paddr, PAGE_SIZE),
                 PageSize::Regular,
-                PageStateChangeOp::PscPrivate,
+                PageStateChangeOp::Private,
             )
             .map_err(|_| SvsmReqError::invalid_request())
     }
@@ -423,7 +424,7 @@ fn set_encrypted_region_4k(vregion: MemoryRegion<VirtAddr>) -> Result<(), SvsmRe
             .page_state_change(
                 MemoryRegion::new(paddr, PAGE_SIZE),
                 PageSize::Regular,
-                PageStateChangeOp::PscPrivate,
+                PageStateChangeOp::Private,
             )
             .map_err(|_| SvsmReqError::invalid_request())?;
     }
@@ -443,7 +444,7 @@ fn set_shared_region_4k(vregion: MemoryRegion<VirtAddr>) -> Result<(), SvsmReqEr
             .page_state_change(
                 MemoryRegion::new(paddr, PAGE_SIZE),
                 PageSize::Regular,
-                PageStateChangeOp::PscShared,
+                PageStateChangeOp::Shared,
             )
             .map_err(|_| SvsmReqError::invalid_request())?;
     }

--- a/kernel/src/greq/msg.rs
+++ b/kernel/src/greq/msg.rs
@@ -27,6 +27,7 @@ use crate::{
     protocols::errors::SvsmReqError,
     sev::{ghcb::PageStateChangeOp, secrets_page::VMPCK_SIZE},
     types::{PageSize, PAGE_SIZE},
+    utils::MemoryRegion,
 };
 
 /// Version of the message header
@@ -247,8 +248,7 @@ impl SnpGuestRequestMsg {
         let paddr = virt_to_phys(vaddr);
         current_ghcb()
             .page_state_change(
-                paddr,
-                paddr + PAGE_SIZE,
+                MemoryRegion::new(paddr, PAGE_SIZE),
                 PageSize::Regular,
                 PageStateChangeOp::PscShared,
             )
@@ -266,8 +266,7 @@ impl SnpGuestRequestMsg {
         let paddr = virt_to_phys(vaddr);
         current_ghcb()
             .page_state_change(
-                paddr,
-                paddr + PAGE_SIZE,
+                MemoryRegion::new(paddr, PAGE_SIZE),
                 PageSize::Regular,
                 PageStateChangeOp::PscPrivate,
             )
@@ -425,8 +424,7 @@ fn set_encrypted_region_4k(start: VirtAddr, end: VirtAddr) -> Result<(), SvsmReq
         let paddr = virt_to_phys(addr);
         current_ghcb()
             .page_state_change(
-                paddr,
-                paddr + PAGE_SIZE,
+                MemoryRegion::new(paddr, PAGE_SIZE),
                 PageSize::Regular,
                 PageStateChangeOp::PscPrivate,
             )
@@ -449,8 +447,7 @@ fn set_shared_region_4k(start: VirtAddr, end: VirtAddr) -> Result<(), SvsmReqErr
         let paddr = virt_to_phys(addr);
         current_ghcb()
             .page_state_change(
-                paddr,
-                paddr + PAGE_SIZE,
+                MemoryRegion::new(paddr, PAGE_SIZE),
                 PageSize::Regular,
                 PageStateChangeOp::PscShared,
             )

--- a/kernel/src/mm/page_visibility.rs
+++ b/kernel/src/mm/page_visibility.rs
@@ -6,21 +6,22 @@
 
 use crate::address::VirtAddr;
 use crate::cpu::flush_tlb_global_sync;
-use crate::cpu::ghcb::current_ghcb;
 use crate::cpu::percpu::this_cpu_mut;
 use crate::mm::validate::{
     valid_bitmap_clear_valid_4k, valid_bitmap_set_valid_4k, valid_bitmap_valid_addr,
 };
 use crate::mm::virt_to_phys;
-use crate::platform::PageStateChangeOp;
-use crate::sev::utils::pvalidate;
+use crate::platform::{PageStateChangeOp, SVSM_PLATFORM};
 use crate::sev::PvalidateOp;
 use crate::types::{PageSize, PAGE_SIZE};
 use crate::utils::MemoryRegion;
 
 pub fn make_page_shared(vaddr: VirtAddr) {
+    let platform = SVSM_PLATFORM.as_dyn_ref();
+
     // Revoke page validation before changing page state.
-    pvalidate(vaddr, PageSize::Regular, PvalidateOp::Invalid)
+    platform
+        .pvalidate_range(MemoryRegion::new(vaddr, PAGE_SIZE), PvalidateOp::Invalid)
         .expect("Pvalidate failed when making page shared");
     let paddr = virt_to_phys(vaddr);
     if valid_bitmap_valid_addr(paddr) {
@@ -28,7 +29,7 @@ pub fn make_page_shared(vaddr: VirtAddr) {
     }
 
     // Ask the hypervisor to make the page shared.
-    current_ghcb()
+    platform
         .page_state_change(
             MemoryRegion::new(paddr, PAGE_SIZE),
             PageSize::Regular,
@@ -52,9 +53,11 @@ pub fn make_page_private(vaddr: VirtAddr) {
         .expect("Failed to remap private page in page tables");
     flush_tlb_global_sync();
 
+    let platform = SVSM_PLATFORM.as_dyn_ref();
+
     // Ask the hypervisor to make the page private.
     let paddr = virt_to_phys(vaddr);
-    current_ghcb()
+    platform
         .page_state_change(
             MemoryRegion::new(paddr, PAGE_SIZE),
             PageSize::Regular,
@@ -63,7 +66,8 @@ pub fn make_page_private(vaddr: VirtAddr) {
         .expect("Hypervisor failed to make page private");
 
     // Revoke page validation before changing page state.
-    pvalidate(vaddr, PageSize::Regular, PvalidateOp::Valid)
+    platform
+        .pvalidate_range(MemoryRegion::new(vaddr, PAGE_SIZE), PvalidateOp::Valid)
         .expect("Pvalidate failed when making page private");
     if valid_bitmap_valid_addr(paddr) {
         valid_bitmap_set_valid_4k(paddr);

--- a/kernel/src/mm/page_visibility.rs
+++ b/kernel/src/mm/page_visibility.rs
@@ -16,6 +16,7 @@ use crate::sev::ghcb::PageStateChangeOp;
 use crate::sev::utils::pvalidate;
 use crate::sev::PvalidateOp;
 use crate::types::{PageSize, PAGE_SIZE};
+use crate::utils::MemoryRegion;
 
 pub fn make_page_shared(vaddr: VirtAddr) {
     // Revoke page validation before changing page state.
@@ -29,8 +30,7 @@ pub fn make_page_shared(vaddr: VirtAddr) {
     // Ask the hypervisor to make the page shared.
     current_ghcb()
         .page_state_change(
-            paddr,
-            paddr + PAGE_SIZE,
+            MemoryRegion::new(paddr, PAGE_SIZE),
             PageSize::Regular,
             PageStateChangeOp::PscShared,
         )
@@ -56,8 +56,7 @@ pub fn make_page_private(vaddr: VirtAddr) {
     let paddr = virt_to_phys(vaddr);
     current_ghcb()
         .page_state_change(
-            paddr,
-            paddr + PAGE_SIZE,
+            MemoryRegion::new(paddr, PAGE_SIZE),
             PageSize::Regular,
             PageStateChangeOp::PscPrivate,
         )

--- a/kernel/src/mm/page_visibility.rs
+++ b/kernel/src/mm/page_visibility.rs
@@ -12,7 +12,7 @@ use crate::mm::validate::{
     valid_bitmap_clear_valid_4k, valid_bitmap_set_valid_4k, valid_bitmap_valid_addr,
 };
 use crate::mm::virt_to_phys;
-use crate::sev::ghcb::PageStateChangeOp;
+use crate::platform::PageStateChangeOp;
 use crate::sev::utils::pvalidate;
 use crate::sev::PvalidateOp;
 use crate::types::{PageSize, PAGE_SIZE};
@@ -32,7 +32,7 @@ pub fn make_page_shared(vaddr: VirtAddr) {
         .page_state_change(
             MemoryRegion::new(paddr, PAGE_SIZE),
             PageSize::Regular,
-            PageStateChangeOp::PscShared,
+            PageStateChangeOp::Shared,
         )
         .expect("Hypervisor failed to make page shared");
 
@@ -58,7 +58,7 @@ pub fn make_page_private(vaddr: VirtAddr) {
         .page_state_change(
             MemoryRegion::new(paddr, PAGE_SIZE),
             PageSize::Regular,
-            PageStateChangeOp::PscPrivate,
+            PageStateChangeOp::Private,
         )
         .expect("Hypervisor failed to make page private");
 

--- a/kernel/src/mm/page_visibility.rs
+++ b/kernel/src/mm/page_visibility.rs
@@ -7,6 +7,7 @@
 use crate::address::VirtAddr;
 use crate::cpu::flush_tlb_global_sync;
 use crate::cpu::percpu::this_cpu_mut;
+use crate::error::SvsmError;
 use crate::mm::validate::{
     valid_bitmap_clear_valid_4k, valid_bitmap_set_valid_4k, valid_bitmap_valid_addr,
 };
@@ -16,60 +17,50 @@ use crate::sev::PvalidateOp;
 use crate::types::{PageSize, PAGE_SIZE};
 use crate::utils::MemoryRegion;
 
-pub fn make_page_shared(vaddr: VirtAddr) {
+pub fn make_page_shared(vaddr: VirtAddr) -> Result<(), SvsmError> {
     let platform = SVSM_PLATFORM.as_dyn_ref();
 
     // Revoke page validation before changing page state.
-    platform
-        .pvalidate_range(MemoryRegion::new(vaddr, PAGE_SIZE), PvalidateOp::Invalid)
-        .expect("Pvalidate failed when making page shared");
+    platform.pvalidate_range(MemoryRegion::new(vaddr, PAGE_SIZE), PvalidateOp::Invalid)?;
     let paddr = virt_to_phys(vaddr);
     if valid_bitmap_valid_addr(paddr) {
         valid_bitmap_clear_valid_4k(paddr);
     }
 
     // Ask the hypervisor to make the page shared.
-    platform
-        .page_state_change(
-            MemoryRegion::new(paddr, PAGE_SIZE),
-            PageSize::Regular,
-            PageStateChangeOp::Shared,
-        )
-        .expect("Hypervisor failed to make page shared");
+    platform.page_state_change(
+        MemoryRegion::new(paddr, PAGE_SIZE),
+        PageSize::Regular,
+        PageStateChangeOp::Shared,
+    )?;
 
     // Update the page tables to map the page as shared.
-    this_cpu_mut()
-        .get_pgtable()
-        .set_shared_4k(vaddr)
-        .expect("Failed to remap shared page in page tables");
+    this_cpu_mut().get_pgtable().set_shared_4k(vaddr)?;
     flush_tlb_global_sync();
+
+    Ok(())
 }
 
-pub fn make_page_private(vaddr: VirtAddr) {
+pub fn make_page_private(vaddr: VirtAddr) -> Result<(), SvsmError> {
     // Update the page tables to map the page as private.
-    this_cpu_mut()
-        .get_pgtable()
-        .set_encrypted_4k(vaddr)
-        .expect("Failed to remap private page in page tables");
+    this_cpu_mut().get_pgtable().set_encrypted_4k(vaddr)?;
     flush_tlb_global_sync();
 
     let platform = SVSM_PLATFORM.as_dyn_ref();
 
     // Ask the hypervisor to make the page private.
     let paddr = virt_to_phys(vaddr);
-    platform
-        .page_state_change(
-            MemoryRegion::new(paddr, PAGE_SIZE),
-            PageSize::Regular,
-            PageStateChangeOp::Private,
-        )
-        .expect("Hypervisor failed to make page private");
+    platform.page_state_change(
+        MemoryRegion::new(paddr, PAGE_SIZE),
+        PageSize::Regular,
+        PageStateChangeOp::Private,
+    )?;
 
     // Revoke page validation before changing page state.
-    platform
-        .pvalidate_range(MemoryRegion::new(vaddr, PAGE_SIZE), PvalidateOp::Valid)
-        .expect("Pvalidate failed when making page private");
+    platform.pvalidate_range(MemoryRegion::new(vaddr, PAGE_SIZE), PvalidateOp::Valid)?;
     if valid_bitmap_valid_addr(paddr) {
         valid_bitmap_set_valid_4k(paddr);
     }
+
+    Ok(())
 }

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -57,8 +57,7 @@ pub trait SvsmPlatform {
     /// Performs a page state change between private and shared states.
     fn page_state_change(
         &self,
-        start: PhysAddr,
-        end: PhysAddr,
+        region: MemoryRegion<PhysAddr>,
         size: PageSize,
         make_private: bool,
     ) -> Result<(), SvsmError>;

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -29,6 +29,14 @@ pub struct PageEncryptionMasks {
     pub phys_addr_sizes: u32,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub enum PageStateChangeOp {
+    Private,
+    Shared,
+    Psmash,
+    Unsmash,
+}
+
 /// This defines a platform abstraction to permit the SVSM to run on different
 /// underlying architectures.
 pub trait SvsmPlatform {
@@ -59,7 +67,7 @@ pub trait SvsmPlatform {
         &self,
         region: MemoryRegion<PhysAddr>,
         size: PageSize,
-        make_private: bool,
+        op: PageStateChangeOp,
     ) -> Result<(), SvsmError>;
 
     /// Marks a page as valid or invalid as a private page.

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -10,6 +10,7 @@ use crate::error::SvsmError;
 use crate::io::IOPort;
 use crate::platform::native::NativePlatform;
 use crate::platform::snp::SnpPlatform;
+use crate::sev::PvalidateOp;
 use crate::types::PageSize;
 use crate::utils::immut_after_init::ImmutAfterInitCell;
 use crate::utils::MemoryRegion;
@@ -71,8 +72,11 @@ pub trait SvsmPlatform {
     ) -> Result<(), SvsmError>;
 
     /// Marks a page as valid or invalid as a private page.
-    fn pvalidate_range(&self, region: MemoryRegion<VirtAddr>, valid: bool)
-        -> Result<(), SvsmError>;
+    fn pvalidate_range(
+        &self,
+        region: MemoryRegion<VirtAddr>,
+        op: PvalidateOp,
+    ) -> Result<(), SvsmError>;
 }
 
 //FIXME - remove Copy trait

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -59,8 +59,7 @@ impl SvsmPlatform for NativePlatform {
 
     fn page_state_change(
         &self,
-        _start: PhysAddr,
-        _end: PhysAddr,
+        _region: MemoryRegion<PhysAddr>,
         _size: PageSize,
         _make_private: bool,
     ) -> Result<(), SvsmError> {

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -4,9 +4,11 @@
 //
 // Author: Jon Lange <jlange@microsoft.com>
 
+use crate::address::{PhysAddr, VirtAddr};
 use crate::cpu::cpuid::CpuidResult;
 use crate::cpu::percpu::PerCpu;
-use crate::platform::{IOPort, PageEncryptionMasks, PhysAddr, SvsmError, SvsmPlatform, VirtAddr};
+use crate::error::SvsmError;
+use crate::platform::{IOPort, PageEncryptionMasks, PageStateChangeOp, SvsmPlatform};
 use crate::svsm_console::NativeIOPort;
 use crate::types::PageSize;
 use crate::utils::MemoryRegion;
@@ -61,7 +63,7 @@ impl SvsmPlatform for NativePlatform {
         &self,
         _region: MemoryRegion<PhysAddr>,
         _size: PageSize,
-        _make_private: bool,
+        _op: PageStateChangeOp,
     ) -> Result<(), SvsmError> {
         Ok(())
     }

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -9,6 +9,7 @@ use crate::cpu::cpuid::CpuidResult;
 use crate::cpu::percpu::PerCpu;
 use crate::error::SvsmError;
 use crate::platform::{IOPort, PageEncryptionMasks, PageStateChangeOp, SvsmPlatform};
+use crate::sev::PvalidateOp;
 use crate::svsm_console::NativeIOPort;
 use crate::types::PageSize;
 use crate::utils::MemoryRegion;
@@ -71,7 +72,7 @@ impl SvsmPlatform for NativePlatform {
     fn pvalidate_range(
         &self,
         _region: MemoryRegion<VirtAddr>,
-        _valid: bool,
+        _op: PvalidateOp,
     ) -> Result<(), SvsmError> {
         Ok(())
     }

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -97,13 +97,12 @@ impl SvsmPlatform for SnpPlatform {
 
     fn page_state_change(
         &self,
-        start: PhysAddr,
-        end: PhysAddr,
+        region: MemoryRegion<PhysAddr>,
         size: PageSize,
         make_private: bool,
     ) -> Result<(), SvsmError> {
         let psc_op = if make_private { PscPrivate } else { PscShared };
-        current_ghcb().page_state_change(start, end, size, psc_op)
+        current_ghcb().page_state_change(region, size, psc_op)
     }
 
     fn pvalidate_range(

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -4,12 +4,13 @@
 //
 // Author: Jon Lange <jlange@microsoft.com>
 
+use crate::address::{PhysAddr, VirtAddr};
 use crate::cpu::cpuid::cpuid_table;
 use crate::cpu::ghcb::current_ghcb;
 use crate::cpu::percpu::PerCpu;
+use crate::error::SvsmError;
 use crate::io::IOPort;
-use crate::platform::{PageEncryptionMasks, PhysAddr, SvsmError, SvsmPlatform, VirtAddr};
-use crate::sev::ghcb::PageStateChangeOp::{PscPrivate, PscShared};
+use crate::platform::{PageEncryptionMasks, PageStateChangeOp, SvsmPlatform};
 use crate::sev::msr_protocol::verify_ghcb_version;
 use crate::sev::status::vtom_enabled;
 use crate::sev::{pvalidate_range, sev_status_init, sev_status_verify, PvalidateOp};
@@ -99,10 +100,9 @@ impl SvsmPlatform for SnpPlatform {
         &self,
         region: MemoryRegion<PhysAddr>,
         size: PageSize,
-        make_private: bool,
+        op: PageStateChangeOp,
     ) -> Result<(), SvsmError> {
-        let psc_op = if make_private { PscPrivate } else { PscShared };
-        current_ghcb().page_state_change(region, size, psc_op)
+        current_ghcb().page_state_change(region, size, op)
     }
 
     fn pvalidate_range(

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -108,13 +108,8 @@ impl SvsmPlatform for SnpPlatform {
     fn pvalidate_range(
         &self,
         region: MemoryRegion<VirtAddr>,
-        valid: bool,
+        op: PvalidateOp,
     ) -> Result<(), SvsmError> {
-        let pvalidate_op = if valid {
-            PvalidateOp::Valid
-        } else {
-            PvalidateOp::Invalid
-        };
-        pvalidate_range(region, pvalidate_op)
+        pvalidate_range(region, op)
     }
 }

--- a/kernel/src/sev/ghcb.rs
+++ b/kernel/src/sev/ghcb.rs
@@ -14,6 +14,7 @@ use crate::mm::validate::{
     valid_bitmap_clear_valid_4k, valid_bitmap_set_valid_4k, valid_bitmap_valid_addr,
 };
 use crate::mm::virt_to_phys;
+use crate::platform::PageStateChangeOp;
 use crate::sev::sev_snp_enabled;
 use crate::sev::utils::raw_vmgexit;
 use crate::types::{PageSize, PAGE_SIZE_2M};
@@ -30,14 +31,6 @@ pub struct PageStateChangeHeader {
     cur_entry: u16,
     end_entry: u16,
     reserved: u32,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub enum PageStateChangeOp {
-    PscPrivate,
-    PscShared,
-    PscPsmash,
-    PscUnsmash,
 }
 
 const PSC_GFN_MASK: u64 = ((1u64 << 52) - 1) & !0xfffu64;
@@ -436,10 +429,10 @@ impl GHCB {
         let mut paddr = region.start();
         let end = region.end();
         let op_mask: u64 = match op {
-            PageStateChangeOp::PscPrivate => PSC_OP_PRIVATE,
-            PageStateChangeOp::PscShared => PSC_OP_SHARED,
-            PageStateChangeOp::PscPsmash => PSC_OP_PSMASH,
-            PageStateChangeOp::PscUnsmash => PSC_OP_UNSMASH,
+            PageStateChangeOp::Private => PSC_OP_PRIVATE,
+            PageStateChangeOp::Shared => PSC_OP_SHARED,
+            PageStateChangeOp::Psmash => PSC_OP_PSMASH,
+            PageStateChangeOp::Unsmash => PSC_OP_UNSMASH,
         };
 
         self.clear();

--- a/kernel/src/sev/ghcb.rs
+++ b/kernel/src/sev/ghcb.rs
@@ -17,6 +17,7 @@ use crate::mm::virt_to_phys;
 use crate::sev::sev_snp_enabled;
 use crate::sev::utils::raw_vmgexit;
 use crate::types::{PageSize, PAGE_SIZE_2M};
+use crate::utils::MemoryRegion;
 use core::mem::{self, offset_of};
 use core::ptr;
 
@@ -425,15 +426,15 @@ impl GHCB {
 
     pub fn page_state_change(
         &mut self,
-        start: PhysAddr,
-        end: PhysAddr,
+        region: MemoryRegion<PhysAddr>,
         size: PageSize,
         op: PageStateChangeOp,
     ) -> Result<(), SvsmError> {
         // Maximum entries (8 bytes each_ minus 8 bytes for header
         let max_entries: u16 = ((GHCB_BUFFER_SIZE - 8) / 8).try_into().unwrap();
         let mut entries: u16 = 0;
-        let mut paddr = start;
+        let mut paddr = region.start();
+        let end = region.end();
         let op_mask: u64 = match op {
             PageStateChangeOp::PscPrivate => PSC_OP_PRIVATE,
             PageStateChangeOp::PscShared => PSC_OP_SHARED,

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -36,6 +36,7 @@ use svsm::mm::validate::{
 };
 use svsm::platform::{PageStateChangeOp, SvsmPlatform, SvsmPlatformCell};
 use svsm::serial::SerialPort;
+use svsm::sev::PvalidateOp;
 use svsm::types::{PageSize, PAGE_SIZE, PAGE_SIZE_2M};
 use svsm::utils::immut_after_init::ImmutAfterInitCell;
 use svsm::utils::{halt, is_aligned, MemoryRegion};
@@ -141,7 +142,7 @@ fn map_and_validate(
             .expect("GHCB::PAGE_STATE_CHANGE call failed for kernel region");
     }
     platform
-        .pvalidate_range(vregion, true)
+        .pvalidate_range(vregion, PvalidateOp::Valid)
         .expect("PVALIDATE kernel region failed");
     valid_bitmap_set_valid_range(paddr, paddr + vregion.len());
 }

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -133,7 +133,11 @@ fn map_and_validate(
 
     if config.page_state_change_required() {
         platform
-            .page_state_change(paddr, paddr + vregion.len(), PageSize::Huge, true)
+            .page_state_change(
+                MemoryRegion::new(paddr, vregion.len()),
+                PageSize::Huge,
+                true,
+            )
             .expect("GHCB::PAGE_STATE_CHANGE call failed for kernel region");
     }
     platform

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -34,7 +34,7 @@ use svsm::mm::pagetable::{
 use svsm::mm::validate::{
     init_valid_bitmap_alloc, valid_bitmap_addr, valid_bitmap_set_valid_range,
 };
-use svsm::platform::{SvsmPlatform, SvsmPlatformCell};
+use svsm::platform::{PageStateChangeOp, SvsmPlatform, SvsmPlatformCell};
 use svsm::serial::SerialPort;
 use svsm::types::{PageSize, PAGE_SIZE, PAGE_SIZE_2M};
 use svsm::utils::immut_after_init::ImmutAfterInitCell;
@@ -136,7 +136,7 @@ fn map_and_validate(
             .page_state_change(
                 MemoryRegion::new(paddr, vregion.len()),
                 PageSize::Huge,
-                true,
+                PageStateChangeOp::Private,
             )
             .expect("GHCB::PAGE_STATE_CHANGE call failed for kernel region");
     }

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -416,7 +416,7 @@ pub extern "C" fn svsm_main() {
     populate_ram_fs(LAUNCH_INFO.kernel_fs_start, LAUNCH_INFO.kernel_fs_end)
         .expect("Failed to unpack FS archive");
 
-    invalidate_early_boot_memory(&config, launch_info)
+    invalidate_early_boot_memory(platform, &config, launch_info)
         .expect("Failed to invalidate early boot memory");
 
     let cpus = config.load_cpu_info().expect("Failed to load ACPI tables");

--- a/kernel/src/svsm_paging.rs
+++ b/kernel/src/svsm_paging.rs
@@ -115,12 +115,7 @@ fn invalidate_boot_memory_region(
 
     if config.page_state_change_required() && !region.is_empty() {
         current_ghcb()
-            .page_state_change(
-                region.start(),
-                region.end(),
-                PageSize::Regular,
-                PageStateChangeOp::PscShared,
-            )
+            .page_state_change(region, PageSize::Regular, PageStateChangeOp::PscShared)
             .expect("Failed to invalidate Stage2 memory");
     }
 

--- a/kernel/src/svsm_paging.rs
+++ b/kernel/src/svsm_paging.rs
@@ -6,14 +6,14 @@
 
 use crate::address::{Address, PhysAddr, VirtAddr};
 use crate::config::SvsmConfig;
-use crate::cpu::ghcb::current_ghcb;
 use crate::error::SvsmError;
 use crate::igvm_params::IgvmParams;
 use crate::mm::pagetable::{set_init_pgtable, PTEntryFlags, PageTableRef};
 use crate::mm::PerCPUPageMappingGuard;
 use crate::platform::PageStateChangeOp;
-use crate::sev::{pvalidate, PvalidateOp};
-use crate::types::PageSize;
+use crate::platform::SvsmPlatform;
+use crate::sev::PvalidateOp;
+use crate::types::{PageSize, PAGE_SIZE};
 use crate::utils::MemoryRegion;
 use bootlib::kernel_launch::KernelLaunchInfo;
 
@@ -97,6 +97,7 @@ pub fn init_page_table(
 }
 
 fn invalidate_boot_memory_region(
+    platform: &dyn SvsmPlatform,
     config: &SvsmConfig<'_>,
     region: MemoryRegion<PhysAddr>,
 ) -> Result<(), SvsmError> {
@@ -110,17 +111,18 @@ fn invalidate_boot_memory_region(
         let guard = PerCPUPageMappingGuard::create_4k(paddr)?;
         let vaddr = guard.virt_addr();
 
-        pvalidate(vaddr, PageSize::Regular, PvalidateOp::Invalid)?;
+        platform.pvalidate_range(MemoryRegion::new(vaddr, PAGE_SIZE), PvalidateOp::Invalid)?;
     }
 
     if config.page_state_change_required() && !region.is_empty() {
-        current_ghcb().page_state_change(region, PageSize::Regular, PageStateChangeOp::Shared)?;
+        platform.page_state_change(region, PageSize::Regular, PageStateChangeOp::Shared)?;
     }
 
     Ok(())
 }
 
 pub fn invalidate_early_boot_memory(
+    platform: &dyn SvsmPlatform,
     config: &SvsmConfig<'_>,
     launch_info: &KernelLaunchInfo,
 ) -> Result<(), SvsmError> {
@@ -130,7 +132,7 @@ pub fn invalidate_early_boot_memory(
     // Also invalidate the boot data if required.
     if !config.fw_in_low_memory() {
         let stage2_region = MemoryRegion::new(PhysAddr::null(), 640 * 1024);
-        invalidate_boot_memory_region(config, stage2_region)?;
+        invalidate_boot_memory_region(platform, config, stage2_region)?;
     }
 
     if config.invalidate_boot_data() {
@@ -140,7 +142,7 @@ pub fn invalidate_early_boot_memory(
             PhysAddr::new(launch_info.kernel_elf_stage2_virt_start.try_into().unwrap()),
             kernel_elf_size.try_into().unwrap(),
         );
-        invalidate_boot_memory_region(config, kernel_elf_region)?;
+        invalidate_boot_memory_region(platform, config, kernel_elf_region)?;
 
         let kernel_fs_size = launch_info.kernel_fs_end - launch_info.kernel_fs_start;
         if kernel_fs_size > 0 {
@@ -148,7 +150,7 @@ pub fn invalidate_early_boot_memory(
                 PhysAddr::new(launch_info.kernel_fs_start.try_into().unwrap()),
                 kernel_fs_size.try_into().unwrap(),
             );
-            invalidate_boot_memory_region(config, kernel_fs_region)?;
+            invalidate_boot_memory_region(platform, config, kernel_fs_region)?;
         }
 
         if launch_info.stage2_igvm_params_size > 0 {
@@ -156,7 +158,7 @@ pub fn invalidate_early_boot_memory(
                 PhysAddr::new(launch_info.stage2_igvm_params_phys_addr.try_into().unwrap()),
                 launch_info.stage2_igvm_params_size as usize,
             );
-            invalidate_boot_memory_region(config, igvm_params_region)?;
+            invalidate_boot_memory_region(platform, config, igvm_params_region)?;
         }
     }
 

--- a/kernel/src/svsm_paging.rs
+++ b/kernel/src/svsm_paging.rs
@@ -11,7 +11,7 @@ use crate::error::SvsmError;
 use crate::igvm_params::IgvmParams;
 use crate::mm::pagetable::{set_init_pgtable, PTEntryFlags, PageTableRef};
 use crate::mm::PerCPUPageMappingGuard;
-use crate::sev::ghcb::PageStateChangeOp;
+use crate::platform::PageStateChangeOp;
 use crate::sev::{pvalidate, PvalidateOp};
 use crate::types::PageSize;
 use crate::utils::MemoryRegion;
@@ -114,9 +114,7 @@ fn invalidate_boot_memory_region(
     }
 
     if config.page_state_change_required() && !region.is_empty() {
-        current_ghcb()
-            .page_state_change(region, PageSize::Regular, PageStateChangeOp::PscShared)
-            .expect("Failed to invalidate Stage2 memory");
+        current_ghcb().page_state_change(region, PageSize::Regular, PageStateChangeOp::Shared)?;
     }
 
     Ok(())


### PR DESCRIPTION
* Replace `start` + `end` function parameters with `MemoryRegion` parameters.
* Replace bool parameters for `SvsmPlatform` methods with enums.
* Use `SvsmPlatform` page state change methods in several places instead of directly calling into the `GHCB` or `PVALIDATE`.