### PR TITLE
svsm: fix clippy warnings

### DIFF
--- a/kernel/src/cpu/gdt.rs
+++ b/kernel/src/cpu/gdt.rs
@@ -12,13 +12,13 @@ use core::arch::asm;
 use core::mem;
 
 #[repr(C, packed(2))]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 struct GDTDesc {
     size: u16,
     addr: VirtAddr,
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 pub struct GDTEntry(u64);
 
 impl GDTEntry {
@@ -53,7 +53,7 @@ impl GDTEntry {
 
 const GDT_SIZE: u16 = 8;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 pub struct GDT {
     entries: [GDTEntry; GDT_SIZE as usize],
 }

--- a/kernel/src/cpu/idt/common.rs
+++ b/kernel/src/cpu/idt/common.rs
@@ -143,6 +143,7 @@ impl IdtEntry {
 const IDT_ENTRIES: usize = 256;
 
 #[repr(C, packed)]
+#[derive(Default, Clone, Copy, Debug)]
 struct IdtDesc {
     size: u16,
     address: VirtAddr,
@@ -194,6 +195,12 @@ impl IDT {
         let base = (self as *const IDT) as u64;
         let limit = (IDT_ENTRIES * mem::size_of::<IdtEntry>()) as u32;
         (base, limit)
+    }
+}
+
+impl Default for IDT {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -93,7 +93,7 @@ impl PerCpuAreas {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 pub struct VmsaRef {
     pub vaddr: VirtAddr,
     pub paddr: PhysAddr,
@@ -128,7 +128,7 @@ impl IstStacks {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct GuestVmsaRef {
     vmsa: Option<PhysAddr>,
     caa: Option<PhysAddr>,

--- a/kernel/src/fw_meta.rs
+++ b/kernel/src/fw_meta.rs
@@ -23,7 +23,7 @@ use core::fmt;
 use core::mem::{align_of, size_of, size_of_val};
 use core::str::FromStr;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct SevFWMetaData {
     pub cpuid_page: Option<PhysAddr>,
     pub secrets_page: Option<PhysAddr>,
@@ -33,7 +33,7 @@ pub struct SevFWMetaData {
 
 impl SevFWMetaData {
     pub const fn new() -> Self {
-        SevFWMetaData {
+        Self {
             cpuid_page: None,
             secrets_page: None,
             caa_page: None,

--- a/kernel/src/locking/spinlock.rs
+++ b/kernel/src/locking/spinlock.rs
@@ -80,7 +80,7 @@ impl<T> DerefMut for LockGuard<'_, T> {
 ///     *guard += 2;
 /// };
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct SpinLock<T> {
     /// This atomic counter is incremented each time a thread attempts to
     /// acquire the lock. It helps to determine the order in which threads

--- a/kernel/src/mm/alloc.rs
+++ b/kernel/src/mm/alloc.rs
@@ -1501,7 +1501,7 @@ static SLAB_PAGE_SLAB: SpinLock<SlabPageSlab> = SpinLock::new(SlabPageSlab::new(
 ///
 /// This allocator uses slab allocation for fixed-size objects and falls
 /// back to page allocation for larger objects.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct SvsmAllocator {
     slabs: [SpinLock<Slab>; 7],
 }

--- a/kernel/src/sev/secrets_page.rs
+++ b/kernel/src/sev/secrets_page.rs
@@ -103,6 +103,12 @@ impl SecretsPage {
     }
 }
 
+impl Default for SecretsPage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 static SECRETS_PAGE: RWLock<SecretsPage> = RWLock::new(SecretsPage::new());
 
 pub fn secrets_page() -> ReadLockGuard<'static, SecretsPage> {

--- a/kernel/src/string.rs
+++ b/kernel/src/string.rs
@@ -38,6 +38,12 @@ impl<const T: usize> FixedString<T> {
     }
 }
 
+impl<const N: usize> Default for FixedString<N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<const N: usize> From<[u8; N]> for FixedString<N> {
     fn from(arr: [u8; N]) -> FixedString<N> {
         let mut data: [MaybeUninit<char>; N] = array::from_fn(|_| MaybeUninit::uninit());

--- a/kernel/src/svsm_console.rs
+++ b/kernel/src/svsm_console.rs
@@ -11,7 +11,7 @@ use crate::sev::msr_protocol::request_termination_msr;
 
 use core::arch::asm;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct SVSMIOPort {}
 
 impl SVSMIOPort {
@@ -52,7 +52,7 @@ impl IOPort for SVSMIOPort {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct NativeIOPort {}
 
 impl NativeIOPort {

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -183,7 +183,7 @@ impl RunQueue {
 
 /// Global task list
 /// This contains every task regardless of affinity or run state.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct TaskList {
     list: Option<LinkedList<TaskListAdapter>>,
 }

--- a/kernel/src/task/waiting.rs
+++ b/kernel/src/task/waiting.rs
@@ -6,7 +6,7 @@
 
 use super::tasks::TaskPointer;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct WaitQueue {
     waiter: Option<TaskPointer>,
 }

--- a/kernel/src/vtpm/mstpm/mod.rs
+++ b/kernel/src/vtpm/mstpm/mod.rs
@@ -27,7 +27,7 @@ use crate::{
     vtpm::{MsTpmSimulatorInterface, VtpmInterface, VtpmProtocolInterface},
 };
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Default)]
 pub struct MsTpm {
     is_powered_on: bool,
 }


### PR DESCRIPTION
Fix several warnings like the following, either by implementing Default manually or by deriving it:

```
error: you should consider adding a `Default` implementation for `SVSMIOPort`
  --> kernel/src/svsm_console.rs:18:5
   |
18 | /     pub const fn new() -> Self {
19 | |         SVSMIOPort {}
20 | |     }
   | |_____^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#new_without_default
help: try adding this
   |
17 + impl Default for SVSMIOPort {
18 +     fn default() -> Self {
19 +         Self::new()
20 +     }
21 + }
   |
```