### PR TITLE
Fix nightly clippy warnings

### DIFF
--- a/kernel/build.rs
+++ b/kernel/build.rs
@@ -5,6 +5,10 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 
 fn main() {
+    // Extra cfgs
+    println!("cargo::rustc-check-cfg=cfg(fuzzing)");
+    println!("cargo::rustc-check-cfg=cfg(test_in_svsm)");
+
     // Stage 2
     println!("cargo:rustc-link-arg-bin=stage2=-nostdlib");
     println!("cargo:rustc-link-arg-bin=stage2=--build-id=none");

--- a/kernel/src/fs/filesystem.rs
+++ b/kernel/src/fs/filesystem.rs
@@ -49,7 +49,7 @@ impl RawFileHandle {
         result
     }
 
-    fn truncate(&mut self, offset: usize) -> Result<usize, SvsmError> {
+    fn truncate(&self, offset: usize) -> Result<usize, SvsmError> {
         self.file.truncate(offset)
     }
 

--- a/kernel/src/greq/msg.rs
+++ b/kernel/src/greq/msg.rs
@@ -238,7 +238,7 @@ impl SnpGuestRequestMsg {
     ///   before the object is dropped. Shared pages should not be freed
     ///   (returned to the allocator)
     pub fn set_shared(&mut self) -> Result<(), SvsmReqError> {
-        let vaddr = VirtAddr::from(addr_of!(*self));
+        let vaddr = VirtAddr::from(addr_of_mut!(*self));
         this_cpu_mut()
             .get_pgtable()
             .set_shared_4k(vaddr)
@@ -257,7 +257,7 @@ impl SnpGuestRequestMsg {
 
     /// Set the C-bit (memory encryption bit) for the Self page
     pub fn set_encrypted(&mut self) -> Result<(), SvsmReqError> {
-        let vaddr = VirtAddr::from(addr_of!(*self));
+        let vaddr = VirtAddr::from(addr_of_mut!(*self));
         this_cpu_mut()
             .get_pgtable()
             .set_encrypted_4k(vaddr)
@@ -495,14 +495,14 @@ impl SnpGuestRequestExtData {
     ///   before the object is dropped. Shared pages should not be freed
     ///   (returned to the allocator)
     pub fn set_shared(&mut self) -> Result<(), SvsmReqError> {
-        let start = VirtAddr::from(addr_of!(*self));
+        let start = VirtAddr::from(addr_of_mut!(*self));
         let end = start + size_of::<Self>();
         set_shared_region_4k(start, end)
     }
 
     /// Set the C-bit (memory encryption bit) for the Self pages
     pub fn set_encrypted(&mut self) -> Result<(), SvsmReqError> {
-        let start = VirtAddr::from(addr_of!(*self));
+        let start = VirtAddr::from(addr_of_mut!(*self));
         let end = start + size_of::<Self>();
         set_encrypted_region_4k(start, end)
     }

--- a/kernel/src/mm/vm/range.rs
+++ b/kernel/src/mm/vm/range.rs
@@ -140,7 +140,7 @@ impl VMR {
     /// # Returns
     ///
     /// `Ok(())` on success, Err(SvsmError::Mem) on allocation error
-    fn initialize_common(&mut self, lazy: bool) -> Result<(), SvsmError> {
+    fn initialize_common(&self, lazy: bool) -> Result<(), SvsmError> {
         let start = VirtAddr::from(self.start_pfn << PAGE_SHIFT);
         let end = VirtAddr::from(self.end_pfn << PAGE_SHIFT);
         assert!(start < end && start.is_aligned(VMR_GRANULE) && end.is_aligned(VMR_GRANULE));
@@ -153,7 +153,7 @@ impl VMR {
     /// # Returns
     ///
     /// `Ok(())` on success, Err(SvsmError::Mem) on allocation error
-    pub fn initialize(&mut self) -> Result<(), SvsmError> {
+    pub fn initialize(&self) -> Result<(), SvsmError> {
         self.initialize_common(false)
     }
 
@@ -162,7 +162,7 @@ impl VMR {
     /// # Returns
     ///
     /// `Ok(())` on success, Err(SvsmError::Mem) on allocation error
-    pub fn initialize_lazy(&mut self) -> Result<(), SvsmError> {
+    pub fn initialize_lazy(&self) -> Result<(), SvsmError> {
         self.initialize_common(true)
     }
 

--- a/kernel/src/sev/ghcb.rs
+++ b/kernel/src/sev/ghcb.rs
@@ -268,7 +268,7 @@ impl GHCB {
     }
 
     pub fn shutdown(&mut self) -> Result<(), SvsmError> {
-        let vaddr = VirtAddr::from(self as *const GHCB);
+        let vaddr = VirtAddr::from(ptr::from_mut(self));
         let paddr = virt_to_phys(vaddr);
 
         // Re-encrypt page

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -173,8 +173,7 @@ impl Task {
 
         cpu.populate_page_table(&mut pgtable);
 
-        let mut vm_kernel_range =
-            VMR::new(SVSM_PERTASK_BASE, SVSM_PERTASK_END, PTEntryFlags::empty());
+        let vm_kernel_range = VMR::new(SVSM_PERTASK_BASE, SVSM_PERTASK_END, PTEntryFlags::empty());
         vm_kernel_range.initialize()?;
 
         let (stack, raw_bounds, rsp_offset) = Self::allocate_ktask_stack(cpu, entry)?;
@@ -214,8 +213,7 @@ impl Task {
 
         cpu.populate_page_table(&mut pgtable);
 
-        let mut vm_kernel_range =
-            VMR::new(SVSM_PERTASK_BASE, SVSM_PERTASK_END, PTEntryFlags::empty());
+        let vm_kernel_range = VMR::new(SVSM_PERTASK_BASE, SVSM_PERTASK_END, PTEntryFlags::empty());
         vm_kernel_range.initialize()?;
 
         let (stack, raw_bounds, stack_offset) = Self::allocate_utask_stack(cpu, user_entry)?;
@@ -223,7 +221,7 @@ impl Task {
 
         vm_kernel_range.populate(&mut pgtable);
 
-        let mut vm_user_range = VMR::new(USER_MEM_START, USER_MEM_END, PTEntryFlags::USER);
+        let vm_user_range = VMR::new(USER_MEM_START, USER_MEM_END, PTEntryFlags::USER);
         vm_user_range.initialize_lazy()?;
 
         // Remap at the per-task offset


### PR DESCRIPTION
* Remove `&mut self` where not needed or add an exception where it makes sense.
* Add extra information in `build.rs` for [compile-time cfg checks](https://blog.rust-lang.org/2024/05/06/check-cfg.html)