### PR TITLE
fuzz: do not use default features when building the SVSM

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-svsm.workspace = true
+svsm = { workspace = true, features = [] }
 
 arbitrary = { workspace = true, features = ["derive"] }
 libfuzzer-sys.workspace = true

--- a/kernel/src/vtpm/mstpm/mod.rs
+++ b/kernel/src/vtpm/mstpm/mod.rs
@@ -8,7 +8,7 @@
 //! Reference Implementation (by Microsoft)
 
 /// Functions required to build the Microsoft TPM libraries
-#[cfg(not(feature = "default-test"))]
+#[cfg(not(any(test, fuzzing)))]
 mod wrapper;
 
 extern crate alloc;


### PR DESCRIPTION
Do not use the default features when building the SVSM for fuzzing, as linking `libmstpm` breaks the fuzzers.
