### PR TITLE
svsm: remove `default-test` feature & fix leftover nightly clippy warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 FEATURES ?= "default"
 SVSM_ARGS = --features ${FEATURES}
 
-FEATURES_TEST ?= "default-test"
-SVSM_ARGS_TEST = --no-default-features --features ${FEATURES_TEST}
+SVSM_ARGS_TEST = --no-default-features
+ifdef FEATURES_TEST
+	SVSM_ARGS_TEST += --features ${FEATURES_TEST}
+endif
 
 ifdef RELEASE
 TARGET_PATH=release

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -38,7 +38,6 @@ test.workspace = true
 
 [features]
 default = ["mstpm"]
-default-test = []
 enable-gdb = ["dep:gdbstub", "dep:gdbstub_arch"]
 mstpm = ["dep:libmstpm"]
 

--- a/kernel/build.rs
+++ b/kernel/build.rs
@@ -21,9 +21,7 @@ fn main() {
     println!("cargo:rustc-link-arg-bin=svsm=--no-relax");
     println!("cargo:rustc-link-arg-bin=svsm=-Tkernel/src/svsm.lds");
     println!("cargo:rustc-link-arg-bin=svsm=-no-pie");
-    if std::env::var("CARGO_FEATURE_MSTPM").is_ok()
-        && std::env::var("CARGO_FEATURE_DEFAULT_TEST").is_err()
-    {
+    if std::env::var("CARGO_FEATURE_MSTPM").is_ok() && std::env::var("CARGO_CFG_TEST").is_err() {
         println!("cargo:rustc-link-arg-bin=svsm=-Llibmstpm");
         println!("cargo:rustc-link-arg-bin=svsm=-lmstpm");
     }

--- a/kernel/src/debug/gdbstub.rs
+++ b/kernel/src/debug/gdbstub.rs
@@ -313,7 +313,7 @@ pub mod svsm_gdbstub {
             Self {}
         }
 
-        fn read(&mut self) -> Result<u8, &'static str> {
+        fn read(&self) -> Result<u8, &'static str> {
             unsafe { Ok(GDB_SERIAL.get_byte()) }
         }
     }


### PR DESCRIPTION
* Remove the `default-test` feature: it is not really needed, as we can detect if we're building tests via the "test" cfg.
* Remove a nightly clippy warning in the gdbstub code.