### PR TITLE
Highlight build issue with std and no_std in the same workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,6 +746,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8edc89eaa583cf6bc4c6ef16a219f0a60d342ca3bf0eae793560038ac8af1795"
 
 [[package]]
+name = "rdrand"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92195228612ac8eed47adbc2ed0f04e513a4ccb98175b6f2bd04d963b533655"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -835,6 +844,7 @@ dependencies = [
  "libmstpm",
  "log",
  "packit",
+ "rdrand",
  "syscall",
  "test",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ p384 = { version = "0.13.0" }
 uuid = "1.6.1"
 # Add the derive feature by default because all crates use it.
 zerocopy = { version = "0.7.32", features = ["derive"] }
+rdrand = { version = "0.8.3", default-features = false }
 
 # other repos
 packit = { git = "https://github.com/coconut-svsm/packit", version = "0.1.1" }

--- a/igvmbuilder/Cargo.toml
+++ b/igvmbuilder/Cargo.toml
@@ -3,7 +3,9 @@ name = "igvmbuilder"
 version = "0.1.0"
 edition = "2021"
 
-[dependencies]
+# specify target to avoid feature unification with SVSM
+# see https://doc.rust-lang.org/cargo/reference/features.html#feature-unification
+[target.'cfg(all(target_os = "linux"))'.dependencies]
 bootlib.workspace = true
 
 clap = { workspace = true, default-features = true, features = ["derive"] }

--- a/igvmmeasure/Cargo.toml
+++ b/igvmmeasure/Cargo.toml
@@ -3,7 +3,9 @@ name = "igvmmeasure"
 version = "0.1.0"
 edition = "2021"
 
-[dependencies]
+# specify target to avoid feature unification with SVSM
+# see https://doc.rust-lang.org/cargo/reference/features.html#feature-unification
+[target.'cfg(all(target_os = "linux"))'.dependencies]
 clap = { workspace = true, default-features = true, features = ["derive"] }
 hmac-sha512.workspace = true
 igvm.workspace = true

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -33,6 +33,7 @@ intrusive-collections.workspace = true
 log = { workspace = true, features = ["max_level_info", "release_max_level_info"] }
 packit.workspace = true
 libmstpm = { workspace = true, optional = true }
+rdrand = { workspace = true }
 
 [target."x86_64-unknown-none".dev-dependencies]
 test.workspace = true

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -57,6 +57,8 @@ use svsm::vtpm::vtpm_init;
 
 use svsm::mm::validate::{init_valid_bitmap_ptr, migrate_valid_bitmap};
 
+use rdrand::RdSeed;
+
 extern "C" {
     pub static bsp_stack_end: u8;
 }
@@ -452,6 +454,9 @@ pub extern "C" fn svsm_main() {
 
     #[cfg(all(feature = "mstpm", not(test)))]
     vtpm_init().expect("vTPM failed to initialize");
+
+    let rdrand = unsafe { RdSeed::new_unchecked() };
+    log::info!("rdrand value: {}", rdrand.try_next_u32().unwrap());
 
     virt_log_usage();
 


### PR DESCRIPTION
PLEASE DON'T MERGE!

This commit is just to highlight the problem I am having. I have minimized the changes to only discuss the problem.

In this case I added a dependency (rdrand) that supports std or no_std with the (std) feature enabled by default. Here I am disabling it for use in the kernel without std.

Dependencies
```
- kernel
  -> rdrand (default-features = false, so "std" feature disabled)
      -> rand_core (default-features = false, so "std" feature disabled)
          -> getrandom (default-features = false, so it should be disabled)
- igvmmeasure
  -> p384 (default-features = true)
      -> elliptic-curve
          -> rand_core
              -> getrandom
```
But when building `svsm`, cargo seems to use an interesention of the features used in the workspace, as it goes to compile `getrandom` which should be disabled, more expecting std.

```
$ make
cargo build --manifest-path kernel/Cargo.toml  --no-default-features --bin stage2
   Compiling svsm v0.1.0 (/home/stefano/repos/coconut/svsm-review/kernel)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.00s
objcopy -O binary "target/x86_64-unknown-none/debug/stage2" bin/stage2.bin
touch bin/svsm-fs.bin
cargo build  --features "default" --bin svsm
   Compiling getrandom v0.2.12
   Compiling svsm v0.1.0 (/home/stefano/repos/coconut/svsm-review/kernel)
   Compiling zerocopy v0.7.32
   Compiling zerocopy v0.6.6
   Compiling crypto-common v0.1.6
   Compiling inout v0.1.3
error[E0463]: can't find crate for `std`
 --> /home/stefano/.cargo/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.2.12/src/error_impls.rs:2:1
  |
2 | extern crate std;
  | ^^^^^^^^^^^^^^^^^ can't find crate
  |
  = note: the `x86_64-unknown-none` target may not support the standard library

error: target is not supported, for more information see: https://docs.rs/getrandom/#unsupported-targets
   --> /home/stefano/.cargo/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.2.12/src/lib.rs:296:9
    |
296 | /         compile_error!("target is not supported, for more information see: \
297 | |                         https://docs.rs/getrandom/#unsupported-targets");
    | |________________________________________________________________________^

   Compiling universal-hash v0.5.1
   Compiling aead v0.5.2
error[E0433]: failed to resolve: use of undeclared crate or module `imp`
   --> /home/stefano/.cargo/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.2.12/src/lib.rs:347:9
    |
347 |         imp::getrandom_inner(dest)?;
    |         ^^^ use of undeclared crate or module `imp`

Some errors have detailed explanations: E0433, E0463.
For more information about an error, try `rustc --explain E0433`.
error: could not compile `getrandom` (lib) due to 3 previous errors
warning: build failed, waiting for other jobs to finish...
make: *** [Makefile:118: bin/svsm-kernel.elf] Error 101
```