### PR TITLE
igvm*: specify dependencies' target to avoid feature unification

### DIFF
--- a/igvmbuilder/Cargo.toml
+++ b/igvmbuilder/Cargo.toml
@@ -3,7 +3,9 @@ name = "igvmbuilder"
 version = "0.1.0"
 edition = "2021"
 
-[dependencies]
+# specify dependencies' target to avoid feature unification with SVSM
+# see https://doc.rust-lang.org/cargo/reference/features.html#feature-unification
+[target.'cfg(all(target_os = "linux"))'.dependencies]
 bootlib.workspace = true
 
 clap = { workspace = true, default-features = true, features = ["derive"] }

--- a/igvmmeasure/Cargo.toml
+++ b/igvmmeasure/Cargo.toml
@@ -3,7 +3,9 @@ name = "igvmmeasure"
 version = "0.1.0"
 edition = "2021"
 
-[dependencies]
+# specify dependencies' target to avoid feature unification with SVSM
+# see https://doc.rust-lang.org/cargo/reference/features.html#feature-unification
+[target.'cfg(all(target_os = "linux"))'.dependencies]
 clap = { workspace = true, default-features = true, features = ["derive"] }
 hmac-sha512.workspace = true
 igvm.workspace = true


### PR DESCRIPTION
When a dependency is used by multiple packages, Cargo will use the union of all features enabled on that dependency when building it. See https://doc.rust-lang.org/cargo/reference/features.html#feature-unification for more details.

These two crates are tools, so let's specify dependencies only for `target_os = "linux"`. This way these dependencies (which can use `std` for example) are not unified with those of SVSM, producing build errors as reported in https://github.com/coconut-svsm/svsm/pull/345