### PR TITLE
platform: separate validate/invalidate method calls

### DIFF
--- a/kernel/src/mm/page_visibility.rs
+++ b/kernel/src/mm/page_visibility.rs
@@ -13,7 +13,6 @@ use crate::mm::validate::{
 };
 use crate::mm::virt_to_phys;
 use crate::platform::{PageStateChangeOp, SVSM_PLATFORM};
-use crate::sev::PvalidateOp;
 use crate::types::{PageSize, PAGE_SIZE};
 use crate::utils::MemoryRegion;
 
@@ -21,7 +20,7 @@ pub fn make_page_shared(vaddr: VirtAddr) -> Result<(), SvsmError> {
     let platform = SVSM_PLATFORM.as_dyn_ref();
 
     // Revoke page validation before changing page state.
-    platform.pvalidate_range(MemoryRegion::new(vaddr, PAGE_SIZE), PvalidateOp::Invalid)?;
+    platform.invalidate_page_range(MemoryRegion::new(vaddr, PAGE_SIZE))?;
     let paddr = virt_to_phys(vaddr);
     if valid_bitmap_valid_addr(paddr) {
         valid_bitmap_clear_valid_4k(paddr);
@@ -60,7 +59,7 @@ pub fn make_page_private(vaddr: VirtAddr) -> Result<(), SvsmError> {
     )?;
 
     // Revoke page validation before changing page state.
-    platform.pvalidate_range(MemoryRegion::new(vaddr, PAGE_SIZE), PvalidateOp::Valid)?;
+    platform.validate_page_range(MemoryRegion::new(vaddr, PAGE_SIZE))?;
     if valid_bitmap_valid_addr(paddr) {
         valid_bitmap_set_valid_4k(paddr);
     }

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -10,7 +10,6 @@ use crate::error::SvsmError;
 use crate::io::IOPort;
 use crate::platform::native::NativePlatform;
 use crate::platform::snp::SnpPlatform;
-use crate::sev::PvalidateOp;
 use crate::types::PageSize;
 use crate::utils::immut_after_init::ImmutAfterInitCell;
 use crate::utils::MemoryRegion;
@@ -71,12 +70,11 @@ pub trait SvsmPlatform {
         op: PageStateChangeOp,
     ) -> Result<(), SvsmError>;
 
-    /// Marks a page as valid or invalid as a private page.
-    fn pvalidate_range(
-        &self,
-        region: MemoryRegion<VirtAddr>,
-        op: PvalidateOp,
-    ) -> Result<(), SvsmError>;
+    /// Marks a range of pages as valid for use as private pages.
+    fn validate_page_range(&self, region: MemoryRegion<VirtAddr>) -> Result<(), SvsmError>;
+
+    /// Marks a range of pages as invalid for use as private pages.
+    fn invalidate_page_range(&self, region: MemoryRegion<VirtAddr>) -> Result<(), SvsmError>;
 
     /// Perform an EOI of the current interrupt.
     fn eoi(&self);

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -9,7 +9,6 @@ use crate::cpu::cpuid::CpuidResult;
 use crate::cpu::percpu::PerCpu;
 use crate::error::SvsmError;
 use crate::platform::{IOPort, PageEncryptionMasks, PageStateChangeOp, SvsmPlatform};
-use crate::sev::PvalidateOp;
 use crate::svsm_console::NativeIOPort;
 use crate::types::PageSize;
 use crate::utils::MemoryRegion;
@@ -69,11 +68,13 @@ impl SvsmPlatform for NativePlatform {
         Ok(())
     }
 
-    fn pvalidate_range(
-        &self,
-        _region: MemoryRegion<VirtAddr>,
-        _op: PvalidateOp,
-    ) -> Result<(), SvsmError> {
+    /// Marks a range of pages as valid for use as private pages.
+    fn validate_page_range(&self, _region: MemoryRegion<VirtAddr>) -> Result<(), SvsmError> {
+        Ok(())
+    }
+
+    /// Marks a range of pages as invalid for use as private pages.
+    fn invalidate_page_range(&self, _region: MemoryRegion<VirtAddr>) -> Result<(), SvsmError> {
         Ok(())
     }
 

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -106,12 +106,14 @@ impl SvsmPlatform for SnpPlatform {
         current_ghcb().page_state_change(region, size, op)
     }
 
-    fn pvalidate_range(
-        &self,
-        region: MemoryRegion<VirtAddr>,
-        op: PvalidateOp,
-    ) -> Result<(), SvsmError> {
-        pvalidate_range(region, op)
+    /// Marks a range of pages as valid for use as private pages.
+    fn validate_page_range(&self, region: MemoryRegion<VirtAddr>) -> Result<(), SvsmError> {
+        pvalidate_range(region, PvalidateOp::Valid)
+    }
+
+    /// Marks a range of pages as invalid for use as private pages.
+    fn invalidate_page_range(&self, region: MemoryRegion<VirtAddr>) -> Result<(), SvsmError> {
+        pvalidate_range(region, PvalidateOp::Invalid)
     }
 
     fn eoi(&self) {

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -36,7 +36,6 @@ use svsm::mm::validate::{
 };
 use svsm::platform::{PageStateChangeOp, SvsmPlatform, SvsmPlatformCell};
 use svsm::serial::SerialPort;
-use svsm::sev::PvalidateOp;
 use svsm::types::{PageSize, PAGE_SIZE, PAGE_SIZE_2M};
 use svsm::utils::immut_after_init::ImmutAfterInitCell;
 use svsm::utils::{halt, is_aligned, MemoryRegion};
@@ -142,7 +141,7 @@ fn map_and_validate(
             .expect("GHCB::PAGE_STATE_CHANGE call failed for kernel region");
     }
     platform
-        .pvalidate_range(vregion, PvalidateOp::Valid)
+        .validate_page_range(vregion)
         .expect("PVALIDATE kernel region failed");
     valid_bitmap_set_valid_range(paddr, paddr + vregion.len());
 }

--- a/kernel/src/svsm_paging.rs
+++ b/kernel/src/svsm_paging.rs
@@ -12,7 +12,6 @@ use crate::mm::pagetable::{set_init_pgtable, PTEntryFlags, PageTableRef};
 use crate::mm::PerCPUPageMappingGuard;
 use crate::platform::PageStateChangeOp;
 use crate::platform::SvsmPlatform;
-use crate::sev::PvalidateOp;
 use crate::types::{PageSize, PAGE_SIZE};
 use crate::utils::MemoryRegion;
 use bootlib::kernel_launch::KernelLaunchInfo;
@@ -111,7 +110,7 @@ fn invalidate_boot_memory_region(
         let guard = PerCPUPageMappingGuard::create_4k(paddr)?;
         let vaddr = guard.virt_addr();
 
-        platform.pvalidate_range(MemoryRegion::new(vaddr, PAGE_SIZE), PvalidateOp::Invalid)?;
+        platform.invalidate_page_range(MemoryRegion::new(vaddr, PAGE_SIZE))?;
     }
 
     if config.page_state_change_required() && !region.is_empty() {


### PR DESCRIPTION
This change separates page validation and invalidation into separate methods to avoid reliance on any platform-specific operation types.  This will further facilitate platform abstractions for platforms that do not treat validation and invalidation as symmetric operations.