### PR TITLE
kernel/vtpm: fix safety documentation

### DIFF
--- a/kernel/src/protocols/vtpm.rs
+++ b/kernel/src/protocols/vtpm.rs
@@ -91,8 +91,8 @@ impl TpmSendCommandRequest {
             .get(..size_of::<Self>())
             .ok_or_else(SvsmReqError::invalid_parameter)?;
 
-        // SAFETY: SnpReportRequest has no invalid representations, as it is
-        // comprised entirely of integer types. It is repr(packed), so its
+        // SAFETY: TpmSendCommandRequest has no invalid representations, as it
+        // is comprised entirely of integer types. It is repr(packed), so its
         // required alignment is simply 1. We have checked the size, so this
         // is entirely safe.
         let request = unsafe { &*buffer.as_ptr().cast::<Self>() };
@@ -150,8 +150,8 @@ impl TpmSendCommandResponse {
             .get_mut(..size_of::<Self>())
             .ok_or_else(SvsmReqError::invalid_parameter)?;
 
-        // SAFETY: SnpReportRequest has no invalid representations, as it is
-        // comprised entirely of integer types. It is repr(packed), so its
+        // SAFETY: TpmSendCommandResponse has no invalid representations, as it
+        // is comprised entirely of integer types. It is repr(packed), so its
         // required alignment is simply 1. We have checked the size, so this
         // is entirely safe.
         let response = unsafe { &mut *buffer.as_mut_ptr().cast::<Self>() };


### PR DESCRIPTION
`SnpReportRequest` was used instead of `TpmSendCommandRequest` and `TpmSendCommandResponse`.