### PR TITLE
mm/pagetable: return errors instead of implicitly panicking

### DIFF
--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -92,7 +92,7 @@ fn setup_env(
         PhysAddr::null(),
     );
     register_cpuid_table(unsafe { &CPUID_PAGE });
-    paging_init_early(platform, launch_info.vtom);
+    paging_init_early(platform, launch_info.vtom).expect("Failed to initialize early paging");
 
     set_init_pgtable(PageTableRef::shared(unsafe { addr_of_mut!(pgtable) }));
     setup_stage2_allocator();

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -327,7 +327,7 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
         Err(e) => panic!("error reading kernel ELF: {}", e),
     };
 
-    paging_init(platform, li.vtom);
+    paging_init(platform, li.vtom).expect("Failed to initialize paging");
     init_page_table(&launch_info, &kernel_elf).expect("Could not initialize the page table");
 
     // SAFETY: this PerCpu has just been allocated and no other CPUs have been


### PR DESCRIPTION
Return possible errors from `paging_init()` and `paging_init_early()` and let callers handle them.