### PR TITLE
scripts: Fix value for init-flags to ensure measurement is correct

### DIFF
--- a/scripts/launch_guest.sh
+++ b/scripts/launch_guest.sh
@@ -103,7 +103,7 @@ $SUDO_CMD \
     -cpu EPYC-v4 \
     -machine $MACHINE \
     -object $MEMORY \
-    -object sev-snp-guest,id=sev0,cbitpos=$C_BIT_POS,reduced-phys-bits=1,init-flags=1,igvm-file=$IGVM \
+    -object sev-snp-guest,id=sev0,cbitpos=$C_BIT_POS,reduced-phys-bits=1,init-flags=5,igvm-file=$IGVM \
     -smp 4 \
     -no-reboot \
     -netdev user,id=vmnic -device e1000,netdev=vmnic,romfile= \


### PR DESCRIPTION
The `init-flags` value in the launch script did not have the 'SVSM' bit set, which causes VMSA areas to be measured for APs during guest launch. This does not affect the running of SVSM but does cause the launch measurement to differ from the value calculated by igvmmeasure.

This fixes https://github.com/coconut-svsm/svsm/issues/349.