### PR TITLE
igvm: initial support for TD Partitioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,15 +69,15 @@ $(IGVMMEASURE):
 	cargo build ${CARGO_ARGS} --target=x86_64-unknown-linux-gnu -p igvmmeasure
 
 bin/coconut-qemu.igvm: $(IGVMBUILDER) $(IGVMMEASURE) bin/svsm-kernel.elf bin/stage2.bin ${FS_BIN}
-	$(IGVMBUILDER) --sort --policy 0x30000 --output $@ --stage2 bin/stage2.bin --kernel bin/svsm-kernel.elf --filesystem ${FS_BIN} ${BUILD_FW} qemu
+	$(IGVMBUILDER) --sort --policy 0x30000 --output $@ --stage2 bin/stage2.bin --kernel bin/svsm-kernel.elf --filesystem ${FS_BIN} ${BUILD_FW} qemu --snp
 	$(IGVMMEASURE) --check-kvm $@ measure
 
 bin/coconut-hyperv.igvm: $(IGVMBUILDER)  $(IGVMMEASURE) bin/svsm-kernel.elf bin/stage2.bin
-	$(IGVMBUILDER) --sort --output $@ --stage2 bin/stage2.bin --kernel bin/svsm-kernel.elf --comport 3 hyper-v --native
+	$(IGVMBUILDER) --sort --output $@ --stage2 bin/stage2.bin --kernel bin/svsm-kernel.elf --comport 3 hyper-v --native --snp
 	$(IGVMMEASURE) $@ measure
 
 bin/coconut-test-qemu.igvm: $(IGVMBUILDER)  $(IGVMMEASURE) bin/test-kernel.elf bin/stage2.bin
-	$(IGVMBUILDER) --sort --output $@ --stage2 bin/stage2.bin --kernel bin/test-kernel.elf qemu
+	$(IGVMBUILDER) --sort --output $@ --stage2 bin/stage2.bin --kernel bin/test-kernel.elf qemu --snp
 	$(IGVMMEASURE) $@ measure
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -69,16 +69,16 @@ $(IGVMBUILDER):
 $(IGVMMEASURE):
 	cargo build ${CARGO_ARGS} --target=x86_64-unknown-linux-gnu -p igvmmeasure
 
-bin/coconut-qemu.igvm: $(IGVMBUILDER) $(IGVMMEASURE) bin/svsm-kernel.elf bin/stage2.bin ${FS_BIN}
-	$(IGVMBUILDER) --sort --policy 0x30000 --output $@ --stage2 bin/stage2.bin --kernel bin/svsm-kernel.elf --filesystem ${FS_BIN} ${BUILD_FW} qemu --snp
+bin/coconut-qemu.igvm: $(IGVMBUILDER) $(IGVMMEASURE) bin/stage1-trampoline.bin bin/svsm-kernel.elf bin/stage2.bin ${FS_BIN}
+	$(IGVMBUILDER) --sort --policy 0x30000 --output $@ --tdx-stage1 bin/stage1-trampoline.bin --stage2 bin/stage2.bin --kernel bin/svsm-kernel.elf --filesystem ${FS_BIN} ${BUILD_FW} qemu --snp --tdp
 	$(IGVMMEASURE) --check-kvm $@ measure
 
-bin/coconut-hyperv.igvm: $(IGVMBUILDER)  $(IGVMMEASURE) bin/svsm-kernel.elf bin/stage2.bin
-	$(IGVMBUILDER) --sort --output $@ --stage2 bin/stage2.bin --kernel bin/svsm-kernel.elf --comport 3 hyper-v --native --snp
+bin/coconut-hyperv.igvm: $(IGVMBUILDER) $(IGVMMEASURE) bin/stage1-trampoline.bin bin/svsm-kernel.elf bin/stage2.bin
+	$(IGVMBUILDER) --sort --output $@ --tdx-stage1 bin/stage1-trampoline.bin --stage2 bin/stage2.bin --kernel bin/svsm-kernel.elf --comport 3 hyper-v --native --snp --tdp
 	$(IGVMMEASURE) $@ measure
 
-bin/coconut-test-qemu.igvm: $(IGVMBUILDER)  $(IGVMMEASURE) bin/test-kernel.elf bin/stage2.bin
-	$(IGVMBUILDER) --sort --output $@ --stage2 bin/stage2.bin --kernel bin/test-kernel.elf qemu --snp
+bin/coconut-test-qemu.igvm: $(IGVMBUILDER) $(IGVMMEASURE) bin/stage1-trampoline.bin bin/test-kernel.elf bin/stage2.bin
+	$(IGVMBUILDER) --sort --output $@ --tdx-stage1 bin/stage1-trampoline.bin --stage2 bin/stage2.bin --kernel bin/test-kernel.elf qemu --snp --tdp
 	$(IGVMMEASURE) $@ measure
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ clippy:
 clean:
 	cargo clean
 	rm -f stage1/*.o stage1/*.bin stage1/*.elf
-	rm -f ${STAGE1_OBJS} utils/gen_meta utils/print-meta
+	rm -f utils/gen_meta utils/print-meta
 	rm -rf bin
 
 distclean: clean

--- a/bootlib/src/igvm_params.rs
+++ b/bootlib/src/igvm_params.rs
@@ -125,6 +125,15 @@ pub struct IgvmParamBlock {
     /// IGVM file.
     pub firmware: IgvmParamBlockFwInfo,
 
+    /// The number of bytes for the stage1 bootloader
+    pub stage1_size: u32,
+
+    #[doc(hidden)]
+    pub _reserved2: u32,
+
+    /// The guest physical address of the base of the stage1 bootloader
+    pub stage1_base: u64,
+
     /// The amount of space that must be reserved at the base of the kernel
     /// memory region (e.g. for VMSA contents).
     pub kernel_reserved_size: u32,

--- a/bootlib/src/platform.rs
+++ b/bootlib/src/platform.rs
@@ -10,12 +10,14 @@
 pub enum SvsmPlatformType {
     Native = 0,
     Snp = 1,
+    Tdp = 2,
 }
 
 impl From<u32> for SvsmPlatformType {
     fn from(value: u32) -> Self {
         match value {
             1 => Self::Snp,
+            2 => Self::Tdp,
             _ => Self::Native,
         }
     }

--- a/igvmbuilder/src/cmd_options.rs
+++ b/igvmbuilder/src/cmd_options.rs
@@ -8,6 +8,10 @@ use clap::{Parser, ValueEnum};
 
 #[derive(Parser, Debug)]
 pub struct CmdOptions {
+    /// Optional TDX stage 1 binary file
+    #[arg(long)]
+    pub tdx_stage1: Option<String>,
+
     /// Stage 2 binary file
     #[arg(short, long)]
     pub stage2: String,

--- a/igvmbuilder/src/cmd_options.rs
+++ b/igvmbuilder/src/cmd_options.rs
@@ -52,6 +52,10 @@ pub struct CmdOptions {
     #[arg(long, default_value_t = false)]
     pub snp: bool,
 
+    /// Include TD Partitioning platform target
+    #[arg(long, default_value_t = false)]
+    pub tdp: bool,
+
     /// Include NATIVE platform target
     #[arg(long, default_value_t = false)]
     pub native: bool,

--- a/igvmbuilder/src/cmd_options.rs
+++ b/igvmbuilder/src/cmd_options.rs
@@ -48,6 +48,10 @@ pub struct CmdOptions {
     #[arg(long)]
     pub policy: Option<String>,
 
+    /// Include SEV-SNP platform target
+    #[arg(long, default_value_t = false)]
+    pub snp: bool,
+
     /// Include NATIVE platform target
     #[arg(long, default_value_t = false)]
     pub native: bool,

--- a/igvmbuilder/src/igvm_builder.rs
+++ b/igvmbuilder/src/igvm_builder.rs
@@ -62,14 +62,18 @@ impl IgvmBuilder {
         // revision.
         let mut use_igvm_v2 = false;
 
-        // SNP is always included in the compatibility mask regardless of the
-        // provided options.
-        COMPATIBILITY_MASK.add(SNP_COMPATIBILITY_MASK);
-
+        // Include the SEV-SNP platform if requested.
+        if options.snp {
+            COMPATIBILITY_MASK.add(SNP_COMPATIBILITY_MASK);
+        }
         // Include the NATIVE platform if requested.
         if options.native {
             COMPATIBILITY_MASK.add(NATIVE_COMPATIBILITY_MASK);
             use_igvm_v2 = true;
+        }
+
+        if COMPATIBILITY_MASK.get() == 0 {
+            return Err("No platform specified".into());
         }
 
         let firmware = match options.firmware {

--- a/igvmbuilder/src/igvm_builder.rs
+++ b/igvmbuilder/src/igvm_builder.rs
@@ -34,6 +34,7 @@ use crate::GpaMap;
 
 pub const SNP_COMPATIBILITY_MASK: u32 = 1u32 << 0;
 pub const NATIVE_COMPATIBILITY_MASK: u32 = 1u32 << 1;
+pub const TDP_COMPATIBILITY_MASK: u32 = 1u32 << 2;
 pub static COMPATIBILITY_MASK: PlatformMask = PlatformMask::new();
 
 // Parameter area indices
@@ -65,6 +66,10 @@ impl IgvmBuilder {
         // Include the SEV-SNP platform if requested.
         if options.snp {
             COMPATIBILITY_MASK.add(SNP_COMPATIBILITY_MASK);
+        }
+        // Include the TDP platform if requested.
+        if options.tdp {
+            COMPATIBILITY_MASK.add(TDP_COMPATIBILITY_MASK);
         }
         // Include the NATIVE platform if requested.
         if options.native {
@@ -242,6 +247,17 @@ impl IgvmBuilder {
                     platform_type: IgvmPlatformType::SEV_SNP,
                     platform_version: 1,
                     shared_gpa_boundary: param_block.vtom,
+                },
+            ));
+        }
+        if COMPATIBILITY_MASK.contains(TDP_COMPATIBILITY_MASK) {
+            self.platforms.push(IgvmPlatformHeader::SupportedPlatform(
+                IGVM_VHS_SUPPORTED_PLATFORM {
+                    compatibility_mask: TDP_COMPATIBILITY_MASK,
+                    highest_vtl: 2,
+                    platform_type: IgvmPlatformType::TDX,
+                    platform_version: 1,
+                    shared_gpa_boundary: 0,
                 },
             ));
         }

--- a/igvmbuilder/src/igvm_builder.rs
+++ b/igvmbuilder/src/igvm_builder.rs
@@ -272,12 +272,16 @@ impl IgvmBuilder {
 
     fn build_initialization(&mut self) -> Result<(), Box<dyn Error>> {
         if let Some(policy) = &self.options.policy {
-            let policy = u64::from_str_radix(policy.trim_start_matches("0x"), 16)?;
-            self.initialization
-                .push(IgvmInitializationHeader::GuestPolicy {
-                    policy,
-                    compatibility_mask: COMPATIBILITY_MASK.get(),
-                })
+            if COMPATIBILITY_MASK.contains(SNP_COMPATIBILITY_MASK) {
+                let policy = u64::from_str_radix(policy.trim_start_matches("0x"), 16)?;
+                self.initialization
+                    .push(IgvmInitializationHeader::GuestPolicy {
+                        policy,
+                        compatibility_mask: SNP_COMPATIBILITY_MASK,
+                    })
+            } else {
+                return Err("Policy not supported by the specified platform(s)".into());
+            }
         }
         Ok(())
     }

--- a/igvmbuilder/src/igvm_builder.rs
+++ b/igvmbuilder/src/igvm_builder.rs
@@ -32,8 +32,8 @@ use crate::stage2_stack::Stage2Stack;
 use crate::vmsa::{construct_start_context, construct_vmsa};
 use crate::GpaMap;
 
-pub const SNP_COMPATIBILITY_MASK: u32 = 1;
-pub const NATIVE_COMPATIBILITY_MASK: u32 = 2;
+pub const SNP_COMPATIBILITY_MASK: u32 = 1u32 << 0;
+pub const NATIVE_COMPATIBILITY_MASK: u32 = 1u32 << 1;
 pub static COMPATIBILITY_MASK: PlatformMask = PlatformMask::new();
 
 // Parameter area indices

--- a/igvmbuilder/src/igvm_builder.rs
+++ b/igvmbuilder/src/igvm_builder.rs
@@ -429,6 +429,13 @@ impl IgvmBuilder {
                 &mut self.directives,
             );
         }
+        if COMPATIBILITY_MASK.contains(TDP_COMPATIBILITY_MASK) {
+            stage2_stack.add_directive(
+                self.gpa_map.stage2_stack.get_start(),
+                SvsmPlatformType::Tdp,
+                &mut self.directives,
+            );
+        }
         if COMPATIBILITY_MASK.contains(NATIVE_COMPATIBILITY_MASK) {
             stage2_stack.add_directive(
                 self.gpa_map.stage2_stack.get_start(),

--- a/igvmbuilder/src/igvm_builder.rs
+++ b/igvmbuilder/src/igvm_builder.rs
@@ -384,7 +384,7 @@ impl IgvmBuilder {
             let cpuid_page = SnpCpuidPage::new()?;
             cpuid_page.add_directive(
                 self.gpa_map.cpuid_page.get_start(),
-                COMPATIBILITY_MASK.get(),
+                SNP_COMPATIBILITY_MASK,
                 &mut self.directives,
             );
 
@@ -392,6 +392,7 @@ impl IgvmBuilder {
             self.add_empty_pages(
                 self.gpa_map.secrets_page.get_start(),
                 self.gpa_map.secrets_page.get_size(),
+                SNP_COMPATIBILITY_MASK,
                 IgvmPageDataType::SECRETS,
             )?;
         }
@@ -400,6 +401,7 @@ impl IgvmBuilder {
         self.add_empty_pages(
             self.gpa_map.stage2_free.get_start(),
             self.gpa_map.stage2_free.get_size(),
+            COMPATIBILITY_MASK.get(),
             IgvmPageDataType::NORMAL,
         )?;
 
@@ -431,6 +433,7 @@ impl IgvmBuilder {
         self.add_empty_pages(
             self.gpa_map.low_memory.get_start(),
             self.gpa_map.low_memory.get_size(),
+            COMPATIBILITY_MASK.get(),
             IgvmPageDataType::NORMAL,
         )?;
 
@@ -501,12 +504,13 @@ impl IgvmBuilder {
         &mut self,
         gpa_start: u64,
         size: u64,
+        compatibility_mask: u32,
         data_type: IgvmPageDataType,
     ) -> Result<(), Box<dyn Error>> {
         for gpa in (gpa_start..(gpa_start + size)).step_by(PAGE_SIZE_4K as usize) {
             self.directives.push(IgvmDirectiveHeader::PageData {
                 gpa,
-                compatibility_mask: COMPATIBILITY_MASK.get(),
+                compatibility_mask,
                 flags: IgvmPageDataFlags::new(),
                 data_type,
                 data: vec![],

--- a/igvmbuilder/src/igvm_builder.rs
+++ b/igvmbuilder/src/igvm_builder.rs
@@ -208,7 +208,7 @@ impl IgvmBuilder {
         };
 
         // Most of the parameter block can be initialised with constants.
-        let mut param_block = IgvmParamBlock {
+        Ok(IgvmParamBlock {
             param_area_size,
             param_page_offset,
             memory_map_offset,
@@ -226,23 +226,7 @@ impl IgvmBuilder {
                 false => 0,
             },
             ..Default::default()
-        };
-
-        // Calculate the kernel size and base.
-        match self.options.hypervisor {
-            Hypervisor::Qemu => {
-                // Place the kernel area at 512 GB with a size of 16 MB.
-                param_block.kernel_base = 0x0000008000000000;
-                param_block.kernel_size = 0x01000000;
-            }
-            Hypervisor::HyperV => {
-                // Place the kernel area at 64 MB with a size of 16 MB.
-                param_block.kernel_base = 0x04000000;
-                param_block.kernel_size = 0x01000000;
-            }
-        }
-
-        Ok(param_block)
+        })
     }
 
     fn build_platforms(&mut self, param_block: &IgvmParamBlock) {

--- a/igvmbuilder/src/stage2_stack.rs
+++ b/igvmbuilder/src/stage2_stack.rs
@@ -13,7 +13,9 @@ use igvm_defs::{IgvmPageDataFlags, IgvmPageDataType, PAGE_SIZE_4K};
 use zerocopy::AsBytes;
 
 use crate::gpa_map::GpaMap;
-use crate::igvm_builder::{NATIVE_COMPATIBILITY_MASK, SNP_COMPATIBILITY_MASK};
+use crate::igvm_builder::{
+    NATIVE_COMPATIBILITY_MASK, SNP_COMPATIBILITY_MASK, TDP_COMPATIBILITY_MASK,
+};
 
 pub struct Stage2Stack {
     stage2_stack: Stage2LaunchInfo,
@@ -43,6 +45,7 @@ impl Stage2Stack {
     ) {
         let compatibility_mask = match platform {
             SvsmPlatformType::Snp => SNP_COMPATIBILITY_MASK,
+            SvsmPlatformType::Tdp => TDP_COMPATIBILITY_MASK,
             SvsmPlatformType::Native => NATIVE_COMPATIBILITY_MASK,
         };
 

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -39,6 +39,8 @@ pub enum SvsmError {
     GhcbMsr(GhcbMsrError),
     /// Errors related to SEV-SNP operations, like PVALIDATE or RMPUPDATE
     SevSnp(SevSnpError),
+    /// Errors related to TDX operations
+    Tdx,
     /// Generic errors related to memory management
     Mem,
     /// Errors related to the memory allocator

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -10,6 +10,7 @@ use crate::error::SvsmError;
 use crate::io::IOPort;
 use crate::platform::native::NativePlatform;
 use crate::platform::snp::SnpPlatform;
+use crate::platform::tdp::TdpPlatform;
 use crate::types::PageSize;
 use crate::utils::immut_after_init::ImmutAfterInitCell;
 use crate::utils::MemoryRegion;
@@ -19,6 +20,7 @@ use bootlib::platform::SvsmPlatformType;
 pub mod guest_cpu;
 pub mod native;
 pub mod snp;
+pub mod tdp;
 
 pub static SVSM_PLATFORM: ImmutAfterInitCell<SvsmPlatformCell> = ImmutAfterInitCell::uninit();
 
@@ -100,6 +102,7 @@ pub trait SvsmPlatform {
 #[derive(Clone, Copy, Debug)]
 pub enum SvsmPlatformCell {
     Snp(SnpPlatform),
+    Tdp(TdpPlatform),
     Native(NativePlatform),
 }
 
@@ -108,6 +111,7 @@ impl SvsmPlatformCell {
         match platform_type {
             SvsmPlatformType::Native => SvsmPlatformCell::Native(NativePlatform::new()),
             SvsmPlatformType::Snp => SvsmPlatformCell::Snp(SnpPlatform::new()),
+            SvsmPlatformType::Tdp => SvsmPlatformCell::Tdp(TdpPlatform::new()),
         }
     }
 
@@ -115,6 +119,7 @@ impl SvsmPlatformCell {
         match self {
             SvsmPlatformCell::Native(platform) => platform,
             SvsmPlatformCell::Snp(platform) => platform,
+            SvsmPlatformCell::Tdp(platform) => platform,
         }
     }
 
@@ -122,6 +127,7 @@ impl SvsmPlatformCell {
         match self {
             SvsmPlatformCell::Native(platform) => platform,
             SvsmPlatformCell::Snp(platform) => platform,
+            SvsmPlatformCell::Tdp(platform) => platform,
         }
     }
 }

--- a/kernel/src/platform/tdp.rs
+++ b/kernel/src/platform/tdp.rs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (C) 2024 Intel Corporation
+//
+// Author: Peter Fang <peter.fang@intel.com>
+
+use crate::address::{PhysAddr, VirtAddr};
+use crate::cpu::cpuid::CpuidResult;
+use crate::cpu::percpu::PerCpu;
+use crate::error::SvsmError;
+use crate::io::IOPort;
+use crate::platform::{PageEncryptionMasks, PageStateChangeOp, SvsmPlatform};
+use crate::svsm_console::SVSMIOPort;
+use crate::types::PageSize;
+use crate::utils::MemoryRegion;
+
+static CONSOLE_IO: SVSMIOPort = SVSMIOPort::new();
+
+#[derive(Clone, Copy, Debug)]
+pub struct TdpPlatform {}
+
+impl TdpPlatform {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for TdpPlatform {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SvsmPlatform for TdpPlatform {
+    fn env_setup(&mut self) {}
+
+    fn env_setup_late(&mut self) {}
+
+    fn setup_percpu(&self, _cpu: &PerCpu) -> Result<(), SvsmError> {
+        Err(SvsmError::Tdx)
+    }
+
+    fn setup_percpu_current(&self, _cpu: &PerCpu) -> Result<(), SvsmError> {
+        Err(SvsmError::Tdx)
+    }
+
+    fn get_page_encryption_masks(&self, vtom: usize) -> PageEncryptionMasks {
+        // Find physical address size.
+        let res = CpuidResult::get(0x80000008, 0);
+        PageEncryptionMasks {
+            private_pte_mask: 0,
+            shared_pte_mask: vtom,
+            addr_mask_width: vtom.trailing_zeros(),
+            phys_addr_sizes: res.eax & 0xff,
+        }
+    }
+
+    fn setup_guest_host_comm(&mut self, _cpu: &PerCpu, _is_bsp: bool) {}
+
+    fn get_console_io_port(&self) -> &'static dyn IOPort {
+        &CONSOLE_IO
+    }
+
+    fn page_state_change(
+        &self,
+        _region: MemoryRegion<PhysAddr>,
+        _size: PageSize,
+        _op: PageStateChangeOp,
+    ) -> Result<(), SvsmError> {
+        Err(SvsmError::Tdx)
+    }
+
+    fn validate_page_range(&self, _region: MemoryRegion<VirtAddr>) -> Result<(), SvsmError> {
+        Err(SvsmError::Tdx)
+    }
+
+    fn invalidate_page_range(&self, _region: MemoryRegion<VirtAddr>) -> Result<(), SvsmError> {
+        Err(SvsmError::Tdx)
+    }
+
+    fn configure_alternate_injection(&mut self, _alt_inj_requested: bool) -> Result<(), SvsmError> {
+        Err(SvsmError::Tdx)
+    }
+
+    fn use_alternate_injection(&self) -> bool {
+        false
+    }
+
+    fn lock_unlock_apic_emulation(&self, _lock: bool) -> Result<(), SvsmError> {
+        Err(SvsmError::Tdx)
+    }
+
+    fn disable_apic_emulation(&self) -> Result<(), SvsmError> {
+        Err(SvsmError::Tdx)
+    }
+
+    fn post_irq(&self, _icr: u64) -> Result<(), SvsmError> {
+        Err(SvsmError::Tdx)
+    }
+
+    fn eoi(&self) {}
+}

--- a/stage1/stage1.S
+++ b/stage1/stage1.S
@@ -32,6 +32,7 @@ startup_32:
 	andl	$~((1 << 30) | (1 << 29)), %eax
 	mov	%eax, %cr0
 
+#ifdef LOAD_STAGE2
 	/* Setup Stack */
 	movl	$STAGE1_STACK, %esp
 
@@ -40,7 +41,9 @@ startup_32:
 2:	popl	%ebp
 	leal	2b, %eax
 	subl	%eax, %ebp
+#endif
 
+#ifdef LOAD_STAGE2
 	leal	stage2_bin(%ebp), %esi
 	movl	$STAGE2_START, %edi
 	movl	stage2_size(%ebp), %ecx
@@ -73,11 +76,16 @@ startup_32:
 	pushl	%eax
 	pushl	%eax
 
+#else
+	/* Setup stack for stage 2 */
+	movl	$(STAGE2_START - 32), %esp
+#endif
 	/* Jump to stage 2 */
 	movl	$STAGE2_START, %eax
 	jmp	*%eax
 .data
 
+#ifdef LOAD_STAGE2
 	.align	4
 stage2_bin:
 	.incbin "bin/stage2.bin"
@@ -96,3 +104,4 @@ kernel_fs_bin_end:
 	.align 4
 stage2_size:
 	.long	stage2_bin_end - stage2_bin
+#endif


### PR DESCRIPTION
This is the first set of patches to begin supporting TD Partitioning in the IGVM framework. Patches for TDX enabling will follow.
No changes to the IGVM spec are proposed yet. The goal is to allow TDP enabling to hit the ground running first.
The main work in this patchset is to separate TDP from SEV platforms.

To generate an IGVM file for a TDP platform as part of the build process, run:

`$ make PLATFORM=tdp FW_FILE=/path/to/OVMF.fd`