### PR TITLE
Add a separate crate insn_decode in kernel for instruction decoding

### DIFF
--- a/fuzz/fuzz_targets/insn.rs
+++ b/fuzz/fuzz_targets/insn.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use libfuzzer_sys::{fuzz_target, Corpus};
-use svsm::cpu::insn::{Instruction, MAX_INSN_SIZE};
+use svsm::insn_decode::{Instruction, MAX_INSN_SIZE};
 
 fuzz_target!(|input: &[u8]| -> Corpus {
     let Some(input) = input.get(..MAX_INSN_SIZE) else {

--- a/fuzz/fuzz_targets/insn.rs
+++ b/fuzz/fuzz_targets/insn.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use libfuzzer_sys::{fuzz_target, Corpus};
-use svsm::insn_decode::{Instruction, MAX_INSN_SIZE};
+use svsm::insn_decode::{Instruction, TestCtx, MAX_INSN_SIZE};
 
 fuzz_target!(|input: &[u8]| -> Corpus {
     let Some(input) = input.get(..MAX_INSN_SIZE) else {
@@ -12,7 +12,7 @@ fuzz_target!(|input: &[u8]| -> Corpus {
     data.copy_from_slice(input);
 
     let insn = Instruction::new(data);
-    let _ = core::hint::black_box(insn.decode());
+    let _ = core::hint::black_box(insn.decode(&TestCtx));
 
     Corpus::Keep
 });

--- a/kernel/src/cpu/control_regs.rs
+++ b/kernel/src/cpu/control_regs.rs
@@ -119,6 +119,7 @@ bitflags! {
         const OSFXSR        = 1 << 9;  // Operating System FXSAVE/FXRSTOR Support
         const OSXMMEXCPT    = 1 << 10; // Operating System Unmasked Exception Support
         const UMIP      = 1 << 11; // User Mode Instruction Prevention
+        const LA57      = 1 << 12; // 57-bit linear address
         const FSGSBASE      = 1 << 16; // Enable RDFSBASE, RDGSBASE, WRFSBASE, and
                            // WRGSBASE instructions
         const PCIDE     = 1 << 17; // Process Context Identifier Enable

--- a/kernel/src/cpu/gdt.rs
+++ b/kernel/src/cpu/gdt.rs
@@ -137,6 +137,14 @@ impl GDT {
             self.clear_tss_entry()
         }
     }
+
+    pub fn kernel_cs(&self) -> GDTEntry {
+        self.entries[(SVSM_CS / 8) as usize]
+    }
+
+    pub fn kernel_ds(&self) -> GDTEntry {
+        self.entries[(SVSM_DS / 8) as usize]
+    }
 }
 
 static GDT: RWLock<GDT> = RWLock::new(GDT::new());

--- a/kernel/src/cpu/mod.rs
+++ b/kernel/src/cpu/mod.rs
@@ -12,7 +12,6 @@ pub mod features;
 pub mod gdt;
 pub mod ghcb;
 pub mod idt;
-pub mod insn;
 pub mod msr;
 pub mod percpu;
 pub mod registers;

--- a/kernel/src/cpu/registers.rs
+++ b/kernel/src/cpu/registers.rs
@@ -4,6 +4,8 @@
 //
 // Author: Roy Hopkins <rhopkins@suse.de>
 
+use bitflags::bitflags;
+
 #[repr(C, packed)]
 #[derive(Default, Debug, Clone, Copy)]
 pub struct X86GeneralRegs {
@@ -43,4 +45,19 @@ pub struct X86InterruptFrame {
     pub flags: usize,
     pub rsp: usize,
     pub ss: usize,
+}
+
+bitflags! {
+    #[derive(Copy, Clone, Debug, PartialEq)]
+    pub struct SegDescAttrFlags: u64 {
+        const A     = 1 << 40;
+        const R_W   = 1 << 41;
+        const C_E   = 1 << 42;
+        const C_D   = 1 << 43;
+        const S     = 1 << 44;
+        const AVL   = 1 << 52;
+        const L     = 1 << 53;
+        const DB    = 1 << 54;
+        const G     = 1 << 55;
+    }
 }

--- a/kernel/src/cpu/vc.rs
+++ b/kernel/src/cpu/vc.rs
@@ -5,16 +5,15 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 
 use super::idt::common::X86ExceptionContext;
-use super::insn::MAX_INSN_SIZE;
 use crate::address::Address;
 use crate::address::VirtAddr;
 use crate::cpu::cpuid::{cpuid_table_raw, CpuidLeaf};
 use crate::cpu::ghcb::current_ghcb;
-use crate::cpu::insn::{DecodedInsn, Immediate, Instruction, Operand, Register};
 use crate::cpu::percpu::this_cpu;
 use crate::cpu::X86GeneralRegs;
 use crate::debug::gdbstub::svsm_gdbstub::handle_debug_exception;
 use crate::error::SvsmError;
+use crate::insn_decode::{DecodedInsn, Immediate, Instruction, Operand, Register, MAX_INSN_SIZE};
 use crate::mm::GuestPtr;
 use crate::sev::ghcb::{GHCBIOSize, GHCB};
 use core::fmt;

--- a/kernel/src/cpu/vc.rs
+++ b/kernel/src/cpu/vc.rs
@@ -13,7 +13,9 @@ use crate::cpu::percpu::this_cpu;
 use crate::cpu::X86GeneralRegs;
 use crate::debug::gdbstub::svsm_gdbstub::handle_debug_exception;
 use crate::error::SvsmError;
-use crate::insn_decode::{DecodedInsn, Immediate, Instruction, Operand, Register, MAX_INSN_SIZE};
+use crate::insn_decode::{
+    DecodedInsn, DecodedInsnCtx, Immediate, Instruction, Operand, Register, MAX_INSN_SIZE,
+};
 use crate::mm::GuestPtr;
 use crate::sev::ghcb::{GHCBIOSize, GHCB};
 use core::fmt;
@@ -84,14 +86,14 @@ impl fmt::Display for VcError {
 
 pub fn stage2_handle_vc_exception_no_ghcb(ctx: &mut X86ExceptionContext) -> Result<(), SvsmError> {
     let err = ctx.error_code;
-    let insn = vc_decode_insn(ctx)?;
+    let insn_ctx = vc_decode_insn(ctx)?;
 
     match err {
         SVM_EXIT_CPUID => handle_cpuid(ctx),
         _ => Err(VcError::new(ctx, VcErrorType::Unsupported).into()),
     }?;
 
-    vc_finish_insn(ctx, &insn);
+    vc_finish_insn(ctx, &insn_ctx);
     Ok(())
 }
 
@@ -105,9 +107,9 @@ pub fn stage2_handle_vc_exception(ctx: &mut X86ExceptionContext) -> Result<(), S
     // handlers.
     let mut ghcb = current_ghcb();
 
-    let insn = vc_decode_insn(ctx)?;
+    let insn_ctx = vc_decode_insn(ctx)?;
 
-    match (err, insn) {
+    match (err, insn_ctx.and_then(|d| d.insn())) {
         (SVM_EXIT_CPUID, Some(DecodedInsn::Cpuid)) => handle_cpuid(ctx),
         (SVM_EXIT_IOIO, Some(ins)) => handle_ioio(ctx, &mut ghcb, ins),
         (SVM_EXIT_MSR, Some(ins)) => handle_msr(ctx, &mut ghcb, ins),
@@ -116,7 +118,7 @@ pub fn stage2_handle_vc_exception(ctx: &mut X86ExceptionContext) -> Result<(), S
         _ => Err(VcError::new(ctx, VcErrorType::Unsupported).into()),
     }?;
 
-    vc_finish_insn(ctx, &insn);
+    vc_finish_insn(ctx, &insn_ctx);
     Ok(())
 }
 
@@ -130,9 +132,9 @@ pub fn handle_vc_exception(ctx: &mut X86ExceptionContext, vector: usize) -> Resu
     // handlers.
     let mut ghcb = current_ghcb();
 
-    let insn = vc_decode_insn(ctx)?;
+    let insn_ctx = vc_decode_insn(ctx)?;
 
-    match (error_code, insn) {
+    match (error_code, insn_ctx.and_then(|d| d.insn())) {
         // If the gdb stub is enabled then debugging operations such as single stepping
         // will cause either an exception via DB_VECTOR if the DEBUG_SWAP sev_feature is
         // clear, or a VC exception with an error code of X86_TRAP if set.
@@ -148,7 +150,7 @@ pub fn handle_vc_exception(ctx: &mut X86ExceptionContext, vector: usize) -> Resu
         _ => Err(VcError::new(ctx, VcErrorType::Unsupported).into()),
     }?;
 
-    vc_finish_insn(ctx, &insn);
+    vc_finish_insn(ctx, &insn_ctx);
     Ok(())
 }
 
@@ -222,8 +224,8 @@ fn snp_cpuid(ctx: &mut X86ExceptionContext) -> Result<(), SvsmError> {
     Ok(())
 }
 
-fn vc_finish_insn(ctx: &mut X86ExceptionContext, insn: &Option<DecodedInsn>) {
-    ctx.frame.rip += insn.as_ref().map(DecodedInsn::size).unwrap_or(0);
+fn vc_finish_insn(ctx: &mut X86ExceptionContext, insn_ctx: &Option<DecodedInsnCtx>) {
+    ctx.frame.rip += insn_ctx.map_or(0, |d| d.size())
 }
 
 fn ioio_get_port(source: Operand, ctx: &X86ExceptionContext) -> u16 {
@@ -285,7 +287,7 @@ fn handle_ioio(
     }
 }
 
-fn vc_decode_insn(ctx: &X86ExceptionContext) -> Result<Option<DecodedInsn>, SvsmError> {
+fn vc_decode_insn(ctx: &X86ExceptionContext) -> Result<Option<DecodedInsnCtx>, SvsmError> {
     if !vc_decoding_needed(ctx.error_code) {
         return Ok(None);
     }
@@ -301,7 +303,7 @@ fn vc_decode_insn(ctx: &X86ExceptionContext) -> Result<Option<DecodedInsn>, Svsm
     let insn_raw = rip.read()?;
 
     let insn = Instruction::new(insn_raw);
-    insn.decode().map(Some)
+    Ok(Some(insn.decode(ctx)?))
 }
 
 fn vc_decoding_needed(error_code: usize) -> bool {

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -47,6 +47,8 @@ pub enum SvsmError {
     MissingSecrets,
     /// Invalid address, usually provided by the guest
     InvalidAddress,
+    /// Error reported when convert a usize to Bytes
+    InvalidBytes,
     /// Errors related to firmware parsing
     Firmware,
     /// Errors related to firmware configuration contents

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -20,6 +20,7 @@
 use crate::cpu::vc::VcError;
 use crate::fs::FsError;
 use crate::fw_cfg::FwCfgError;
+use crate::insn_decode::InsnError;
 use crate::mm::alloc::AllocError;
 use crate::sev::ghcb::GhcbError;
 use crate::sev::msr_protocol::GhcbMsrError;
@@ -45,6 +46,8 @@ pub enum SvsmError {
     MissingCAA,
     /// Error reported when there is no secrets page set up.
     MissingSecrets,
+    /// Instruction decode related errors
+    Insn(InsnError),
     /// Invalid address, usually provided by the guest
     InvalidAddress,
     /// Error reported when convert a usize to Bytes

--- a/kernel/src/insn_decode/decode.rs
+++ b/kernel/src/insn_decode/decode.rs
@@ -3,11 +3,52 @@
 // Copyright (c) 2024 Intel Corporation.
 //
 // Author: Chuanxiao Dong <chuanxiao.dong@intel.com>
+//
+// The instruction decoding is implemented by refering instr_emul.c
+// from the Arcn project, with some modifications. A copy of license
+// is included below:
+//
+// Copyright (c) 2012 Sandvine, Inc.
+// Copyright (c) 2012 NetApp, Inc.
+// Copyright (c) 2017-2022 Intel Corporation.
+//
+// Aedistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+// SUCH DAMAGE.
+//
+// $FreeBSD$
+//
+// The original file can be found in this repository:
+// https://github.com/projectacrn/acrn-hypervisor/blob/master/hypervisor/
+// arch/x86/guest/instr_emul.c
 
 #![allow(dead_code)]
 
 use super::insn::MAX_INSN_SIZE;
-use super::InsnError;
+use super::opcode::{OpCodeDesc, OpCodeFlags};
+use super::{InsnError, Register, SegRegister};
+use crate::cpu::control_regs::{CR0Flags, CR4Flags};
+use crate::cpu::efer::EFERFlags;
+use crate::cpu::registers::SegDescAttrFlags;
+use crate::types::Bytes;
+use bitflags::bitflags;
 
 /// Represents the raw bytes of an instruction and
 /// tracks the number of bytes being processed.
@@ -67,3 +108,632 @@ impl InsnBytes {
 /// The instruction bytes specifically for OpCode decoding
 #[derive(Clone, Copy, Debug)]
 pub struct OpCodeBytes(pub InsnBytes);
+
+// The instruction bytes specifically for prefix decoding
+#[derive(Clone, Copy, Debug)]
+struct PrefixBytes(InsnBytes);
+// The instruction bytes specifically for ModR/M decoding
+#[derive(Clone, Copy, Debug)]
+struct ModRmBytes(InsnBytes);
+// The instruction bytes specifically for SIB decoding
+#[derive(Clone, Copy, Debug)]
+struct SibBytes(InsnBytes);
+// The instruction bytes specifically for displacement decoding
+#[derive(Clone, Copy, Debug)]
+struct DisBytes(InsnBytes);
+// The instruction bytes specifically for immediate decoding
+#[derive(Clone, Copy, Debug)]
+struct ImmBytes(InsnBytes);
+// The instruction bytes specifically for Mem-Offset decoding
+#[derive(Clone, Copy, Debug)]
+struct MoffBytes(InsnBytes);
+// The instruction bytes specifically after decoding completed
+#[derive(Clone, Copy, Debug)]
+struct DecodedBytes(InsnBytes);
+
+/// This trait provides the necessary context for an instruction decoder
+/// to decode instructions based on the current state of the machine
+/// that executed them. It abstracts the interfaces through which an
+/// instruction decoder can access specific registers and state that may
+/// influence the decoding from the machine (such as a CPU or VMM).
+pub trait InsnMachineCtx: core::fmt::Debug {
+    /// Read EFER register
+    fn read_efer(&self) -> u64;
+    /// Read a code segment register
+    fn read_seg(&self, seg: SegRegister) -> u64;
+    /// Read CR0 register
+    fn read_cr0(&self) -> u64;
+    /// Read CR4 register
+    fn read_cr4(&self) -> u64;
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum PagingLevel {
+    Level4,
+    Level5,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+enum CpuMode {
+    #[default]
+    Real,
+    Protected,
+    Compatibility,
+    Bit64(PagingLevel),
+}
+
+impl CpuMode {
+    fn is_bit64(&self) -> bool {
+        matches!(self, CpuMode::Bit64(_))
+    }
+}
+
+fn get_cpu_mode<I: InsnMachineCtx>(mctx: &I) -> CpuMode {
+    if (mctx.read_efer() & EFERFlags::LMA.bits()) != 0 {
+        // EFER.LMA = 1
+        if (mctx.read_seg(SegRegister::CS) & SegDescAttrFlags::L.bits()) != 0 {
+            // CS.L = 1 represents 64bit mode.
+            // While this sub-mode produces 64-bit linear addresses, the processor
+            // enforces canonicality, meaning that the upper bits of such an address
+            // are identical: bits 63:47 for 4-level paging and bits 63:56 for
+            // 5-level paging. 4-level paging (respectively, 5-level paging) does not
+            // use bits 63:48 (respectively, bits 63:57) of such addresses
+            let level = if (mctx.read_cr4() & CR4Flags::LA57.bits()) != 0 {
+                PagingLevel::Level5
+            } else {
+                PagingLevel::Level4
+            };
+            CpuMode::Bit64(level)
+        } else {
+            CpuMode::Compatibility
+        }
+    } else if (mctx.read_cr0() & CR0Flags::PE.bits()) != 0 {
+        // CR0.PE = 1
+        CpuMode::Protected
+    } else {
+        CpuMode::Real
+    }
+}
+
+// Translate the decoded number from the instruction ModR/M
+// or SIB to the corresponding register
+struct RegCode(u8);
+impl TryFrom<RegCode> for Register {
+    type Error = InsnError;
+
+    fn try_from(val: RegCode) -> Result<Register, Self::Error> {
+        match val.0 {
+            0 => Ok(Register::Rax),
+            1 => Ok(Register::Rcx),
+            2 => Ok(Register::Rdx),
+            3 => Ok(Register::Rbx),
+            4 => Ok(Register::Rsp),
+            5 => Ok(Register::Rbp),
+            6 => Ok(Register::Rsi),
+            7 => Ok(Register::Rdi),
+            8 => Ok(Register::R8),
+            9 => Ok(Register::R9),
+            10 => Ok(Register::R10),
+            11 => Ok(Register::R11),
+            12 => Ok(Register::R12),
+            13 => Ok(Register::R13),
+            14 => Ok(Register::R14),
+            15 => Ok(Register::R15),
+            // Rip is not represented by ModR/M or SIB
+            _ => Err(InsnError::InvalidRegister),
+        }
+    }
+}
+
+const PREFIX_SIZE: usize = 4;
+
+bitflags! {
+    #[derive(Copy, Clone, Debug, Default, PartialEq)]
+    struct PrefixFlags: u16 {
+        const REX_W                 = 1 << 0;
+        const REX_R                 = 1 << 1;
+        const REX_X                 = 1 << 2;
+        const REX_B                 = 1 << 3;
+        const REX_P                 = 1 << 4;
+        const REPZ_P                = 1 << 5;
+        const REPNZ_P               = 1 << 6;
+        const OPSIZE_OVERRIDE       = 1 << 7;
+        const ADDRSIZE_OVERRIDE     = 1 << 8;
+    }
+}
+
+bitflags! {
+    #[derive(Copy, Clone, Debug, Default, PartialEq)]
+    struct RexPrefix: u8 {
+        const B     = 1 << 0;
+        const X     = 1 << 1;
+        const R     = 1 << 2;
+        const W     = 1 << 3;
+    }
+}
+
+#[derive(Copy, Clone, Default, Debug, PartialEq)]
+struct ModRM(u8);
+
+const MOD_INDIRECT: u8 = 0;
+const MOD_INDIRECT_DISP8: u8 = 1;
+const MOD_INDIRECT_DISP32: u8 = 2;
+const MOD_DIRECT: u8 = 3;
+const RM_SIB: u8 = 4;
+const RM_DISP32: u8 = 5;
+
+impl From<u8> for ModRM {
+    fn from(val: u8) -> Self {
+        ModRM(val)
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+enum RM {
+    Reg(Register),
+    Sib,
+    Disp32,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+enum Mod {
+    Indirect,
+    IndirectDisp8,
+    IndirectDisp32,
+    Direct,
+}
+
+impl ModRM {
+    fn get_mod(&self) -> Mod {
+        let v = (self.0 >> 6) & 0x3;
+
+        match v {
+            MOD_INDIRECT => Mod::Indirect,
+            MOD_INDIRECT_DISP8 => Mod::IndirectDisp8,
+            MOD_INDIRECT_DISP32 => Mod::IndirectDisp32,
+            MOD_DIRECT => Mod::Direct,
+            _ => {
+                unreachable!("Mod has only two bits, so its value is always 0 ~ 3");
+            }
+        }
+    }
+
+    fn get_reg(&self) -> u8 {
+        (self.0 >> 3) & 0x7
+    }
+
+    fn get_rm(&self) -> RM {
+        let rm = self.0 & 0x7;
+        let r#mod = self.get_mod();
+
+        // RM depends on the Mod value
+        if r#mod == Mod::Indirect && rm == RM_DISP32 {
+            RM::Disp32
+        } else if r#mod != Mod::Direct && rm == RM_SIB {
+            RM::Sib
+        } else {
+            RM::Reg(Register::try_from(RegCode(rm)).unwrap())
+        }
+    }
+}
+
+#[derive(Copy, Clone, Default, Debug, PartialEq)]
+struct Sib(u8);
+
+impl From<u8> for Sib {
+    fn from(val: u8) -> Self {
+        Sib(val)
+    }
+}
+
+impl Sib {
+    fn get_scale(&self) -> u8 {
+        (self.0 >> 6) & 0x3
+    }
+
+    fn get_index(&self) -> u8 {
+        (self.0 >> 3) & 0x7
+    }
+
+    fn get_base(&self) -> u8 {
+        self.0 & 0x7
+    }
+}
+
+/// Represents the context of a decoded instruction, which is used to
+/// interpret the instruction. It holds the decoded instruction length
+/// and various components that are decoded from the instruction bytes.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct DecodedInsnCtx {
+    insn_len: usize,
+    cpu_mode: CpuMode,
+
+    // Prefix
+    prefix: PrefixFlags,
+    override_seg: Option<SegRegister>,
+
+    // Opcode description
+    opdesc: Option<OpCodeDesc>,
+    opsize: Bytes,
+    addrsize: Bytes,
+
+    // ModR/M byte
+    modrm: ModRM,
+    reg: u8,
+    modrm_reg: Option<Register>,
+
+    // SIB byte
+    sib: Sib,
+    scale: u8,
+    index_reg: Option<Register>,
+    base_reg: Option<Register>,
+
+    // Optional addr displacement
+    displacement: i64,
+
+    // Optional immediate operand
+    immediate: i64,
+}
+
+impl DecodedInsnCtx {
+    fn new<I: InsnMachineCtx>(bytes: &[u8; MAX_INSN_SIZE], mctx: &I) -> Result<Self, InsnError> {
+        let mut insn_ctx = Self {
+            cpu_mode: get_cpu_mode(mctx),
+            ..Default::default()
+        };
+
+        insn_ctx.decode(bytes, mctx).map(|_| insn_ctx)
+    }
+
+    fn decode<I: InsnMachineCtx>(
+        &mut self,
+        bytes: &[u8; MAX_INSN_SIZE],
+        mctx: &I,
+    ) -> Result<(), InsnError> {
+        self.decode_prefixes(bytes, mctx)
+            .and_then(|insn| self.decode_opcode(insn))
+            .and_then(|insn| self.decode_modrm_sib(insn))
+            .and_then(|(insn, disp_bytes)| self.decode_displacement(insn, disp_bytes))
+            .and_then(|insn| self.decode_immediate(insn))
+            .and_then(|insn| self.decode_moffset(insn))
+            .and_then(|insn| self.complete_decode(insn))
+    }
+
+    #[inline]
+    fn get_opdesc(&self) -> Result<OpCodeDesc, InsnError> {
+        self.opdesc.ok_or(InsnError::NoOpCodeDesc)
+    }
+
+    fn decode_rex_prefix(&mut self, code: u8) -> bool {
+        if !self.cpu_mode.is_bit64() {
+            return false;
+        }
+
+        match code {
+            0x40..=0x4F => {
+                let rex = RexPrefix::from_bits_truncate(code);
+                self.prefix.insert(PrefixFlags::REX_P);
+                if rex.contains(RexPrefix::W) {
+                    self.prefix.insert(PrefixFlags::REX_W);
+                }
+                if rex.contains(RexPrefix::R) {
+                    self.prefix.insert(PrefixFlags::REX_R);
+                }
+                if rex.contains(RexPrefix::X) {
+                    self.prefix.insert(PrefixFlags::REX_X);
+                }
+                if rex.contains(RexPrefix::B) {
+                    self.prefix.insert(PrefixFlags::REX_B);
+                }
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn decode_op_addr_size(&mut self, cs: u64) {
+        (self.addrsize, self.opsize) = if self.cpu_mode.is_bit64() {
+            (
+                if self.prefix.contains(PrefixFlags::ADDRSIZE_OVERRIDE) {
+                    Bytes::Four
+                } else {
+                    Bytes::Eight
+                },
+                if self.prefix.contains(PrefixFlags::REX_W) {
+                    Bytes::Eight
+                } else if self.prefix.contains(PrefixFlags::OPSIZE_OVERRIDE) {
+                    Bytes::Two
+                } else {
+                    Bytes::Four
+                },
+            )
+        } else if (cs & SegDescAttrFlags::DB.bits()) != 0 {
+            // Default address and operand sizes are 32-bits
+            (
+                if self.prefix.contains(PrefixFlags::ADDRSIZE_OVERRIDE) {
+                    Bytes::Two
+                } else {
+                    Bytes::Four
+                },
+                if self.prefix.contains(PrefixFlags::OPSIZE_OVERRIDE) {
+                    Bytes::Two
+                } else {
+                    Bytes::Four
+                },
+            )
+        } else {
+            // Default address and operand sizes are 16-bits
+            (
+                if self.prefix.contains(PrefixFlags::ADDRSIZE_OVERRIDE) {
+                    Bytes::Four
+                } else {
+                    Bytes::Two
+                },
+                if self.prefix.contains(PrefixFlags::OPSIZE_OVERRIDE) {
+                    Bytes::Four
+                } else {
+                    Bytes::Two
+                },
+            )
+        };
+    }
+
+    fn decode_prefixes<I: InsnMachineCtx>(
+        &mut self,
+        bytes: &[u8; MAX_INSN_SIZE],
+        mctx: &I,
+    ) -> Result<OpCodeBytes, InsnError> {
+        let mut insn = PrefixBytes(InsnBytes::new(*bytes));
+        for _ in 0..PREFIX_SIZE {
+            match insn.0.peek()? {
+                0x66 => self.prefix.insert(PrefixFlags::OPSIZE_OVERRIDE),
+                0x67 => self.prefix.insert(PrefixFlags::ADDRSIZE_OVERRIDE),
+                0xF3 => self.prefix.insert(PrefixFlags::REPZ_P),
+                0xF2 => self.prefix.insert(PrefixFlags::REPNZ_P),
+                0x2E => self.override_seg = Some(SegRegister::CS),
+                0x36 => self.override_seg = Some(SegRegister::SS),
+                0x3E => self.override_seg = Some(SegRegister::DS),
+                0x26 => self.override_seg = Some(SegRegister::ES),
+                0x64 => self.override_seg = Some(SegRegister::FS),
+                0x65 => self.override_seg = Some(SegRegister::GS),
+                _ => break,
+            }
+            insn.0.advance();
+        }
+
+        // From section 2.2.1, "REX Prefixes", Intel SDM Vol 2:
+        // - Only one REX prefix is allowed per instruction.
+        // - The REX prefix must immediately precede the opcode byte or the
+        //   escape opcode byte.
+        // - If an instruction has a mandatory prefix (0x66, 0xF2 or 0xF3)
+        //   the mandatory prefix must come before the REX prefix.
+        if self.decode_rex_prefix(insn.0.peek()?) {
+            insn.0.advance();
+        }
+
+        self.decode_op_addr_size(mctx.read_seg(SegRegister::CS));
+
+        Ok(OpCodeBytes(insn.0))
+    }
+
+    fn decode_opcode(&mut self, mut insn: OpCodeBytes) -> Result<ModRmBytes, InsnError> {
+        let opdesc = OpCodeDesc::decode(&mut insn).ok_or(InsnError::DecodeOpCode)?;
+
+        if opdesc.flags.contains(OpCodeFlags::BYTE_OP) {
+            self.opsize = Bytes::One;
+        } else if opdesc.flags.contains(OpCodeFlags::WORD_OP) {
+            self.opsize = Bytes::Two;
+        }
+
+        self.opdesc = Some(opdesc);
+
+        Ok(ModRmBytes(insn.0))
+    }
+
+    fn decode_modrm_sib(&mut self, mut insn: ModRmBytes) -> Result<(DisBytes, Bytes), InsnError> {
+        if self.get_opdesc()?.flags.contains(OpCodeFlags::NO_MODRM) {
+            return Ok((DisBytes(insn.0), Bytes::Zero));
+        }
+
+        if self.cpu_mode == CpuMode::Real {
+            return Err(InsnError::DecodeModRM);
+        }
+
+        self.modrm = ModRM::from(insn.0.peek()?);
+
+        if self.get_opdesc()?.flags.contains(OpCodeFlags::OP_NONE) {
+            insn.0.advance();
+            return Ok((DisBytes(insn.0), Bytes::Zero));
+        }
+
+        let r#mod = self.modrm.get_mod();
+        self.reg = self.modrm.get_reg() | ((self.prefix.contains(PrefixFlags::REX_R) as u8) << 3);
+        self.modrm_reg = Some(Register::try_from(RegCode(self.reg))?);
+
+        // As the modrm decoding is majorly for MMIO instructions which requires
+        // a memory access, a direct addressing mode makes no sense in the context.
+        // There has to be a memory access involved to trap the MMIO instruction.
+        if r#mod == Mod::Direct {
+            return Err(InsnError::DecodeModRM);
+        }
+
+        // SDM Vol2 Table 2-5: Special Cases of REX Encodings
+        // For mod=0 r/m=5 and mod!=3 r/m=4, the 'b' bit in the REX
+        // prefix is 'don't care' in these two cases.
+        //
+        // RM::Disp32 represent mod=0 r/m=5
+        // RM::Sib represent mod!=3 r/m=4
+        // RM::Reg(r) represent the other cases.
+        let disp_bytes = match self.modrm.get_rm() {
+            RM::Reg(r) => {
+                let ext_r = Register::try_from(RegCode(
+                    r as u8 | ((self.prefix.contains(PrefixFlags::REX_B) as u8) << 3),
+                ))?;
+                self.base_reg = Some(ext_r);
+                match r#mod {
+                    Mod::IndirectDisp8 => Bytes::One,
+                    Mod::IndirectDisp32 => Bytes::Four,
+                    Mod::Indirect | Mod::Direct => Bytes::Zero,
+                }
+            }
+            RM::Disp32 => {
+                // SDM Vol2 Table 2-7: RIP-Relative Addressing
+                // In 64bit mode, mod=0 r/m=5 implies [rip] + disp32
+                // whereas in compatibility mode it just implies disp32.
+                self.base_reg = if self.cpu_mode.is_bit64() {
+                    Some(Register::Rip)
+                } else {
+                    None
+                };
+                Bytes::Four
+            }
+            RM::Sib => {
+                insn.0.advance();
+                return self.decode_sib(SibBytes(insn.0));
+            }
+        };
+
+        insn.0.advance();
+        Ok((DisBytes(insn.0), disp_bytes))
+    }
+
+    fn decode_sib(&mut self, mut insn: SibBytes) -> Result<(DisBytes, Bytes), InsnError> {
+        // Process only if SIB byte is present
+        if self.modrm.get_rm() != RM::Sib {
+            return Err(InsnError::DecodeSib);
+        }
+
+        self.sib = Sib::from(insn.0.peek()?);
+        let index = self.sib.get_index() | ((self.prefix.contains(PrefixFlags::REX_X) as u8) << 3);
+        let base = self.sib.get_base() | ((self.prefix.contains(PrefixFlags::REX_B) as u8) << 3);
+
+        let r#mod = self.modrm.get_mod();
+        let disp_bytes = match r#mod {
+            Mod::IndirectDisp8 => {
+                self.base_reg = Some(Register::try_from(RegCode(base))?);
+                Bytes::One
+            }
+            Mod::IndirectDisp32 => {
+                self.base_reg = Some(Register::try_from(RegCode(base))?);
+                Bytes::Four
+            }
+            Mod::Indirect => {
+                let mut disp_bytes = Bytes::Zero;
+                // SMD Vol 2 Table 2-5 Special Cases of REX Encoding
+                // Base register is unused if mod=0 base=RBP/R13.
+                self.base_reg = if base == Register::Rbp as u8 || base == Register::R13 as u8 {
+                    disp_bytes = Bytes::Four;
+                    None
+                } else {
+                    Some(Register::try_from(RegCode(base))?)
+                };
+                disp_bytes
+            }
+            Mod::Direct => Bytes::Zero,
+        };
+
+        // SMD Vol 2 Table 2-5 Special Cases of REX Encoding
+        // Index register not used when index=RSP
+        if index != Register::Rsp as u8 {
+            self.index_reg = Some(Register::try_from(RegCode(index))?);
+            // 'scale' makes sense only in the context of an index register
+            self.scale = 1 << self.sib.get_scale();
+        }
+
+        insn.0.advance();
+        Ok((DisBytes(insn.0), disp_bytes))
+    }
+
+    fn decode_displacement(
+        &mut self,
+        mut insn: DisBytes,
+        disp_bytes: Bytes,
+    ) -> Result<ImmBytes, InsnError> {
+        match disp_bytes {
+            Bytes::Zero => Ok(ImmBytes(insn.0)),
+            Bytes::One | Bytes::Four => {
+                let mut buf = [0; 4];
+
+                for v in buf.iter_mut().take(disp_bytes as usize) {
+                    *v = insn.0.peek()?;
+                    insn.0.advance();
+                }
+
+                self.displacement = if disp_bytes == Bytes::One {
+                    buf[0] as i8 as i64
+                } else {
+                    i32::from_le_bytes(buf) as i64
+                };
+
+                Ok(ImmBytes(insn.0))
+            }
+            _ => Err(InsnError::DecodeDisp),
+        }
+    }
+
+    fn decode_immediate(&mut self, mut insn: ImmBytes) -> Result<MoffBytes, InsnError> {
+        // Figure out immediate operand size (if any)
+        let imm_bytes = if self.get_opdesc()?.flags.contains(OpCodeFlags::IMM) {
+            match self.opsize {
+                // SDM Vol 2 2.2.1.5 "Immediates"
+                // In 64-bit mode the typical size of immediate operands
+                // remains 32-bits. When the operand size if 64-bits, the
+                // processor sign-extends all immediates to 64-bits prior
+                // to their use.
+                Bytes::Four | Bytes::Eight => Bytes::Four,
+                _ => Bytes::Two,
+            }
+        } else if self.get_opdesc()?.flags.contains(OpCodeFlags::IMM8) {
+            Bytes::One
+        } else {
+            // No flags on immediate operand size
+            return Ok(MoffBytes(insn.0));
+        };
+
+        let mut buf = [0; 4];
+
+        for v in buf.iter_mut().take(imm_bytes as usize) {
+            *v = insn.0.peek()?;
+            insn.0.advance();
+        }
+
+        self.immediate = match imm_bytes {
+            Bytes::One => buf[0] as i8 as i64,
+            Bytes::Two => i16::from_le_bytes([buf[0], buf[1]]) as i64,
+            Bytes::Four => i32::from_le_bytes(buf) as i64,
+            _ => return Err(InsnError::DecodeImm),
+        };
+
+        Ok(MoffBytes(insn.0))
+    }
+
+    fn decode_moffset(&mut self, mut insn: MoffBytes) -> Result<DecodedBytes, InsnError> {
+        if !self.get_opdesc()?.flags.contains(OpCodeFlags::MOFFSET) {
+            return Ok(DecodedBytes(insn.0));
+        }
+
+        match self.addrsize {
+            Bytes::Zero | Bytes::One => Err(InsnError::DecodeMOffset),
+            _ => {
+                // SDM Vol 2 Section 2.2.1.4, "Direct Memory-Offset MOVs"
+                // In 64-bit mode, direct memory-offset forms of the MOV
+                // instruction are extended to specify a 64-bit immediate
+                // absolute address.
+                //
+                // The memory offset size follows the address-size of the instruction.
+                let mut buf = [0; 8];
+                for v in buf.iter_mut().take(self.addrsize as usize) {
+                    *v = insn.0.peek()?;
+                    insn.0.advance();
+                }
+                self.displacement = i64::from_le_bytes(buf);
+                Ok(DecodedBytes(insn.0))
+            }
+        }
+    }
+
+    fn complete_decode(&mut self, insn: DecodedBytes) -> Result<(), InsnError> {
+        self.insn_len = insn.0.processed();
+        Ok(())
+    }
+}

--- a/kernel/src/insn_decode/decode.rs
+++ b/kernel/src/insn_decode/decode.rs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 Intel Corporation.
+//
+// Author: Chuanxiao Dong <chuanxiao.dong@intel.com>
+
+#![allow(dead_code)]
+
+use super::insn::MAX_INSN_SIZE;
+use super::InsnError;
+
+/// Represents the raw bytes of an instruction and
+/// tracks the number of bytes being processed.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct InsnBytes {
+    /// Raw instruction bytes
+    bytes: [u8; MAX_INSN_SIZE],
+    /// Number of instruction bytes being processed
+    nr_processed: usize,
+}
+
+impl InsnBytes {
+    /// Creates a new `OpCodeBytes` instance with the provided instruction bytes.
+    ///
+    /// # Arguments
+    ///
+    /// * `bytes` - An array of raw instruction bytes
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `OpCodeBytes` with the `bytes` set to the provided
+    /// array and the `nr_processed` field initialized to zero.
+    pub const fn new(bytes: [u8; MAX_INSN_SIZE]) -> Self {
+        Self {
+            bytes,
+            nr_processed: 0,
+        }
+    }
+
+    /// Retrieves a single unprocessed instruction byte.
+    ///
+    /// # Returns
+    ///
+    /// An instruction byte if success or an [`InsnError`] otherwise.
+    pub fn peek(&self) -> Result<u8, InsnError> {
+        self.bytes
+            .get(self.nr_processed)
+            .copied()
+            .ok_or(InsnError::InsnPeek)
+    }
+
+    /// Increases the count by one after a peeked byte being processed.
+    pub fn advance(&mut self) {
+        self.nr_processed += 1
+    }
+
+    /// Retrieves the number of processed instruction bytes.
+    ///
+    /// # Returns
+    ///
+    /// Returns the number of processed bytes as a `usize`.
+    pub fn processed(&self) -> usize {
+        self.nr_processed
+    }
+}
+
+/// The instruction bytes specifically for OpCode decoding
+#[derive(Clone, Copy, Debug)]
+pub struct OpCodeBytes(pub InsnBytes);

--- a/kernel/src/insn_decode/decode.rs
+++ b/kernel/src/insn_decode/decode.rs
@@ -778,29 +778,23 @@ impl DecodedInsnCtx {
         Ok(match opdesc.class {
             OpCodeClass::Cpuid => DecodedInsn::Cpuid,
             OpCodeClass::In => {
-                let operand = if opdesc.flags.contains(OpCodeFlags::IMM8) {
-                    Operand::Imm(Immediate::U8(self.immediate as u8))
+                if opdesc.flags.contains(OpCodeFlags::IMM8) {
+                    DecodedInsn::In(
+                        Operand::Imm(Immediate::U8(self.immediate as u8)),
+                        self.opsize,
+                    )
                 } else {
-                    Operand::rdx()
-                };
-                match self.opsize {
-                    Bytes::One => DecodedInsn::Inb(operand),
-                    Bytes::Two => DecodedInsn::Inw(operand),
-                    Bytes::Four => DecodedInsn::Inl(operand),
-                    _ => return Err(InsnError::UnSupportedInsn),
+                    DecodedInsn::In(Operand::rdx(), self.opsize)
                 }
             }
             OpCodeClass::Out => {
-                let operand = if opdesc.flags.contains(OpCodeFlags::IMM8) {
-                    Operand::Imm(Immediate::U8(self.immediate as u8))
+                if opdesc.flags.contains(OpCodeFlags::IMM8) {
+                    DecodedInsn::Out(
+                        Operand::Imm(Immediate::U8(self.immediate as u8)),
+                        self.opsize,
+                    )
                 } else {
-                    Operand::rdx()
-                };
-                match self.opsize {
-                    Bytes::One => DecodedInsn::Outb(operand),
-                    Bytes::Two => DecodedInsn::Outw(operand),
-                    Bytes::Four => DecodedInsn::Outl(operand),
-                    _ => return Err(InsnError::UnSupportedInsn),
+                    DecodedInsn::Out(Operand::rdx(), self.opsize)
                 }
             }
             OpCodeClass::Rdmsr => DecodedInsn::Rdmsr,

--- a/kernel/src/insn_decode/decode.rs
+++ b/kernel/src/insn_decode/decode.rs
@@ -39,8 +39,6 @@
 // https://github.com/projectacrn/acrn-hypervisor/blob/master/hypervisor/
 // arch/x86/guest/instr_emul.c
 
-#![allow(dead_code)]
-
 use super::insn::{DecodedInsn, Immediate, Operand, MAX_INSN_SIZE};
 use super::opcode::{OpCodeClass, OpCodeDesc, OpCodeFlags};
 use super::{InsnError, Register, SegRegister};
@@ -378,7 +376,24 @@ pub struct DecodedInsnCtx {
 }
 
 impl DecodedInsnCtx {
-    fn new<I: InsnMachineCtx>(bytes: &[u8; MAX_INSN_SIZE], mctx: &I) -> Result<Self, InsnError> {
+    /// Constructs a new `DecodedInsnCtx` by decoding the given
+    /// instruction bytes using the provided machine context.
+    ///
+    /// # Arguments
+    ///
+    /// * `bytes` - The raw bytes of the instruction to be decoded.
+    /// * `mctx` - A reference to an object implementing the
+    /// `InsnMachineCtx` trait to provide the necessary machine context
+    /// for decoding.
+    ///
+    ///  # Returns
+    ///
+    ///  A `DecodedInsnCtx` if decoding is successful or an `InsnError`
+    ///  otherwise.
+    pub(super) fn new<I: InsnMachineCtx>(
+        bytes: &[u8; MAX_INSN_SIZE],
+        mctx: &I,
+    ) -> Result<Self, InsnError> {
         let mut insn_ctx = Self {
             cpu_mode: get_cpu_mode(mctx),
             ..Default::default()

--- a/kernel/src/insn_decode/insn.rs
+++ b/kernel/src/insn_decode/insn.rs
@@ -88,7 +88,6 @@ impl DecodedInsn {
 }
 
 pub const MAX_INSN_SIZE: usize = 15;
-pub const MAX_INSN_FIELD_SIZE: usize = 3;
 
 /// A view of an x86 instruction.
 #[derive(Default, Debug, Copy, Clone, PartialEq)]

--- a/kernel/src/insn_decode/insn.rs
+++ b/kernel/src/insn_decode/insn.rs
@@ -20,11 +20,13 @@ pub enum Immediate {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Register {
     Rax,
-    Rbx,
     Rcx,
     Rdx,
+    Rbx,
     Rsp,
     Rbp,
+    Rsi,
+    Rdi,
     R8,
     R9,
     R10,
@@ -33,6 +35,18 @@ pub enum Register {
     R13,
     R14,
     R15,
+    Rip,
+}
+
+/// A Segment register in instruction
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SegRegister {
+    CS,
+    SS,
+    DS,
+    ES,
+    FS,
+    GS,
 }
 
 /// An operand in an instruction, which might be a register or an immediate.

--- a/kernel/src/insn_decode/insn.rs
+++ b/kernel/src/insn_decode/insn.rs
@@ -133,7 +133,47 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_decode_inb() {
+        let raw_insn: [u8; MAX_INSN_SIZE] = [
+            0xE4, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
+            0x41,
+        ];
+
+        let decoded = Instruction::new(raw_insn).decode(&TestCtx).unwrap();
+        assert_eq!(
+            decoded.insn().unwrap(),
+            DecodedInsn::In(Operand::Imm(Immediate::U8(0x41)), Bytes::One)
+        );
+        assert_eq!(decoded.size(), 2);
+
+        let raw_insn: [u8; MAX_INSN_SIZE] = [
+            0xEC, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
+            0x41,
+        ];
+
+        let decoded = Instruction::new(raw_insn).decode(&TestCtx).unwrap();
+        assert_eq!(
+            decoded.insn().unwrap(),
+            DecodedInsn::In(Operand::rdx(), Bytes::One)
+        );
+        assert_eq!(decoded.size(), 1);
+    }
+
+    #[test]
     fn test_decode_inw() {
+        let raw_insn: [u8; MAX_INSN_SIZE] = [
+            0x66, 0xE5, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
+            0x41,
+        ];
+
+        let insn = Instruction::new(raw_insn);
+        let decoded = insn.decode(&TestCtx).unwrap();
+        assert_eq!(
+            decoded.insn().unwrap(),
+            DecodedInsn::In(Operand::Imm(Immediate::U8(0x41)), Bytes::Two)
+        );
+        assert_eq!(decoded.size(), 3);
+
         let raw_insn: [u8; MAX_INSN_SIZE] = [
             0x66, 0xED, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
             0x41,
@@ -149,7 +189,49 @@ mod tests {
     }
 
     #[test]
+    fn test_decode_inl() {
+        let raw_insn: [u8; MAX_INSN_SIZE] = [
+            0xE5, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
+            0x41,
+        ];
+
+        let insn = Instruction::new(raw_insn);
+        let decoded = insn.decode(&TestCtx).unwrap();
+        assert_eq!(
+            decoded.insn().unwrap(),
+            DecodedInsn::In(Operand::Imm(Immediate::U8(0x41)), Bytes::Four)
+        );
+        assert_eq!(decoded.size(), 2);
+
+        let raw_insn: [u8; MAX_INSN_SIZE] = [
+            0xED, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
+            0x41,
+        ];
+
+        let insn = Instruction::new(raw_insn);
+        let decoded = insn.decode(&TestCtx).unwrap();
+        assert_eq!(
+            decoded.insn().unwrap(),
+            DecodedInsn::In(Operand::rdx(), Bytes::Four)
+        );
+        assert_eq!(decoded.size(), 1);
+    }
+
+    #[test]
     fn test_decode_outb() {
+        let raw_insn: [u8; MAX_INSN_SIZE] = [
+            0xE6, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
+            0x41,
+        ];
+
+        let insn = Instruction::new(raw_insn);
+        let decoded = insn.decode(&TestCtx).unwrap();
+        assert_eq!(
+            decoded.insn().unwrap(),
+            DecodedInsn::Out(Operand::Imm(Immediate::U8(0x41)), Bytes::One)
+        );
+        assert_eq!(decoded.size(), 2);
+
         let raw_insn: [u8; MAX_INSN_SIZE] = [
             0xEE, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
             0x41,
@@ -165,7 +247,49 @@ mod tests {
     }
 
     #[test]
+    fn test_decode_outw() {
+        let raw_insn: [u8; MAX_INSN_SIZE] = [
+            0x66, 0xE7, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
+            0x41,
+        ];
+
+        let insn = Instruction::new(raw_insn);
+        let decoded = insn.decode(&TestCtx).unwrap();
+        assert_eq!(
+            decoded.insn().unwrap(),
+            DecodedInsn::Out(Operand::Imm(Immediate::U8(0x41)), Bytes::Two)
+        );
+        assert_eq!(decoded.size(), 3);
+
+        let raw_insn: [u8; MAX_INSN_SIZE] = [
+            0x66, 0xEF, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
+            0x41,
+        ];
+
+        let insn = Instruction::new(raw_insn);
+        let decoded = insn.decode(&TestCtx).unwrap();
+        assert_eq!(
+            decoded.insn().unwrap(),
+            DecodedInsn::Out(Operand::rdx(), Bytes::Two)
+        );
+        assert_eq!(decoded.size(), 2);
+    }
+
+    #[test]
     fn test_decode_outl() {
+        let raw_insn: [u8; MAX_INSN_SIZE] = [
+            0xE7, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
+            0x41,
+        ];
+
+        let insn = Instruction::new(raw_insn);
+        let decoded = insn.decode(&TestCtx).unwrap();
+        assert_eq!(
+            decoded.insn().unwrap(),
+            DecodedInsn::Out(Operand::Imm(Immediate::U8(0x41)), Bytes::Four)
+        );
+        assert_eq!(decoded.size(), 2);
+
         let raw_insn: [u8; MAX_INSN_SIZE] = [
             0xEF, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
             0x41,
@@ -191,6 +315,58 @@ mod tests {
         let decoded = insn.decode(&TestCtx).unwrap();
         assert_eq!(decoded.insn().unwrap(), DecodedInsn::Cpuid);
         assert_eq!(decoded.size(), 2);
+    }
+
+    #[test]
+    fn test_decode_wrmsr() {
+        let raw_insn: [u8; MAX_INSN_SIZE] = [
+            0x0F, 0x30, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
+            0x41,
+        ];
+
+        let insn = Instruction::new(raw_insn);
+        let decoded = insn.decode(&TestCtx).unwrap();
+        assert_eq!(decoded.insn().unwrap(), DecodedInsn::Wrmsr);
+        assert_eq!(decoded.size(), 2);
+    }
+
+    #[test]
+    fn test_decode_rdmsr() {
+        let raw_insn: [u8; MAX_INSN_SIZE] = [
+            0x0F, 0x32, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
+            0x41,
+        ];
+
+        let insn = Instruction::new(raw_insn);
+        let decoded = insn.decode(&TestCtx).unwrap();
+        assert_eq!(decoded.insn().unwrap(), DecodedInsn::Rdmsr);
+        assert_eq!(decoded.size(), 2);
+    }
+
+    #[test]
+    fn test_decode_rdtsc() {
+        let raw_insn: [u8; MAX_INSN_SIZE] = [
+            0x0F, 0x31, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
+            0x41,
+        ];
+
+        let insn = Instruction::new(raw_insn);
+        let decoded = insn.decode(&TestCtx).unwrap();
+        assert_eq!(decoded.insn().unwrap(), DecodedInsn::Rdtsc);
+        assert_eq!(decoded.size(), 2);
+    }
+
+    #[test]
+    fn test_decode_rdtscp() {
+        let raw_insn: [u8; MAX_INSN_SIZE] = [
+            0x0F, 0x01, 0xF9, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
+            0x41,
+        ];
+
+        let insn = Instruction::new(raw_insn);
+        let decoded = insn.decode(&TestCtx).unwrap();
+        assert_eq!(decoded.insn().unwrap(), DecodedInsn::Rdtscp);
+        assert_eq!(decoded.size(), 3);
     }
 
     #[test]

--- a/kernel/src/insn_decode/insn.rs
+++ b/kernel/src/insn_decode/insn.rs
@@ -58,7 +58,7 @@ pub enum Operand {
 
 impl Operand {
     #[inline]
-    const fn rdx() -> Self {
+    pub const fn rdx() -> Self {
         Self::Reg(Register::Rdx)
     }
 }

--- a/kernel/src/insn_decode/insn.rs
+++ b/kernel/src/insn_decode/insn.rs
@@ -6,6 +6,7 @@
 
 use super::decode::DecodedInsnCtx;
 use super::{InsnError, InsnMachineCtx};
+use crate::types::Bytes;
 
 /// An immediate value in an instruction
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -65,12 +66,8 @@ impl Operand {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum DecodedInsn {
     Cpuid,
-    Inl(Operand),
-    Inb(Operand),
-    Inw(Operand),
-    Outl(Operand),
-    Outb(Operand),
-    Outw(Operand),
+    In(Operand, Bytes),
+    Out(Operand, Bytes),
     Wrmsr,
     Rdmsr,
     Rdtsc,
@@ -144,7 +141,10 @@ mod tests {
 
         let insn = Instruction::new(raw_insn);
         let decoded = insn.decode(&TestCtx).unwrap();
-        assert_eq!(decoded.insn().unwrap(), DecodedInsn::Inw(Operand::rdx()));
+        assert_eq!(
+            decoded.insn().unwrap(),
+            DecodedInsn::In(Operand::rdx(), Bytes::Two)
+        );
         assert_eq!(decoded.size(), 2);
     }
 
@@ -157,7 +157,10 @@ mod tests {
 
         let insn = Instruction::new(raw_insn);
         let decoded = insn.decode(&TestCtx).unwrap();
-        assert_eq!(decoded.insn().unwrap(), DecodedInsn::Outb(Operand::rdx()));
+        assert_eq!(
+            decoded.insn().unwrap(),
+            DecodedInsn::Out(Operand::rdx(), Bytes::One)
+        );
         assert_eq!(decoded.size(), 1);
     }
 
@@ -170,7 +173,10 @@ mod tests {
 
         let insn = Instruction::new(raw_insn);
         let decoded = insn.decode(&TestCtx).unwrap();
-        assert_eq!(decoded.insn().unwrap(), DecodedInsn::Outl(Operand::rdx()));
+        assert_eq!(
+            decoded.insn().unwrap(),
+            DecodedInsn::Out(Operand::rdx(), Bytes::Four)
+        );
         assert_eq!(decoded.size(), 1);
     }
 

--- a/kernel/src/insn_decode/mod.rs
+++ b/kernel/src/insn_decode/mod.rs
@@ -8,11 +8,31 @@ mod decode;
 mod insn;
 mod opcode;
 
-pub use insn::{DecodedInsn, Immediate, Instruction, Operand, Register, MAX_INSN_SIZE};
+pub use insn::{
+    DecodedInsn, Immediate, Instruction, Operand, Register, SegRegister, MAX_INSN_SIZE,
+};
 
 /// An error that can occur during instruction decoding.
 #[derive(Copy, Clone, Debug)]
 pub enum InsnError {
+    /// Error while decoding the displacement bytes.
+    DecodeDisp,
+    /// Error while decoding the immediate bytes.
+    DecodeImm,
+    /// Error while decoding the Mem-Offset bytes.
+    DecodeMOffset,
+    /// Error while decoding the ModR/M byte.
+    DecodeModRM,
+    /// Error while decoding the OpCode bytes.
+    DecodeOpCode,
+    /// Error while decoding the prefix bytes.
+    DecodePrefix,
+    /// Error while decoding the SIB byte.
+    DecodeSib,
+    /// No OpCodeDesc generated while decoding.
+    NoOpCodeDesc,
     /// Error while peeking an instruction byte.
     InsnPeek,
+    /// Invalid RegCode for decoding Register.
+    InvalidRegister,
 }

--- a/kernel/src/insn_decode/mod.rs
+++ b/kernel/src/insn_decode/mod.rs
@@ -4,6 +4,15 @@
 //
 // Author: Chuanxiao Dong <chuanxiao.dong@intel.com>
 
+mod decode;
 mod insn;
+mod opcode;
 
 pub use insn::{DecodedInsn, Immediate, Instruction, Operand, Register, MAX_INSN_SIZE};
+
+/// An error that can occur during instruction decoding.
+#[derive(Copy, Clone, Debug)]
+pub enum InsnError {
+    /// Error while peeking an instruction byte.
+    InsnPeek,
+}

--- a/kernel/src/insn_decode/mod.rs
+++ b/kernel/src/insn_decode/mod.rs
@@ -35,4 +35,6 @@ pub enum InsnError {
     InsnPeek,
     /// Invalid RegCode for decoding Register.
     InvalidRegister,
+    /// The decoded instruction is not supported.
+    UnSupportedInsn,
 }

--- a/kernel/src/insn_decode/mod.rs
+++ b/kernel/src/insn_decode/mod.rs
@@ -8,6 +8,7 @@ mod decode;
 mod insn;
 mod opcode;
 
+pub use decode::InsnMachineCtx;
 pub use insn::{
     DecodedInsn, Immediate, Instruction, Operand, Register, SegRegister, MAX_INSN_SIZE,
 };

--- a/kernel/src/insn_decode/mod.rs
+++ b/kernel/src/insn_decode/mod.rs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 Intel Corporation.
+//
+// Author: Chuanxiao Dong <chuanxiao.dong@intel.com>
+
+mod insn;
+
+pub use insn::{DecodedInsn, Immediate, Instruction, Operand, Register, MAX_INSN_SIZE};

--- a/kernel/src/insn_decode/mod.rs
+++ b/kernel/src/insn_decode/mod.rs
@@ -8,7 +8,9 @@ mod decode;
 mod insn;
 mod opcode;
 
-pub use decode::InsnMachineCtx;
+pub use decode::{DecodedInsnCtx, InsnMachineCtx};
+#[cfg(any(test, fuzzing))]
+pub use insn::TestCtx;
 pub use insn::{
     DecodedInsn, Immediate, Instruction, Operand, Register, SegRegister, MAX_INSN_SIZE,
 };
@@ -38,4 +40,10 @@ pub enum InsnError {
     InvalidRegister,
     /// The decoded instruction is not supported.
     UnSupportedInsn,
+}
+
+impl From<InsnError> for crate::error::SvsmError {
+    fn from(e: InsnError) -> Self {
+        Self::Insn(e)
+    }
 }

--- a/kernel/src/insn_decode/opcode.rs
+++ b/kernel/src/insn_decode/opcode.rs
@@ -4,8 +4,6 @@
 //
 // Author: Chuanxiao Dong <chuanxiao.dong@intel.com>
 
-#![allow(dead_code)]
-
 use super::decode::OpCodeBytes;
 use bitflags::bitflags;
 

--- a/kernel/src/insn_decode/opcode.rs
+++ b/kernel/src/insn_decode/opcode.rs
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 Intel Corporation
+//
+// Author: Chuanxiao Dong <chuanxiao.dong@intel.com>
+
+#![allow(dead_code)]
+
+use super::decode::OpCodeBytes;
+use bitflags::bitflags;
+
+bitflags! {
+    /// Defines a set of flags for opcode attributes. These flags provide
+    /// information about the characteristics of an opcode, such as the
+    /// presence of an immediate operand, operand size, and special decoding
+    /// requirements.
+    #[derive(Clone, Copy, Debug, Default, PartialEq)]
+    pub struct OpCodeFlags: u64 {
+        // Immediate operand with decoded size
+        const IMM           = 1 << 0;
+        // U8 immediate operand
+        const IMM8          = 1 << 1;
+        // No need to decode ModRm
+        const NO_MODRM      = 1 << 2;
+        // Operand size is one byte
+        const BYTE_OP       = 1 << 3;
+        // Operand size is two byte
+        const WORD_OP       = 1 << 4;
+        // Doesn't have an operand
+        const OP_NONE       = 1 << 5;
+        // Need to decode Moffset
+        const MOFFSET       = 1 << 6;
+    }
+}
+
+/// Represents the classification of opcodes into distinct categories.
+/// Each variant of the enum corresponds to a specific type of opcode
+/// or a group of opcodes that share common characteristics or decoding
+/// behaviors.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum OpCodeClass {
+    Cpuid,
+    Group7,
+    Group7Rm7,
+    In,
+    Out,
+    Rdmsr,
+    Rdtsc,
+    Rdtscp,
+    TwoByte,
+    Wrmsr,
+}
+
+/// Descriptor for an opcode, which contains the raw instruction opcode
+/// value, its corresponding class and flags for fully decoding the
+/// instruction.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct OpCodeDesc {
+    /// The opcode value
+    pub code: u8,
+    /// The type of the opcode
+    pub class: OpCodeClass,
+    /// The flags for fully decoding the instruction
+    pub flags: OpCodeFlags,
+}
+
+macro_rules! opcode {
+    ($class:expr) => {
+        Some(OpCodeDesc {
+            code: 0,
+            class: $class,
+            flags: OpCodeFlags::empty(),
+        })
+    };
+    ($code:expr, $class:expr) => {
+        Some(OpCodeDesc {
+            code: $code,
+            class: $class,
+            flags: OpCodeFlags::empty(),
+        })
+    };
+    ($code:expr, $class:expr, $flags:expr) => {
+        Some(OpCodeDesc {
+            code: $code,
+            class: $class,
+            flags: OpCodeFlags::from_bits_truncate($flags),
+        })
+    };
+}
+
+static ONE_BYTE_TABLE: [Option<OpCodeDesc>; 256] = {
+    let mut table: [Option<OpCodeDesc>; 256] = [None; 256];
+
+    table[0x0F] = opcode!(OpCodeClass::TwoByte);
+    table[0xE4] = opcode!(
+        0xE4,
+        OpCodeClass::In,
+        OpCodeFlags::IMM8.bits() | OpCodeFlags::BYTE_OP.bits() | OpCodeFlags::NO_MODRM.bits()
+    );
+    table[0xE5] = opcode!(
+        0xE5,
+        OpCodeClass::In,
+        OpCodeFlags::IMM8.bits() | OpCodeFlags::NO_MODRM.bits()
+    );
+    table[0xE6] = opcode!(
+        0xE6,
+        OpCodeClass::Out,
+        OpCodeFlags::IMM8.bits() | OpCodeFlags::BYTE_OP.bits() | OpCodeFlags::NO_MODRM.bits()
+    );
+    table[0xE7] = opcode!(
+        0xE7,
+        OpCodeClass::Out,
+        OpCodeFlags::IMM8.bits() | OpCodeFlags::NO_MODRM.bits()
+    );
+    table[0xEC] = opcode!(
+        0xEC,
+        OpCodeClass::In,
+        OpCodeFlags::BYTE_OP.bits() | OpCodeFlags::NO_MODRM.bits()
+    );
+    table[0xED] = opcode!(0xED, OpCodeClass::In, OpCodeFlags::NO_MODRM.bits());
+    table[0xEE] = opcode!(
+        0xEE,
+        OpCodeClass::Out,
+        OpCodeFlags::BYTE_OP.bits() | OpCodeFlags::NO_MODRM.bits()
+    );
+    table[0xEF] = opcode!(0xEF, OpCodeClass::Out, OpCodeFlags::NO_MODRM.bits());
+
+    table
+};
+
+static GROUP7_RM7_TABLE: [Option<OpCodeDesc>; 8] = {
+    let mut table = [None; 8];
+
+    table[1] = opcode!(0xF9, OpCodeClass::Rdtscp, OpCodeFlags::OP_NONE.bits());
+
+    table
+};
+
+static GROUP7_TABLE: [Option<OpCodeDesc>; 16] = {
+    let mut table = [None; 16];
+
+    table[15] = opcode!(OpCodeClass::Group7Rm7);
+
+    table
+};
+
+static TWO_BYTE_TABLE: [Option<OpCodeDesc>; 256] = {
+    let mut table = [None; 256];
+
+    table[0x01] = opcode!(OpCodeClass::Group7);
+    table[0x30] = opcode!(0x30, OpCodeClass::Wrmsr, OpCodeFlags::NO_MODRM.bits());
+    table[0x31] = opcode!(0x31, OpCodeClass::Rdtsc, OpCodeFlags::NO_MODRM.bits());
+    table[0x32] = opcode!(0x32, OpCodeClass::Rdmsr, OpCodeFlags::NO_MODRM.bits());
+    table[0xA2] = opcode!(0xA2, OpCodeClass::Cpuid, OpCodeFlags::NO_MODRM.bits());
+
+    table
+};
+
+impl OpCodeDesc {
+    fn one_byte(insn: &mut OpCodeBytes) -> Option<OpCodeDesc> {
+        if let Ok(byte) = insn.0.peek() {
+            // Advance the OpCodeBytes as this is a opcode byte
+            insn.0.advance();
+            ONE_BYTE_TABLE.get(byte as usize).cloned().flatten()
+        } else {
+            None
+        }
+    }
+
+    fn two_byte(insn: &mut OpCodeBytes) -> Option<OpCodeDesc> {
+        if let Ok(byte) = insn.0.peek() {
+            // Advance the OpCodeBytes as this is a opcode byte
+            insn.0.advance();
+            TWO_BYTE_TABLE.get(byte as usize).cloned().flatten()
+        } else {
+            None
+        }
+    }
+
+    fn group7(insn: &OpCodeBytes) -> Option<OpCodeDesc> {
+        if let Ok(modrm) = insn.0.peek() {
+            // Not to advance the OpCodeBytes as this is not a opcode byte
+            let r#mod = modrm >> 6;
+            let offset = (modrm >> 3) & 0x7;
+            let idx = if r#mod == 3 { 8 + offset } else { offset };
+            GROUP7_TABLE.get(idx as usize).cloned().flatten()
+        } else {
+            None
+        }
+    }
+
+    fn group7_rm7(insn: &OpCodeBytes) -> Option<OpCodeDesc> {
+        if let Ok(modrm) = insn.0.peek() {
+            // Not to advance the OpCodeBytes as this is not a opcode byte
+            let idx = modrm & 0x7;
+            GROUP7_RM7_TABLE.get(idx as usize).cloned().flatten()
+        } else {
+            None
+        }
+    }
+
+    /// Decodes an opcode from the given `OpCodeBytes`.
+    ///
+    /// # Arguments
+    ///
+    /// * `insn` - A mutable reference to the `OpCodeBytes` representing
+    /// the bytes of the opcode to be decoded.
+    ///
+    /// # Returns
+    ///
+    /// A Some(OpCodeDesc) if the opcode is supported or None otherwise
+    pub fn decode(insn: &mut OpCodeBytes) -> Option<OpCodeDesc> {
+        let mut opdesc = Self::one_byte(insn);
+
+        loop {
+            if let Some(desc) = opdesc {
+                opdesc = match desc.class {
+                    OpCodeClass::TwoByte => Self::two_byte(insn),
+                    OpCodeClass::Group7 => Self::group7(insn),
+                    OpCodeClass::Group7Rm7 => Self::group7_rm7(insn),
+                    _ => return opdesc,
+                }
+            } else {
+                return None;
+            }
+        }
+    }
+}

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -23,6 +23,7 @@ pub mod fw_cfg;
 pub mod fw_meta;
 pub mod greq;
 pub mod igvm_params;
+pub mod insn_decode;
 pub mod io;
 pub mod kernel_region;
 pub mod locking;

--- a/kernel/src/sev/ghcb.rs
+++ b/kernel/src/sev/ghcb.rs
@@ -18,7 +18,7 @@ use crate::platform::PageStateChangeOp;
 use crate::sev::hv_doorbell::HVDoorbell;
 use crate::sev::sev_snp_enabled;
 use crate::sev::utils::raw_vmgexit;
-use crate::types::{PageSize, PAGE_SIZE_2M};
+use crate::types::{Bytes, PageSize, PAGE_SIZE_2M};
 use crate::utils::MemoryRegion;
 
 use core::arch::global_asm;
@@ -137,6 +137,19 @@ pub enum GHCBIOSize {
     Size8,
     Size16,
     Size32,
+}
+
+impl TryFrom<Bytes> for GHCBIOSize {
+    type Error = SvsmError;
+
+    fn try_from(size: Bytes) -> Result<GHCBIOSize, Self::Error> {
+        match size {
+            Bytes::One => Ok(GHCBIOSize::Size8),
+            Bytes::Two => Ok(GHCBIOSize::Size16),
+            Bytes::Four => Ok(GHCBIOSize::Size32),
+            _ => Err(SvsmError::InvalidBytes),
+        }
+    }
 }
 
 impl GHCB {


### PR DESCRIPTION
This pull request introduces the kernel/insn_decode crate, which provides instruction decoding capabilities. It is implemented by referring the [ instruction decoder](https://github.com/projectacrn/acrn-hypervisor/blob/master/hypervisor/arch/x86/guest/instr_emul.c) from the ACRN project. As an acknowledgment, its copyright notice has been included in the header of decode.rs.

Upon a successful decoding for a given set of instruction bytes, a DecodedInsnCtx is created, containing detailed decoding outcomes. This structure exposes two public interfaces that allow access to the corresponding DecodedInsn and the decoded instruction length.

Currently, the crate supports decoding for the in/out, rdmsr, wrmsr, rdtsc, rdtscp, and cpuid instructions, which are essential for the current SEV #VC handler. So the #VC handler has been revised to utilize this crate for instruction decoding. The test suite is also expanded to cover all the aforementioned instructions. But due to the lack of an AMD machine on my end, this pull request has not been tested on an actual hardware. Appreciate it if someone can help to try this PR on an actual AMD machine.