### PR TITLE
stage2: refactor stage2

### DIFF
--- a/bootlib/src/platform.rs
+++ b/bootlib/src/platform.rs
@@ -12,18 +12,17 @@ pub enum SvsmPlatformType {
     Snp = 1,
 }
 
-impl SvsmPlatformType {
-    pub fn as_u32(&self) -> u32 {
-        match self {
-            Self::Native => 0,
-            Self::Snp => 1,
-        }
-    }
-
-    pub fn from_u32(value: u32) -> Self {
+impl From<u32> for SvsmPlatformType {
+    fn from(value: u32) -> Self {
         match value {
             1 => Self::Snp,
             _ => Self::Native,
         }
+    }
+}
+
+impl From<SvsmPlatformType> for u32 {
+    fn from(p: SvsmPlatformType) -> u32 {
+        p as u32
     }
 }

--- a/igvmbuilder/src/stage2_stack.rs
+++ b/igvmbuilder/src/stage2_stack.rs
@@ -47,7 +47,7 @@ impl Stage2Stack {
         };
 
         let mut stage2_stack = self.stage2_stack;
-        stage2_stack.platform_type = platform.as_u32();
+        stage2_stack.platform_type = u32::from(platform);
 
         // The native platform does not record VTOM because there is no
         // encryption in native platforms.

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -26,10 +26,13 @@ use crate::sev::ghcb::GhcbError;
 use crate::sev::msr_protocol::GhcbMsrError;
 use crate::sev::SevSnpError;
 use crate::task::TaskError;
+use elf::ElfError;
 
 /// A generic error during SVSM operation.
 #[derive(Clone, Copy, Debug)]
 pub enum SvsmError {
+    /// Errors during ELF parsing and loading.
+    Elf(ElfError),
     /// Errors related to GHCB
     Ghcb(GhcbError),
     /// Errors related to MSR protocol
@@ -64,4 +67,10 @@ pub enum SvsmError {
     Task(TaskError),
     /// Errors from #VC handler
     Vc(VcError),
+}
+
+impl From<ElfError> for SvsmError {
+    fn from(err: ElfError) -> Self {
+        Self::Elf(err)
+    }
 }

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -159,7 +159,7 @@ pub extern "C" fn stage2_main(launch_info: &Stage2LaunchInfo) {
     let kernel_elf_start: PhysAddr = PhysAddr::from(launch_info.kernel_elf_start as u64);
     let kernel_elf_end: PhysAddr = PhysAddr::from(launch_info.kernel_elf_end as u64);
 
-    let platform_type = SvsmPlatformType::from_u32(launch_info.platform_type);
+    let platform_type = SvsmPlatformType::from(launch_info.platform_type);
     let mut platform_cell = SvsmPlatformCell::new(platform_type);
     let platform = platform_cell.as_mut_dyn_ref();
 

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -16,6 +16,7 @@ use core::panic::PanicInfo;
 use core::ptr::{addr_of, addr_of_mut};
 use core::slice;
 use cpuarch::snp_cpuid::SnpCpuidTable;
+use elf::ElfError;
 use svsm::address::{Address, PhysAddr, VirtAddr};
 use svsm::config::SvsmConfig;
 use svsm::console::{init_console, install_console_logger};
@@ -23,6 +24,7 @@ use svsm::cpu::cpuid::{dump_cpuid_table, register_cpuid_table};
 use svsm::cpu::gdt;
 use svsm::cpu::idt::stage2::{early_idt_init, early_idt_init_no_ghcb};
 use svsm::cpu::percpu::{this_cpu, PerCpu};
+use svsm::error::SvsmError;
 use svsm::fw_cfg::FwCfg;
 use svsm::igvm_params::IgvmParams;
 use svsm::mm::alloc::{memory_info, print_memory_info, root_mem_init};
@@ -56,15 +58,14 @@ fn setup_stage2_allocator() {
     root_mem_init(pstart, vstart, nr_pages);
 }
 
-fn init_percpu(platform: &mut dyn SvsmPlatform) {
-    let bsp_percpu = PerCpu::alloc(0).expect("Failed to allocate BSP per-cpu data");
+fn init_percpu(platform: &mut dyn SvsmPlatform) -> Result<(), SvsmError> {
+    let bsp_percpu = PerCpu::alloc(0)?;
     unsafe {
         bsp_percpu.set_pgtable(PageTableRef::shared(addr_of_mut!(pgtable)));
     }
-    bsp_percpu
-        .map_self_stage2()
-        .expect("Failed to map per-cpu area");
+    bsp_percpu.map_self_stage2()?;
     platform.setup_guest_host_comm(bsp_percpu, true);
+    Ok(())
 }
 
 fn shutdown_percpu() {
@@ -95,7 +96,7 @@ fn setup_env(
 
     set_init_pgtable(PageTableRef::shared(unsafe { addr_of_mut!(pgtable) }));
     setup_stage2_allocator();
-    init_percpu(platform);
+    init_percpu(platform).expect("Failed to initialize per-cpu area");
 
     // Init IDT again with handlers requiring GHCB (eg. #VC handler)
     early_idt_init();
@@ -115,35 +116,32 @@ fn setup_env(
     platform.env_setup_late();
 }
 
+/// Map and validate the specified virtual memory region at the given physical
+/// address.
 fn map_and_validate(
     platform: &dyn SvsmPlatform,
     config: &SvsmConfig<'_>,
     vregion: MemoryRegion<VirtAddr>,
     paddr: PhysAddr,
-) {
+) -> Result<(), SvsmError> {
     let flags = PTEntryFlags::PRESENT
         | PTEntryFlags::WRITABLE
         | PTEntryFlags::ACCESSED
         | PTEntryFlags::DIRTY;
 
     let mut pgtbl = get_init_pgtable_locked();
-    pgtbl
-        .map_region(vregion, paddr, flags)
-        .expect("Error mapping kernel region");
+    pgtbl.map_region(vregion, paddr, flags)?;
 
     if config.page_state_change_required() {
-        platform
-            .page_state_change(
-                MemoryRegion::new(paddr, vregion.len()),
-                PageSize::Huge,
-                PageStateChangeOp::Private,
-            )
-            .expect("GHCB::PAGE_STATE_CHANGE call failed for kernel region");
+        platform.page_state_change(
+            MemoryRegion::new(paddr, vregion.len()),
+            PageSize::Huge,
+            PageStateChangeOp::Private,
+        )?;
     }
-    platform
-        .validate_page_range(vregion)
-        .expect("PVALIDATE kernel region failed");
+    platform.validate_page_range(vregion)?;
     valid_bitmap_set_valid_range(paddr, paddr + vregion.len());
+    Ok(())
 }
 
 #[inline]
@@ -154,50 +152,71 @@ fn check_launch_info(launch_info: &KernelLaunchInfo) {
     assert!(is_aligned(offset, align));
 }
 
-#[no_mangle]
-pub extern "C" fn stage2_main(launch_info: &Stage2LaunchInfo) {
-    let kernel_elf_start: PhysAddr = PhysAddr::from(launch_info.kernel_elf_start as u64);
-    let kernel_elf_end: PhysAddr = PhysAddr::from(launch_info.kernel_elf_end as u64);
+fn get_svsm_config(
+    launch_info: &Stage2LaunchInfo,
+    platform: &dyn SvsmPlatform,
+) -> Result<SvsmConfig<'static>, SvsmError> {
+    if launch_info.igvm_params == 0 {
+        return Ok(SvsmConfig::FirmwareConfig(FwCfg::new(
+            platform.get_console_io_port(),
+        )));
+    }
 
-    let platform_type = SvsmPlatformType::from(launch_info.platform_type);
-    let mut platform_cell = SvsmPlatformCell::new(platform_type);
-    let platform = platform_cell.as_mut_dyn_ref();
+    IgvmParams::new(VirtAddr::from(launch_info.igvm_params as u64)).map(SvsmConfig::IgvmConfig)
+}
 
-    let config = if launch_info.igvm_params != 0 {
-        let igvm_params = IgvmParams::new(VirtAddr::from(launch_info.igvm_params as u64))
-            .expect("Invalid IGVM parameters");
-        SvsmConfig::IgvmConfig(igvm_params)
-    } else {
-        SvsmConfig::FirmwareConfig(FwCfg::new(platform.get_console_io_port()))
-    };
+/// Loads a single ELF segment and returns its virtual memory region.
+fn load_elf_segment(
+    segment: elf::Elf64ImageLoadSegment<'_>,
+    paddr: PhysAddr,
+    platform: &dyn SvsmPlatform,
+    config: &SvsmConfig<'_>,
+) -> Result<MemoryRegion<VirtAddr>, SvsmError> {
+    // Find the segment's bounds
+    let segment_start = VirtAddr::from(segment.vaddr_range.vaddr_begin);
+    let segment_end = VirtAddr::from(segment.vaddr_range.vaddr_end).page_align_up();
+    let segment_len = segment_end - segment_start;
+    let segment_region = MemoryRegion::new(segment_start, segment_len);
 
-    setup_env(&config, platform, launch_info);
+    // All ELF segments should be aligned to the page size. If not, there's
+    // the risk of pvalidating a page twice, bail out if so. Note that the
+    // ELF reading code had already verified that the individual segments,
+    // with bounds specified as in the ELF file, are non-overlapping.
+    if !segment_start.is_page_aligned() {
+        return Err(SvsmError::Elf(ElfError::UnalignedSegmentAddress));
+    }
 
-    let r = config
-        .find_kernel_region()
-        .expect("Failed to find memory region for SVSM kernel");
+    // Map and validate the segment at the next contiguous physical address
+    map_and_validate(platform, config, segment_region, paddr)?;
 
-    log::info!("COCONUT Secure Virtual Machine Service Module (SVSM) Stage 2 Loader");
+    // Copy the segment contents and pad with zeroes
+    let segment_buf =
+        unsafe { slice::from_raw_parts_mut(segment_start.as_mut_ptr::<u8>(), segment_len) };
+    let contents_len = segment.file_contents.len();
+    segment_buf[..contents_len].copy_from_slice(segment.file_contents);
+    segment_buf[contents_len..].fill(0);
 
-    let kernel_region_phys_start = r.start();
-    let kernel_region_phys_end = r.end();
-    init_valid_bitmap_alloc(r).expect("Failed to allocate valid-bitmap");
+    Ok(segment_region)
+}
 
-    // Read the SVSM kernel's ELF file metadata.
-    let kernel_elf_len = kernel_elf_end - kernel_elf_start;
-    let kernel_elf_buf =
-        unsafe { slice::from_raw_parts(kernel_elf_start.bits() as *const u8, kernel_elf_len) };
-    let kernel_elf = match elf::Elf64File::read(kernel_elf_buf) {
-        Ok(kernel_elf) => kernel_elf,
-        Err(e) => panic!("error reading kernel ELF: {}", e),
-    };
+/// Loads the kernel ELF and returns the virtual memory region where it
+/// resides, as well as its entry point. Updates the used physical memory
+/// region accordingly.
+fn load_kernel_elf(
+    launch_info: &Stage2LaunchInfo,
+    loaded_phys: &mut MemoryRegion<PhysAddr>,
+    platform: &dyn SvsmPlatform,
+    config: &SvsmConfig<'_>,
+) -> Result<(VirtAddr, MemoryRegion<VirtAddr>), SvsmError> {
+    // Find the bounds of the kernel ELF and load it into the ELF parser
+    let elf_start = PhysAddr::from(launch_info.kernel_elf_start as u64);
+    let elf_end = PhysAddr::from(launch_info.kernel_elf_end as u64);
+    let elf_len = elf_end - elf_start;
+    let bytes = unsafe { slice::from_raw_parts(elf_start.bits() as *const u8, elf_len) };
+    let elf = elf::Elf64File::read(bytes)?;
 
-    let kernel_vaddr_alloc_info = kernel_elf.image_load_vaddr_alloc_info();
-    let kernel_vaddr_alloc_base = kernel_vaddr_alloc_info.range.vaddr_begin;
-
-    // Determine the starting physical address at which the kernel should be
-    // relocated.
-    let mut loaded_kernel_phys_end = kernel_region_phys_start;
+    let vaddr_alloc_info = elf.image_load_vaddr_alloc_info();
+    let vaddr_alloc_base = vaddr_alloc_info.range.vaddr_begin;
 
     // Map, validate and populate the SVSM kernel ELF's PT_LOAD segments. The
     // segments' virtual address range might not necessarily be contiguous,
@@ -205,68 +224,34 @@ pub extern "C" fn stage2_main(launch_info: &Stage2LaunchInfo) {
     // being taken from the physical memory region, the remaining space will be
     // available as heap space for the SVSM kernel. Remember the end of all
     // physical memory occupied by the loaded ELF image.
-    let mut loaded_kernel_virt_start: Option<VirtAddr> = None;
-    let mut loaded_kernel_virt_end = VirtAddr::null();
-    for segment in kernel_elf.image_load_segment_iter(kernel_vaddr_alloc_base) {
-        // All ELF segments should be aligned to the page size. If not, there's
-        // the risk of pvalidating a page twice, bail out if so. Note that the
-        // ELF reading code had already verified that the individual segments,
-        // with bounds specified as in the ELF file, are non-overlapping.
-        let vaddr_start = VirtAddr::from(segment.vaddr_range.vaddr_begin);
-        if !vaddr_start.is_page_aligned() {
-            panic!("kernel ELF segment not aligned to page boundary");
+    let mut load_virt_start = None;
+    let mut load_virt_end = VirtAddr::null();
+    for segment in elf.image_load_segment_iter(vaddr_alloc_base) {
+        let region = load_elf_segment(segment, loaded_phys.end(), platform, config)?;
+        // Remember the mapping range's lower and upper bounds to pass it on
+        // the kernel later. Note that the segments are being iterated over
+        // here in increasing load order.
+        if load_virt_start.is_none() {
+            load_virt_start = Some(region.start());
         }
+        load_virt_end = region.end();
 
-        // Remember the mapping range's lower bound to pass it on the kernel
-        // later. Note that the segments are being iterated over here in
-        // increasing load order.
-        if loaded_kernel_virt_start.is_none() {
-            loaded_kernel_virt_start = Some(vaddr_start);
-        }
-
-        let vaddr_end = VirtAddr::from(segment.vaddr_range.vaddr_end);
-        let aligned_vaddr_end = vaddr_end.page_align_up();
-        loaded_kernel_virt_end = aligned_vaddr_end;
-
-        let segment_len = aligned_vaddr_end - vaddr_start;
-        let paddr_start = loaded_kernel_phys_end;
-        loaded_kernel_phys_end = loaded_kernel_phys_end + segment_len;
-
-        let vregion = MemoryRegion::new(vaddr_start, segment_len);
-        map_and_validate(platform, &config, vregion, paddr_start);
-
-        let segment_buf =
-            unsafe { slice::from_raw_parts_mut(vaddr_start.as_mut_ptr::<u8>(), segment_len) };
-        let segment_contents = segment.file_contents;
-        let contents_len = segment_contents.len();
-        segment_buf[..contents_len].copy_from_slice(segment_contents);
-        segment_buf[contents_len..].fill(0);
+        // Update to the next contiguous physical address
+        *loaded_phys = loaded_phys.expand(region.len());
     }
 
-    let loaded_kernel_virt_start = match loaded_kernel_virt_start {
-        Some(loaded_kernel_virt_start) => loaded_kernel_virt_start,
-        None => {
-            panic!("no loadable segment found in kernel ELF");
-        }
+    let Some(load_virt_start) = load_virt_start else {
+        log::error!("No loadable segment found in kernel ELF");
+        return Err(SvsmError::Mem);
     };
 
-    // Apply relocations, if any.
-    let dyn_relocs = match kernel_elf
-        .apply_dyn_relas(elf::Elf64X86RelocProcessor::new(), kernel_vaddr_alloc_base)
+    // Apply relocations, if any
+    if let Some(dyn_relocs) =
+        elf.apply_dyn_relas(elf::Elf64X86RelocProcessor::new(), vaddr_alloc_base)?
     {
-        Ok(dyn_relocs) => dyn_relocs,
-        Err(e) => {
-            panic!("failed to read ELF relocations : {}", e);
-        }
-    };
-    if let Some(dyn_relocs) = dyn_relocs {
         for reloc in dyn_relocs {
-            let reloc = match reloc {
-                Ok(Some(reloc)) => reloc,
-                Ok(None) => continue,
-                Err(e) => {
-                    panic!("ELF relocation error: {}", e);
-                }
+            let Some(reloc) = reloc? else {
+                continue;
             };
             let dst = unsafe { slice::from_raw_parts_mut(reloc.dst as *mut u8, reloc.value_len) };
             let src = &reloc.value[..reloc.value_len];
@@ -274,72 +259,151 @@ pub extern "C" fn stage2_main(launch_info: &Stage2LaunchInfo) {
         }
     }
 
-    // If IGVM parameters are present, then map them into the address space
-    // after the kernel.
-    let mut igvm_params_virt_address = VirtAddr::null();
-    let mut igvm_params_phys_address = PhysAddr::null();
-    let mut igvm_params_size = 0;
-    if let SvsmConfig::IgvmConfig(ref igvm_params) = config {
-        igvm_params_virt_address = loaded_kernel_virt_end;
-        igvm_params_phys_address = loaded_kernel_phys_end;
-        igvm_params_size = igvm_params.size();
+    let entry = VirtAddr::from(elf.get_entry(vaddr_alloc_base));
+    let region = MemoryRegion::from_addresses(load_virt_start, load_virt_end);
+    Ok((entry, region))
+}
 
-        let igvm_params_vregion = MemoryRegion::new(igvm_params_virt_address, igvm_params_size);
-        map_and_validate(
+/// Loads the IGVM params at the next contiguous location from the loaded
+/// kernel image. Returns the virtual and physical memory regions hosting the
+/// loaded data.
+fn load_igvm_params(
+    launch_info: &Stage2LaunchInfo,
+    params: &IgvmParams<'_>,
+    loaded_kernel_vregion: &MemoryRegion<VirtAddr>,
+    loaded_kernel_pregion: &MemoryRegion<PhysAddr>,
+    platform: &dyn SvsmPlatform,
+    config: &SvsmConfig<'_>,
+) -> Result<(MemoryRegion<VirtAddr>, MemoryRegion<PhysAddr>), SvsmError> {
+    // Map and validate destination region
+    let igvm_vregion = MemoryRegion::new(loaded_kernel_vregion.end(), params.size());
+    let igvm_pregion = MemoryRegion::new(loaded_kernel_pregion.end(), params.size());
+    map_and_validate(platform, config, igvm_vregion, igvm_pregion.start())?;
+
+    // Copy the contents over
+    let src_addr = VirtAddr::from(launch_info.igvm_params as u64);
+    let igvm_src = unsafe { slice::from_raw_parts(src_addr.as_ptr::<u8>(), igvm_vregion.len()) };
+    let igvm_dst = unsafe {
+        slice::from_raw_parts_mut(igvm_vregion.start().as_mut_ptr::<u8>(), igvm_vregion.len())
+    };
+    igvm_dst.copy_from_slice(igvm_src);
+
+    Ok((igvm_vregion, igvm_pregion))
+}
+
+/// Maps any remaining memory between the end of the kernel image and the end
+/// of the allocated kernel memory region as heap space. Exclude any memory
+/// reserved by the configuration.
+///
+/// # Panics
+///
+/// Panics if the allocated kernel region (`kernel_region`) is not sufficient
+/// to host the loaded kernel region (`loaded_kernel_pregion`) plus memory
+/// reserved for configuration.
+fn prepare_heap(
+    kernel_region: MemoryRegion<PhysAddr>,
+    loaded_kernel_pregion: MemoryRegion<PhysAddr>,
+    loaded_kernel_vregion: MemoryRegion<VirtAddr>,
+    platform: &dyn SvsmPlatform,
+    config: &SvsmConfig<'_>,
+) -> Result<(MemoryRegion<VirtAddr>, MemoryRegion<PhysAddr>), SvsmError> {
+    // Heap starts after kernel
+    let heap_pstart = loaded_kernel_pregion.end();
+    let heap_vstart = loaded_kernel_vregion.end();
+
+    // Compute size, excluding any memory reserved by the configuration.
+    let heap_size = kernel_region
+        .end()
+        .checked_sub(heap_pstart.into())
+        .and_then(|r| r.checked_sub(config.reserved_kernel_area_size()))
+        .expect("Insufficient physical space for kernel image")
+        .into();
+    let heap_pregion = MemoryRegion::new(heap_pstart, heap_size);
+    let heap_vregion = MemoryRegion::new(heap_vstart, heap_size);
+
+    map_and_validate(platform, config, heap_vregion, heap_pregion.start())?;
+
+    Ok((heap_vregion, heap_pregion))
+}
+
+#[no_mangle]
+pub extern "C" fn stage2_main(launch_info: &Stage2LaunchInfo) {
+    let platform_type = SvsmPlatformType::from(launch_info.platform_type);
+    let mut platform_cell = SvsmPlatformCell::new(platform_type);
+    let platform = platform_cell.as_mut_dyn_ref();
+
+    let config = get_svsm_config(launch_info, platform).expect("Failed to get SVSM configuration");
+    setup_env(&config, platform, launch_info);
+
+    log::info!("COCONUT Secure Virtual Machine Service Module (SVSM) Stage 2 Loader");
+
+    // Get the available physical memory region for the kernel
+    let kernel_region = config
+        .find_kernel_region()
+        .expect("Failed to find memory region for SVSM kernel");
+
+    init_valid_bitmap_alloc(kernel_region).expect("Failed to allocate valid-bitmap");
+
+    // The physical memory region we've loaded so far
+    let mut loaded_kernel_pregion = MemoryRegion::new(kernel_region.start(), 0);
+
+    // Load first the kernel ELF and update the loaded physical region
+    let (kernel_entry, mut loaded_kernel_vregion) =
+        load_kernel_elf(launch_info, &mut loaded_kernel_pregion, platform, &config)
+            .expect("Failed to load kernel ELF");
+
+    // Load the IGVM params, if present. Update loaded region accordingly.
+    let (igvm_vregion, igvm_pregion) = if let SvsmConfig::IgvmConfig(ref igvm_params) = config {
+        let (igvm_vregion, igvm_pregion) = load_igvm_params(
+            launch_info,
+            igvm_params,
+            &loaded_kernel_vregion,
+            &loaded_kernel_pregion,
             platform,
             &config,
-            igvm_params_vregion,
-            igvm_params_phys_address,
-        );
+        )
+        .expect("Failed to load IGVM params");
 
-        let igvm_params_src_addr = VirtAddr::from(launch_info.igvm_params as u64);
-        let igvm_src =
-            unsafe { slice::from_raw_parts(igvm_params_src_addr.as_ptr::<u8>(), igvm_params_size) };
-        let igvm_dest = unsafe {
-            slice::from_raw_parts_mut(
-                igvm_params_virt_address.as_mut_ptr::<u8>(),
-                igvm_params_size,
-            )
-        };
-        igvm_dest.copy_from_slice(igvm_src);
+        // Update the loaded kernel region
+        loaded_kernel_pregion = loaded_kernel_pregion.expand(igvm_vregion.len());
+        loaded_kernel_vregion = loaded_kernel_vregion.expand(igvm_pregion.len());
+        (igvm_vregion, igvm_pregion)
+    } else {
+        (
+            MemoryRegion::new(VirtAddr::null(), 0),
+            MemoryRegion::new(PhysAddr::null(), 0),
+        )
+    };
 
-        loaded_kernel_virt_end = loaded_kernel_virt_end + igvm_params_size;
-        loaded_kernel_phys_end = loaded_kernel_phys_end + igvm_params_size;
-    }
-
-    // Map the rest of the memory region to right after the kernel image.
-    // Exclude any memory reserved by the configuration.
-    let heap_area_phys_start = loaded_kernel_phys_end;
-    let heap_area_virt_start = loaded_kernel_virt_end;
-    let heap_area_size =
-        kernel_region_phys_end - heap_area_phys_start - config.reserved_kernel_area_size();
-    let heap_area_virt_region = MemoryRegion::new(heap_area_virt_start, heap_area_size);
-    map_and_validate(
+    // Use remaining space after kernel image as heap space.
+    let (heap_vregion, heap_pregion) = prepare_heap(
+        kernel_region,
+        loaded_kernel_pregion,
+        loaded_kernel_vregion,
         platform,
         &config,
-        heap_area_virt_region,
-        heap_area_phys_start,
-    );
+    )
+    .expect("Failed to map and validate heap");
 
     // Build the handover information describing the memory layout and hand
     // control to the SVSM kernel.
     let launch_info = KernelLaunchInfo {
-        kernel_region_phys_start: u64::from(kernel_region_phys_start),
-        kernel_region_phys_end: u64::from(kernel_region_phys_end),
-        heap_area_phys_start: u64::from(heap_area_phys_start),
-        heap_area_size: heap_area_size as u64,
-        kernel_region_virt_start: u64::from(loaded_kernel_virt_start),
-        heap_area_virt_start: u64::from(heap_area_virt_start),
-        kernel_elf_stage2_virt_start: u64::from(kernel_elf_start),
-        kernel_elf_stage2_virt_end: u64::from(kernel_elf_end),
+        kernel_region_phys_start: u64::from(kernel_region.start()),
+        kernel_region_phys_end: u64::from(kernel_region.end()),
+        heap_area_phys_start: u64::from(heap_pregion.start()),
+        heap_area_virt_start: u64::from(heap_vregion.start()),
+        heap_area_size: heap_vregion.len() as u64,
+        kernel_region_virt_start: u64::from(loaded_kernel_vregion.start()),
+        kernel_elf_stage2_virt_start: u64::from(launch_info.kernel_elf_start),
+        kernel_elf_stage2_virt_end: u64::from(launch_info.kernel_elf_end),
         kernel_fs_start: u64::from(launch_info.kernel_fs_start),
         kernel_fs_end: u64::from(launch_info.kernel_fs_end),
         cpuid_page: config.get_cpuid_page_address(),
         secrets_page: config.get_secrets_page_address(),
         stage2_igvm_params_phys_addr: u64::from(launch_info.igvm_params),
-        stage2_igvm_params_size: igvm_params_size as u64,
-        igvm_params_phys_addr: u64::from(igvm_params_phys_address),
-        igvm_params_virt_addr: u64::from(igvm_params_virt_address),
+        stage2_igvm_params_size: igvm_pregion.len() as u64,
+        igvm_params_phys_addr: u64::from(igvm_pregion.start()),
+        igvm_params_virt_addr: u64::from(igvm_vregion.start()),
         vtom: launch_info.vtom,
         debug_serial_port: config.debug_serial_port(),
         platform_type,
@@ -352,18 +416,14 @@ pub extern "C" fn stage2_main(launch_info: &Stage2LaunchInfo) {
 
     log::info!(
         "  kernel_region_phys_start = {:#018x}",
-        kernel_region_phys_start
+        kernel_region.start()
     );
-    log::info!(
-        "  kernel_region_phys_end   = {:#018x}",
-        kernel_region_phys_end
-    );
+    log::info!("  kernel_region_phys_end   = {:#018x}", kernel_region.end());
     log::info!(
         "  kernel_virtual_base   = {:#018x}",
-        loaded_kernel_virt_start
+        loaded_kernel_vregion.start()
     );
 
-    let kernel_entry = kernel_elf.get_entry(kernel_vaddr_alloc_base);
     let valid_bitmap = valid_bitmap_addr();
 
     // Shut down the GHCB
@@ -371,7 +431,7 @@ pub extern "C" fn stage2_main(launch_info: &Stage2LaunchInfo) {
 
     unsafe {
         asm!("jmp *%rax",
-             in("rax") kernel_entry,
+             in("rax") u64::from(kernel_entry),
              in("r8") &launch_info,
              in("r9") valid_bitmap.bits(),
              options(att_syntax))

--- a/kernel/src/utils/memory_region.rs
+++ b/kernel/src/utils/memory_region.rs
@@ -221,4 +221,18 @@ where
     pub fn contains_region(&self, other: &Self) -> bool {
         self.start() <= other.start() && other.end() <= self.end()
     }
+
+    /// Returns a new memory region with the specified added length at the end.
+    ///
+    /// ```
+    /// # use svsm::address::VirtAddr;
+    /// # use svsm::types::PAGE_SIZE;
+    /// # use svsm::utils::MemoryRegion;
+    /// let region = MemoryRegion::new(VirtAddr::from(0xffffff1000u64), PAGE_SIZE);
+    /// let bigger = region.expand(PAGE_SIZE);
+    /// assert_eq!(bigger.len(), PAGE_SIZE * 2);
+    /// ```
+    pub fn expand(&self, len: usize) -> Self {
+        Self::new(self.start(), self.len() + len)
+    }
 }


### PR DESCRIPTION
`stage2_main()` was very long and plagued with spread out panics in different places. Split out functionality into separate functions, each returning an error, and panic at the top level.

While we are at it, clean up the kernel layout logic, using the `MemoryRegion` type and updating the loaded region at each stage. Add documentation on each step for clarity.

Finally, add a missing check in the new `prepare_heap()` function to verify that we did not exceed the reserved kernel region size.