### PR TITLE
sev/ghcb: fix `GHCB::write_buffer()` soundness issues and clean up `GHCBExitCode`

### DIFF
--- a/kernel/src/sev/ghcb.rs
+++ b/kernel/src/sev/ghcb.rs
@@ -118,18 +118,19 @@ impl From<GhcbError> for SvsmError {
     }
 }
 
-enum GHCBExitCode {}
-
-impl GHCBExitCode {
-    pub const RDTSC: u64 = 0x6e;
-    pub const IOIO: u64 = 0x7b;
-    pub const MSR: u64 = 0x7c;
-    pub const RDTSCP: u64 = 0x87;
-    pub const SNP_PSC: u64 = 0x8000_0010;
-    pub const GUEST_REQUEST: u64 = 0x8000_0011;
-    pub const GUEST_EXT_REQUEST: u64 = 0x8000_0012;
-    pub const AP_CREATE: u64 = 0x80000013;
-    pub const HV_DOORBELL: u64 = 0x8000_0014;
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u64)]
+#[allow(non_camel_case_types, clippy::upper_case_acronyms)]
+enum GHCBExitCode {
+    RDTSC = 0x6e,
+    IOIO = 0x7b,
+    MSR = 0x7c,
+    RDTSCP = 0x87,
+    SNP_PSC = 0x8000_0010,
+    GUEST_REQUEST = 0x8000_0011,
+    GUEST_EXT_REQUEST = 0x8000_0012,
+    AP_CREATE = 0x80000013,
+    HV_DOORBELL = 0x8000_0014,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -323,7 +324,7 @@ impl GHCB {
 
     fn vmgexit(
         &mut self,
-        exit_code: u64,
+        exit_code: GHCBExitCode,
         exit_info_1: u64,
         exit_info_2: u64,
     ) -> Result<(), GhcbError> {
@@ -331,7 +332,7 @@ impl GHCB {
         self.set_version_valid(2);
         // GHCB Follows standard format
         self.set_usage_valid(0);
-        self.set_exit_code_valid(exit_code);
+        self.set_exit_code_valid(exit_code as u64);
         self.set_exit_info_1_valid(exit_info_1);
         self.set_exit_info_2_valid(exit_info_2);
 


### PR DESCRIPTION
* `GHCB::write_buffer()` had several soundness issues, so fix them:
    * Computing the destination pointer could overflow.
    * The resulting pointer could be misaligned.
    * The specified  `T` needed to be `Copy`.
* There is no reason to use associated constants for `GHCBExitCode` values, so simply use enum variants with defined discriminants.