### PR TITLE
igvm tools: fix pre-calculated launch measurement with QEMU/KVM

### DIFF
--- a/igvmbuilder/src/cmd_options.rs
+++ b/igvmbuilder/src/cmd_options.rs
@@ -51,6 +51,14 @@ pub struct CmdOptions {
     /// Include NATIVE platform target
     #[arg(long, default_value_t = false)]
     pub native: bool,
+
+    /// Enable debug features (e.g. SNP debug_swap)
+    #[arg(short, long, default_value_t = false)]
+    pub debug: bool,
+
+    /// Extra SEV features to be enabled in the VMSA (multiple values can be provided separated by ',')
+    #[arg(long, value_delimiter = ',')]
+    pub sev_features: Vec<SevExtraFeatures>,
 }
 
 impl CmdOptions {
@@ -72,4 +80,13 @@ pub enum Hypervisor {
 
     /// Build an IGVM file compatible with Hyper-V
     HyperV,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
+pub enum SevExtraFeatures {
+    ReflectVc,
+    AlternateInjection,
+    DebugSwap,
+    PreventHostIBS,
+    SNPBTBIsolation,
 }

--- a/igvmbuilder/src/igvm_builder.rs
+++ b/igvmbuilder/src/igvm_builder.rs
@@ -347,6 +347,7 @@ impl IgvmBuilder {
                 self.gpa_map.vmsa.get_start(),
                 param_block.vtom,
                 SNP_COMPATIBILITY_MASK,
+                &self.options.sev_features,
             ));
         }
 

--- a/igvmbuilder/src/vmsa.rs
+++ b/igvmbuilder/src/vmsa.rs
@@ -11,6 +11,7 @@ use igvm::IgvmDirectiveHeader;
 use igvm_defs::IgvmNativeVpContextX64;
 use zerocopy::FromZeroes;
 
+use crate::cmd_options::SevExtraFeatures;
 use crate::stage2_stack::Stage2Stack;
 
 pub fn construct_start_context() -> Box<IgvmNativeVpContextX64> {
@@ -49,6 +50,7 @@ pub fn construct_vmsa(
     gpa_start: u64,
     vtom: u64,
     compatibility_mask: u32,
+    extra_features: &Vec<SevExtraFeatures>,
 ) -> IgvmDirectiveHeader {
     let mut vmsa_box = SevVmsa::new_box_zeroed();
     let vmsa = vmsa_box.as_mut();
@@ -115,6 +117,17 @@ pub fn construct_vmsa(
         vmsa.virtual_tom = vtom;
         features.set_vtom(true);
     }
+
+    for extra_f in extra_features {
+        match extra_f {
+            SevExtraFeatures::ReflectVc => features.set_reflect_vc(true),
+            SevExtraFeatures::AlternateInjection => features.set_alternate_injection(true),
+            SevExtraFeatures::DebugSwap => features.set_debug_swap(true),
+            SevExtraFeatures::PreventHostIBS => features.set_prevent_host_ibs(true),
+            SevExtraFeatures::SNPBTBIsolation => features.set_snp_btb_isolation(true),
+        }
+    }
+
     vmsa.sev_features = features;
 
     IgvmDirectiveHeader::SnpVpContext {

--- a/igvmbuilder/src/vmsa.rs
+++ b/igvmbuilder/src/vmsa.rs
@@ -115,7 +115,6 @@ pub fn construct_vmsa(
         vmsa.virtual_tom = vtom;
         features.set_vtom(true);
     }
-    features.set_debug_swap(true);
     vmsa.sev_features = features;
 
     IgvmDirectiveHeader::SnpVpContext {

--- a/igvmmeasure/src/igvm_measure.rs
+++ b/igvmmeasure/src/igvm_measure.rs
@@ -339,7 +339,7 @@ impl IgvmMeasure {
             if vmsa.cr0 != 0x31 {
                 return Err(IgvmMeasureError::InvalidVmsaCr0);
             }
-            if !vmsa.sev_features.debug_swap() {
+            if vmsa.sev_features.debug_swap() {
                 return Err(IgvmMeasureError::InvalidDebugSwap);
             }
         }


### PR DESCRIPTION
The latest versions of KVM patches (not yet upstream) set `debug_swap` to false by default. Also being a debug feature, we don't expect it to be enabled in production, so let's disable it to avoid difference between the launch measurement at runtime and the pre-calculated one.

The latest patch adds a new option to check debugging features like SNP debug_swap, but I'm not sure it's needed.

Any comments are welcome!

Tested with one patch on top to print the launch measurement (https://github.com/stefano-garzarella/svsm/tree/get_report_fixed):

```
$ make
...
"target/x86_64-unknown-linux-gnu/debug/igvmmeasure" --check-kvm bin/coconut-qemu.igvm measure

===============================================================================================================
igvmmeasure 'bin/coconut-qemu.igvm'
Launch Digest: B520B306FE8F57D3B14EA1F755A48A9F2E77642A41167B4AC0183AF8BD1BB629E2C3FCB224892E92110100C178EA148C
===============================================================================================================

$ ./scripts/launch_guest.sh --qemu /path/to/qemu-system-x86_64
...
[SVSM] VTPM: Microsoft TPM 2.0 initialized
[SVSM] [CPU 0] Virtual memory pages used: 0 * 4K, 0 * 2M
[SVSM] VMSA PA: 0x8000f34000
[SVSM] Launching Firmware
[SVSM] Launching request-processing task on CPU 0
[SVSM] ERROR: Panic: CPU[0] panicked at kernel/src/svsm.rs:485:9:
SNP Launch Measurement: b520b306fe8f57d3b14ea1f755a48a9f2e77642a41167b4ac0183af8bd1bb629e2c3fcb224892e92110100c178ea148c
```

Fixes: https://github.com/coconut-svsm/svsm/issues/349