### PR TITLE
cpu: fix IDT and GDT lifetimes on load methods

### DIFF
--- a/kernel/src/cpu/idt/common.rs
+++ b/kernel/src/cpu/idt/common.rs
@@ -176,8 +176,18 @@ impl IDT {
 
         self
     }
+}
 
-    pub fn load(&self) -> &Self {
+impl Default for IDT {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WriteLockGuard<'static, IDT> {
+    /// Load an IDT. Its lifetime must be static so that its entries are
+    /// always available to the CPU.
+    pub fn load(&self) {
         let desc: IdtDesc = IdtDesc {
             size: (IDT_ENTRIES * 16) as u16,
             address: VirtAddr::from(self.entries.as_ptr()),
@@ -186,20 +196,14 @@ impl IDT {
         unsafe {
             asm!("lidt (%rax)", in("rax") &desc, options(att_syntax));
         }
-
-        self
-    }
-
-    pub fn base_limit(&self) -> (u64, u32) {
-        let base = (self as *const IDT) as u64;
-        let limit = (IDT_ENTRIES * mem::size_of::<IdtEntry>()) as u32;
-        (base, limit)
     }
 }
 
-impl Default for IDT {
-    fn default() -> Self {
-        Self::new()
+impl ReadLockGuard<'static, IDT> {
+    pub fn base_limit(&self) -> (u64, u32) {
+        let base: *const IDT = core::ptr::from_ref(self);
+        let limit = (IDT_ENTRIES * mem::size_of::<IdtEntry>()) as u32;
+        (base as u64, limit)
     }
 }
 

--- a/kernel/src/cpu/idt/stage2.rs
+++ b/kernel/src/cpu/idt/stage2.rs
@@ -13,17 +13,17 @@ use core::ptr::addr_of;
 
 pub fn early_idt_init_no_ghcb() {
     unsafe {
-        idt_mut()
-            .init(addr_of!(stage2_idt_handler_array_no_ghcb), 32)
-            .load();
+        let mut idt = idt_mut();
+        idt.init(addr_of!(stage2_idt_handler_array_no_ghcb), 32);
+        idt.load();
     }
 }
 
 pub fn early_idt_init() {
     unsafe {
-        idt_mut()
-            .init(addr_of!(stage2_idt_handler_array), 32)
-            .load();
+        let mut idt = idt_mut();
+        idt.init(addr_of!(stage2_idt_handler_array), 32);
+        idt.load();
     }
 }
 

--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -9,11 +9,11 @@ use super::super::extable::handle_exception_table;
 use super::super::percpu::{current_task, this_cpu};
 use super::super::tss::IST_DF;
 use super::super::vc::handle_vc_exception;
-use super::common::PF_ERROR_WRITE;
 use super::common::{
     idt_mut, user_mode, IdtEntry, AC_VECTOR, BP_VECTOR, BR_VECTOR, CP_VECTOR, DB_VECTOR, DE_VECTOR,
     DF_VECTOR, GP_VECTOR, HV_VECTOR, MCE_VECTOR, MF_VECTOR, NMI_VECTOR, NM_VECTOR, NP_VECTOR,
-    OF_VECTOR, PF_VECTOR, SS_VECTOR, SX_VECTOR, TS_VECTOR, UD_VECTOR, VC_VECTOR, XF_VECTOR,
+    OF_VECTOR, PF_ERROR_WRITE, PF_VECTOR, SS_VECTOR, SX_VECTOR, TS_VECTOR, UD_VECTOR, VC_VECTOR,
+    XF_VECTOR,
 };
 use crate::address::VirtAddr;
 use crate::cpu::percpu::this_cpu_unsafe;


### PR DESCRIPTION
When running the LIDT or LGDT instructions, we pass addresses pointing to architecture-specific tables that the CPU will use during operation. These tables must reside on valid memory during CPU operation to avoid malfunction.

In practical terms, this means the GDT and IDT entries must have a `static` lifetime. This will avoid at compile time the following construct:

```rust
{
    let idt = IDT::new();
    idt.load();
}
// the IDT entries are no longer valid here
```

We could enforce this at the type level by requiring the `load()` method on these structs to take a `&'static lifetime`. However, since we use locking, we cannot get such reference, only a reference that lives as long as a lock guard we get from the lock protecting the struct. However, this does not matter, as we can check that the guard points to a struct with static lifetime (`Guard<'static, T>`).

Thus, rewrite the methods on these structs that have these requirements such that they take a guard pointing to a `'static` IDT or GDT.