### PR TITLE
svsm: implement SVSM Alternate Injection protocol for APIC emulation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 [[package]]
 name = "cpuarch"
 version = "0.1.0"
+dependencies = [
+ "bitfield-struct",
+]
 
 [[package]]
 name = "cpufeatures"

--- a/bootlib/src/igvm_params.rs
+++ b/bootlib/src/igvm_params.rs
@@ -107,8 +107,11 @@ pub struct IgvmParamBlock {
     /// The port number of the serial port to use for debugging.
     pub debug_serial_port: u16,
 
+    /// Indicates whether the guest can support alternate injection.
+    pub use_alternate_injection: u8,
+
     #[doc(hidden)]
-    pub _reserved: [u16; 3],
+    pub _reserved: [u8; 5],
 
     /// Metadata containing information about the firmware image embedded in the
     /// IGVM file.

--- a/bootlib/src/kernel_launch.rs
+++ b/bootlib/src/kernel_launch.rs
@@ -31,6 +31,7 @@ pub struct KernelLaunchInfo {
     pub igvm_params_virt_addr: u64,
     pub vtom: u64,
     pub debug_serial_port: u16,
+    pub use_alternate_injection: bool,
     pub platform_type: SvsmPlatformType,
 }
 

--- a/cpuarch/Cargo.toml
+++ b/cpuarch/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+bitfield-struct.workspace = true
 
 [lints]
 workspace = true

--- a/cpuarch/src/vmsa.rs
+++ b/cpuarch/src/vmsa.rs
@@ -279,13 +279,3 @@ impl Default for VMSA {
         }
     }
 }
-
-impl VMSA {
-    pub fn enable(&mut self) {
-        self.efer |= 1u64 << 12;
-    }
-
-    pub fn disable(&mut self) {
-        self.efer &= !(1u64 << 12);
-    }
-}

--- a/igvmbuilder/src/cmd_options.rs
+++ b/igvmbuilder/src/cmd_options.rs
@@ -59,6 +59,10 @@ pub struct CmdOptions {
     /// Extra SEV features to be enabled in the VMSA (multiple values can be provided separated by ',')
     #[arg(long, value_delimiter = ',')]
     pub sev_features: Vec<SevExtraFeatures>,
+
+    /// Use Alternate Injection if available
+    #[arg(long, default_value_t = false)]
+    pub alt_injection: bool,
 }
 
 impl CmdOptions {

--- a/igvmbuilder/src/igvm_builder.rs
+++ b/igvmbuilder/src/igvm_builder.rs
@@ -221,6 +221,10 @@ impl IgvmBuilder {
             kernel_size: self.gpa_map.kernel.get_size() as u32,
             kernel_base: self.gpa_map.kernel.get_start(),
             vtom,
+            use_alternate_injection: match self.options.alt_injection {
+                true => 1,
+                false => 0,
+            },
             ..Default::default()
         };
 

--- a/kernel/src/config.rs
+++ b/kernel/src/config.rs
@@ -178,4 +178,11 @@ impl SvsmConfig<'_> {
             SvsmConfig::IgvmConfig(igvm_params) => igvm_params.initialize_guest_vmsa(vmsa),
         }
     }
+
+    pub fn use_alternate_injection(&self) -> bool {
+        match self {
+            SvsmConfig::FirmwareConfig(_) => false,
+            SvsmConfig::IgvmConfig(igvm_params) => igvm_params.use_alternate_injection(),
+        }
+    }
 }

--- a/kernel/src/cpu/apic.rs
+++ b/kernel/src/cpu/apic.rs
@@ -9,6 +9,7 @@ use crate::platform::guest_cpu::GuestCpuState;
 #[derive(Clone, Copy, Debug, Default)]
 pub struct LocalApic {
     irr: [u32; 8],
+    _allowed_irr: [u32; 8],
     isr_stack_index: usize,
     isr_stack: [u8; 16],
     update_required: bool,
@@ -20,6 +21,7 @@ impl LocalApic {
     pub fn new() -> Self {
         LocalApic {
             irr: [0; 8],
+            _allowed_irr: [0; 8],
             isr_stack_index: 0,
             isr_stack: [0; 16],
             update_required: false,

--- a/kernel/src/cpu/apic.rs
+++ b/kernel/src/cpu/apic.rs
@@ -5,12 +5,15 @@
 // Author: Jon Lange (jlange@microsoft.com)
 
 use crate::address::VirtAddr;
-use crate::cpu::percpu::PerCpuShared;
+use crate::cpu::percpu::{this_cpu, PerCpuShared};
 use crate::mm::GuestPtr;
 use crate::platform::guest_cpu::GuestCpuState;
 use crate::requests::SvsmCaa;
+use crate::sev::hv_doorbell::HVExtIntStatus;
+use crate::types::GUEST_VMPL;
 
 use bitfield_struct::bitfield;
+use core::sync::atomic::Ordering;
 
 const APIC_REGISTER_APIC_ID: u64 = 0x802;
 const APIC_REGISTER_TPR: u64 = 0x808;
@@ -250,6 +253,10 @@ impl LocalApic {
         cpu_state: &mut T,
         caa_addr: Option<VirtAddr>,
     ) {
+        // Make sure any interrupts being presented by the host have been
+        // consumed.
+        self.consume_host_interrupts();
+
         if self.update_required {
             // Make sure that all previously delivered interrupts have been
             // processed before attempting to process any more.
@@ -440,6 +447,7 @@ impl LocalApic {
             _ => Err(ApicError::ApicError),
         }
     }
+
     pub fn configure_vector(&mut self, vector: u8, allowed: bool) {
         let index = (vector >> 5) as usize;
         let mask = 1 << (vector & 31);
@@ -447,6 +455,104 @@ impl LocalApic {
             self.allowed_irr[index] |= mask;
         } else {
             self.allowed_irr[index] &= !mask;
+        }
+    }
+
+    fn signal_one_host_interrupt(&mut self, vector: u8) {
+        let index = (vector >> 5) as usize;
+        let mask = 1 << (vector & 31);
+        if (self.allowed_irr[index] & mask) != 0 {
+            self.post_interrupt(vector);
+        }
+    }
+
+    fn signal_several_interrupts(&mut self, group: usize, mut bits: u32) {
+        let vector = (group as u8) << 5;
+        while bits != 0 {
+            let index = 31 - bits.leading_zeros();
+            bits &= !(1 << index);
+            self.post_interrupt(vector + index as u8);
+        }
+    }
+
+    pub fn consume_host_interrupts(&mut self) {
+        let hv_doorbell = this_cpu().hv_doorbell().unwrap();
+        let vmpl_event_mask = hv_doorbell.per_vmpl_events.swap(0, Ordering::Relaxed);
+        // Ignore events other than for the guest VMPL.
+        if vmpl_event_mask & (1 << (GUEST_VMPL - 1)) != 0 {
+            let descriptor = &hv_doorbell.per_vmpl[GUEST_VMPL - 1];
+
+            // First consume any level-sensitive vector that is present.
+            let mut flags = HVExtIntStatus::from(descriptor.status.load(Ordering::Relaxed));
+            if flags.level_sensitive() {
+                // Consume the correct vector atomically.
+                loop {
+                    let mut new_flags = flags;
+                    new_flags.set_pending_vector(0);
+                    new_flags.set_level_sensitive(false);
+                    if let Err(fail_flags) = descriptor.status.compare_exchange(
+                        flags.into(),
+                        new_flags.into(),
+                        Ordering::Relaxed,
+                        Ordering::Relaxed,
+                    ) {
+                        flags = fail_flags.into();
+                    } else {
+                        //flags = new_flags;
+                        break;
+                    }
+                }
+                // FIXME - signal the flags.vector as a level-sensitive
+                // interrupt.
+                panic!("No support yet for host-presented level-sensitive interrupts");
+            }
+
+            // If a single vector is present, then signal it, otherwise
+            // process the entire IRR.
+            if flags.multiple_vectors() {
+                // Clear the multiple vectors flag first so that additional
+                // interrupts are presented via the 8-bit vector.  This must
+                // be done before the IRR is scanned so that if additional
+                // vectors are presented later, the multiple vectors flag
+                // will be set again.
+                let multiple_vectors_mask: u32 =
+                    HVExtIntStatus::new().with_multiple_vectors(true).into();
+                descriptor
+                    .status
+                    .fetch_and(!multiple_vectors_mask, Ordering::Relaxed);
+
+                // Handle the special case of vector 31.
+                if flags.vector_31() {
+                    descriptor
+                        .status
+                        .fetch_and(!(1u32 << 31), Ordering::Relaxed);
+                    self.signal_one_host_interrupt(31);
+                }
+
+                for i in 1..8 {
+                    let bits = descriptor.irr[i - 1].swap(0, Ordering::Relaxed);
+                    self.signal_several_interrupts(i, bits & self.allowed_irr[i]);
+                }
+            } else if flags.pending_vector() != 0 {
+                // Atomically consume this interrupt.  If it cannot be consumed
+                // atomically, then it must be because some other interrupt
+                // has been presented, and that can be consumed in another
+                // pass.
+                let mut new_flags = flags;
+                new_flags.set_pending_vector(0);
+                if descriptor
+                    .status
+                    .compare_exchange(
+                        flags.into(),
+                        new_flags.into(),
+                        Ordering::Relaxed,
+                        Ordering::Relaxed,
+                    )
+                    .is_ok()
+                {
+                    self.signal_one_host_interrupt(flags.pending_vector());
+                }
+            }
         }
     }
 }

--- a/kernel/src/cpu/apic.rs
+++ b/kernel/src/cpu/apic.rs
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Jon Lange (jlange@microsoft.com)
+
+use crate::platform::guest_cpu::GuestCpuState;
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct LocalApic {
+    irr: [u32; 8],
+    isr_stack_index: usize,
+    isr_stack: [u8; 16],
+    update_required: bool,
+    interrupt_delivered: bool,
+    interrupt_queued: bool,
+}
+
+impl LocalApic {
+    pub fn new() -> Self {
+        LocalApic {
+            irr: [0; 8],
+            isr_stack_index: 0,
+            isr_stack: [0; 16],
+            update_required: false,
+            interrupt_delivered: false,
+            interrupt_queued: false,
+        }
+    }
+
+    fn scan_irr(&self) -> u8 {
+        // Scan to find the highest pending IRR vector.
+        for (i, irr) in self.irr.into_iter().enumerate().rev() {
+            if irr != 0 {
+                let bit_index = 31 - irr.leading_zeros();
+                let vector = (i as u32) * 32 + bit_index;
+                return vector.try_into().unwrap();
+            }
+        }
+        0
+    }
+
+    fn remove_irr(&mut self, irq: u8) {
+        self.irr[irq as usize >> 5] &= !(1 << (irq & 31));
+    }
+
+    fn insert_irr(&mut self, irq: u8) {
+        self.irr[irq as usize >> 5] |= 1 << (irq & 31);
+    }
+
+    fn rewind_pending_interrupt(&mut self, irq: u8) {
+        let new_index = self.isr_stack_index.checked_sub(1).unwrap();
+        assert!(self.isr_stack.get(new_index) == Some(&irq));
+        self.insert_irr(irq);
+        self.isr_stack_index = new_index;
+        self.update_required = true;
+    }
+
+    pub fn check_delivered_interrupts<T: GuestCpuState>(&mut self, cpu_state: &mut T) {
+        // Check to see if a previously delivered interrupt is still pending.
+        // If so, move it back to the IRR.
+        if self.interrupt_delivered {
+            let irq = cpu_state.check_and_clear_pending_interrupt_event();
+            if irq != 0 {
+                self.rewind_pending_interrupt(irq);
+            }
+            self.interrupt_delivered = false;
+        }
+
+        // Check to see if a previously queued interrupt is still pending.
+        // If so, move it back to the IRR.
+        if self.interrupt_queued {
+            let irq = cpu_state.check_and_clear_pending_virtual_interrupt();
+            if irq != 0 {
+                self.rewind_pending_interrupt(irq);
+            }
+            self.interrupt_queued = false;
+        }
+    }
+
+    fn get_ppr_with_tpr(&self, tpr: u8) -> u8 {
+        // Determine the priority of the current in-service interrupt, if any.
+        let ppr = if self.isr_stack_index != 0 {
+            self.isr_stack[self.isr_stack_index]
+        } else {
+            0
+        };
+
+        // The PPR is the higher of the in-service interrupt priority and the
+        // task priority.
+        if (ppr >> 4) > (tpr >> 4) {
+            ppr
+        } else {
+            tpr
+        }
+    }
+
+    fn get_ppr<T: GuestCpuState>(&self, cpu_state: &T) -> u8 {
+        self.get_ppr_with_tpr(cpu_state.get_tpr())
+    }
+
+    fn deliver_interrupt_immediately<T: GuestCpuState>(
+        &mut self,
+        irq: u8,
+        cpu_state: &mut T,
+    ) -> bool {
+        if !cpu_state.interrupts_enabled() || cpu_state.in_intr_shadow() {
+            false
+        } else {
+            // This interrupt can only be delivered if it is a higher priority
+            // than the processor's current priority.
+            let ppr = self.get_ppr(cpu_state);
+            if (irq >> 4) <= (ppr >> 4) {
+                false
+            } else {
+                cpu_state.try_deliver_interrupt_immediately(irq)
+            }
+        }
+    }
+
+    pub fn present_interrupts<T: GuestCpuState>(&mut self, cpu_state: &mut T) {
+        if self.update_required {
+            // Make sure that all previously delivered interrupts have been
+            // processed before attempting to process any more.
+            self.check_delivered_interrupts(cpu_state);
+
+            let irq = self.scan_irr();
+            let current_priority = if self.isr_stack_index != 0 {
+                self.isr_stack[self.isr_stack_index - 1]
+            } else {
+                0
+            };
+
+            // This interrupt is a candidate for delivery only if its priority
+            // exceeds the priority of the highest priority interrupt currently
+            // in service.  This check does not consider TPR, because an
+            // interrupt lower in priority than TPR must be queued for delivery
+            // as soon as TPR is lowered.
+            if (irq & 0xF0) > (current_priority & 0xF0) {
+                // Determine whether this interrupt can be injected
+                // immediately.  If not, queue it for delivery when possible.
+                if self.deliver_interrupt_immediately(irq, cpu_state) {
+                    self.interrupt_delivered = true;
+                } else {
+                    cpu_state.queue_interrupt(irq);
+                    self.interrupt_queued = true;
+                }
+
+                // Mark this interrupt in-service.  It will be recalled if
+                // the ISR is examined again before the interrupt is actually
+                // delivered.
+                self.remove_irr(irq);
+                self.isr_stack[self.isr_stack_index] = irq;
+                self.isr_stack_index += 1;
+            }
+            self.update_required = false;
+        }
+    }
+
+    pub fn perform_eoi(&mut self) {
+        // Pop any in-service interrupt from the stack, and schedule the APIC
+        // for reevaluation.
+        if self.isr_stack_index != 0 {
+            self.isr_stack_index -= 1;
+            self.update_required = true;
+        }
+    }
+}

--- a/kernel/src/cpu/apic.rs
+++ b/kernel/src/cpu/apic.rs
@@ -4,8 +4,11 @@
 //
 // Author: Jon Lange (jlange@microsoft.com)
 
+use crate::address::VirtAddr;
 use crate::cpu::percpu::PerCpuShared;
+use crate::mm::GuestPtr;
 use crate::platform::guest_cpu::GuestCpuState;
+use crate::requests::SvsmCaa;
 
 use bitfield_struct::bitfield;
 
@@ -101,6 +104,7 @@ pub struct LocalApic {
     update_required: bool,
     interrupt_delivered: bool,
     interrupt_queued: bool,
+    lazy_eoi_pending: bool,
 }
 
 impl LocalApic {
@@ -113,6 +117,7 @@ impl LocalApic {
             update_required: false,
             interrupt_delivered: false,
             interrupt_queued: false,
+            lazy_eoi_pending: false,
         }
     }
 
@@ -144,13 +149,18 @@ impl LocalApic {
         self.update_required = true;
     }
 
-    pub fn check_delivered_interrupts<T: GuestCpuState>(&mut self, cpu_state: &mut T) {
+    pub fn check_delivered_interrupts<T: GuestCpuState>(
+        &mut self,
+        cpu_state: &mut T,
+        caa_addr: Option<VirtAddr>,
+    ) {
         // Check to see if a previously delivered interrupt is still pending.
         // If so, move it back to the IRR.
         if self.interrupt_delivered {
             let irq = cpu_state.check_and_clear_pending_interrupt_event();
             if irq != 0 {
                 self.rewind_pending_interrupt(irq);
+                self.lazy_eoi_pending = false;
             }
             self.interrupt_delivered = false;
         }
@@ -161,8 +171,27 @@ impl LocalApic {
             let irq = cpu_state.check_and_clear_pending_virtual_interrupt();
             if irq != 0 {
                 self.rewind_pending_interrupt(irq);
+                self.lazy_eoi_pending = false;
             }
             self.interrupt_queued = false;
+        }
+
+        // If a lazy EOI is pending, then check to see whether an EOI has been
+        // requested by the guest.  Note that if a lazy EOI was dismissed
+        // above, the guest lazy EOI flag need not be cleared here, since
+        // dismissal of any interrupt above will require reprocessing of
+        // interrupt state prior to guest reentry, and that reprocessing will
+        // reset the guest lazy EOI flag.
+        if self.lazy_eoi_pending {
+            if let Some(virt_addr) = caa_addr {
+                let calling_area = GuestPtr::<SvsmCaa>::new(virt_addr);
+                if let Ok(caa) = calling_area.read() {
+                    if caa.no_eoi_required == 0 {
+                        assert!(self.isr_stack_index != 0);
+                        self.perform_eoi();
+                    }
+                }
+            }
         }
     }
 
@@ -187,6 +216,16 @@ impl LocalApic {
         self.get_ppr_with_tpr(cpu_state.get_tpr())
     }
 
+    fn clear_guest_eoi_pending(caa_addr: Option<VirtAddr>) -> Option<GuestPtr<SvsmCaa>> {
+        let virt_addr = caa_addr?;
+        let calling_area = GuestPtr::<SvsmCaa>::new(virt_addr);
+        // Ignore errors here, since nothing can be done if an error occurs.
+        if let Ok(caa) = calling_area.read() {
+            let _ = calling_area.write(caa.update_no_eoi_required(0));
+        }
+        Some(calling_area)
+    }
+
     fn deliver_interrupt_immediately<T: GuestCpuState>(
         &mut self,
         irq: u8,
@@ -206,11 +245,15 @@ impl LocalApic {
         }
     }
 
-    pub fn present_interrupts<T: GuestCpuState>(&mut self, cpu_state: &mut T) {
+    pub fn present_interrupts<T: GuestCpuState>(
+        &mut self,
+        cpu_state: &mut T,
+        caa_addr: Option<VirtAddr>,
+    ) {
         if self.update_required {
             // Make sure that all previously delivered interrupts have been
             // processed before attempting to process any more.
-            self.check_delivered_interrupts(cpu_state);
+            self.check_delivered_interrupts(cpu_state, caa_addr);
 
             let irq = self.scan_irr();
             let current_priority = if self.isr_stack_index != 0 {
@@ -218,6 +261,11 @@ impl LocalApic {
             } else {
                 0
             };
+
+            // Assume no lazy EOI can be attempted unless it is recalculated
+            // below.
+            self.lazy_eoi_pending = false;
+            let guest_caa = Self::clear_guest_eoi_pending(caa_addr);
 
             // This interrupt is a candidate for delivery only if its priority
             // exceeds the priority of the highest priority interrupt currently
@@ -227,12 +275,24 @@ impl LocalApic {
             if (irq & 0xF0) > (current_priority & 0xF0) {
                 // Determine whether this interrupt can be injected
                 // immediately.  If not, queue it for delivery when possible.
-                if self.deliver_interrupt_immediately(irq, cpu_state) {
+                let try_lazy_eoi = if self.deliver_interrupt_immediately(irq, cpu_state) {
                     self.interrupt_delivered = true;
+
+                    // Use of lazy EOI can safely be attempted, because the
+                    // highest priority interrupt in service is unambiguous.
+                    true
                 } else {
                     cpu_state.queue_interrupt(irq);
                     self.interrupt_queued = true;
-                }
+
+                    // A lazy EOI can only be attempted if there is no lower
+                    // priority interrupt in service.  If a lower priority
+                    // interrupt is in service, then the lazy EOI handler
+                    // won't know whether the lazy EOI is for the one that
+                    // is already in service or the one that is being queued
+                    // here.
+                    self.isr_stack_index == 0
+                };
 
                 // Mark this interrupt in-service.  It will be recalled if
                 // the ISR is examined again before the interrupt is actually
@@ -240,6 +300,26 @@ impl LocalApic {
                 self.remove_irr(irq);
                 self.isr_stack[self.isr_stack_index] = irq;
                 self.isr_stack_index += 1;
+
+                // Configure a lazy EOI if possible.
+                if try_lazy_eoi {
+                    // A lazy EOI is possible only if there is no other
+                    // interrupt pending.  If another interrupt is pending,
+                    // then an explicit EOI will be required to prompt
+                    // delivery of the next interrupt.
+                    if self.scan_irr() == 0 {
+                        if let Some(calling_area) = guest_caa {
+                            if let Ok(caa) = calling_area.read() {
+                                if calling_area.write(caa.update_no_eoi_required(1)).is_ok() {
+                                    // Only track a pending lazy EOI if the
+                                    // calling area page could successfully be
+                                    // updated.
+                                    self.lazy_eoi_pending = true;
+                                }
+                            }
+                        }
+                    }
+                }
             }
             self.update_required = false;
         }
@@ -251,6 +331,7 @@ impl LocalApic {
         if self.isr_stack_index != 0 {
             self.isr_stack_index -= 1;
             self.update_required = true;
+            self.lazy_eoi_pending = false;
         }
     }
 
@@ -275,11 +356,12 @@ impl LocalApic {
         &mut self,
         cpu_shared: &PerCpuShared,
         cpu_state: &mut T,
+        caa_addr: Option<VirtAddr>,
         register: u64,
     ) -> Result<u64, ApicError> {
         // Rewind any undelivered interrupt so it is reflected in any register
         // read.
-        self.check_delivered_interrupts(cpu_state);
+        self.check_delivered_interrupts(cpu_state, caa_addr);
 
         match register {
             APIC_REGISTER_APIC_ID => Ok(u64::from(cpu_shared.apic_id())),
@@ -324,12 +406,13 @@ impl LocalApic {
     pub fn write_register<T: GuestCpuState>(
         &mut self,
         cpu_state: &mut T,
+        caa_addr: Option<VirtAddr>,
         register: u64,
         value: u64,
     ) -> Result<(), ApicError> {
         // Rewind any undelivered interrupt so it is correctly processed by
         // any register write.
-        self.check_delivered_interrupts(cpu_state);
+        self.check_delivered_interrupts(cpu_state, caa_addr);
 
         match register {
             APIC_REGISTER_TPR => {

--- a/kernel/src/cpu/idt/common.rs
+++ b/kernel/src/cpu/idt/common.rs
@@ -42,6 +42,8 @@ pub const SX_VECTOR: usize = 30;
 
 pub const PF_ERROR_WRITE: usize = 2;
 
+pub const INT_INJ_VECTOR: usize = 0x50;
+
 #[repr(C, packed)]
 #[derive(Default, Debug, Clone, Copy)]
 pub struct X86ExceptionContext {

--- a/kernel/src/cpu/idt/entry.S
+++ b/kernel/src/cpu/idt/entry.S
@@ -44,6 +44,16 @@ asm_entry_\name:
 	jmp	default_return
 .endm
 
+.macro irq_entry name:req vector:req
+	.globl asm_entry_irq_\name
+asm_entry_irq_\name:
+	pushq	$0
+	push_regs
+	movl	$\vector, %edi
+	call	common_isr_handler
+	jmp	default_return
+.endm
+
 // The #HV handler is coded specially in order to deal with control flow
 // alterations that may be required based on when the #HV arrives.  If the #HV
 // arrives from a context in which interrupts are enabled, then the #HV can

--- a/kernel/src/cpu/idt/entry.S
+++ b/kernel/src/cpu/idt/entry.S
@@ -342,3 +342,6 @@ default_entry_no_ist	name=sx		handler=panic			error_code=1	vector=30
 
 // INT 0x80 system call handler
 default_entry_no_ist	name=int80	handler=system_call		error_code=0	vector=0x80
+
+// Interrupt injection vector
+irq_entry	name=int_inj	vector=0x50

--- a/kernel/src/cpu/mod.rs
+++ b/kernel/src/cpu/mod.rs
@@ -4,6 +4,7 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
+pub mod apic;
 pub mod control_regs;
 pub mod cpuid;
 pub mod efer;
@@ -20,6 +21,7 @@ pub mod tss;
 pub mod vc;
 pub mod vmsa;
 
+pub use apic::LocalApic;
 pub use gdt::{gdt, gdt_mut};
 pub use idt::common::X86ExceptionContext;
 pub use registers::{X86GeneralRegs, X86InterruptFrame, X86SegmentRegs};

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -437,6 +437,19 @@ impl PerCpu {
         Ok(())
     }
 
+    pub fn hv_doorbell(&self) -> Option<&'static HVDoorbell> {
+        unsafe {
+            let hv_doorbell = self.hv_doorbell.get();
+            if hv_doorbell.is_null() {
+                None
+            } else {
+                // The HV doorbell page can only ever be borrowed shared, never
+                // mutable, and can safely have a static lifetime.
+                Some(&*hv_doorbell)
+            }
+        }
+    }
+
     fn setup_tss(&self) {
         let double_fault_stack = self.get_top_of_df_stack();
         let mut tss = self.tss.get();

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -219,6 +219,7 @@ pub struct PerCpuShared {
     online: AtomicBool,
     ipi_irr: [AtomicU32; 8],
     ipi_pending: AtomicBool,
+    nmi_pending: AtomicBool,
 }
 
 impl PerCpuShared {
@@ -238,6 +239,7 @@ impl PerCpuShared {
                 AtomicU32::new(0),
             ],
             ipi_pending: AtomicBool::new(false),
+            nmi_pending: AtomicBool::new(false),
         }
     }
 
@@ -289,12 +291,21 @@ impl PerCpuShared {
         self.ipi_pending.store(true, Ordering::Release);
     }
 
+    pub fn request_nmi(&self) {
+        self.nmi_pending.store(true, Ordering::Relaxed);
+        self.ipi_pending.store(true, Ordering::Release);
+    }
+
     pub fn ipi_pending(&self) -> bool {
         self.ipi_pending.swap(false, Ordering::Acquire)
     }
 
     pub fn ipi_irr_vector(&self, index: usize) -> u32 {
         self.ipi_irr[index].swap(0, Ordering::Relaxed)
+    }
+
+    pub fn nmi_pending(&self) -> bool {
+        self.nmi_pending.swap(false, Ordering::Relaxed)
     }
 }
 

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -12,6 +12,7 @@ use crate::address::{Address, PhysAddr, VirtAddr};
 use crate::cpu::tss::TSS_LIMIT;
 use crate::cpu::vmsa::init_guest_vmsa;
 use crate::cpu::vmsa::vmsa_mut_ref_from_vaddr;
+use crate::cpu::LocalApic;
 use crate::error::SvsmError;
 use crate::locking::{LockGuard, RWLock, SpinLock};
 use crate::mm::alloc::{allocate_zeroed_page, free_page};
@@ -272,6 +273,8 @@ pub struct PerCpu {
     runqueue: RefCell<RunQueue>,
     /// WaitQueue for request processing
     request_waitqueue: RefCell<WaitQueue>,
+    /// Local APIC state for APIC emulation
+    apic: RefCell<LocalApic>,
 
     ghcb: Cell<Option<&'static GHCB>>,
     hv_doorbell: Cell<*const HVDoorbell>,
@@ -295,6 +298,7 @@ impl PerCpu {
             runqueue: RefCell::new(RunQueue::new()),
             request_waitqueue: RefCell::new(WaitQueue::new()),
             apic_emulation: Cell::new(false),
+            apic: RefCell::new(LocalApic::new()),
 
             shared: PerCpuShared::new(apic_id),
             ghcb: Cell::new(None),
@@ -619,6 +623,12 @@ impl PerCpu {
         self.vm_range.insert_at(SVSM_PERCPU_CAA_BASE, caa_mapping)?;
 
         Ok(())
+    }
+
+    pub fn update_apic_emulation(&self, vmsa: &mut VMSA) {
+        if self.apic_emulation.get() {
+            self.apic.borrow_mut().present_interrupts(vmsa);
+        }
     }
 
     fn vmsa_tr_segment(&self) -> VMSASegment {

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -40,11 +40,12 @@ use alloc::vec::Vec;
 use core::cell::{Cell, RefCell, RefMut, UnsafeCell};
 use core::mem::size_of;
 use core::ptr;
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::slice::Iter;
+use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use cpuarch::vmsa::{VMSASegment, VMSA};
 
-#[derive(Debug)]
-struct PerCpuInfo {
+#[derive(Copy, Clone, Debug)]
+pub struct PerCpuInfo {
     apic_id: u32,
     cpu_shared: &'static PerCpuShared,
 }
@@ -55,6 +56,10 @@ impl PerCpuInfo {
             apic_id,
             cpu_shared,
         }
+    }
+
+    pub fn unwrap(&self) -> &'static PerCpuShared {
+        self.cpu_shared
     }
 }
 
@@ -83,6 +88,11 @@ impl PerCpuAreas {
     unsafe fn push(&self, info: PerCpuInfo) {
         let ptr = self.areas.get().as_mut().unwrap();
         ptr.push(info);
+    }
+
+    pub fn iter(&self) -> Iter<'_, PerCpuInfo> {
+        let ptr = unsafe { self.areas.get().as_ref().unwrap() };
+        ptr.iter()
     }
 
     // Fails if no such area exists or its address is NULL
@@ -207,6 +217,8 @@ pub struct PerCpuShared {
     apic_id: u32,
     guest_vmsa: SpinLock<GuestVmsaRef>,
     online: AtomicBool,
+    ipi_irr: [AtomicU32; 8],
+    ipi_pending: AtomicBool,
 }
 
 impl PerCpuShared {
@@ -215,6 +227,17 @@ impl PerCpuShared {
             apic_id,
             guest_vmsa: SpinLock::new(GuestVmsaRef::new()),
             online: AtomicBool::new(false),
+            ipi_irr: [
+                AtomicU32::new(0),
+                AtomicU32::new(0),
+                AtomicU32::new(0),
+                AtomicU32::new(0),
+                AtomicU32::new(0),
+                AtomicU32::new(0),
+                AtomicU32::new(0),
+                AtomicU32::new(0),
+            ],
+            ipi_pending: AtomicBool::new(false),
         }
     }
 
@@ -255,6 +278,23 @@ impl PerCpuShared {
 
     pub fn is_online(&self) -> bool {
         self.online.load(Ordering::Acquire)
+    }
+
+    pub fn request_ipi(&self, vector: u8) {
+        let index = vector >> 5;
+        let bit = 1u32 << (vector & 31);
+        // Request the IPI via the IRR vector before signaling that an IPI has
+        // been requested.
+        self.ipi_irr[index as usize].fetch_or(bit, Ordering::Relaxed);
+        self.ipi_pending.store(true, Ordering::Release);
+    }
+
+    pub fn ipi_pending(&self) -> bool {
+        self.ipi_pending.swap(false, Ordering::Acquire)
+    }
+
+    pub fn ipi_irr_vector(&self, index: usize) -> u32 {
+        self.ipi_irr[index].swap(0, Ordering::Relaxed)
     }
 }
 
@@ -671,7 +711,9 @@ impl PerCpu {
 
     pub fn update_apic_emulation(&self, vmsa: &mut VMSA, caa_addr: Option<VirtAddr>) {
         if self.apic_emulation.get() {
-            self.apic.borrow_mut().present_interrupts(vmsa, caa_addr);
+            self.apic
+                .borrow_mut()
+                .present_interrupts(self.shared(), vmsa, caa_addr);
         }
     }
 

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -693,6 +693,14 @@ impl PerCpu {
             // APIC emulation cannot be disabled if the platform has locked
             // the use of APIC emulation.
             SVSM_PLATFORM.as_dyn_ref().disable_apic_emulation()?;
+            let mut vmsa_ref = self.guest_vmsa_ref();
+            let caa_addr = vmsa_ref.caa_addr();
+            let vmsa = vmsa_ref.vmsa();
+            self.apic
+                .borrow_mut()
+                .disable_apic_emulation(vmsa, caa_addr);
+            drop(vmsa_ref);
+
             self.apic_emulation.set(false);
         }
         Ok(())

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -640,9 +640,20 @@ impl PerCpu {
         Ok(())
     }
 
-    pub fn update_apic_emulation(&self, vmsa: &mut VMSA) {
+    pub fn clear_pending_interrupts(&self) {
         if self.apic_emulation.get() {
-            self.apic.borrow_mut().present_interrupts(vmsa);
+            let mut vmsa_ref = self.guest_vmsa_ref();
+            let caa_addr = vmsa_ref.caa_addr();
+            let vmsa = vmsa_ref.vmsa();
+            self.apic
+                .borrow_mut()
+                .check_delivered_interrupts(vmsa, caa_addr);
+        }
+    }
+
+    pub fn update_apic_emulation(&self, vmsa: &mut VMSA, caa_addr: Option<VirtAddr>) {
+        if self.apic_emulation.get() {
+            self.apic.borrow_mut().present_interrupts(vmsa, caa_addr);
         }
     }
 
@@ -652,16 +663,20 @@ impl PerCpu {
 
     pub fn read_apic_register(&self, register: u64) -> Result<u64, ApicError> {
         let mut vmsa_ref = self.guest_vmsa_ref();
+        let caa_addr = vmsa_ref.caa_addr();
         let vmsa = vmsa_ref.vmsa();
         self.apic
             .borrow_mut()
-            .read_register(self.shared(), vmsa, register)
+            .read_register(self.shared(), vmsa, caa_addr, register)
     }
 
     pub fn write_apic_register(&self, register: u64, value: u64) -> Result<(), ApicError> {
         let mut vmsa_ref = self.guest_vmsa_ref();
+        let caa_addr = vmsa_ref.caa_addr();
         let vmsa = vmsa_ref.vmsa();
-        self.apic.borrow_mut().write_register(vmsa, register, value)
+        self.apic
+            .borrow_mut()
+            .write_register(vmsa, caa_addr, register, value)
     }
 
     pub fn configure_apic_vector(&self, vector: u8, allowed: bool) {

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -10,6 +10,7 @@ use super::gdt_mut;
 use super::tss::{X86Tss, IST_DF};
 use crate::address::{Address, PhysAddr, VirtAddr};
 use crate::cpu::apic::ApicError;
+use crate::cpu::idt::common::INT_INJ_VECTOR;
 use crate::cpu::tss::TSS_LIMIT;
 use crate::cpu::vmsa::init_guest_vmsa;
 use crate::cpu::vmsa::vmsa_mut_ref_from_vaddr;
@@ -616,6 +617,10 @@ impl PerCpu {
         // Enable alternate injection if the hypervisor supports it.
         if SVSM_PLATFORM.as_dyn_ref().use_alternate_injection() {
             self.apic_emulation.set(true);
+
+            // Configure the interrupt injection vector.
+            let ghcb = self.ghcb().unwrap();
+            ghcb.configure_interrupt_injection(INT_INJ_VECTOR)?;
         }
 
         let vaddr = allocate_new_vmsa(RMPFlags::GUEST_VMPL)?;

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -9,6 +9,7 @@ extern crate alloc;
 use super::gdt_mut;
 use super::tss::{X86Tss, IST_DF};
 use crate::address::{Address, PhysAddr, VirtAddr};
+use crate::cpu::apic::ApicError;
 use crate::cpu::tss::TSS_LIMIT;
 use crate::cpu::vmsa::init_guest_vmsa;
 use crate::cpu::vmsa::vmsa_mut_ref_from_vaddr;
@@ -216,6 +217,10 @@ impl PerCpuShared {
         }
     }
 
+    pub const fn apic_id(&self) -> u32 {
+        self.apic_id
+    }
+
     pub fn update_guest_vmsa_caa(&self, vmsa: PhysAddr, caa: PhysAddr) {
         let mut locked = self.guest_vmsa.lock();
         locked.update_vmsa_caa(Some(vmsa), Some(caa));
@@ -360,7 +365,7 @@ impl PerCpu {
     }
 
     pub fn get_apic_id(&self) -> u32 {
-        self.shared().apic_id
+        self.shared().apic_id()
     }
 
     fn allocate_page_table(&self) -> Result<(), SvsmError> {
@@ -625,10 +630,42 @@ impl PerCpu {
         Ok(())
     }
 
+    pub fn disable_apic_emulation(&self) -> Result<(), SvsmError> {
+        if self.apic_emulation.get() {
+            // APIC emulation cannot be disabled if the platform has locked
+            // the use of APIC emulation.
+            SVSM_PLATFORM.as_dyn_ref().disable_apic_emulation()?;
+            self.apic_emulation.set(false);
+        }
+        Ok(())
+    }
+
     pub fn update_apic_emulation(&self, vmsa: &mut VMSA) {
         if self.apic_emulation.get() {
             self.apic.borrow_mut().present_interrupts(vmsa);
         }
+    }
+
+    pub fn use_apic_emulation(&self) -> bool {
+        self.apic_emulation.get()
+    }
+
+    pub fn read_apic_register(&self, register: u64) -> Result<u64, ApicError> {
+        let mut vmsa_ref = self.guest_vmsa_ref();
+        let vmsa = vmsa_ref.vmsa();
+        self.apic
+            .borrow_mut()
+            .read_register(self.shared(), vmsa, register)
+    }
+
+    pub fn write_apic_register(&self, register: u64, value: u64) -> Result<(), ApicError> {
+        let mut vmsa_ref = self.guest_vmsa_ref();
+        let vmsa = vmsa_ref.vmsa();
+        self.apic.borrow_mut().write_register(vmsa, register, value)
+    }
+
+    pub fn configure_apic_vector(&self, vector: u8, allowed: bool) {
+        self.apic.borrow_mut().configure_vector(vector, allowed)
     }
 
     fn vmsa_tr_segment(&self) -> VMSASegment {

--- a/kernel/src/cpu/smp.rs
+++ b/kernel/src/cpu/smp.rs
@@ -10,6 +10,7 @@ use crate::cpu::vmsa::init_svsm_vmsa;
 use crate::platform::SvsmPlatform;
 use crate::platform::SVSM_PLATFORM;
 use crate::requests::{request_loop, request_processing_main};
+use crate::sev::vmsa::VMSAControl;
 use crate::task::{create_kernel_task, schedule_init};
 use crate::utils::immut_after_init::immut_after_init_set_multithreaded;
 

--- a/kernel/src/cpu/vmsa.rs
+++ b/kernel/src/cpu/vmsa.rs
@@ -115,7 +115,7 @@ pub fn vmsa_mut_ref_from_vaddr(vaddr: VirtAddr) -> &'static mut VMSA {
     unsafe { vaddr.as_mut_ptr::<VMSA>().as_mut().unwrap() }
 }
 
-pub fn init_guest_vmsa(v: &mut VMSA, rip: u64) {
+pub fn init_guest_vmsa(v: &mut VMSA, rip: u64, alternate_injection: bool) {
     v.cr0 = 0x6000_0010;
     v.rflags = 0x2;
     v.rip = rip & 0xffff;
@@ -143,5 +143,11 @@ pub fn init_guest_vmsa(v: &mut VMSA, rip: u64) {
 
     // Ensure that guest VMSAs do not enable restricted injection.
     sev_status.remove(SEVStatusFlags::REST_INJ);
+
+    // Enable alternate injection if requested.
+    if alternate_injection {
+        sev_status.insert(SEVStatusFlags::ALT_INJ);
+    }
+
     v.sev_features = sev_status.as_sev_features();
 }

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -66,4 +66,6 @@ pub enum SvsmError {
     Vc(VcError),
     /// The operation is not supported.
     NotSupported,
+    /// Generic errors related to APIC emulation.
+    Apic,
 }

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -64,4 +64,6 @@ pub enum SvsmError {
     Task(TaskError),
     /// Errors from #VC handler
     Vc(VcError),
+    /// The operation is not supported.
+    NotSupported,
 }

--- a/kernel/src/igvm_params.rs
+++ b/kernel/src/igvm_params.rs
@@ -302,4 +302,8 @@ impl IgvmParams<'_> {
     pub fn get_vtom(&self) -> u64 {
         self.igvm_param_block.vtom
     }
+
+    pub fn use_alternate_injection(&self) -> bool {
+        self.igvm_param_block.use_alternate_injection != 0
+    }
 }

--- a/kernel/src/platform/guest_cpu.rs
+++ b/kernel/src/platform/guest_cpu.rs
@@ -13,4 +13,5 @@ pub trait GuestCpuState {
     fn interrupts_enabled(&self) -> bool;
     fn check_and_clear_pending_interrupt_event(&mut self) -> u8;
     fn check_and_clear_pending_virtual_interrupt(&mut self) -> u8;
+    fn disable_alternate_injection(&mut self);
 }

--- a/kernel/src/platform/guest_cpu.rs
+++ b/kernel/src/platform/guest_cpu.rs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Jon Lange (jlange@microsoft.com)
+
+pub trait GuestCpuState {
+    fn get_tpr(&self) -> u8;
+    fn queue_interrupt(&mut self, irq: u8);
+    fn try_deliver_interrupt_immediately(&mut self, irq: u8) -> bool;
+    fn in_intr_shadow(&self) -> bool;
+    fn interrupts_enabled(&self) -> bool;
+    fn check_and_clear_pending_interrupt_event(&mut self) -> u8;
+    fn check_and_clear_pending_virtual_interrupt(&mut self) -> u8;
+}

--- a/kernel/src/platform/guest_cpu.rs
+++ b/kernel/src/platform/guest_cpu.rs
@@ -6,6 +6,7 @@
 
 pub trait GuestCpuState {
     fn get_tpr(&self) -> u8;
+    fn set_tpr(&mut self, tpr: u8);
     fn queue_interrupt(&mut self, irq: u8);
     fn try_deliver_interrupt_immediately(&mut self, irq: u8) -> bool;
     fn in_intr_shadow(&self) -> bool;

--- a/kernel/src/platform/guest_cpu.rs
+++ b/kernel/src/platform/guest_cpu.rs
@@ -7,10 +7,12 @@
 pub trait GuestCpuState {
     fn get_tpr(&self) -> u8;
     fn set_tpr(&mut self, tpr: u8);
+    fn request_nmi(&mut self);
     fn queue_interrupt(&mut self, irq: u8);
     fn try_deliver_interrupt_immediately(&mut self, irq: u8) -> bool;
     fn in_intr_shadow(&self) -> bool;
     fn interrupts_enabled(&self) -> bool;
+    fn check_and_clear_pending_nmi(&mut self) -> bool;
     fn check_and_clear_pending_interrupt_event(&mut self) -> u8;
     fn check_and_clear_pending_virtual_interrupt(&mut self) -> u8;
     fn disable_alternate_injection(&mut self);

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -83,6 +83,12 @@ pub trait SvsmPlatform {
     /// Indicates whether this system should make use of alternate injection.
     fn use_alternate_injection(&self) -> bool;
 
+    /// Locks or unlocks the use of APIC emulation on this system.
+    fn lock_unlock_apic_emulation(&self, lock: bool) -> Result<(), SvsmError>;
+
+    /// Determines whether APIC emulation can be disabled on this system.
+    fn disable_apic_emulation(&self) -> Result<(), SvsmError>;
+
     /// Signal an IRQ on one or more CPUs.
     fn post_irq(&self, icr: u64) -> Result<(), SvsmError>;
 

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -76,6 +76,12 @@ pub trait SvsmPlatform {
     /// Marks a range of pages as invalid for use as private pages.
     fn invalidate_page_range(&self, region: MemoryRegion<VirtAddr>) -> Result<(), SvsmError>;
 
+    /// Configures the use of alternate injection as requested.
+    fn configure_alternate_injection(&mut self, alt_inj_requested: bool) -> Result<(), SvsmError>;
+
+    /// Indicates whether this system should make use of alternate injection.
+    fn use_alternate_injection(&self) -> bool;
+
     /// Signal an IRQ on one or more CPUs.
     fn post_irq(&self, icr: u64) -> Result<(), SvsmError>;
 

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -16,6 +16,7 @@ use crate::utils::MemoryRegion;
 
 use bootlib::platform::SvsmPlatformType;
 
+pub mod guest_cpu;
 pub mod native;
 pub mod snp;
 

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -76,6 +76,9 @@ pub trait SvsmPlatform {
     /// Marks a range of pages as invalid for use as private pages.
     fn invalidate_page_range(&self, region: MemoryRegion<VirtAddr>) -> Result<(), SvsmError>;
 
+    /// Signal an IRQ on one or more CPUs.
+    fn post_irq(&self, icr: u64) -> Result<(), SvsmError>;
+
     /// Perform an EOI of the current interrupt.
     fn eoi(&self);
 }

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -89,6 +89,14 @@ impl SvsmPlatform for NativePlatform {
         false
     }
 
+    fn lock_unlock_apic_emulation(&self, _lock: bool) -> Result<(), SvsmError> {
+        Err(SvsmError::NotSupported)
+    }
+
+    fn disable_apic_emulation(&self) -> Result<(), SvsmError> {
+        Err(SvsmError::NotSupported)
+    }
+
     fn post_irq(&self, icr: u64) -> Result<(), SvsmError> {
         write_msr(APIC_MSR_ICR, icr);
         Ok(())

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -6,6 +6,7 @@
 
 use crate::address::{PhysAddr, VirtAddr};
 use crate::cpu::cpuid::CpuidResult;
+use crate::cpu::msr::write_msr;
 use crate::cpu::percpu::PerCpu;
 use crate::error::SvsmError;
 use crate::platform::{IOPort, PageEncryptionMasks, PageStateChangeOp, SvsmPlatform};
@@ -14,6 +15,8 @@ use crate::types::PageSize;
 use crate::utils::MemoryRegion;
 
 static CONSOLE_IO: NativeIOPort = NativeIOPort::new();
+
+const APIC_MSR_ICR: u32 = 0x830;
 
 #[derive(Clone, Copy, Debug)]
 pub struct NativePlatform {}
@@ -75,6 +78,11 @@ impl SvsmPlatform for NativePlatform {
 
     /// Marks a range of pages as invalid for use as private pages.
     fn invalidate_page_range(&self, _region: MemoryRegion<VirtAddr>) -> Result<(), SvsmError> {
+        Ok(())
+    }
+
+    fn post_irq(&self, icr: u64) -> Result<(), SvsmError> {
+        write_msr(APIC_MSR_ICR, icr);
         Ok(())
     }
 

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -81,6 +81,14 @@ impl SvsmPlatform for NativePlatform {
         Ok(())
     }
 
+    fn configure_alternate_injection(&mut self, _alt_inj_requested: bool) -> Result<(), SvsmError> {
+        Ok(())
+    }
+
+    fn use_alternate_injection(&self) -> bool {
+        false
+    }
+
     fn post_irq(&self, icr: u64) -> Result<(), SvsmError> {
         write_msr(APIC_MSR_ICR, icr);
         Ok(())

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -117,6 +117,11 @@ impl SvsmPlatform for SnpPlatform {
         pvalidate_range(region, PvalidateOp::Invalid)
     }
 
+    fn post_irq(&self, icr: u64) -> Result<(), SvsmError> {
+        current_ghcb().hv_ipi(icr)?;
+        Ok(())
+    }
+
     fn eoi(&self) {
         // Issue an explicit EOI unless no explicit EOI is required.
         if !current_hv_doorbell().no_eoi_required() {

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -13,7 +13,9 @@ use crate::platform::{PageEncryptionMasks, PageStateChangeOp, SvsmPlatform};
 use crate::sev::hv_doorbell::current_hv_doorbell;
 use crate::sev::msr_protocol::verify_ghcb_version;
 use crate::sev::status::vtom_enabled;
-use crate::sev::{pvalidate_range, sev_status_init, sev_status_verify, PvalidateOp};
+use crate::sev::{
+    init_hypervisor_ghcb_features, pvalidate_range, sev_status_init, sev_status_verify, PvalidateOp,
+};
 use crate::svsm_console::SVSMIOPort;
 use crate::types::PageSize;
 use crate::utils::MemoryRegion;
@@ -42,6 +44,7 @@ impl SvsmPlatform for SnpPlatform {
 
     fn env_setup_late(&mut self) {
         sev_status_verify();
+        init_hypervisor_ghcb_features().expect("Failed to obtain hypervisor GHCB features");
     }
 
     fn setup_percpu(&self, cpu: &PerCpu) -> Result<(), SvsmError> {

--- a/kernel/src/protocols/apic.rs
+++ b/kernel/src/protocols/apic.rs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Jon Lange (jlange@microsoft.com)
+
+use crate::cpu::percpu::this_cpu;
+use crate::platform::SVSM_PLATFORM;
+use crate::protocols::errors::SvsmReqError;
+use crate::protocols::RequestParams;
+
+const SVSM_REQ_APIC_QUERY_FEATURES: u32 = 0;
+const SVSM_REQ_APIC_CONFIGURE: u32 = 1;
+const SVSM_REQ_APIC_READ_REGISTER: u32 = 2;
+const SVSM_REQ_APIC_WRITE_REGISTER: u32 = 3;
+const SVSM_REQ_APIC_CONFIGURE_VECTOR: u32 = 4;
+
+const SVSM_APIC_CONFIGURE_DISABLED: u64 = 0;
+const SVSM_APIC_CONFIGURE_ENABLED: u64 = 1;
+const SVSM_APIC_CONFIGURE_LOCKED: u64 = 2;
+
+pub const APIC_PROTOCOL: u32 = 3;
+pub const APIC_PROTOCOL_VERSION_MIN: u32 = 1;
+pub const APIC_PROTOCOL_VERSION_MAX: u32 = 1;
+
+const SVSM_ERR_APIC_CANNOT_DISABLE: u64 = 0;
+const SVSM_ERR_APIC_CANNOT_LOCK: u64 = 1;
+
+fn apic_query_features(params: &mut RequestParams) -> Result<(), SvsmReqError> {
+    // No features are supported beyond the base feature set.
+    params.rcx = 0;
+    Ok(())
+}
+
+fn apic_configure(params: &RequestParams) -> Result<(), SvsmReqError> {
+    match params.rcx {
+        SVSM_APIC_CONFIGURE_DISABLED => this_cpu()
+            .disable_apic_emulation()
+            .map_err(|_| SvsmReqError::protocol(SVSM_ERR_APIC_CANNOT_DISABLE)),
+        SVSM_APIC_CONFIGURE_ENABLED => {
+            // If this fails, the platform is known not to be in the locked
+            // state, so any error can be ignored in that case.
+            let _ = SVSM_PLATFORM.as_dyn_ref().lock_unlock_apic_emulation(false);
+            Ok(())
+        }
+        SVSM_APIC_CONFIGURE_LOCKED => SVSM_PLATFORM
+            .as_dyn_ref()
+            .lock_unlock_apic_emulation(false)
+            .map_err(|_| SvsmReqError::protocol(SVSM_ERR_APIC_CANNOT_LOCK)),
+        _ => Err(SvsmReqError::invalid_parameter()),
+    }
+}
+
+fn apic_read_register(params: &mut RequestParams) -> Result<(), SvsmReqError> {
+    let cpu = this_cpu();
+    if !cpu.use_apic_emulation() {
+        return Err(SvsmReqError::invalid_request());
+    }
+    let value = cpu
+        .read_apic_register(params.rcx)
+        .map_err(|_| SvsmReqError::invalid_parameter())?;
+    params.rdx = value;
+    Ok(())
+}
+
+fn apic_write_register(params: &RequestParams) -> Result<(), SvsmReqError> {
+    let cpu = this_cpu();
+    if !cpu.use_apic_emulation() {
+        return Err(SvsmReqError::invalid_request());
+    }
+    cpu.write_apic_register(params.rcx, params.rdx)
+        .map_err(|_| SvsmReqError::invalid_parameter())
+}
+
+fn apic_configure_vector(params: &RequestParams) -> Result<(), SvsmReqError> {
+    let cpu = this_cpu();
+    if !cpu.use_apic_emulation() {
+        return Err(SvsmReqError::invalid_request());
+    }
+    if params.rcx <= 0x1FF {
+        let vector: u8 = (params.rcx & 0xFF) as u8;
+        let allowed = (params.rcx & 0x100) != 0;
+        cpu.configure_apic_vector(vector, allowed);
+        Ok(())
+    } else {
+        Err(SvsmReqError::invalid_parameter())
+    }
+}
+
+pub fn apic_protocol_request(request: u32, params: &mut RequestParams) -> Result<(), SvsmReqError> {
+    if !this_cpu().use_apic_emulation() {
+        return Err(SvsmReqError::unsupported_protocol());
+    }
+    match request {
+        SVSM_REQ_APIC_QUERY_FEATURES => apic_query_features(params),
+        SVSM_REQ_APIC_CONFIGURE => apic_configure(params),
+        SVSM_REQ_APIC_READ_REGISTER => apic_read_register(params),
+        SVSM_REQ_APIC_WRITE_REGISTER => apic_write_register(params),
+        SVSM_REQ_APIC_CONFIGURE_VECTOR => apic_configure_vector(params),
+
+        _ => Err(SvsmReqError::unsupported_call()),
+    }
+}

--- a/kernel/src/protocols/core.rs
+++ b/kernel/src/protocols/core.rs
@@ -400,6 +400,10 @@ fn core_remap_ca(params: &RequestParams) -> Result<(), SvsmReqError> {
     let pending = GuestPtr::<SvsmCaa>::new(vaddr);
     pending.write(SvsmCaa::zeroed())?;
 
+    // Clear any pending interrupt state before remapping the calling area to
+    // ensure that any pending lazy EOI has been processed.
+    this_cpu().clear_pending_interrupts();
+
     this_cpu_shared().update_guest_caa(gpa);
 
     Ok(())

--- a/kernel/src/protocols/core.rs
+++ b/kernel/src/protocols/core.rs
@@ -20,6 +20,7 @@ use crate::sev::utils::{
     pvalidate, rmp_clear_guest_vmsa, rmp_grant_guest_access, rmp_revoke_guest_access,
     rmp_set_guest_vmsa, PvalidateOp, RMPFlags, SevSnpError,
 };
+use crate::sev::vmsa::VMSAControl;
 use crate::types::{PageSize, PAGE_SIZE, PAGE_SIZE_2M};
 use crate::utils::zero_mem_region;
 use cpuarch::vmsa::VMSA;

--- a/kernel/src/protocols/errors.rs
+++ b/kernel/src/protocols/errors.rs
@@ -62,7 +62,7 @@ impl SvsmReqError {
     impl_req_err!(invalid_parameter, INVALID_PARAMETER);
     impl_req_err!(invalid_request, INVALID_REQUEST);
     impl_req_err!(busy, BUSY);
-    fn protocol(code: u64) -> Self {
+    pub fn protocol(code: u64) -> Self {
         Self::RequestError(SvsmResultCode::PROTOCOL_BASE(code))
     }
 }

--- a/kernel/src/protocols/mod.rs
+++ b/kernel/src/protocols/mod.rs
@@ -4,6 +4,7 @@
 //
 // Author: Dov Murik <dovmurik@linux.ibm.com>
 
+pub mod apic;
 pub mod core;
 pub mod errors;
 #[cfg(all(feature = "mstpm", not(test)))]
@@ -14,6 +15,7 @@ use cpuarch::vmsa::{GuestVMExit, VMSA};
 // SVSM protocols
 pub const SVSM_CORE_PROTOCOL: u32 = 0;
 pub const SVSM_VTPM_PROTOCOL: u32 = 2;
+pub const SVSM_APIC_PROTOCOL: u32 = 3;
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct RequestParams {

--- a/kernel/src/requests.rs
+++ b/kernel/src/requests.rs
@@ -8,13 +8,14 @@ use crate::cpu::flush_tlb_global_sync;
 use crate::cpu::percpu::{process_requests, this_cpu, wait_for_requests};
 use crate::error::SvsmError;
 use crate::mm::GuestPtr;
+use crate::protocols::apic::apic_protocol_request;
 use crate::protocols::core::core_protocol_request;
 use crate::protocols::errors::{SvsmReqError, SvsmResultCode};
 use crate::sev::ghcb::switch_to_vmpl;
 
 #[cfg(all(feature = "mstpm", not(test)))]
 use crate::protocols::{vtpm::vtpm_protocol_request, SVSM_VTPM_PROTOCOL};
-use crate::protocols::{RequestParams, SVSM_CORE_PROTOCOL};
+use crate::protocols::{RequestParams, SVSM_APIC_PROTOCOL, SVSM_CORE_PROTOCOL};
 use crate::sev::vmsa::VMSAControl;
 use crate::types::GUEST_VMPL;
 use crate::utils::halt;
@@ -98,6 +99,7 @@ fn request_loop_once(
         SVSM_CORE_PROTOCOL => core_protocol_request(request, params).map(|_| true),
         #[cfg(all(feature = "mstpm", not(test)))]
         SVSM_VTPM_PROTOCOL => vtpm_protocol_request(request, params).map(|_| true),
+        SVSM_APIC_PROTOCOL => apic_protocol_request(request, params).map(|_| true),
         _ => Err(SvsmReqError::unsupported_protocol()),
     }
 }

--- a/kernel/src/requests.rs
+++ b/kernel/src/requests.rs
@@ -128,6 +128,11 @@ pub fn request_loop() {
                 let cpu = this_cpu();
                 let mut vmsa_ref = cpu.guest_vmsa_ref();
                 let vmsa = vmsa_ref.vmsa();
+
+                // Update APIC interrupt emulation state if required.
+                cpu.update_apic_emulation(vmsa);
+
+                // Make VMSA runnable again by setting EFER.SVME
                 vmsa.enable();
             }
 

--- a/kernel/src/requests.rs
+++ b/kernel/src/requests.rs
@@ -15,6 +15,7 @@ use crate::sev::ghcb::switch_to_vmpl;
 #[cfg(all(feature = "mstpm", not(test)))]
 use crate::protocols::{vtpm::vtpm_protocol_request, SVSM_VTPM_PROTOCOL};
 use crate::protocols::{RequestParams, SVSM_CORE_PROTOCOL};
+use crate::sev::vmsa::VMSAControl;
 use crate::types::GUEST_VMPL;
 use crate::utils::halt;
 use cpuarch::vmsa::GuestVMExit;

--- a/kernel/src/sev/ghcb.rs
+++ b/kernel/src/sev/ghcb.rs
@@ -101,6 +101,7 @@ enum GHCBExitCode {
     AP_CREATE = 0x80000013,
     HV_DOORBELL = 0x8000_0014,
     HV_IPI = 0x8000_0015,
+    CONFIGURE_INT_INJ = 0x8000_0019,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -601,6 +602,12 @@ impl GHCB {
     pub fn hv_ipi(&self, icr: u64) -> Result<(), SvsmError> {
         self.clear();
         self.vmgexit(GHCBExitCode::HV_IPI, icr, 0)?;
+        Ok(())
+    }
+
+    pub fn configure_interrupt_injection(&self, vector: usize) -> Result<(), SvsmError> {
+        self.clear();
+        self.vmgexit(GHCBExitCode::CONFIGURE_INT_INJ, vector as u64, 0)?;
         Ok(())
     }
 

--- a/kernel/src/sev/ghcb.rs
+++ b/kernel/src/sev/ghcb.rs
@@ -102,6 +102,7 @@ enum GHCBExitCode {
     HV_DOORBELL = 0x8000_0014,
     HV_IPI = 0x8000_0015,
     CONFIGURE_INT_INJ = 0x8000_0019,
+    SPECIFIC_EOI = 0x8000_001B,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -608,6 +609,13 @@ impl GHCB {
     pub fn configure_interrupt_injection(&self, vector: usize) -> Result<(), SvsmError> {
         self.clear();
         self.vmgexit(GHCBExitCode::CONFIGURE_INT_INJ, vector as u64, 0)?;
+        Ok(())
+    }
+
+    pub fn specific_eoi(&self, vector: u8, vmpl: u8) -> Result<(), SvsmError> {
+        self.clear();
+        let exit_info = ((vmpl as u64) << 16) | (vector as u64);
+        self.vmgexit(GHCBExitCode::SPECIFIC_EOI, exit_info, 0)?;
         Ok(())
     }
 

--- a/kernel/src/sev/ghcb.rs
+++ b/kernel/src/sev/ghcb.rs
@@ -100,6 +100,7 @@ enum GHCBExitCode {
     GUEST_EXT_REQUEST = 0x8000_0012,
     AP_CREATE = 0x80000013,
     HV_DOORBELL = 0x8000_0014,
+    HV_IPI = 0x8000_0015,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -594,6 +595,12 @@ impl GHCB {
             return Err(GhcbError::VmgexitError(self.rbx.get(), sw_exit_info_2).into());
         }
 
+        Ok(())
+    }
+
+    pub fn hv_ipi(&self, icr: u64) -> Result<(), SvsmError> {
+        self.clear();
+        self.vmgexit(GHCBExitCode::HV_IPI, icr, 0)?;
         Ok(())
     }
 

--- a/kernel/src/sev/msr_protocol.rs
+++ b/kernel/src/sev/msr_protocol.rs
@@ -57,6 +57,7 @@ bitflags! {
         const APIC_ID_LIST            = 1 << 4;
         const SEV_SNP_MULTI_VMPL      = 1 << 5;
         const SEV_PAGE_STATE_CHANGE   = 1 << 6;
+        const SEV_SNP_EXT_INTERRUPTS  = 1 << 7;
     }
 }
 

--- a/kernel/src/sev/status.rs
+++ b/kernel/src/sev/status.rs
@@ -186,6 +186,10 @@ pub fn sev_status_verify() {
 }
 
 impl SEVStatusFlags {
+    pub fn from_sev_features(sev_features: u64) -> Self {
+        SEVStatusFlags::from_bits(sev_features << 2).unwrap()
+    }
+
     pub fn as_sev_features(&self) -> u64 {
         let sev_features = self.bits();
         sev_features >> 2

--- a/kernel/src/sev/vmsa.rs
+++ b/kernel/src/sev/vmsa.rs
@@ -69,6 +69,11 @@ impl GuestCpuState for VMSA {
         vintr_ctrl.v_tpr() << 4
     }
 
+    fn set_tpr(&mut self, tpr: u8) {
+        let mut vintr_ctrl = self.vintr_ctrl;
+        vintr_ctrl.set_v_tpr(tpr >> 4)
+    }
+
     fn queue_interrupt(&mut self, irq: u8) {
         // Schedule the interrupt vector for delivery as a virtual interrupt.
         let mut vintr_ctrl = self.vintr_ctrl;

--- a/kernel/src/sev/vmsa.rs
+++ b/kernel/src/sev/vmsa.rs
@@ -11,6 +11,8 @@ use crate::mm::alloc::{allocate_pages, free_page};
 use crate::types::{PageSize, PAGE_SIZE, PAGE_SIZE_2M};
 use crate::utils::zero_mem_region;
 
+use cpuarch::vmsa::VMSA;
+
 pub const VMPL_MAX: usize = 4;
 
 pub fn allocate_new_vmsa(vmpl: RMPFlags) -> Result<VirtAddr, SvsmError> {
@@ -40,4 +42,19 @@ pub fn free_vmsa(vaddr: VirtAddr) {
     rmp_adjust(vaddr, RMPFlags::RWX | RMPFlags::VMPL0, PageSize::Regular)
         .expect("Failed to free VMSA page");
     free_page(vaddr);
+}
+
+pub trait VMSAControl {
+    fn enable(&mut self);
+    fn disable(&mut self);
+}
+
+impl VMSAControl for VMSA {
+    fn enable(&mut self) {
+        self.efer |= 1u64 << 12;
+    }
+
+    fn disable(&mut self) {
+        self.efer &= !(1u64 << 12);
+    }
 }

--- a/kernel/src/sev/vmsa.rs
+++ b/kernel/src/sev/vmsa.rs
@@ -8,10 +8,11 @@ use super::utils::{rmp_adjust, RMPFlags};
 use crate::address::{Address, VirtAddr};
 use crate::error::SvsmError;
 use crate::mm::alloc::{allocate_pages, free_page};
+use crate::platform::guest_cpu::GuestCpuState;
 use crate::types::{PageSize, PAGE_SIZE, PAGE_SIZE_2M};
 use crate::utils::zero_mem_region;
 
-use cpuarch::vmsa::VMSA;
+use cpuarch::vmsa::{VmsaEventInject, VmsaEventType, VMSA};
 
 pub const VMPL_MAX: usize = 4;
 
@@ -56,5 +57,75 @@ impl VMSAControl for VMSA {
 
     fn disable(&mut self) {
         self.efer &= !(1u64 << 12);
+    }
+}
+
+impl GuestCpuState for VMSA {
+    fn get_tpr(&self) -> u8 {
+        let vintr_ctrl = self.vintr_ctrl;
+
+        // The VMSA holds a 4-bit TPR but this routine must return an 8-bit
+        // TPR to maintain consistency with PPR.
+        vintr_ctrl.v_tpr() << 4
+    }
+
+    fn queue_interrupt(&mut self, irq: u8) {
+        // Schedule the interrupt vector for delivery as a virtual interrupt.
+        let mut vintr_ctrl = self.vintr_ctrl;
+        vintr_ctrl.set_v_intr_vector(irq);
+        vintr_ctrl.set_v_intr_prio(irq >> 4);
+        vintr_ctrl.set_v_ign_tpr(false);
+        vintr_ctrl.set_v_irq(true);
+        self.vintr_ctrl = vintr_ctrl;
+    }
+
+    fn try_deliver_interrupt_immediately(&mut self, irq: u8) -> bool {
+        // Attempt to inject the interrupt immediately using event injection.
+        // If the event injection field already contains a pending event, then
+        // injection is not possible.
+        let event_inj = self.event_inj;
+        if event_inj.valid() {
+            false
+        } else {
+            self.event_inj = VmsaEventInject::new()
+                .with_vector(irq)
+                .with_valid(true)
+                .with_event_type(VmsaEventType::Interrupt);
+            true
+        }
+    }
+
+    fn in_intr_shadow(&self) -> bool {
+        let vintr_ctrl = self.vintr_ctrl;
+        vintr_ctrl.int_shadow()
+    }
+
+    fn interrupts_enabled(&self) -> bool {
+        (self.rflags & 0x200) != 0
+    }
+
+    fn check_and_clear_pending_interrupt_event(&mut self) -> u8 {
+        // Check to see whether the current event injection is for an
+        // interrupt.  If so, clear the pending event..
+        let event_inj = self.event_inj;
+        if event_inj.valid() && event_inj.event_type() == VmsaEventType::Interrupt {
+            self.event_inj = VmsaEventInject::new();
+            event_inj.vector()
+        } else {
+            0
+        }
+    }
+
+    fn check_and_clear_pending_virtual_interrupt(&mut self) -> u8 {
+        // Check to see whether a virtual interrupt is queued for delivery.
+        // If so, clear the virtual interrupt request.
+        let mut vintr_ctrl = self.vintr_ctrl;
+        if vintr_ctrl.v_irq() {
+            vintr_ctrl.set_v_irq(false);
+            self.vintr_ctrl = vintr_ctrl;
+            vintr_ctrl.v_intr_vector()
+        } else {
+            0
+        }
     }
 }

--- a/kernel/src/sev/vmsa.rs
+++ b/kernel/src/sev/vmsa.rs
@@ -9,6 +9,7 @@ use crate::address::{Address, VirtAddr};
 use crate::error::SvsmError;
 use crate::mm::alloc::{allocate_pages, free_page};
 use crate::platform::guest_cpu::GuestCpuState;
+use crate::sev::status::SEVStatusFlags;
 use crate::types::{PageSize, PAGE_SIZE, PAGE_SIZE_2M};
 use crate::utils::zero_mem_region;
 
@@ -132,5 +133,10 @@ impl GuestCpuState for VMSA {
         } else {
             0
         }
+    }
+    fn disable_alternate_injection(&mut self) {
+        let mut sev_status = SEVStatusFlags::from_sev_features(self.sev_features);
+        sev_status.remove(SEVStatusFlags::ALT_INJ);
+        self.sev_features = sev_status.as_sev_features();
     }
 }

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -342,6 +342,7 @@ pub extern "C" fn stage2_main(launch_info: &Stage2LaunchInfo) {
         igvm_params_virt_addr: u64::from(igvm_params_virt_address),
         vtom: launch_info.vtom,
         debug_serial_port: config.debug_serial_port(),
+        use_alternate_injection: config.use_alternate_injection(),
         platform_type,
     };
 

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -45,7 +45,7 @@ use svsm::platform::{SvsmPlatformCell, SVSM_PLATFORM};
 use svsm::requests::{request_loop, request_processing_main, update_mappings};
 use svsm::serial::SerialPort;
 use svsm::sev::utils::{rmp_adjust, RMPFlags};
-use svsm::sev::{init_hypervisor_ghcb_features, secrets_page, secrets_page_mut};
+use svsm::sev::{secrets_page, secrets_page_mut};
 use svsm::svsm_console::SVSMIOPort;
 use svsm::svsm_paging::{init_page_table, invalidate_early_boot_memory};
 use svsm::task::exec_user;
@@ -390,8 +390,6 @@ pub extern "C" fn svsm_main() {
     // Uncomment the line below if you want to wait for
     // a remote GDB connection
     //debug_break();
-
-    init_hypervisor_ghcb_features().expect("Failed to obtain hypervisor GHCB features");
 
     this_cpu()
         .configure_hv_doorbell()

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -371,6 +371,10 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
     let bp = this_cpu().get_top_of_stack();
     log::info!("BSP Runtime stack starts @ {:#018x}", bp);
 
+    platform
+        .configure_alternate_injection(launch_info.use_alternate_injection)
+        .expect("Alternate injection required but not available");
+
     SVSM_PLATFORM
         .init(&platform_cell)
         .expect("Failed to initialize SVSM platform object");


### PR DESCRIPTION
This change includes an APIC emulator and all of the logic required to enable Alternate Injection, including the extensions to the GHCB protocol to accept interrupts from the hypervisor, as well as an SVSM protocol to enable guest interaction with APIC state.

This change does not include support for APIC timers nor INIT/SIPI.  APIC timers will come in a future change.  INIT/SIPI will likely not be implemented for SNP because processor startup is already controlled through the VCPU creation elements of the SVSM Core Protocol.