### PR TITLE
docs: add myself as owner of InstrDec and TdxParaV

### DIFF
--- a/Documentation/docs/developer/DEVELOPMENT-PLAN.md
+++ b/Documentation/docs/developer/DEVELOPMENT-PLAN.md
@@ -369,6 +369,8 @@ partitioning support.
 
 ### [TdxParaV] TDX Paravisor Support
 
+* Owner: Chuanxiao Dong ([@cxdong](https://www.github.com/cxdong)).
+
 Depends on: **ParaV**, **UsrMode.VmmIf**
 
 Implement support for running un-enlightened guest operating systems in an

--- a/Documentation/docs/developer/DEVELOPMENT-PLAN.md
+++ b/Documentation/docs/developer/DEVELOPMENT-PLAN.md
@@ -393,6 +393,8 @@ states.
 
 ### [InstrDec] X86 Instruction Decoder
 
+* Owner: Chuanxiao Dong ([@cxdong](https://www.github.com/cxdong)).
+
 The SVSM needs an instruction decoder to handle events from the guest OS which
 were triggered by specific instructions. An incomplete lists of events:
 


### PR DESCRIPTION
- The initial PR([358](https://github.com/coconut-svsm/svsm/pull/358)) of InstrDec support patches have been submitted from my side, which is to support the instructions used by #VC handlers. The more complex instructions ins/outs/mov will be supported in the future, which is also part of my plans.
- Add myself as the owner of the TdxParaV item, which will implement the TDX paravisor in both the user mode and the kernel mode.