### PR TITLE
platform: Get correct phys addr sizes when not using vtom

### DIFF
--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -57,24 +57,25 @@ impl SvsmPlatform for SnpPlatform {
 
     fn get_page_encryption_masks(&self, vtom: usize) -> PageEncryptionMasks {
         // Find physical address size.
-        let res =
+        let processor_capacity =
             cpuid_table(0x80000008).expect("Can not get physical address size from CPUID table");
         if vtom_enabled() {
             PageEncryptionMasks {
                 private_pte_mask: 0,
                 shared_pte_mask: vtom,
                 addr_mask_width: vtom.leading_zeros(),
-                phys_addr_sizes: res.eax,
+                phys_addr_sizes: processor_capacity.eax,
             }
         } else {
             // Find C-bit position.
-            let res = cpuid_table(0x8000001f).expect("Can not get C-Bit position from CPUID table");
-            let c_bit = res.ebx & 0x3f;
+            let sev_capabilities =
+                cpuid_table(0x8000001f).expect("Can not get C-Bit position from CPUID table");
+            let c_bit = sev_capabilities.ebx & 0x3f;
             PageEncryptionMasks {
                 private_pte_mask: 1 << c_bit,
                 shared_pte_mask: 0,
                 addr_mask_width: c_bit,
-                phys_addr_sizes: res.eax,
+                phys_addr_sizes: processor_capacity.eax,
             }
         }
     }


### PR DESCRIPTION
The physical address sizes come from cpuid Fn8000_0008_EAX but due to a variable shadowing problem, when vtom was disabled it was instead taking it from cpuid Fn8000_001F_EAX.

Fixes: edf38b0c7f ("platform: Calculate PTE masks through platform abstraction")