### PR TITLE
svsm: drop `VmsaRegProt` support, add missing SEV features and other improvements

### DIFF
--- a/igvmbuilder/src/cmd_options.rs
+++ b/igvmbuilder/src/cmd_options.rs
@@ -89,4 +89,8 @@ pub enum SevExtraFeatures {
     DebugSwap,
     PreventHostIBS,
     SNPBTBIsolation,
+    VmplSSS,
+    SecureTscEn,
+    VmsaRegProt,
+    SmtProtection,
 }

--- a/igvmbuilder/src/vmsa.rs
+++ b/igvmbuilder/src/vmsa.rs
@@ -125,6 +125,10 @@ pub fn construct_vmsa(
             SevExtraFeatures::DebugSwap => features.set_debug_swap(true),
             SevExtraFeatures::PreventHostIBS => features.set_prevent_host_ibs(true),
             SevExtraFeatures::SNPBTBIsolation => features.set_snp_btb_isolation(true),
+            SevExtraFeatures::VmplSSS => features.set_vmpl_supervisor_shadow_stack(true),
+            SevExtraFeatures::SecureTscEn => features.set_secure_tsc(true),
+            SevExtraFeatures::VmsaRegProt => features.set_vmsa_reg_protection(true),
+            SevExtraFeatures::SmtProtection => features.set_smt_protection(true),
         }
     }
 

--- a/kernel/src/sev/status.rs
+++ b/kernel/src/sev/status.rs
@@ -22,8 +22,10 @@ bitflags! {
         const DBGSWP        = 1 << 7;
         const PREV_HOST_IBS = 1 << 8;
         const BTB_ISOLATION = 1 << 9;
+        const VMPL_SSS      = 1 << 10;
         const SECURE_TSC    = 1 << 11;
         const VMSA_REG_PROT = 1 << 16;
+        const SMT_PROT      = 1 << 17;
     }
 }
 
@@ -163,7 +165,8 @@ pub fn sev_status_verify() {
         | SEVStatusFlags::REST_INJ
         | SEVStatusFlags::PREV_HOST_IBS
         | SEVStatusFlags::BTB_ISOLATION
-        | SEVStatusFlags::VMSA_REG_PROT;
+        | SEVStatusFlags::VMSA_REG_PROT
+        | SEVStatusFlags::SMT_PROT;
 
     let status = sev_flags();
     let required_check = status & required;

--- a/kernel/src/sev/status.rs
+++ b/kernel/src/sev/status.rs
@@ -165,7 +165,6 @@ pub fn sev_status_verify() {
         | SEVStatusFlags::REST_INJ
         | SEVStatusFlags::PREV_HOST_IBS
         | SEVStatusFlags::BTB_ISOLATION
-        | SEVStatusFlags::VMSA_REG_PROT
         | SEVStatusFlags::SMT_PROT;
 
     let status = sev_flags();

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -45,7 +45,7 @@ use svsm::platform::{SvsmPlatformCell, SVSM_PLATFORM};
 use svsm::requests::{request_loop, request_processing_main, update_mappings};
 use svsm::serial::SerialPort;
 use svsm::sev::utils::{rmp_adjust, RMPFlags};
-use svsm::sev::{init_hypervisor_ghcb_features, secrets_page, secrets_page_mut, sev_status_init};
+use svsm::sev::{init_hypervisor_ghcb_features, secrets_page, secrets_page_mut};
 use svsm::svsm_console::SVSMIOPort;
 use svsm::svsm_paging::{init_page_table, invalidate_early_boot_memory};
 use svsm::task::exec_user;
@@ -309,7 +309,7 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
     cr0_init();
     cr4_init();
     efer_init();
-    sev_status_init();
+    platform.env_setup();
 
     memory_init(&launch_info);
     migrate_valid_bitmap().expect("Failed to migrate valid-bitmap");
@@ -362,6 +362,8 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
     install_console_logger("SVSM").expect("Console logger already initialized");
 
     log::info!("COCONUT Secure Virtual Machine Service Module (SVSM)");
+
+    platform.env_setup_late();
 
     let mem_info = memory_info();
     print_memory_info(&mem_info);

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -300,7 +300,6 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
     let platform = platform_cell.as_mut_dyn_ref();
 
     init_cpuid_table(VirtAddr::from(launch_info.cpuid_page));
-    dump_cpuid_table();
 
     let secrets_page_virt = VirtAddr::from(launch_info.secrets_page);
     secrets_page_mut().copy_from(secrets_page_virt);
@@ -363,6 +362,7 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
 
     log::info!("COCONUT Secure Virtual Machine Service Module (SVSM)");
 
+    dump_cpuid_table();
     platform.env_setup_late();
 
     let mem_info = memory_info();


### PR DESCRIPTION
* Add missing SEV feature definitions to the kernel and igvmbuilder.
* Get SEV features via the platform API
* Check SEV features in the SVSM kernel again, since we reload them.
* Dump CPUID table after logging is enabled.
* Initialize `reg_prot_nonce` if `VmsaRegProt` is enabled.