### PR TITLE
svsm: pass the memory map to guest firmware

### DIFF
--- a/bootlib/src/igvm_params.rs
+++ b/bootlib/src/igvm_params.rs
@@ -69,6 +69,14 @@ pub struct IgvmParamBlockFwInfo {
     /// CPUID page.
     pub cpuid_page: u32,
 
+    /// The guest physical address of the IGVM memory map consumed by the
+    /// guest firmware.
+    pub memory_map_page: u32,
+
+    /// The number of pages reserved for the IGVM memory map consumed by the
+    /// guest firmware.
+    pub memory_map_page_count: u32,
+
     /// The number of prevalidated memory regions defined by the firmware.
     pub prevalidated_count: u32,
 

--- a/kernel/src/config.rs
+++ b/kernel/src/config.rs
@@ -95,6 +95,12 @@ impl SvsmConfig<'_> {
             SvsmConfig::IgvmConfig(igvm_params) => igvm_params.get_memory_regions(),
         }
     }
+    pub fn write_guest_memory_map(&self, map: &[MemoryRegion<PhysAddr>]) -> Result<(), SvsmError> {
+        match self {
+            SvsmConfig::FirmwareConfig(_) => Ok(()),
+            SvsmConfig::IgvmConfig(igvm_params) => igvm_params.write_guest_memory_map(map),
+        }
+    }
     pub fn reserved_kernel_area_size(&self) -> usize {
         match self {
             SvsmConfig::FirmwareConfig(_) => 0,

--- a/kernel/src/mm/memory.rs
+++ b/kernel/src/mm/memory.rs
@@ -91,6 +91,11 @@ pub fn init_memory_map(
     Ok(())
 }
 
+pub fn write_guest_memory_map(config: &SvsmConfig<'_>) -> Result<(), SvsmError> {
+    // Supply the memory map to the guest if required by the configuration.
+    config.write_guest_memory_map(&MEMORY_MAP.lock_read())
+}
+
 /// Returns `true` if the provided physical address `paddr` is valid, i.e.
 /// it is within the configured memory regions, otherwise returns `false`.
 pub fn valid_phys_address(paddr: PhysAddr) -> bool {

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -37,7 +37,7 @@ use svsm::greq::driver::guest_request_driver_init;
 use svsm::igvm_params::IgvmParams;
 use svsm::kernel_region::new_kernel_region;
 use svsm::mm::alloc::{memory_info, print_memory_info, root_mem_init};
-use svsm::mm::memory::init_memory_map;
+use svsm::mm::memory::{init_memory_map, write_guest_memory_map};
 use svsm::mm::pagetable::paging_init;
 use svsm::mm::virtualrange::virt_log_usage;
 use svsm::mm::{init_kernel_mapping_info, PerCPUPageMappingGuard};
@@ -435,6 +435,7 @@ pub extern "C" fn svsm_main() {
     let fw_metadata = config.get_fw_metadata();
     if let Some(ref fw_meta) = fw_metadata {
         print_fw_meta(fw_meta);
+        write_guest_memory_map(&config).expect("Failed to write guest memory map");
         validate_fw_memory(&config, fw_meta, &LAUNCH_INFO).expect("Failed to validate memory");
         copy_tables_to_fw(fw_meta).expect("Failed to copy firmware tables");
         validate_fw(&config, &LAUNCH_INFO).expect("Failed to validate flash memory");


### PR DESCRIPTION
This change permits the SVSM kernel to adjust the memory map according to its own needs before passing it to the guest firmware.  This is necessary in case the SVSM requires additional memory beyond the SVSM carveout based on runtime state, such as the total amount of memory in the VM.  The memory map is presented in IGVM format, and its location is specified in the IGVM parameters established when the SVSM IGVM file is built.