### PR TITLE
Only ignore the top level bin and target dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,8 @@
 *.elf
 *.swp
 *~
-bin/
-target/
+/bin/
+/target/
 gen_meta
 stage1/stage1
 stage1/stage1-test


### PR DESCRIPTION
The bin/ and target/ directories in the repo-relative root are irrelevant to change management, but vendor/*/src/{bin,target} are relavent to checked-in repos that use `cargo vendor` to track dependendies.