### PR TITLE
Make read/write methods from GuestPtr unsafe, and copy_{from, to} methods from SecretsPage as well 

### DIFF
--- a/kernel/src/cpu/vc.rs
+++ b/kernel/src/cpu/vc.rs
@@ -272,7 +272,10 @@ fn vc_decode_insn(ctx: &X86ExceptionContext) -> Result<Option<DecodedInsnCtx>, S
     // rip and rip+15 addresses should belong to a mapped page.
     // To ensure this, we rely on GuestPtr::read() that uses the exception table
     // to handle faults while fetching.
-    let insn_raw = rip.read()?;
+    // SAFETY: we trust the CPU-provided register state to be valid. Thus, RIP
+    // will point to the instruction that caused #VC to be raised, so it can
+    // safely be read.
+    let insn_raw = unsafe { rip.read()? };
 
     let insn = Instruction::new(insn_raw);
     Ok(Some(insn.decode(ctx)?))

--- a/kernel/src/igvm_params.rs
+++ b/kernel/src/igvm_params.rs
@@ -196,29 +196,35 @@ impl IgvmParams<'_> {
                 return Err(SvsmError::Firmware);
             }
 
-            mem_map
-                .offset(i as isize)
-                .write(IGVM_VHS_MEMORY_MAP_ENTRY {
+            mem_map.offset(i as isize);
+            // SAFETY: mem_map_va points to newly mapped memory, whose physical
+            // address is defined in the IGVM config.
+            unsafe {
+                mem_map.write(IGVM_VHS_MEMORY_MAP_ENTRY {
                     starting_gpa_page_number: u64::from(entry.start()) / PAGE_SIZE as u64,
                     number_of_pages: entry.len() as u64 / PAGE_SIZE as u64,
                     entry_type: MemoryMapEntryType::default(),
                     flags: 0,
                     reserved: 0,
                 })?;
+            }
         }
 
         // Write a zero page count into the last entry to terminate the list.
         let index = map.len();
         if index < max_entries {
-            mem_map
-                .offset(index as isize)
-                .write(IGVM_VHS_MEMORY_MAP_ENTRY {
+            mem_map.offset(index as isize);
+            // SAFETY: mem_map_va points to newly mapped memory, whose physical
+            // address is defined in the IGVM config.
+            unsafe {
+                mem_map.write(IGVM_VHS_MEMORY_MAP_ENTRY {
                     starting_gpa_page_number: 0,
                     number_of_pages: 0,
                     entry_type: MemoryMapEntryType::default(),
                     flags: 0,
                     reserved: 0,
                 })?;
+            }
         }
 
         Ok(())

--- a/kernel/src/mm/guestmem.rs
+++ b/kernel/src/mm/guestmem.rs
@@ -39,9 +39,20 @@ pub fn read_u8(v: VirtAddr) -> Result<u8, SvsmError> {
     }
 }
 
+/// Writes 1 byte at a virtual address.
+///
+/// # Safety
+///
+/// The caller must verify not to corrupt arbitrary memory, as this function
+/// doesn't make any checks in that regard.
+///
+/// # Returns
+///
+/// Returns an error if the specified address is not mapped or is not mapped
+/// with the appropriate write permissions.
 #[allow(dead_code)]
 #[inline]
-pub fn write_u8(v: VirtAddr, val: u8) -> Result<(), SvsmError> {
+pub unsafe fn write_u8(v: VirtAddr, val: u8) -> Result<(), SvsmError> {
     let mut rcx: u64;
 
     unsafe {
@@ -244,7 +255,10 @@ mod tests {
         let test_address = VirtAddr::from(test_buffer.as_mut_ptr());
         let data_to_write = 0x42;
 
-        write_u8(test_address, data_to_write).unwrap();
+        // SAFETY: test_address points to the virtual address of test_buffer.
+        unsafe {
+            write_u8(test_address, data_to_write).unwrap();
+        }
 
         assert_eq!(test_buffer[0], data_to_write);
     }

--- a/kernel/src/requests.rs
+++ b/kernel/src/requests.rs
@@ -120,8 +120,19 @@ fn check_requests() -> Result<bool, SvsmReqError> {
     let vmsa_ref = cpu.guest_vmsa_ref();
     if let Some(caa_addr) = vmsa_ref.caa_addr() {
         let calling_area = GuestPtr::<SvsmCaa>::new(caa_addr);
-        let caa = calling_area.read()?;
-        calling_area.write(caa.serviced())?;
+        // SAFETY: guest vmsa and ca are always validated before beeing updated
+        // (core_remap_ca(), core_create_vcpu() or prepare_fw_launch()) so
+        // they're safe to use.
+        let caa = unsafe { calling_area.read()? };
+
+        let caa_serviced = caa.serviced();
+
+        // SAFETY: guest vmsa is always validated before beeing updated
+        // (core_remap_ca() or core_create_vcpu()) so it's safe to use.
+        unsafe {
+            calling_area.write(caa_serviced)?;
+        }
+
         Ok(caa.call_pending != 0)
     } else {
         Ok(false)

--- a/kernel/src/sev/secrets_page.rs
+++ b/kernel/src/sev/secrets_page.rs
@@ -37,7 +37,7 @@ pub struct SecretsPage {
 
 impl SecretsPage {
     pub const fn new() -> Self {
-        SecretsPage {
+        Self {
             version: 0,
             gctxt: 0,
             fms: 0,
@@ -57,7 +57,13 @@ impl SecretsPage {
         }
     }
 
-    pub fn copy_from(&mut self, source: VirtAddr) {
+    /// Copy secrets page's content pointed by a [`VirtAddr`]
+    ///
+    /// # Safety
+    ///
+    /// The caller should verify that `source` points to mapped memory whose
+    /// size is at least the size of the [`SecretsPage`] structure.
+    pub unsafe fn copy_from(&mut self, source: VirtAddr) {
         let from = source.as_ptr::<SecretsPage>();
 
         unsafe {
@@ -65,7 +71,16 @@ impl SecretsPage {
         }
     }
 
-    pub fn copy_to(&self, target: VirtAddr) {
+    /// Copy a secrets page's content to memory pointed by a [`VirtAddr`]
+    ///
+    /// # Safety
+    ///
+    /// The caller should verify that `target` points to mapped memory whose
+    /// size is at least the size of the [`SecretsPage`] structure.
+    ///
+    /// The caller should verify not to corrupt arbitrary memory, as this function
+    /// doesn't make any checks in that regard.
+    pub unsafe fn copy_to(&self, target: VirtAddr) {
         let to = target.as_mut_ptr::<SecretsPage>();
 
         unsafe {


### PR DESCRIPTION
Leaving as draft because I still have doubts.

Providing partial fix for #359 (tasks 7, 8, 9).

My two interrogations are:

1. There are several uses of the following pattern:
```rust
    let guard = PerCPUPageMappingGuard::create_4k(paddr)?; // paddr possibly guest or HV controlled
    let start = guard.virt_addr();
    let guest_page = GuestPtr::<Tt>::new(start + offset);
    let mut request = unsafe { guest_page.read()? };
``` 
As already discussed with @00xc, if `start + offset` is valid but `start + offset + size_of::<T>` ends on an unmapped page or on an adjacent page belonging to another guest or the SVSM kernel (I don't really know if it's possible), `read()` could raise a #PF and possibly return an error and panicking, or reading content from an unauthorized page. If such scenarii are possible, we should either:
- check that `start +  offset + size_of::<T>` doesn't cross the page end
- allow `GuestPtr::read()/write()` for partial read/write
- more general, we should always check that a guest or the HV can't force `GuestPtr::read()/write()` to return an error that will be treated as a fatal error by the SVSM kernel (that would be valid DoS).

2. In some core protocol handlers, a guest provides a physical address (example the [pvalidate](https://github.com/coconut-svsm/svsm/blob/75b83b3e1a5c860a84ccfe0e4b503e7efee5834f/kernel/src/protocols/core.rs#L312) handler), if I understand the code correctly, the guest-provided physical address pointing to the request entries is only verified if it's mapped or not. My understanding is that a guest could make the kernel read at any mapped address to fetch the `PValidateRequest` (including the kernel memory). Moreover, the guest-provided entries suffer from the same issue, the `paddr` to pvalidate are only verified to be mapped. A guest could make the SVSM kernel pvalidate any page. For the core protocol handlers that work with guest-provided paddrs, my understanding is that we should validate that paddrs only belong to the guest's memory region. I left TODOs is some places (not all of them) to points where there is this issue.
