### PR TITLE
igvmbuilder: remove firmware field in GpaMap

### DIFF
--- a/igvmbuilder/src/gpa_map.rs
+++ b/igvmbuilder/src/gpa_map.rs
@@ -62,7 +62,6 @@ pub struct GpaMap {
     pub general_params: GpaRange,
     pub memory_map: GpaRange,
     pub guest_context: GpaRange,
-    pub firmware: GpaRange,
     pub kernel: GpaRange,
     pub vmsa: GpaRange,
 }
@@ -172,7 +171,6 @@ impl GpaMap {
             general_params,
             memory_map,
             guest_context,
-            firmware: firmware_range,
             kernel,
             vmsa,
         };


### PR DESCRIPTION
The firmware field of GpaMap was initialized once but never read. This raises a warning in the last clippy release.