### PR TITLE
cpu/percpu: store LocalApic in an Option

### DIFF
--- a/kernel/src/protocols/core.rs
+++ b/kernel/src/protocols/core.rs
@@ -216,7 +216,7 @@ fn core_query_protocol(params: &mut RequestParams) -> Result<(), SvsmReqError> {
         APIC_PROTOCOL => {
             // The APIC protocol is only supported if the calling CPU supports
             // alternate injection.
-            if this_cpu().use_apic_emulation() {
+            if this_cpu().apic().is_some() {
                 protocol_supported(
                     version,
                     APIC_PROTOCOL_VERSION_MIN,


### PR DESCRIPTION
Instead of having a separate boolean variable indicating whether APIC emulation is enabled, simply store the `LocalApic` type in an `Option`. When APIC emulation is enabled, the field in the `PerCpu` structure will contain a `Some(LocalApic)`, and a `None` otherwise. This enforces at the type level a consistent state of APIC emulation and removes duplicate checks for such state.