### PR TITLE
cpu/percpu: store safe references to HV doorbell page and SVSM VMSA

### DIFF
--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -110,7 +110,7 @@ pub fn idt_init() {
     // that uses the value is not type safe in any case, so enforcing type
     // safety on the pointer would offer no meaningful value.
     unsafe {
-        HV_DOORBELL_ADDR = this_cpu().hv_doorbell_addr();
+        HV_DOORBELL_ADDR = this_cpu().hv_doorbell_addr() as usize;
     };
 }
 

--- a/kernel/src/cpu/smp.rs
+++ b/kernel/src/cpu/smp.rs
@@ -6,6 +6,7 @@
 
 use crate::acpi::tables::ACPICPUInfo;
 use crate::cpu::percpu::{current_ghcb, this_cpu, this_cpu_shared, PerCpu};
+use crate::error::SvsmError;
 use crate::platform::SvsmPlatform;
 use crate::platform::SVSM_PLATFORM;
 use crate::requests::{request_loop, request_processing_main};
@@ -13,16 +14,12 @@ use crate::sev::vmsa::VMSAControl;
 use crate::task::{create_kernel_task, schedule_init};
 use crate::utils::immut_after_init::immut_after_init_set_multithreaded;
 
-fn start_cpu(platform: &dyn SvsmPlatform, apic_id: u32, vtom: u64) {
+fn start_cpu(platform: &dyn SvsmPlatform, apic_id: u32, vtom: u64) -> Result<(), SvsmError> {
     let start_rip: u64 = (start_ap as *const u8) as u64;
-    let percpu = PerCpu::alloc(apic_id).expect("Failed to allocate AP per-cpu data");
+    let percpu = PerCpu::alloc(apic_id)?;
 
-    percpu
-        .setup(platform)
-        .expect("Failed to setup AP per-cpu area");
-    let mut vmsa = percpu
-        .alloc_svsm_vmsa(vtom, start_rip)
-        .expect("Failed to allocate AP SVSM VMSA");
+    percpu.setup(platform)?;
+    let mut vmsa = percpu.alloc_svsm_vmsa(vtom, start_rip)?;
 
     let sev_features = vmsa.vmsa().sev_features;
     let vmsa_pa = vmsa.paddr;
@@ -30,14 +27,9 @@ fn start_cpu(platform: &dyn SvsmPlatform, apic_id: u32, vtom: u64) {
     let percpu_shared = percpu.shared();
 
     vmsa.vmsa_mut().enable();
-    current_ghcb()
-        .ap_create(vmsa_pa, apic_id.into(), 0, sev_features)
-        .expect("Failed to launch secondary CPU");
-    loop {
-        if percpu_shared.is_online() {
-            break;
-        }
-    }
+    current_ghcb().ap_create(vmsa_pa, apic_id.into(), 0, sev_features)?;
+    while !percpu_shared.is_online() {}
+    Ok(())
 }
 
 pub fn start_secondary_cpus(platform: &dyn SvsmPlatform, cpus: &[ACPICPUInfo], vtom: u64) {
@@ -45,7 +37,7 @@ pub fn start_secondary_cpus(platform: &dyn SvsmPlatform, cpus: &[ACPICPUInfo], v
     let mut count: usize = 0;
     for c in cpus.iter().filter(|c| c.apic_id != 0 && c.enabled) {
         log::info!("Launching AP with APIC-ID {}", c.apic_id);
-        start_cpu(platform, c.apic_id, vtom);
+        start_cpu(platform, c.apic_id, vtom).expect("Failed to bring CPU online");
         count += 1;
     }
     log::info!("Brought {} AP(s) online", count);

--- a/kernel/src/sev/hv_doorbell.rs
+++ b/kernel/src/sev/hv_doorbell.rs
@@ -134,12 +134,15 @@ impl HVDoorbell {
     }
 }
 
+/// Gets the HV doorbell page configured for this CPU.
+///
+/// # Panics
+///
+/// Panics if te HV doorbell page has not been set up beforehand.
 pub fn current_hv_doorbell() -> &'static HVDoorbell {
-    let hv_doorbell_ptr = this_cpu().hv_doorbell_unsafe();
-    if hv_doorbell_ptr.is_null() {
-        panic!("HV doorbell page dereferenced before allocating");
-    }
-    unsafe { &*hv_doorbell_ptr }
+    this_cpu()
+        .hv_doorbell()
+        .expect("HV doorbell page dereferenced before allocating")
 }
 
 /// # Safety


### PR DESCRIPTION
* Store a safe reference to the HV doorbell in the PerCpu
* Cleanups and add some documentation
* Store a safe reference to the SVSM VMSA in the PerCpu