### PR TITLE
INSTALL.md: fix unit tests instructions

### DIFF
--- a/Documentation/docs/installation/INSTALL.md
+++ b/Documentation/docs/installation/INSTALL.md
@@ -236,7 +236,16 @@ $ make test
 Unit tests can be run inside the SVSM by
 
 ```
-$ QEMU=/path/to/qemu OVMF=/path/to/firmware/ make test-in-svsm
+$ QEMU=/path/to/qemu make test-in-svsm
+```
+
+Note: to compile the test kernel used for unit tests, we use the nightly
+toolchain, so if the test kernel build fails, try installing the
+`x86_64-unknown-none` target for the nightly toolchain via your distro or
+using rustup:
+
+```
+$ rustup +nightly target add x86_64-unknown-none
 ```
 
 Different (non-QEMU) hypervisors may provide the ACPI tables and ACPI RSDP at


### PR DESCRIPTION
The OVMF variable is now unnecessary since the firmware will eventually be embedded in the IGVM file.

Let's also add a note to clarify that we need to install the target `x86_64-unknown-none` for the nightly toolchain to avoid the following error:

    $ QEMU=/path/to/qemu-system-x86_64 make test-in-svsm
    ...
    LINK_TEST=1 cargo +nightly test  -p svsm --config 'target.x86_64-unknown-none.runner=["sh", "-c", "cp $0 ../target/x86_64-unknown-none/debug/svsm-test"]'
    error[E0463]: can't find crate for `core`
      |
      = note: the `x86_64-unknown-none` target may not be installed
      = help: consider downloading the target with `rustup target add x86_64-unknown-none`
      = help: consider building the standard library from source with `cargo build -Zbuild-std`