### PR TITLE
igvmmeasure: Implement launch measurement calculation for SEV and SEV-ES

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,12 +477,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hmac-sha512"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ce1f4656bae589a3fab938f9f09bf58645b7ed01a2c5f8a3c238e01a4ef78a"
-
-[[package]]
 name = "igvm"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,10 +522,10 @@ name = "igvmmeasure"
 version = "0.1.0"
 dependencies = [
  "clap",
- "hmac-sha512",
  "igvm",
  "igvm_defs",
  "p384",
+ "sha2",
  "zerocopy",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ bitflags = "2.4"
 clap = { version = "4.4.14", default-features = false}
 gdbstub = { version = "0.6.6", default-features = false }
 gdbstub_arch = { version = "0.2.4" }
-hmac-sha512 = "1.1.5"
+sha2 = "0.10.8"
 igvm_defs = { version = "0.3.2", default-features = false}
 igvm = { version = "0.3.2", default-features = false}
 intrusive-collections = "0.9.6"

--- a/igvmmeasure/Cargo.toml
+++ b/igvmmeasure/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # see https://doc.rust-lang.org/cargo/reference/features.html#feature-unification
 [target.'cfg(all(target_os = "linux"))'.dependencies]
 clap = { workspace = true, default-features = true, features = ["derive"] }
-hmac-sha512.workspace = true
+sha2.workspace = true
 igvm.workspace = true
 igvm_defs.workspace = true
 p384.workspace = true

--- a/igvmmeasure/src/cmd_options.rs
+++ b/igvmmeasure/src/cmd_options.rs
@@ -85,6 +85,10 @@ pub enum Commands {
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
 pub enum Platform {
+    /// Calculate the launch measurement for SEV
+    Sev,
+    /// Calculate the launch measurement for SEV-ES
+    SevEs,
     /// Calculate the launch measurement for SEV-SNP
     SevSnp,
 }

--- a/igvmmeasure/src/id_block.rs
+++ b/igvmmeasure/src/id_block.rs
@@ -39,12 +39,14 @@ pub struct SevIdBlockBuilder {
 
 impl SevIdBlockBuilder {
     pub fn build(igvm: &IgvmFile, measure: &IgvmMeasure) -> Result<Self, Box<dyn Error>> {
-        let ld = measure.digest();
         let compatibility_mask = get_compatibility_mask(igvm, IgvmPlatformType::SEV_SNP).ok_or(
             String::from("IGVM file is not compatible with the specified platform."),
         )?;
         let policy = get_policy(igvm, compatibility_mask)
             .ok_or(String::from("IGVM file does not contain a guest policy."))?;
+
+        let mut ld = [0u8; 48];
+        ld.copy_from_slice(measure.digest());
 
         Ok(Self {
             compatibility_mask,

--- a/igvmmeasure/src/page_info.rs
+++ b/igvmmeasure/src/page_info.rs
@@ -4,7 +4,7 @@
 //
 // Author: Roy Hopkins <roy.hopkins@suse.com>
 
-use hmac_sha512::sha384::Hash;
+use sha2::{Digest, Sha384};
 use zerocopy::AsBytes;
 
 #[repr(u8)]
@@ -35,9 +35,11 @@ pub struct PageInfo {
 
 impl PageInfo {
     pub fn new_normal_page(digest_cur: [u8; 48], gpa: u64, data: &Vec<u8>) -> Self {
+        let mut sha384 = Sha384::default();
+        sha384.update(data);
         Self {
             digest_cur,
-            contents: Hash::hash(data),
+            contents: sha384.finalize().into(),
             length: 0x70,
             page_type: PageType::Normal,
             imi_page: 0,
@@ -50,9 +52,11 @@ impl PageInfo {
     }
 
     pub fn new_vmsa_page(digest_cur: [u8; 48], gpa: u64, data: &Vec<u8>) -> Self {
+        let mut sha384 = Sha384::default();
+        sha384.update(data);
         Self {
             digest_cur,
-            contents: Hash::hash(data),
+            contents: sha384.finalize().into(),
             length: 0x70,
             page_type: PageType::Vmsa,
             imi_page: 0,
@@ -96,6 +100,8 @@ impl PageInfo {
     }
 
     pub fn update_hash(&self) -> [u8; 48] {
-        Hash::hash(self.as_bytes())
+        let mut sha384 = Sha384::default();
+        sha384.update(self.as_bytes());
+        sha384.finalize().into()
     }
 }


### PR DESCRIPTION
This PR adds implements calculation of the expected launch measurement for IGVM files that target the SEV and SEV-ES platforms.

Although not needed for COCONUT-SVSM itself as this always requires SEV-SNP, these changes are required to support the testing of the QEMU IGVM patch series, which supports all flavours of SEV.

As part of this, the create previously used for the SHA-384 implementation has been replaced with the RustCrypto equivalent. As well as providing SHA-256 implementation as part of the same library (which the previous one did not), this provides consistency in use of RustCrypto with other cryptographic crates we are already using in COCONUT.