### PR TITLE
Add instruction decoding and emulating support for IOIO instructions

### DIFF
--- a/fuzz/fuzz_targets/insn.rs
+++ b/fuzz/fuzz_targets/insn.rs
@@ -12,7 +12,13 @@ fuzz_target!(|input: &[u8]| -> Corpus {
     data.copy_from_slice(input);
 
     let insn = Instruction::new(data);
-    let _ = core::hint::black_box(insn.decode(&TestCtx));
+    let _ = core::hint::black_box({
+        let mut ctx = TestCtx::default();
+        match insn.decode(&ctx) {
+            Ok(insn_ctx) => insn_ctx.emulate(&mut ctx),
+            Err(e) => Err(e),
+        }
+    });
 
     Corpus::Keep
 });

--- a/kernel/src/cpu/efer.rs
+++ b/kernel/src/cpu/efer.rs
@@ -10,6 +10,7 @@ use crate::platform::SvsmPlatform;
 use bitflags::bitflags;
 
 bitflags! {
+    #[derive(Clone, Copy, Debug)]
     pub struct EFERFlags: u64 {
         const SCE   = 1 << 0;  // System Call Extensions
         const LME   = 1 << 8;  // Long Mode Enable

--- a/kernel/src/cpu/idt/common.rs
+++ b/kernel/src/cpu/idt/common.rs
@@ -44,6 +44,18 @@ pub const PF_ERROR_WRITE: usize = 2;
 
 pub const INT_INJ_VECTOR: usize = 0x50;
 
+bitflags::bitflags! {
+    /// Page fault error code flags.
+    #[derive(Clone, Copy, Debug, PartialEq)]
+    pub struct PageFaultError :u32 {
+        const P     = 1 << 0;
+        const W     = 1 << 1;
+        const U     = 1 << 2;
+        const R     = 1 << 3;
+        const I     = 1 << 4;
+    }
+}
+
 #[repr(C, packed)]
 #[derive(Default, Debug, Clone, Copy)]
 pub struct X86ExceptionContext {

--- a/kernel/src/cpu/idt/common.rs
+++ b/kernel/src/cpu/idt/common.rs
@@ -9,7 +9,7 @@ use crate::cpu::control_regs::{read_cr0, read_cr4};
 use crate::cpu::efer::read_efer;
 use crate::cpu::gdt::gdt;
 use crate::cpu::registers::{X86GeneralRegs, X86InterruptFrame};
-use crate::insn_decode::{InsnMachineCtx, SegRegister};
+use crate::insn_decode::{InsnMachineCtx, Register, SegRegister};
 use crate::locking::{RWLock, ReadLockGuard, WriteLockGuard};
 use crate::types::SVSM_CS;
 use core::arch::{asm, global_asm};
@@ -70,6 +70,58 @@ impl InsnMachineCtx for X86ExceptionContext {
 
     fn read_cr4(&self) -> u64 {
         read_cr4().bits()
+    }
+
+    fn read_reg(&self, reg: Register) -> usize {
+        match reg {
+            Register::Rax => self.regs.rax,
+            Register::Rdx => self.regs.rdx,
+            Register::Rcx => self.regs.rcx,
+            Register::Rbx => self.regs.rdx,
+            Register::Rsp => self.frame.rsp,
+            Register::Rbp => self.regs.rbp,
+            Register::Rdi => self.regs.rdi,
+            Register::Rsi => self.regs.rsi,
+            Register::R8 => self.regs.r8,
+            Register::R9 => self.regs.r9,
+            Register::R10 => self.regs.r10,
+            Register::R11 => self.regs.r11,
+            Register::R12 => self.regs.r12,
+            Register::R13 => self.regs.r13,
+            Register::R14 => self.regs.r14,
+            Register::R15 => self.regs.r15,
+            Register::Rip => self.frame.rip,
+        }
+    }
+
+    fn read_flags(&self) -> usize {
+        self.frame.flags
+    }
+
+    fn write_reg(&mut self, reg: Register, val: usize) {
+        match reg {
+            Register::Rax => self.regs.rax = val,
+            Register::Rdx => self.regs.rdx = val,
+            Register::Rcx => self.regs.rcx = val,
+            Register::Rbx => self.regs.rdx = val,
+            Register::Rsp => self.frame.rsp = val,
+            Register::Rbp => self.regs.rbp = val,
+            Register::Rdi => self.regs.rdi = val,
+            Register::Rsi => self.regs.rsi = val,
+            Register::R8 => self.regs.r8 = val,
+            Register::R9 => self.regs.r9 = val,
+            Register::R10 => self.regs.r10 = val,
+            Register::R11 => self.regs.r11 = val,
+            Register::R12 => self.regs.r12 = val,
+            Register::R13 => self.regs.r13 = val,
+            Register::R14 => self.regs.r14 = val,
+            Register::R15 => self.regs.r15 = val,
+            Register::Rip => self.frame.rip = val,
+        }
+    }
+
+    fn read_cpl(&self) -> usize {
+        self.frame.cs & 3
     }
 }
 

--- a/kernel/src/cpu/registers.rs
+++ b/kernel/src/cpu/registers.rs
@@ -61,3 +61,28 @@ bitflags! {
         const G     = 1 << 55;
     }
 }
+
+bitflags! {
+    #[derive(Clone, Copy, Debug)]
+    pub struct RFlags: usize {
+        const CF    = 1 << 0;
+        const FIXED = 1 << 1;
+        const PF    = 1 << 2;
+        const AF    = 1 << 4;
+        const ZF    = 1 << 6;
+        const SF    = 1 << 7;
+        const TF    = 1 << 8;
+        const IF    = 1 << 9;
+        const DF    = 1 << 10;
+        const OF    = 1 << 11;
+        const IOPL  = 3 << 12;
+        const NT    = 1 << 14;
+        const MD    = 1 << 15;
+        const RF    = 1 << 16;
+        const VM    = 1 << 17;
+        const AC    = 1 << 18;
+        const VIF   = 1 << 19;
+        const VIP   = 1 << 20;
+        const ID    = 1 << 21;
+    }
+}

--- a/kernel/src/insn_decode/decode.rs
+++ b/kernel/src/insn_decode/decode.rs
@@ -39,13 +39,16 @@
 // https://github.com/projectacrn/acrn-hypervisor/blob/master/hypervisor/
 // arch/x86/guest/instr_emul.c
 
+extern crate alloc;
+
 use super::insn::{DecodedInsn, Immediate, Operand, MAX_INSN_SIZE};
 use super::opcode::{OpCodeClass, OpCodeDesc, OpCodeFlags};
 use super::{InsnError, Register, SegRegister};
 use crate::cpu::control_regs::{CR0Flags, CR4Flags};
 use crate::cpu::efer::EFERFlags;
-use crate::cpu::registers::SegDescAttrFlags;
+use crate::cpu::registers::{RFlags, SegDescAttrFlags};
 use crate::types::Bytes;
+use alloc::boxed::Box;
 use bitflags::bitflags;
 
 /// Represents the raw bytes of an instruction and
@@ -143,6 +146,98 @@ pub trait InsnMachineCtx: core::fmt::Debug {
     fn read_cr0(&self) -> u64;
     /// Read CR4 register
     fn read_cr4(&self) -> u64;
+
+    /// Read a register
+    fn read_reg(&self, _reg: Register) -> usize {
+        unimplemented!("Reading register is not implemented");
+    }
+
+    /// Read rflags register
+    fn read_flags(&self) -> usize {
+        unimplemented!("Reading flags is not implemented");
+    }
+
+    /// Write a register
+    fn write_reg(&mut self, _reg: Register, _val: usize) {
+        unimplemented!("Writing register is not implemented");
+    }
+
+    /// Read the current privilege level
+    fn read_cpl(&self) -> usize {
+        unimplemented!("Reading CPL is not implemented");
+    }
+
+    /// Map the given linear address region to a machine memory object
+    /// which provides access to the memory of this linear address region.
+    ///
+    /// # Arguments
+    ///
+    /// * `la` - The linear address of the region to map.
+    /// * `write` - Whether write access is allowed to the mapped region.
+    /// * `fetch` - Whether fetch access is allowed to the mapped region.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing a boxed trait object representing the mapped
+    /// memory, or an `InsnError` if mapping fails.
+    fn map_linear_addr<T: Copy + 'static>(
+        &self,
+        _la: usize,
+        _write: bool,
+        _fetch: bool,
+    ) -> Result<Box<dyn InsnMachineMem<Item = T>>, InsnError> {
+        Err(InsnError::MapLinearAddr)
+    }
+
+    /// Check IO permission bitmap.
+    ///
+    /// # Arguments
+    ///
+    /// * `port` - The I/O port to check.
+    /// * `size` - The size of the I/O operation.
+    /// * `io_read` - Whether the I/O operation is a read operation.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing true if the port is permitted otherwise false.
+    fn ioio_perm(&self, _port: u16, _size: Bytes, _io_read: bool) -> bool {
+        unimplemented!("Checking IO permission bitmap is not implemented");
+    }
+
+    /// Handle an I/O out operation.
+    ///
+    /// # Arguments
+    ///
+    /// * `port` - The I/O port to write to.
+    /// * `size` - The size of the data to write.
+    /// * `data` - The data to write to the I/O port.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` indicating success or an `InsnError` if the operation fails.
+    fn ioio_out(&mut self, _port: u16, _size: Bytes, _data: u64) -> Result<(), InsnError> {
+        Err(InsnError::IoIoOut)
+    }
+}
+
+/// Trait representing a machine memory for instruction decoding.
+pub trait InsnMachineMem {
+    type Item;
+
+    /// Read data from the memory at the specified offset.
+    ///
+    /// # Safety
+    ///
+    /// The caller must verify not to read data from arbitrary memory. The object implements this
+    /// trait should guarantee the memory region is readable.
+    ///
+    /// # Returns
+    ///
+    /// Returns the read data on success, or an `InsnError` if the read
+    /// operation fails.
+    unsafe fn mem_read(&self) -> Result<Self::Item, InsnError> {
+        Err(InsnError::MemRead)
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -338,6 +433,63 @@ impl Sib {
     }
 }
 
+#[inline]
+fn read_reg<I: InsnMachineCtx>(mctx: &I, reg: Register, size: Bytes) -> usize {
+    mctx.read_reg(reg) & size.mask() as usize
+}
+
+#[inline]
+fn write_reg<I: InsnMachineCtx>(mctx: &mut I, reg: Register, data: usize, size: Bytes) {
+    mctx.write_reg(
+        reg,
+        match size {
+            Bytes::Zero => return,
+            // Writing 8bit or 16bit register will not affect the upper bits.
+            Bytes::One | Bytes::Two => {
+                let old = mctx.read_reg(reg);
+                (data & size.mask() as usize) | (old & !size.mask() as usize)
+            }
+            // Writing 32bit register will zero out the upper bits.
+            Bytes::Four => data & size.mask() as usize,
+            Bytes::Eight => data,
+        },
+    );
+}
+
+#[inline]
+fn segment_base(segment: u64) -> u32 {
+    // Segment base bits 0 ~ 23: raw value bits 16 ~ 39
+    // Segment base bits 24 ~ 31: raw value bits 56 ~ 63
+    (((segment >> 16) & 0xffffff) | ((segment >> 56) << 24)) as u32
+}
+
+#[inline]
+fn segment_limit(segment: u64) -> u32 {
+    // Segment limit bits 0 ~ 15: raw value bits 0 ~ 15
+    // Segment limit bits 16 ~ 19: raw value bits 48 ~ 51
+    let limit = ((segment & 0xffff) | ((segment >> 32) & 0xf0000)) as u32;
+
+    if SegDescAttrFlags::from_bits_truncate(segment).contains(SegDescAttrFlags::G) {
+        (limit << 12) | 0xfff
+    } else {
+        limit
+    }
+}
+
+fn ioio_perm<I: InsnMachineCtx>(mctx: &I, port: u16, size: Bytes, io_read: bool) -> bool {
+    if mctx.read_cr0() & CR0Flags::PE.bits() != 0
+        && (mctx.read_cpl() > ((mctx.read_flags() >> 12) & 3)
+            || mctx.read_cr4() & CR4Flags::VME.bits() != 0)
+    {
+        // In protected mode with CPL > IOPL or virtual-8086 mode, if
+        // any I/O Permission Bit for I/O port being accessed = 1, the I/O
+        // operation is not allowed.
+        mctx.ioio_perm(port, size, io_read)
+    } else {
+        true
+    }
+}
+
 /// Represents the context of a decoded instruction, which is used to
 /// interpret the instruction. It holds the decoded instruction, its
 /// length and various components that are decoded from the instruction
@@ -373,6 +525,9 @@ pub struct DecodedInsnCtx {
 
     // Optional immediate operand
     immediate: i64,
+
+    // Instruction repeat count
+    repeat: usize,
 }
 
 impl DecodedInsnCtx {
@@ -415,9 +570,36 @@ impl DecodedInsnCtx {
     ///
     /// # Returns
     ///
-    /// The length of the decoded instruction as a `usize`.
+    /// The length of the decoded instruction as a `usize`. If the
+    /// repeat count is greater than 1, then return 0 to indicate not to
+    /// skip this instruction. If the repeat count is less than 1, then
+    /// return instruction len to indicate this instruction can be skipped.
     pub fn size(&self) -> usize {
-        self.insn_len
+        if self.repeat > 1 {
+            0
+        } else {
+            self.insn_len
+        }
+    }
+
+    /// Emulates the decoded instruction using the provided machine context.
+    ///
+    /// # Arguments
+    ///
+    /// * `mctx` - A mutable reference to an object implementing the
+    ///   `InsnMachineCtx` trait to provide the necessary machine context
+    ///   for emulation.
+    ///
+    /// # Returns
+    ///
+    /// An `Ok(())` if emulation is successful or an `InsnError` otherwise.
+    pub fn emulate<I: InsnMachineCtx>(&self, mctx: &mut I) -> Result<(), InsnError> {
+        self.insn
+            .ok_or(InsnError::UnSupportedInsn)
+            .and_then(|insn| match insn {
+                DecodedInsn::Outs => self.emulate_ins_outs(mctx, false),
+                _ => Err(InsnError::UnSupportedInsn),
+            })
     }
 
     fn decode<I: InsnMachineCtx>(
@@ -431,7 +613,7 @@ impl DecodedInsnCtx {
             .and_then(|(insn, disp_bytes)| self.decode_displacement(insn, disp_bytes))
             .and_then(|insn| self.decode_immediate(insn))
             .and_then(|insn| self.decode_moffset(insn))
-            .and_then(|insn| self.complete_decode(insn))
+            .and_then(|insn| self.complete_decode(insn, mctx))
     }
 
     #[inline]
@@ -767,13 +949,17 @@ impl DecodedInsnCtx {
         }
     }
 
-    fn complete_decode(&mut self, insn: DecodedBytes) -> Result<(), InsnError> {
+    fn complete_decode<I: InsnMachineCtx>(
+        &mut self,
+        insn: DecodedBytes,
+        mctx: &I,
+    ) -> Result<(), InsnError> {
         self.insn_len = insn.0.processed();
-        self.decoded_insn()
+        self.decoded_insn(mctx)
             .map(|decoded_insn| self.insn = Some(decoded_insn))
     }
 
-    fn decoded_insn(&self) -> Result<DecodedInsn, InsnError> {
+    fn decoded_insn<I: InsnMachineCtx>(&mut self, mctx: &I) -> Result<DecodedInsn, InsnError> {
         let opdesc = self.get_opdesc()?;
         Ok(match opdesc.class {
             OpCodeClass::Cpuid => DecodedInsn::Cpuid,
@@ -797,11 +983,237 @@ impl DecodedInsnCtx {
                     DecodedInsn::Out(Operand::rdx(), self.opsize)
                 }
             }
+            OpCodeClass::Outs => {
+                if self.prefix.contains(PrefixFlags::REPZ_P) {
+                    // The prefix REPZ(F3h) actually represents REP for ins/outs.
+                    // The count register is depending on the address size of the
+                    // instruction.
+                    self.repeat = read_reg(mctx, Register::Rcx, self.addrsize);
+                };
+
+                DecodedInsn::Outs
+            }
             OpCodeClass::Rdmsr => DecodedInsn::Rdmsr,
             OpCodeClass::Rdtsc => DecodedInsn::Rdtsc,
             OpCodeClass::Rdtscp => DecodedInsn::Rdtscp,
             OpCodeClass::Wrmsr => DecodedInsn::Wrmsr,
             _ => return Err(InsnError::UnSupportedInsn),
         })
+    }
+
+    fn canonical_check(&self, la: usize) -> Option<usize> {
+        if match self.cpu_mode {
+            CpuMode::Bit64(level) => {
+                let virtaddr_bits = if level == PagingLevel::Level4 { 48 } else { 57 };
+                let mask = !((1 << virtaddr_bits) - 1);
+                if la & (1 << (virtaddr_bits - 1)) != 0 {
+                    la & mask == mask
+                } else {
+                    la & mask == 0
+                }
+            }
+            _ => true,
+        } {
+            Some(la)
+        } else {
+            None
+        }
+    }
+
+    fn alignment_check(&self, la: usize, size: Bytes) -> Option<usize> {
+        match size {
+            // Zero size is not allowed
+            Bytes::Zero => None,
+            // One byte is always aligned
+            Bytes::One => Some(la),
+            // Two/Four/Eight bytes must be aligned on a boundary
+            _ => {
+                if la & (size as usize - 1) != 0 {
+                    None
+                } else {
+                    Some(la)
+                }
+            }
+        }
+    }
+
+    fn cal_linear_addr<I: InsnMachineCtx>(
+        &self,
+        mctx: &I,
+        seg: SegRegister,
+        ea: usize,
+        writable: bool,
+    ) -> Option<usize> {
+        let segment = mctx.read_seg(seg);
+
+        let addrsize = if self.cpu_mode.is_bit64() {
+            Bytes::Eight
+        } else {
+            let attr = SegDescAttrFlags::from_bits_truncate(segment);
+            // Invalid if is system segment
+            if !attr.contains(SegDescAttrFlags::S) {
+                return None;
+            }
+
+            if writable {
+                // Writing to a code segment, or writing to a read-only
+                // data segment is not allowed.
+                if attr.contains(SegDescAttrFlags::C_D) || !attr.contains(SegDescAttrFlags::R_W) {
+                    return None;
+                }
+            } else {
+                // Data segment is always read-able, but code segment
+                // may be execute only. Invalid if read an execute only
+                // code segment.
+                if attr.contains(SegDescAttrFlags::C_D) && !attr.contains(SegDescAttrFlags::R_W) {
+                    return None;
+                }
+            }
+
+            let mut limit = segment_limit(segment) as usize;
+
+            if !attr.contains(SegDescAttrFlags::C_D) && attr.contains(SegDescAttrFlags::C_E) {
+                // Expand-down segment, check low limit
+                if ea <= limit {
+                    return None;
+                }
+
+                limit = if attr.contains(SegDescAttrFlags::DB) {
+                    u32::MAX as usize
+                } else {
+                    u16::MAX as usize
+                }
+            }
+
+            // Check high limit for each byte
+            for i in 0..self.opsize as usize {
+                if ea + i > limit {
+                    return None;
+                }
+            }
+
+            Bytes::Four
+        };
+
+        self.canonical_check(
+            if self.cpu_mode.is_bit64() && seg != SegRegister::FS && seg != SegRegister::GS {
+                ea & (addrsize.mask() as usize)
+            } else {
+                (segment_base(segment) as usize + ea) & addrsize.mask() as usize
+            },
+        )
+    }
+
+    fn get_linear_addr<I: InsnMachineCtx>(
+        &self,
+        mctx: &I,
+        seg: SegRegister,
+        ea: usize,
+        writable: bool,
+    ) -> Result<usize, InsnError> {
+        self.cal_linear_addr(mctx, seg, ea, writable)
+            .ok_or(if seg == SegRegister::SS {
+                InsnError::ExceptionSS
+            } else {
+                InsnError::ExceptionGP(0)
+            })
+            .and_then(|la| {
+                if (mctx.read_cpl() == 3)
+                    && (mctx.read_cr0() & CR0Flags::AM.bits()) != 0
+                    && (mctx.read_flags() & RFlags::AC.bits()) != 0
+                {
+                    self.alignment_check(la, self.opsize)
+                        .ok_or(InsnError::ExceptionAC)
+                } else {
+                    Ok(la)
+                }
+            })
+    }
+
+    fn emulate_ins_outs<I: InsnMachineCtx>(
+        &self,
+        mctx: &mut I,
+        io_read: bool,
+    ) -> Result<(), InsnError> {
+        // I/O port number is stored in DX.
+        let port = mctx.read_reg(Register::Rdx) as u16;
+
+        // Check the IO permission bit map.
+        if !ioio_perm(mctx, port, self.opsize, io_read) {
+            return Err(InsnError::ExceptionGP(0));
+        }
+
+        let (seg, reg) = if io_read {
+            todo!();
+        } else {
+            // Output byte/word/doubleword from memory location specified in
+            // DS:(E)SI (The DS segment may be overridden with a segment
+            // override prefix.) or RSI to I/O port specified in DX.
+            (
+                self.override_seg.map_or(SegRegister::DS, |s| s),
+                Register::Rsi,
+            )
+        };
+
+        // Decoed the linear addresses and map as a memory object
+        // which allows accessing to the memory represented by the
+        // linear addresses.
+        let linear_addr =
+            self.get_linear_addr(mctx, seg, read_reg(mctx, reg, self.addrsize), io_read)?;
+        if io_read {
+            todo!();
+        } else {
+            // Read data from memory location and then write to the IO port
+            //
+            // Safety: The linear address is decoded from the instruction and checked. It can be
+            // remapped to a memory object with the read permission successfully, and the remapped
+            // memory size matches the operand size of the instruction.
+            let data = unsafe {
+                match self.opsize {
+                    Bytes::One => mctx
+                        .map_linear_addr::<u8>(linear_addr, io_read, false)?
+                        .mem_read()? as u64,
+                    Bytes::Two => mctx
+                        .map_linear_addr::<u16>(linear_addr, io_read, false)?
+                        .mem_read()? as u64,
+                    Bytes::Four => mctx
+                        .map_linear_addr::<u32>(linear_addr, io_read, false)?
+                        .mem_read()? as u64,
+                    _ => return Err(InsnError::IoIoOut),
+                }
+            };
+            mctx.ioio_out(port, self.opsize, data)?;
+        }
+
+        let rflags = RFlags::from_bits_truncate(mctx.read_flags());
+        if rflags.contains(RFlags::DF) {
+            // The DF flag is 1, the (E)SI/DI register is decremented.
+            write_reg(
+                mctx,
+                reg,
+                read_reg(mctx, reg, self.addrsize)
+                    .checked_sub(self.opsize as usize)
+                    .ok_or(InsnError::IoIoOut)?,
+                self.addrsize,
+            );
+        } else {
+            // The DF flag is 0, the (E)SI/DI register is incremented.
+            write_reg(
+                mctx,
+                reg,
+                read_reg(mctx, reg, self.addrsize)
+                    .checked_add(self.opsize as usize)
+                    .ok_or(InsnError::IoIoOut)?,
+                self.addrsize,
+            );
+        }
+
+        if self.repeat != 0 {
+            // Update the count register with the left count which are not
+            // emulated yet.
+            write_reg(mctx, Register::Rcx, self.repeat - 1, self.addrsize);
+        }
+
+        Ok(())
     }
 }

--- a/kernel/src/insn_decode/insn.rs
+++ b/kernel/src/insn_decode/insn.rs
@@ -97,221 +97,548 @@ impl Instruction {
     }
 }
 
-/// A dummy struct to implement InsnMachineCtx for testing purposes.
 #[cfg(any(test, fuzzing))]
-#[derive(Copy, Clone, Debug)]
-pub struct TestCtx;
+pub mod test_utils {
+    extern crate alloc;
 
-#[cfg(any(test, fuzzing))]
-impl InsnMachineCtx for TestCtx {
-    fn read_efer(&self) -> u64 {
-        use crate::cpu::efer::EFERFlags;
+    use crate::cpu::control_regs::{CR0Flags, CR4Flags};
+    use crate::cpu::efer::EFERFlags;
+    use crate::insn_decode::*;
+    use crate::types::Bytes;
+    use alloc::boxed::Box;
 
-        EFERFlags::LMA.bits()
+    pub const TEST_PORT: u16 = 0xE0;
+
+    /// A dummy struct to implement InsnMachineCtx for testing purposes.
+    #[allow(dead_code)]
+    #[derive(Copy, Clone, Debug)]
+    pub struct TestCtx {
+        pub efer: u64,
+        pub cr0: u64,
+        pub cr4: u64,
+
+        pub rax: usize,
+        pub rdx: usize,
+        pub rcx: usize,
+        pub rbx: usize,
+        pub rsp: usize,
+        pub rbp: usize,
+        pub rdi: usize,
+        pub rsi: usize,
+        pub r8: usize,
+        pub r9: usize,
+        pub r10: usize,
+        pub r11: usize,
+        pub r12: usize,
+        pub r13: usize,
+        pub r14: usize,
+        pub r15: usize,
+        pub rip: usize,
+        pub flags: usize,
+
+        pub ioport: u16,
+        pub iodata: u64,
     }
 
-    fn read_seg(&self, seg: SegRegister) -> u64 {
-        match seg {
-            SegRegister::CS => 0x00af9a000000ffffu64,
-            _ => 0x00cf92000000ffffu64,
+    impl Default for TestCtx {
+        fn default() -> Self {
+            Self {
+                efer: EFERFlags::LMA.bits(),
+                cr0: CR0Flags::PE.bits(),
+                cr4: CR4Flags::LA57.bits(),
+                rax: 0,
+                rdx: 0,
+                rcx: 0,
+                rbx: 0,
+                rsp: 0,
+                rbp: 0,
+                rdi: 0,
+                rsi: 0,
+                r8: 0,
+                r9: 0,
+                r10: 0,
+                r11: 0,
+                r12: 0,
+                r13: 0,
+                r14: 0,
+                r15: 0,
+                rip: 0,
+                flags: 0,
+                ioport: TEST_PORT,
+                iodata: u64::MAX,
+            }
         }
     }
 
-    fn read_cr0(&self) -> u64 {
-        use crate::cpu::control_regs::CR0Flags;
-
-        CR0Flags::PE.bits()
+    #[allow(dead_code)]
+    struct TestMem<T: Copy> {
+        ptr: *mut T,
     }
 
-    fn read_cr4(&self) -> u64 {
-        use crate::cpu::control_regs::CR4Flags;
+    impl InsnMachineCtx for TestCtx {
+        fn read_efer(&self) -> u64 {
+            self.efer
+        }
 
-        CR4Flags::LA57.bits()
+        fn read_seg(&self, seg: SegRegister) -> u64 {
+            match seg {
+                SegRegister::CS => 0x00af9a000000ffffu64,
+                _ => 0x00cf92000000ffffu64,
+            }
+        }
+
+        fn read_cr0(&self) -> u64 {
+            self.cr0
+        }
+
+        fn read_cr4(&self) -> u64 {
+            self.cr4
+        }
+
+        fn read_reg(&self, reg: Register) -> usize {
+            match reg {
+                Register::Rax => self.rax,
+                Register::Rdx => self.rdx,
+                Register::Rcx => self.rcx,
+                Register::Rbx => self.rdx,
+                Register::Rsp => self.rsp,
+                Register::Rbp => self.rbp,
+                Register::Rdi => self.rdi,
+                Register::Rsi => self.rsi,
+                Register::R8 => self.r8,
+                Register::R9 => self.r9,
+                Register::R10 => self.r10,
+                Register::R11 => self.r11,
+                Register::R12 => self.r12,
+                Register::R13 => self.r13,
+                Register::R14 => self.r14,
+                Register::R15 => self.r15,
+                Register::Rip => self.rip,
+            }
+        }
+
+        fn write_reg(&mut self, reg: Register, val: usize) {
+            match reg {
+                Register::Rax => self.rax = val,
+                Register::Rdx => self.rdx = val,
+                Register::Rcx => self.rcx = val,
+                Register::Rbx => self.rdx = val,
+                Register::Rsp => self.rsp = val,
+                Register::Rbp => self.rbp = val,
+                Register::Rdi => self.rdi = val,
+                Register::Rsi => self.rsi = val,
+                Register::R8 => self.r8 = val,
+                Register::R9 => self.r9 = val,
+                Register::R10 => self.r10 = val,
+                Register::R11 => self.r11 = val,
+                Register::R12 => self.r12 = val,
+                Register::R13 => self.r13 = val,
+                Register::R14 => self.r14 = val,
+                Register::R15 => self.r15 = val,
+                Register::Rip => self.rip = val,
+            }
+        }
+
+        fn read_cpl(&self) -> usize {
+            0
+        }
+
+        fn read_flags(&self) -> usize {
+            self.flags
+        }
+
+        fn map_linear_addr<T: Copy + 'static>(
+            &self,
+            la: usize,
+            _write: bool,
+            _fetch: bool,
+        ) -> Result<Box<dyn InsnMachineMem<Item = T>>, InsnError> {
+            Ok(Box::new(TestMem { ptr: la as *mut T }))
+        }
+
+        fn ioio_in(&self, _port: u16, size: Bytes) -> Result<u64, InsnError> {
+            match size {
+                Bytes::One => Ok(self.iodata as u8 as u64),
+                Bytes::Two => Ok(self.iodata as u16 as u64),
+                Bytes::Four => Ok(self.iodata as u32 as u64),
+                _ => Err(InsnError::IoIoIn),
+            }
+        }
+
+        fn ioio_out(&mut self, _port: u16, size: Bytes, data: u64) -> Result<(), InsnError> {
+            match size {
+                Bytes::One => self.iodata = data as u8 as u64,
+                Bytes::Two => self.iodata = data as u16 as u64,
+                Bytes::Four => self.iodata = data as u32 as u64,
+                _ => return Err(InsnError::IoIoOut),
+            }
+
+            Ok(())
+        }
     }
 
-    fn read_reg(&self, _reg: Register) -> usize {
-        0
+    #[cfg(test)]
+    impl<T: Copy> InsnMachineMem for TestMem<T> {
+        type Item = T;
+
+        unsafe fn mem_read(&self) -> Result<Self::Item, InsnError> {
+            Ok(*(self.ptr))
+        }
+
+        unsafe fn mem_write(&mut self, data: Self::Item) -> Result<(), InsnError> {
+            *(self.ptr) = data;
+            Ok(())
+        }
     }
 
-    fn read_cpl(&self) -> usize {
-        0
+    #[cfg(fuzzing)]
+    impl<T: Copy> InsnMachineMem for TestMem<T> {
+        type Item = T;
+
+        unsafe fn mem_read(&self) -> Result<Self::Item, InsnError> {
+            Err(InsnError::MemRead)
+        }
+
+        unsafe fn mem_write(&mut self, _data: Self::Item) -> Result<(), InsnError> {
+            Ok(())
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::test_utils::*;
     use super::*;
+    use crate::cpu::registers::RFlags;
 
     #[test]
     fn test_decode_inb() {
+        let mut testctx = TestCtx {
+            iodata: 0xab,
+            ..Default::default()
+        };
         let raw_insn: [u8; MAX_INSN_SIZE] = [
-            0xE4, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
+            0xE4,
+            TEST_PORT as u8,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
             0x41,
         ];
 
-        let decoded = Instruction::new(raw_insn).decode(&TestCtx).unwrap();
+        let decoded = Instruction::new(raw_insn).decode(&testctx).unwrap();
+        decoded.emulate(&mut testctx).unwrap();
+
         assert_eq!(
             decoded.insn().unwrap(),
-            DecodedInsn::In(Operand::Imm(Immediate::U8(0x41)), Bytes::One)
+            DecodedInsn::In(Operand::Imm(Immediate::U8(TEST_PORT as u8)), Bytes::One)
         );
         assert_eq!(decoded.size(), 2);
+        assert_eq!(testctx.rax as u64, testctx.iodata);
 
+        let mut testctx = TestCtx {
+            rdx: TEST_PORT as usize,
+            iodata: 0xab,
+            ..Default::default()
+        };
         let raw_insn: [u8; MAX_INSN_SIZE] = [
             0xEC, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
             0x41,
         ];
 
-        let decoded = Instruction::new(raw_insn).decode(&TestCtx).unwrap();
+        let decoded = Instruction::new(raw_insn).decode(&testctx).unwrap();
+        decoded.emulate(&mut testctx).unwrap();
+
         assert_eq!(
             decoded.insn().unwrap(),
             DecodedInsn::In(Operand::rdx(), Bytes::One)
         );
         assert_eq!(decoded.size(), 1);
+        assert_eq!(testctx.rax as u64, testctx.iodata);
     }
 
     #[test]
     fn test_decode_inw() {
+        let mut testctx = TestCtx {
+            iodata: 0xabcd,
+            ..Default::default()
+        };
         let raw_insn: [u8; MAX_INSN_SIZE] = [
-            0x66, 0xE5, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
+            0x66,
+            0xE5,
+            TEST_PORT as u8,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
             0x41,
         ];
 
-        let insn = Instruction::new(raw_insn);
-        let decoded = insn.decode(&TestCtx).unwrap();
+        let decoded = Instruction::new(raw_insn).decode(&testctx).unwrap();
+        decoded.emulate(&mut testctx).unwrap();
+
         assert_eq!(
             decoded.insn().unwrap(),
-            DecodedInsn::In(Operand::Imm(Immediate::U8(0x41)), Bytes::Two)
+            DecodedInsn::In(Operand::Imm(Immediate::U8(TEST_PORT as u8)), Bytes::Two)
         );
         assert_eq!(decoded.size(), 3);
+        assert_eq!(testctx.rax as u64, testctx.iodata);
 
+        let mut testctx = TestCtx {
+            rdx: TEST_PORT as usize,
+            iodata: 0xabcd,
+            ..Default::default()
+        };
         let raw_insn: [u8; MAX_INSN_SIZE] = [
             0x66, 0xED, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
             0x41,
         ];
 
-        let insn = Instruction::new(raw_insn);
-        let decoded = insn.decode(&TestCtx).unwrap();
+        let decoded = Instruction::new(raw_insn).decode(&testctx).unwrap();
+        decoded.emulate(&mut testctx).unwrap();
+
         assert_eq!(
             decoded.insn().unwrap(),
             DecodedInsn::In(Operand::rdx(), Bytes::Two)
         );
         assert_eq!(decoded.size(), 2);
+        assert_eq!(testctx.rax as u64, testctx.iodata);
     }
 
     #[test]
     fn test_decode_inl() {
+        let mut testctx = TestCtx {
+            iodata: 0xabcdef01,
+            ..Default::default()
+        };
         let raw_insn: [u8; MAX_INSN_SIZE] = [
-            0xE5, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
+            0xE5,
+            TEST_PORT as u8,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
             0x41,
         ];
 
-        let insn = Instruction::new(raw_insn);
-        let decoded = insn.decode(&TestCtx).unwrap();
+        let decoded = Instruction::new(raw_insn).decode(&testctx).unwrap();
+        decoded.emulate(&mut testctx).unwrap();
+
         assert_eq!(
             decoded.insn().unwrap(),
-            DecodedInsn::In(Operand::Imm(Immediate::U8(0x41)), Bytes::Four)
+            DecodedInsn::In(Operand::Imm(Immediate::U8(TEST_PORT as u8)), Bytes::Four)
         );
         assert_eq!(decoded.size(), 2);
+        assert_eq!(testctx.rax as u64, testctx.iodata);
 
+        let mut testctx = TestCtx {
+            rdx: TEST_PORT as usize,
+            iodata: 0xabcdef01,
+            ..Default::default()
+        };
         let raw_insn: [u8; MAX_INSN_SIZE] = [
             0xED, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
             0x41,
         ];
 
-        let insn = Instruction::new(raw_insn);
-        let decoded = insn.decode(&TestCtx).unwrap();
+        let decoded = Instruction::new(raw_insn).decode(&testctx).unwrap();
+        decoded.emulate(&mut testctx).unwrap();
+
         assert_eq!(
             decoded.insn().unwrap(),
             DecodedInsn::In(Operand::rdx(), Bytes::Four)
         );
         assert_eq!(decoded.size(), 1);
+        assert_eq!(testctx.rax as u64, testctx.iodata);
     }
 
     #[test]
     fn test_decode_outb() {
+        let mut testctx = TestCtx {
+            rax: 0xab,
+            ..Default::default()
+        };
         let raw_insn: [u8; MAX_INSN_SIZE] = [
-            0xE6, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
+            0xE6,
+            TEST_PORT as u8,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
             0x41,
         ];
 
-        let insn = Instruction::new(raw_insn);
-        let decoded = insn.decode(&TestCtx).unwrap();
+        let decoded = Instruction::new(raw_insn).decode(&testctx).unwrap();
+        decoded.emulate(&mut testctx).unwrap();
+
         assert_eq!(
             decoded.insn().unwrap(),
-            DecodedInsn::Out(Operand::Imm(Immediate::U8(0x41)), Bytes::One)
+            DecodedInsn::Out(Operand::Imm(Immediate::U8(TEST_PORT as u8)), Bytes::One)
         );
         assert_eq!(decoded.size(), 2);
+        assert_eq!(testctx.rax as u64, testctx.iodata);
 
+        let mut testctx = TestCtx {
+            rax: 0xab,
+            rdx: TEST_PORT as usize,
+            ..Default::default()
+        };
         let raw_insn: [u8; MAX_INSN_SIZE] = [
             0xEE, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
             0x41,
         ];
 
-        let insn = Instruction::new(raw_insn);
-        let decoded = insn.decode(&TestCtx).unwrap();
+        let decoded = Instruction::new(raw_insn).decode(&testctx).unwrap();
+        decoded.emulate(&mut testctx).unwrap();
+
         assert_eq!(
             decoded.insn().unwrap(),
             DecodedInsn::Out(Operand::rdx(), Bytes::One)
         );
         assert_eq!(decoded.size(), 1);
+        assert_eq!(testctx.rax as u64, testctx.iodata);
     }
 
     #[test]
     fn test_decode_outw() {
+        let mut testctx = TestCtx {
+            rax: 0xabcd,
+            ..Default::default()
+        };
         let raw_insn: [u8; MAX_INSN_SIZE] = [
-            0x66, 0xE7, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
+            0x66,
+            0xE7,
+            TEST_PORT as u8,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
             0x41,
         ];
 
-        let insn = Instruction::new(raw_insn);
-        let decoded = insn.decode(&TestCtx).unwrap();
+        let decoded = Instruction::new(raw_insn).decode(&testctx).unwrap();
+        decoded.emulate(&mut testctx).unwrap();
+
         assert_eq!(
             decoded.insn().unwrap(),
-            DecodedInsn::Out(Operand::Imm(Immediate::U8(0x41)), Bytes::Two)
+            DecodedInsn::Out(Operand::Imm(Immediate::U8(TEST_PORT as u8)), Bytes::Two)
         );
         assert_eq!(decoded.size(), 3);
+        assert_eq!(testctx.rax as u64, testctx.iodata);
 
+        let mut testctx = TestCtx {
+            rax: 0xabcd,
+            rdx: TEST_PORT as usize,
+            ..Default::default()
+        };
         let raw_insn: [u8; MAX_INSN_SIZE] = [
             0x66, 0xEF, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
             0x41,
         ];
 
-        let insn = Instruction::new(raw_insn);
-        let decoded = insn.decode(&TestCtx).unwrap();
+        let decoded = Instruction::new(raw_insn).decode(&testctx).unwrap();
+        decoded.emulate(&mut testctx).unwrap();
+
         assert_eq!(
             decoded.insn().unwrap(),
             DecodedInsn::Out(Operand::rdx(), Bytes::Two)
         );
         assert_eq!(decoded.size(), 2);
+        assert_eq!(testctx.rax as u64, testctx.iodata);
     }
 
     #[test]
     fn test_decode_outl() {
+        let mut testctx = TestCtx {
+            rax: 0xabcdef01,
+            ..Default::default()
+        };
         let raw_insn: [u8; MAX_INSN_SIZE] = [
-            0xE7, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
+            0xE7,
+            TEST_PORT as u8,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
+            0x41,
             0x41,
         ];
 
-        let insn = Instruction::new(raw_insn);
-        let decoded = insn.decode(&TestCtx).unwrap();
+        let decoded = Instruction::new(raw_insn).decode(&testctx).unwrap();
+        decoded.emulate(&mut testctx).unwrap();
+
         assert_eq!(
             decoded.insn().unwrap(),
-            DecodedInsn::Out(Operand::Imm(Immediate::U8(0x41)), Bytes::Four)
+            DecodedInsn::Out(Operand::Imm(Immediate::U8(TEST_PORT as u8)), Bytes::Four)
         );
         assert_eq!(decoded.size(), 2);
+        assert_eq!(testctx.rax as u64, testctx.iodata);
 
+        let mut testctx = TestCtx {
+            rax: 0xabcdef01,
+            rdx: TEST_PORT as usize,
+            ..Default::default()
+        };
         let raw_insn: [u8; MAX_INSN_SIZE] = [
             0xEF, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
             0x41,
         ];
 
-        let insn = Instruction::new(raw_insn);
-        let decoded = insn.decode(&TestCtx).unwrap();
+        let decoded = Instruction::new(raw_insn).decode(&testctx).unwrap();
+        decoded.emulate(&mut testctx).unwrap();
+
         assert_eq!(
             decoded.insn().unwrap(),
             DecodedInsn::Out(Operand::rdx(), Bytes::Four)
         );
         assert_eq!(decoded.size(), 1);
+        assert_eq!(testctx.rax as u64, testctx.iodata);
     }
 
     #[test]
@@ -322,7 +649,7 @@ mod tests {
         ];
 
         let insn = Instruction::new(raw_insn);
-        let decoded = insn.decode(&TestCtx).unwrap();
+        let decoded = insn.decode(&TestCtx::default()).unwrap();
         assert_eq!(decoded.insn().unwrap(), DecodedInsn::Cpuid);
         assert_eq!(decoded.size(), 2);
     }
@@ -335,7 +662,7 @@ mod tests {
         ];
 
         let insn = Instruction::new(raw_insn);
-        let decoded = insn.decode(&TestCtx).unwrap();
+        let decoded = insn.decode(&TestCtx::default()).unwrap();
         assert_eq!(decoded.insn().unwrap(), DecodedInsn::Wrmsr);
         assert_eq!(decoded.size(), 2);
     }
@@ -348,7 +675,7 @@ mod tests {
         ];
 
         let insn = Instruction::new(raw_insn);
-        let decoded = insn.decode(&TestCtx).unwrap();
+        let decoded = insn.decode(&TestCtx::default()).unwrap();
         assert_eq!(decoded.insn().unwrap(), DecodedInsn::Rdmsr);
         assert_eq!(decoded.size(), 2);
     }
@@ -361,7 +688,7 @@ mod tests {
         ];
 
         let insn = Instruction::new(raw_insn);
-        let decoded = insn.decode(&TestCtx).unwrap();
+        let decoded = insn.decode(&TestCtx::default()).unwrap();
         assert_eq!(decoded.insn().unwrap(), DecodedInsn::Rdtsc);
         assert_eq!(decoded.size(), 2);
     }
@@ -374,9 +701,442 @@ mod tests {
         ];
 
         let insn = Instruction::new(raw_insn);
-        let decoded = insn.decode(&TestCtx).unwrap();
+        let decoded = insn.decode(&TestCtx::default()).unwrap();
         assert_eq!(decoded.insn().unwrap(), DecodedInsn::Rdtscp);
         assert_eq!(decoded.size(), 3);
+    }
+
+    #[test]
+    fn test_decode_ins_u8() {
+        let raw_insn: [u8; MAX_INSN_SIZE] = [
+            0xF3, 0x6C, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
+            0x41,
+        ];
+        let iodata: [u8; 4] = [0x12, 0x34, 0x56, 0x78];
+
+        let mut i = 0usize;
+        let mut testdata: [u8; 4] = [0; 4];
+        let mut testctx = TestCtx {
+            rdx: TEST_PORT as usize,
+            rcx: testdata.len(),
+            rdi: core::ptr::addr_of!(testdata[0]) as usize,
+            ..Default::default()
+        };
+        loop {
+            testctx.iodata = *iodata.get(i).unwrap() as u64;
+            let decoded = Instruction::new(raw_insn).decode(&testctx).unwrap();
+            decoded.emulate(&mut testctx).unwrap();
+            if decoded.size() == 0 {
+                i += 1;
+                continue;
+            }
+
+            assert_eq!(decoded.insn().unwrap(), DecodedInsn::Ins);
+            assert_eq!(decoded.size(), 2);
+            assert_eq!(0, testctx.rcx);
+            assert_eq!(
+                core::ptr::addr_of!(testdata) as usize + testdata.len() * Bytes::One as usize,
+                testctx.rdi
+            );
+            assert_eq!(i, testdata.len() - 1);
+            for (i, d) in testdata.iter().enumerate() {
+                assert_eq!(d, iodata.get(i).unwrap());
+            }
+            break;
+        }
+
+        i = iodata.len() - 1;
+        testdata = [0; 4];
+        testctx = TestCtx {
+            rdx: TEST_PORT as usize,
+            rcx: testdata.len(),
+            rdi: core::ptr::addr_of!(testdata[testdata.len() - 1]) as usize,
+            flags: RFlags::DF.bits(),
+            ..Default::default()
+        };
+        loop {
+            testctx.iodata = *iodata.get(i).unwrap() as u64;
+            let decoded = Instruction::new(raw_insn).decode(&testctx).unwrap();
+            decoded.emulate(&mut testctx).unwrap();
+            if decoded.size() == 0 {
+                i = i.checked_sub(1).unwrap();
+                continue;
+            }
+
+            assert_eq!(decoded.insn().unwrap(), DecodedInsn::Ins);
+            assert_eq!(decoded.size(), 2);
+            assert_eq!(0, testctx.rcx);
+            assert_eq!(
+                core::ptr::addr_of!(testdata[0]) as usize - Bytes::One as usize,
+                testctx.rdi
+            );
+            assert_eq!(i, 0);
+            for (i, d) in testdata.iter().enumerate() {
+                assert_eq!(d, iodata.get(i).unwrap());
+            }
+            break;
+        }
+    }
+
+    #[test]
+    fn test_decode_ins_u16() {
+        let raw_insn: [u8; MAX_INSN_SIZE] = [
+            0x66, 0xF3, 0x6D, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
+            0x41,
+        ];
+        let iodata: [u16; 4] = [0x1234, 0x5678, 0x9abc, 0xdef0];
+
+        let mut i = 0usize;
+        let mut testdata: [u16; 4] = [0; 4];
+        let mut testctx = TestCtx {
+            rdx: TEST_PORT as usize,
+            rcx: testdata.len(),
+            rdi: core::ptr::addr_of!(testdata[0]) as usize,
+            ..Default::default()
+        };
+        loop {
+            testctx.iodata = *iodata.get(i).unwrap() as u64;
+            let decoded = Instruction::new(raw_insn).decode(&testctx).unwrap();
+            decoded.emulate(&mut testctx).unwrap();
+            if decoded.size() == 0 {
+                i += 1;
+                continue;
+            }
+
+            assert_eq!(decoded.insn().unwrap(), DecodedInsn::Ins);
+            assert_eq!(decoded.size(), 3);
+            assert_eq!(0, testctx.rcx);
+            assert_eq!(
+                core::ptr::addr_of!(testdata) as usize + testdata.len() * Bytes::Two as usize,
+                testctx.rdi
+            );
+            assert_eq!(i, testdata.len() - 1);
+            for (i, d) in testdata.iter().enumerate() {
+                assert_eq!(d, iodata.get(i).unwrap());
+            }
+            break;
+        }
+
+        i = iodata.len() - 1;
+        testdata = [0; 4];
+        testctx = TestCtx {
+            rdx: TEST_PORT as usize,
+            rcx: testdata.len(),
+            rdi: core::ptr::addr_of!(testdata[testdata.len() - 1]) as usize,
+            flags: RFlags::DF.bits(),
+            ..Default::default()
+        };
+        loop {
+            testctx.iodata = *iodata.get(i).unwrap() as u64;
+            let decoded = Instruction::new(raw_insn).decode(&testctx).unwrap();
+            decoded.emulate(&mut testctx).unwrap();
+            if decoded.size() == 0 {
+                i = i.checked_sub(1).unwrap();
+                continue;
+            }
+
+            assert_eq!(decoded.insn().unwrap(), DecodedInsn::Ins);
+            assert_eq!(decoded.size(), 3);
+            assert_eq!(0, testctx.rcx);
+            assert_eq!(
+                core::ptr::addr_of!(testdata) as usize - Bytes::Two as usize,
+                testctx.rdi
+            );
+            assert_eq!(i, 0);
+            for (i, d) in testdata.iter().enumerate() {
+                assert_eq!(d, iodata.get(i).unwrap());
+            }
+            break;
+        }
+    }
+
+    #[test]
+    fn test_decode_ins_u32() {
+        let raw_insn: [u8; MAX_INSN_SIZE] = [
+            0xF3, 0x6D, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
+            0x41,
+        ];
+        let iodata: [u32; 4] = [0x12345678, 0x9abcdef0, 0x87654321, 0x0fedcba9];
+
+        let mut i = 0usize;
+        let mut testdata: [u32; 4] = [0; 4];
+        let mut testctx = TestCtx {
+            rdx: TEST_PORT as usize,
+            rcx: testdata.len(),
+            rdi: core::ptr::addr_of!(testdata[0]) as usize,
+            ..Default::default()
+        };
+        loop {
+            testctx.iodata = *iodata.get(i).unwrap() as u64;
+            let decoded = Instruction::new(raw_insn).decode(&testctx).unwrap();
+            decoded.emulate(&mut testctx).unwrap();
+            if decoded.size() == 0 {
+                i += 1;
+                continue;
+            }
+
+            assert_eq!(decoded.insn().unwrap(), DecodedInsn::Ins);
+            assert_eq!(decoded.size(), 2);
+            assert_eq!(0, testctx.rcx);
+            assert_eq!(
+                core::ptr::addr_of!(testdata) as usize + testdata.len() * Bytes::Four as usize,
+                testctx.rdi
+            );
+            assert_eq!(i, testdata.len() - 1);
+            for (i, d) in testdata.iter().enumerate() {
+                assert_eq!(d, iodata.get(i).unwrap());
+            }
+            break;
+        }
+
+        i = iodata.len() - 1;
+        testdata = [0; 4];
+        testctx = TestCtx {
+            rdx: TEST_PORT as usize,
+            rcx: testdata.len(),
+            rdi: core::ptr::addr_of!(testdata[testdata.len() - 1]) as usize,
+            flags: RFlags::DF.bits(),
+            ..Default::default()
+        };
+        loop {
+            testctx.iodata = *iodata.get(i).unwrap() as u64;
+            let decoded = Instruction::new(raw_insn).decode(&testctx).unwrap();
+            decoded.emulate(&mut testctx).unwrap();
+            if decoded.size() == 0 {
+                i = i.checked_sub(1).unwrap();
+                continue;
+            }
+
+            assert_eq!(decoded.insn().unwrap(), DecodedInsn::Ins);
+            assert_eq!(decoded.size(), 2);
+            assert_eq!(0, testctx.rcx);
+            assert_eq!(
+                core::ptr::addr_of!(testdata) as usize - Bytes::Four as usize,
+                testctx.rdi
+            );
+            assert_eq!(i, 0);
+            for (i, d) in testdata.iter().enumerate() {
+                assert_eq!(d, iodata.get(i).unwrap());
+            }
+            break;
+        }
+    }
+
+    #[test]
+    fn test_decode_outs_u8() {
+        let raw_insn: [u8; MAX_INSN_SIZE] = [
+            0xF3, 0x6E, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
+            0x41,
+        ];
+        let testdata: [u8; 4] = [0x12, 0x34, 0x56, 0x78];
+
+        let mut i = 0usize;
+        let mut iodata: [u8; 4] = [0; 4];
+        let mut testctx = TestCtx {
+            rdx: TEST_PORT as usize,
+            rcx: testdata.len(),
+            rsi: core::ptr::addr_of!(testdata[0]) as usize,
+            ..Default::default()
+        };
+        loop {
+            let decoded = Instruction::new(raw_insn).decode(&testctx).unwrap();
+            decoded.emulate(&mut testctx).unwrap();
+            *iodata.get_mut(i).unwrap() = testctx.iodata as u8;
+            if decoded.size() == 0 {
+                i += 1;
+                continue;
+            }
+
+            assert_eq!(decoded.insn().unwrap(), DecodedInsn::Outs);
+            assert_eq!(decoded.size(), 2);
+            assert_eq!(0, testctx.rcx);
+            assert_eq!(
+                core::ptr::addr_of!(testdata) as usize + testdata.len(),
+                testctx.rsi
+            );
+            assert_eq!(i, testdata.len() - 1);
+            for (i, d) in testdata.iter().enumerate() {
+                assert_eq!(d, iodata.get(i).unwrap());
+            }
+            break;
+        }
+
+        i = iodata.len() - 1;
+        iodata = [0; 4];
+        testctx = TestCtx {
+            rdx: TEST_PORT as usize,
+            rcx: testdata.len(),
+            rsi: core::ptr::addr_of!(testdata[testdata.len() - 1]) as usize,
+            flags: RFlags::DF.bits(),
+            ..Default::default()
+        };
+        loop {
+            let decoded = Instruction::new(raw_insn).decode(&testctx).unwrap();
+            decoded.emulate(&mut testctx).unwrap();
+            *iodata.get_mut(i).unwrap() = testctx.iodata as u8;
+            if decoded.size() == 0 {
+                i = i.checked_sub(1).unwrap();
+                continue;
+            }
+
+            assert_eq!(decoded.insn().unwrap(), DecodedInsn::Outs);
+            assert_eq!(decoded.size(), 2);
+            assert_eq!(0, testctx.rcx);
+            assert_eq!(
+                core::ptr::addr_of!(testdata[0]) as usize - Bytes::One as usize,
+                testctx.rsi
+            );
+            assert_eq!(i, 0);
+            for (i, d) in testdata.iter().enumerate() {
+                assert_eq!(d, iodata.get(i).unwrap());
+            }
+            break;
+        }
+    }
+
+    #[test]
+    fn test_decode_outs_u16() {
+        let raw_insn: [u8; MAX_INSN_SIZE] = [
+            0x66, 0xF3, 0x6F, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
+            0x41,
+        ];
+        let testdata: [u16; 4] = [0x1234, 0x5678, 0x9abc, 0xdef0];
+
+        let mut i = 0usize;
+        let mut iodata: [u16; 4] = [0; 4];
+        let mut testctx = TestCtx {
+            rdx: TEST_PORT as usize,
+            rcx: testdata.len(),
+            rsi: core::ptr::addr_of!(testdata[0]) as usize,
+            ..Default::default()
+        };
+        loop {
+            let decoded = Instruction::new(raw_insn).decode(&testctx).unwrap();
+            decoded.emulate(&mut testctx).unwrap();
+            *iodata.get_mut(i).unwrap() = testctx.iodata as u16;
+            if decoded.size() == 0 {
+                i += 1;
+                continue;
+            }
+
+            assert_eq!(decoded.insn().unwrap(), DecodedInsn::Outs);
+            assert_eq!(decoded.size(), 3);
+            assert_eq!(0, testctx.rcx);
+            assert_eq!(
+                core::ptr::addr_of!(testdata) as usize + testdata.len() * Bytes::Two as usize,
+                testctx.rsi
+            );
+            assert_eq!(i, testdata.len() - 1);
+            for (i, d) in testdata.iter().enumerate() {
+                assert_eq!(d, iodata.get(i).unwrap());
+            }
+            break;
+        }
+
+        i = iodata.len() - 1;
+        iodata = [0; 4];
+        testctx = TestCtx {
+            rdx: TEST_PORT as usize,
+            rcx: testdata.len(),
+            rsi: core::ptr::addr_of!(testdata[testdata.len() - 1]) as usize,
+            flags: RFlags::DF.bits(),
+            ..Default::default()
+        };
+        loop {
+            let decoded = Instruction::new(raw_insn).decode(&testctx).unwrap();
+            decoded.emulate(&mut testctx).unwrap();
+            *iodata.get_mut(i).unwrap() = testctx.iodata as u16;
+            if decoded.size() == 0 {
+                i = i.checked_sub(1).unwrap();
+                continue;
+            }
+
+            assert_eq!(decoded.insn().unwrap(), DecodedInsn::Outs);
+            assert_eq!(decoded.size(), 3);
+            assert_eq!(0, testctx.rcx);
+            assert_eq!(
+                core::ptr::addr_of!(testdata[0]) as usize - Bytes::Two as usize,
+                testctx.rsi
+            );
+            assert_eq!(i, 0);
+            for (i, d) in testdata.iter().enumerate() {
+                assert_eq!(d, iodata.get(i).unwrap());
+            }
+            break;
+        }
+    }
+
+    #[test]
+    fn test_decode_outs_u32() {
+        let raw_insn: [u8; MAX_INSN_SIZE] = [
+            0xF3, 0x6F, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
+            0x41,
+        ];
+        let testdata: [u32; 4] = [0x12345678, 0x9abcdef0, 0xdeadbeef, 0xfeedface];
+
+        let mut i = 0usize;
+        let mut iodata: [u32; 4] = [0; 4];
+        let mut testctx = TestCtx {
+            rdx: TEST_PORT as usize,
+            rcx: testdata.len(),
+            rsi: core::ptr::addr_of!(testdata) as usize,
+            ..Default::default()
+        };
+        loop {
+            let decoded = Instruction::new(raw_insn).decode(&testctx).unwrap();
+            decoded.emulate(&mut testctx).unwrap();
+            *iodata.get_mut(i).unwrap() = testctx.iodata as u32;
+            if decoded.size() == 0 {
+                i += 1;
+                continue;
+            }
+
+            assert_eq!(decoded.insn().unwrap(), DecodedInsn::Outs);
+            assert_eq!(decoded.size(), 2);
+            assert_eq!(*testdata.last().unwrap() as u64, testctx.iodata);
+            assert_eq!(0, testctx.rcx);
+            assert_eq!(
+                core::ptr::addr_of!(testdata) as usize + testdata.len() * Bytes::Four as usize,
+                testctx.rsi
+            );
+            assert_eq!(i, testdata.len() - 1);
+            for (i, d) in testdata.iter().enumerate() {
+                assert_eq!(d, iodata.get(i).unwrap());
+            }
+            break;
+        }
+
+        i = iodata.len() - 1;
+        iodata = [0; 4];
+        testctx = TestCtx {
+            rdx: TEST_PORT as usize,
+            rcx: testdata.len(),
+            rsi: core::ptr::addr_of!(testdata[testdata.len() - 1]) as usize,
+            flags: RFlags::DF.bits(),
+            ..Default::default()
+        };
+        loop {
+            let decoded = Instruction::new(raw_insn).decode(&testctx).unwrap();
+            decoded.emulate(&mut testctx).unwrap();
+            *iodata.get_mut(i).unwrap() = testctx.iodata as u32;
+            if decoded.size() == 0 {
+                i = i.checked_sub(1).unwrap();
+                continue;
+            }
+
+            assert_eq!(decoded.insn().unwrap(), DecodedInsn::Outs);
+            assert_eq!(decoded.size(), 2);
+            assert_eq!(0, testctx.rcx);
+            assert_eq!(
+                core::ptr::addr_of!(testdata[0]) as usize - Bytes::Four as usize,
+                testctx.rsi
+            );
+            assert_eq!(i, 0);
+            for (i, d) in testdata.iter().enumerate() {
+                assert_eq!(d, iodata.get(i).unwrap());
+            }
+            break;
+        }
     }
 
     #[test]
@@ -387,7 +1147,7 @@ mod tests {
         ];
 
         let insn = Instruction::new(raw_insn);
-        let err = insn.decode(&TestCtx);
+        let err = insn.decode(&TestCtx::default());
 
         assert!(err.is_err());
     }

--- a/kernel/src/insn_decode/insn.rs
+++ b/kernel/src/insn_decode/insn.rs
@@ -68,6 +68,7 @@ pub enum DecodedInsn {
     Cpuid,
     In(Operand, Bytes),
     Out(Operand, Bytes),
+    Outs,
     Wrmsr,
     Rdmsr,
     Rdtsc,
@@ -125,6 +126,14 @@ impl InsnMachineCtx for TestCtx {
         use crate::cpu::control_regs::CR4Flags;
 
         CR4Flags::LA57.bits()
+    }
+
+    fn read_reg(&self, _reg: Register) -> usize {
+        0
+    }
+
+    fn read_cpl(&self) -> usize {
+        0
     }
 }
 

--- a/kernel/src/insn_decode/insn.rs
+++ b/kernel/src/insn_decode/insn.rs
@@ -67,6 +67,7 @@ impl Operand {
 pub enum DecodedInsn {
     Cpuid,
     In(Operand, Bytes),
+    Ins,
     Out(Operand, Bytes),
     Outs,
     Wrmsr,

--- a/kernel/src/insn_decode/mod.rs
+++ b/kernel/src/insn_decode/mod.rs
@@ -42,12 +42,16 @@ pub enum InsnError {
     MapLinearAddr,
     /// Error while reading from memory.
     MemRead,
+    /// Error while writing to memory.
+    MemWrite,
     /// No OpCodeDesc generated while decoding.
     NoOpCodeDesc,
     /// Error while peeking an instruction byte.
     InsnPeek,
     /// Invalid RegCode for decoding Register.
     InvalidRegister,
+    /// Error while handling input IO operation.
+    IoIoIn,
     /// Error while handling output IO operation.
     IoIoOut,
     /// The decoded instruction is not supported.

--- a/kernel/src/insn_decode/mod.rs
+++ b/kernel/src/insn_decode/mod.rs
@@ -8,7 +8,7 @@ mod decode;
 mod insn;
 mod opcode;
 
-pub use decode::{DecodedInsnCtx, InsnMachineCtx};
+pub use decode::{DecodedInsnCtx, InsnMachineCtx, InsnMachineMem};
 #[cfg(any(test, fuzzing))]
 pub use insn::TestCtx;
 pub use insn::{
@@ -32,12 +32,24 @@ pub enum InsnError {
     DecodePrefix,
     /// Error while decoding the SIB byte.
     DecodeSib,
+    /// Error due to alignment check exception.
+    ExceptionAC,
+    /// Error due to general protection exception.
+    ExceptionGP(u8),
+    /// Error due to stack segment exception.
+    ExceptionSS,
+    /// Error while mapping linear addresses.
+    MapLinearAddr,
+    /// Error while reading from memory.
+    MemRead,
     /// No OpCodeDesc generated while decoding.
     NoOpCodeDesc,
     /// Error while peeking an instruction byte.
     InsnPeek,
     /// Invalid RegCode for decoding Register.
     InvalidRegister,
+    /// Error while handling output IO operation.
+    IoIoOut,
     /// The decoded instruction is not supported.
     UnSupportedInsn,
 }

--- a/kernel/src/insn_decode/mod.rs
+++ b/kernel/src/insn_decode/mod.rs
@@ -10,7 +10,7 @@ mod opcode;
 
 pub use decode::{DecodedInsnCtx, InsnMachineCtx, InsnMachineMem};
 #[cfg(any(test, fuzzing))]
-pub use insn::TestCtx;
+pub use insn::test_utils::TestCtx;
 pub use insn::{
     DecodedInsn, Immediate, Instruction, Operand, Register, SegRegister, MAX_INSN_SIZE,
 };

--- a/kernel/src/insn_decode/opcode.rs
+++ b/kernel/src/insn_decode/opcode.rs
@@ -42,6 +42,7 @@ pub enum OpCodeClass {
     Group7Rm7,
     In,
     Out,
+    Outs,
     Rdmsr,
     Rdtsc,
     Rdtscp,
@@ -90,6 +91,12 @@ static ONE_BYTE_TABLE: [Option<OpCodeDesc>; 256] = {
     let mut table: [Option<OpCodeDesc>; 256] = [None; 256];
 
     table[0x0F] = opcode!(OpCodeClass::TwoByte);
+    table[0x6E] = opcode!(
+        0x6E,
+        OpCodeClass::Outs,
+        OpCodeFlags::BYTE_OP.bits() | OpCodeFlags::NO_MODRM.bits()
+    );
+    table[0x6F] = opcode!(0x6F, OpCodeClass::Outs, OpCodeFlags::NO_MODRM.bits());
     table[0xE4] = opcode!(
         0xE4,
         OpCodeClass::In,

--- a/kernel/src/insn_decode/opcode.rs
+++ b/kernel/src/insn_decode/opcode.rs
@@ -41,6 +41,7 @@ pub enum OpCodeClass {
     Group7,
     Group7Rm7,
     In,
+    Ins,
     Out,
     Outs,
     Rdmsr,
@@ -91,6 +92,12 @@ static ONE_BYTE_TABLE: [Option<OpCodeDesc>; 256] = {
     let mut table: [Option<OpCodeDesc>; 256] = [None; 256];
 
     table[0x0F] = opcode!(OpCodeClass::TwoByte);
+    table[0x6C] = opcode!(
+        0x6C,
+        OpCodeClass::Ins,
+        OpCodeFlags::BYTE_OP.bits() | OpCodeFlags::NO_MODRM.bits()
+    );
+    table[0x6D] = opcode!(0x6D, OpCodeClass::Ins, OpCodeFlags::NO_MODRM.bits());
     table[0x6E] = opcode!(
         0x6E,
         OpCodeClass::Outs,

--- a/kernel/src/io.rs
+++ b/kernel/src/io.rs
@@ -31,6 +31,18 @@ pub trait IOPort: Sync + Debug {
             ret
         }
     }
+
+    fn outl(&self, port: u16, value: u32) {
+        unsafe { asm!("outl %eax, %dx", in("eax") value, in("dx") port, options(att_syntax)) }
+    }
+
+    fn inl(&self, port: u16) -> u32 {
+        unsafe {
+            let ret: u32;
+            asm!("inl %dx, %eax", in("dx") port, out("eax") ret, options(att_syntax));
+            ret
+        }
+    }
 }
 
 #[derive(Default, Debug, Clone, Copy)]

--- a/kernel/src/mm/guestmem.rs
+++ b/kernel/src/mm/guestmem.rs
@@ -6,7 +6,7 @@
 
 use crate::address::{Address, VirtAddr};
 use crate::error::SvsmError;
-
+use crate::insn_decode::{InsnError, InsnMachineMem};
 use core::arch::asm;
 use core::mem::{size_of, MaybeUninit};
 
@@ -254,6 +254,20 @@ impl<T: Copy> GuestPtr<T> {
     #[inline]
     pub fn offset(&self, count: isize) -> Self {
         GuestPtr::from_ptr(self.ptr.wrapping_offset(count))
+    }
+}
+
+impl<T: Copy> InsnMachineMem for GuestPtr<T> {
+    type Item = T;
+
+    /// Safety: See the GuestPtr's read() method documentation for safety requirements.
+    unsafe fn mem_read(&self) -> Result<Self::Item, InsnError> {
+        self.read().map_err(|_| InsnError::MemRead)
+    }
+
+    /// Safety: See the GuestPtr's write() method documentation for safety requirements.
+    unsafe fn mem_write(&mut self, data: Self::Item) -> Result<(), InsnError> {
+        self.write(data).map_err(|_| InsnError::MemWrite)
     }
 }
 

--- a/kernel/src/svsm_console.rs
+++ b/kernel/src/svsm_console.rs
@@ -50,6 +50,21 @@ impl IOPort for SVSMIOPort {
             Err(_e) => request_termination_msr(),
         }
     }
+
+    fn outl(&self, port: u16, value: u32) {
+        let ret = current_ghcb().ioio_out(port, GHCBIOSize::Size32, value as u64);
+        if ret.is_err() {
+            request_termination_msr();
+        }
+    }
+
+    fn inl(&self, port: u16) -> u32 {
+        let ret = current_ghcb().ioio_in(port, GHCBIOSize::Size32);
+        match ret {
+            Ok(v) => (v & 0xffffffff) as u32,
+            Err(_e) => request_termination_msr(),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default)]

--- a/kernel/src/utils/util.rs
+++ b/kernel/src/utils/util.rs
@@ -70,6 +70,18 @@ macro_rules! BIT {
     };
 }
 
+/// Obtain bit mask for the given positions
+#[macro_export]
+macro_rules! BIT_MASK {
+    ($e: expr, $s: expr) => {{
+        assert!(
+            $s <= 63 && $e <= 63 && $s <= $e,
+            "Start bit position must be less than or equal to end bit position"
+        );
+        (((1u64 << ($e - $s + 1)) - 1) << $s)
+    }};
+}
+
 #[cfg(test)]
 mod tests {
 


### PR DESCRIPTION
Add the instruction decoding and emulating support for ins/outs instructions. To support emulating, the InsnMachineCtx has been extended with more methods for the instruction decoder to get CPU state. And implemented these new methods for the X86ExceptionContext.

Beside provides more CPU states, it also provides the memory accessing ability to the instruction decoder via the new trait InsnMachineMem. The PageTable has been extended to support translating virtual addresses to the corresponding physical addresses, with the accessing rights been checked. And the physical addresses are temporarily mapped in the page table with contiguous virtual addresses via a PerCPUPageMappingGuard, which is wrapped in the new structure MemMappingGuard. This new structure implements the trait InsnMachineMem and is used by the instruction decoder to access memory.

Besides emulating ins/outs instruction, in/out instruction can also be emulated. The test cases have been enhanced to cover the emulation for ins/outs/in/out instructions with byte, word and double word size.

In the end, the SEV #VC handler has been simplified by directly using the emulation interface to handle IOIO instructions. The test_in_svsm test_port_io_string_16_get_last() now is enabled. Has set up a TDX machine which can boot the SVSM in TD, so performed similar test as what test_port_io_string_16_get_last() did with TD, but didn't have a chance to test on with SEV due to lack of AMD machine. Appreciate it if someone can help to try this PR on an AMD machine.