### PR TITLE
clippy: remove unused-qualifications lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,6 @@ missing_copy_implementations = "deny"
 missing_debug_implementations = "deny"
 single_use_lifetimes = "warn"
 trivial-numeric-casts = "deny"
-unused-qualifications = "deny"
 
 [workspace.lints.clippy]
 await_holding_lock = "warn"


### PR DESCRIPTION
The lint is currently broken on nightly and causes in-SVSM tests to fail, so just remove it for now.