### PR TITLE
svsm: permit early initialization of console logging

### DIFF
--- a/kernel/src/console.rs
+++ b/kernel/src/console.rs
@@ -30,7 +30,9 @@ static CONSOLE_INITIALIZED: ImmutAfterInitCell<bool> = ImmutAfterInitCell::new(f
 
 pub fn init_console(writer: &'static dyn Terminal) -> ImmutAfterInitResult<()> {
     WRITER.lock().writer = writer;
-    CONSOLE_INITIALIZED.reinit(&true)
+    CONSOLE_INITIALIZED.reinit(&true)?;
+    log::info!("COCONUT Secure Virtual Machine Service Module");
+    Ok(())
 }
 
 #[doc(hidden)]

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -70,6 +70,8 @@ pub enum SvsmError {
     InvalidBytes,
     /// Errors related to firmware parsing
     Firmware,
+    /// Errors related to console operation
+    Console,
     /// Errors related to firmware configuration contents
     FwCfg(FwCfgError),
     /// Errors related to ACPI parsing.

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -44,11 +44,11 @@ pub enum PageStateChangeOp {
 /// underlying architectures.
 pub trait SvsmPlatform {
     /// Performs basic early initialization of the runtime environment.
-    fn env_setup(&mut self);
+    fn env_setup(&mut self, debug_serial_port: u16) -> Result<(), SvsmError>;
 
     /// Performs initialization of the platform runtime environment after
-    /// console logging has been initialized.
-    fn env_setup_late(&mut self);
+    /// the core system environment has been initialized.
+    fn env_setup_late(&mut self, debug_serial_port: u16) -> Result<(), SvsmError>;
 
     /// Completes initialization of a per-CPU object during construction.
     fn setup_percpu(&self, cpu: &PerCpu) -> Result<(), SvsmError>;
@@ -62,8 +62,9 @@ pub trait SvsmPlatform {
     /// Establishes state required for guest/host communication.
     fn setup_guest_host_comm(&mut self, cpu: &PerCpu, is_bsp: bool);
 
-    /// Obtains a console I/O port reference.
-    fn get_console_io_port(&self) -> &'static dyn IOPort;
+    /// Obtains a reference to an I/O port implemetation appropriate to the
+    /// platform.
+    fn get_io_port(&self) -> &'static dyn IOPort;
 
     /// Performs a page state change between private and shared states.
     fn page_state_change(

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -5,16 +5,21 @@
 // Author: Jon Lange <jlange@microsoft.com>
 
 use crate::address::{PhysAddr, VirtAddr};
+use crate::console::init_console;
 use crate::cpu::cpuid::CpuidResult;
 use crate::cpu::msr::write_msr;
 use crate::cpu::percpu::PerCpu;
 use crate::error::SvsmError;
-use crate::platform::{IOPort, PageEncryptionMasks, PageStateChangeOp, SvsmPlatform};
+use crate::io::IOPort;
+use crate::platform::{PageEncryptionMasks, PageStateChangeOp, SvsmPlatform};
+use crate::serial::SerialPort;
 use crate::svsm_console::NativeIOPort;
 use crate::types::PageSize;
+use crate::utils::immut_after_init::ImmutAfterInitCell;
 use crate::utils::MemoryRegion;
 
 static CONSOLE_IO: NativeIOPort = NativeIOPort::new();
+static CONSOLE_SERIAL: ImmutAfterInitCell<SerialPort<'_>> = ImmutAfterInitCell::uninit();
 
 const APIC_MSR_ICR: u32 = 0x830;
 
@@ -34,8 +39,19 @@ impl Default for NativePlatform {
 }
 
 impl SvsmPlatform for NativePlatform {
-    fn env_setup(&mut self) {}
-    fn env_setup_late(&mut self) {}
+    fn env_setup(&mut self, debug_serial_port: u16) -> Result<(), SvsmError> {
+        // In the native platform, console output does not require the use of
+        // any platform services, so it can be initialized immediately.
+        CONSOLE_SERIAL
+            .init(&SerialPort::new(&CONSOLE_IO, debug_serial_port))
+            .map_err(|_| SvsmError::Console)?;
+        (*CONSOLE_SERIAL).init();
+        init_console(&*CONSOLE_SERIAL).map_err(|_| SvsmError::Console)
+    }
+
+    fn env_setup_late(&mut self, _debug_serial_port: u16) -> Result<(), SvsmError> {
+        Ok(())
+    }
 
     fn setup_percpu(&self, _cpu: &PerCpu) -> Result<(), SvsmError> {
         Ok(())
@@ -58,7 +74,7 @@ impl SvsmPlatform for NativePlatform {
 
     fn setup_guest_host_comm(&mut self, _cpu: &PerCpu, _is_bsp: bool) {}
 
-    fn get_console_io_port(&self) -> &'static dyn IOPort {
+    fn get_io_port(&self) -> &'static dyn IOPort {
         &CONSOLE_IO
     }
 


### PR DESCRIPTION
On platforms that do not require extensive platform setup (e.g. GHCB) for console output services, initialize the console logger as early as possible to facilitate earlier logging of initialization activity.