### PR TITLE
stage1: add TD Partitioning support

### DIFF
--- a/stage1/reset.S
+++ b/stage1/reset.S
@@ -13,6 +13,7 @@
 
 	.code16gcc
 	.section .init
+/* to_pm_mode must be at 0xfffffe00 */
 ENTRY(to_pm_mode)
 	xor	%ax, %ax
 	mov	%ax, %ds
@@ -27,7 +28,7 @@ ENTRY(to_pm_mode)
 	mov	%eax, %cr0
 
 	lgdtl	%cs:0xfe00 + gdt32_descr - to_pm_mode
-	ljmpl	$8, $0xfffffe00 + protected_mode - to_pm_mode
+	ljmpl	$8, $protected_mode
 
 	.code32
 protected_mode:
@@ -47,7 +48,7 @@ gdt32_end:
 
 gdt32_descr:
 	.word	gdt32_end - gdt32 - 1
-	.long	0xfffffe00 + gdt32 - to_pm_mode
+	.long	gdt32
 
 END(to_pm_mode)
 

--- a/stage1/reset.S
+++ b/stage1/reset.S
@@ -15,14 +15,13 @@
 	.section .init
 /* to_pm_mode must be at 0xfffffe00 */
 ENTRY(to_pm_mode)
-	xor	%ax, %ax
-	mov	%ax, %ds
-	mov	%ax, %es
-	mov	%ax, %fs
-	mov	%ax, %gs
-	mov	%ax, %ss
+	xor	%bx, %bx
+	mov	%bx, %ds
+	mov	%bx, %es
+	mov	%bx, %fs
+	mov	%bx, %gs
+	mov	%bx, %ss
 
-	mov	%cr0, %eax
 	and	$~((1 << 30) | (1 << 29)), %eax
 	or	$1, %al
 	mov	%eax, %cr0
@@ -31,6 +30,13 @@ ENTRY(to_pm_mode)
 	ljmpl	$8, $protected_mode
 
 	.code32
+td_mode:
+	and	$~((1 << 30) | (1 << 29)), %eax
+	mov	%eax, %cr0
+
+	lgdtl	%cs:gdt32_descr // flat 32-bit code segment
+	ljmpl	$8, $protected_mode
+
 protected_mode:
 	mov	$16, %ax
 	mov	%ax, %ds
@@ -57,4 +63,12 @@ END(to_pm_mode)
 
 	.code16gcc
 	.section .resetvector
+	mov	%cr0, %eax
+	test	$1, %al
+	// "JZ rel8" is compatible with both 16-bit and 32-bit mode
+	jz	real_mode
+	.code32
+	jmp	td_mode
+	.code16
+real_mode:
 	jmp	to_pm_mode

--- a/stage1/stage1.S
+++ b/stage1/stage1.S
@@ -41,9 +41,7 @@ startup_32:
 2:	popl	%ebp
 	leal	2b, %eax
 	subl	%eax, %ebp
-#endif
 
-#ifdef LOAD_STAGE2
 	leal	stage2_bin(%ebp), %esi
 	movl	$STAGE2_START, %edi
 	movl	stage2_size(%ebp), %ecx
@@ -54,7 +52,7 @@ startup_32:
 	movl	$STAGE2_START, %esp
 
 	/* Write startup information to stage2 stack */
-	xorl 	%eax, %eax
+	xorl	%eax, %eax
 	pushl	%eax
 
 	leal	kernel_fs_bin_end(%ebp), %edi
@@ -75,14 +73,45 @@ startup_32:
 	/* Reserve space for VTOM */
 	pushl	%eax
 	pushl	%eax
-
 #else
-	/* Setup stack for stage 2 */
+	/*
+	 * Stage 2 launch info has been prepared
+	 * Make sure platform type is TDP
+	 */
+	movl	$(STAGE2_START - 24), %eax
+	movl	(%eax), %eax
+	cmpl	$2, %eax
+	je	.Lsetup_td
+	ud2
+
+.Lsetup_td:
+	/* %esi is initialized with TD CPU index */
+	test	%esi, %esi
+	jz	.Lsetup_bsp_stack
+
+	/* Set up invalid stack for APs since they must run stacklessly */
+	movl	$0x7ffff000, %esp
+	jmp	.Lenter_stage2
+
+.Lsetup_bsp_stack:
+	/* Set up BSP stack for stage 2 */
 	movl	$(STAGE2_START - 32), %esp
+	/* %ebx is initialized with GPAW - save (1u64 << (GPAW - 1)) to vtom */
+	mov	%esp, %eax
+	/* GPAW must be either 48 or 52 */
+	xorl	%ecx, %ecx
+	movl	%ecx, (%eax)
+	addl	$4, %eax
+	subl	$33, %ebx
+	bts	%ebx, %ecx
+	movl	%ecx, (%eax)
+.Lenter_stage2:
 #endif
+
 	/* Jump to stage 2 */
 	movl	$STAGE2_START, %eax
 	jmp	*%eax
+
 .data
 
 #ifdef LOAD_STAGE2


### PR DESCRIPTION
This set of patches enables TDX in stage1 trampoline-only mode. This includes bootstrapping from the reset vector in protected non-paged mode, performing sanity checks, and setting up the ESP register.