### PR TITLE
protocols/apic: update the registration-based APIC protocol

### DIFF
--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -82,14 +82,12 @@ pub trait SvsmPlatform {
     /// Configures the use of alternate injection as requested.
     fn configure_alternate_injection(&mut self, alt_inj_requested: bool) -> Result<(), SvsmError>;
 
-    /// Indicates whether this system should make use of alternate injection.
-    fn use_alternate_injection(&self) -> bool;
+    /// Changes the state of APIC registration on this system, returning either
+    /// the current registration state or an error.
+    fn change_apic_registration_state(&self, incr: bool) -> Result<bool, SvsmError>;
 
-    /// Locks or unlocks the use of APIC emulation on this system.
-    fn lock_unlock_apic_emulation(&self, lock: bool) -> Result<(), SvsmError>;
-
-    /// Determines whether APIC emulation can be disabled on this system.
-    fn disable_apic_emulation(&self) -> Result<(), SvsmError>;
+    /// Queries the state of APIC registration on this system.
+    fn query_apic_registration_state(&self) -> bool;
 
     /// Signal an IRQ on one or more CPUs.
     fn post_irq(&self, icr: u64) -> Result<(), SvsmError>;

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -85,16 +85,12 @@ impl SvsmPlatform for NativePlatform {
         Ok(())
     }
 
-    fn use_alternate_injection(&self) -> bool {
+    fn change_apic_registration_state(&self, _incr: bool) -> Result<bool, SvsmError> {
+        Err(SvsmError::NotSupported)
+    }
+
+    fn query_apic_registration_state(&self) -> bool {
         false
-    }
-
-    fn lock_unlock_apic_emulation(&self, _lock: bool) -> Result<(), SvsmError> {
-        Err(SvsmError::NotSupported)
-    }
-
-    fn disable_apic_emulation(&self) -> Result<(), SvsmError> {
-        Err(SvsmError::NotSupported)
     }
 
     fn post_irq(&self, icr: u64) -> Result<(), SvsmError> {

--- a/kernel/src/platform/tdp.rs
+++ b/kernel/src/platform/tdp.rs
@@ -82,16 +82,12 @@ impl SvsmPlatform for TdpPlatform {
         Err(SvsmError::Tdx)
     }
 
-    fn use_alternate_injection(&self) -> bool {
+    fn change_apic_registration_state(&self, _incr: bool) -> Result<bool, SvsmError> {
+        Err(SvsmError::NotSupported)
+    }
+
+    fn query_apic_registration_state(&self) -> bool {
         false
-    }
-
-    fn lock_unlock_apic_emulation(&self, _lock: bool) -> Result<(), SvsmError> {
-        Err(SvsmError::Tdx)
-    }
-
-    fn disable_apic_emulation(&self) -> Result<(), SvsmError> {
-        Err(SvsmError::Tdx)
     }
 
     fn post_irq(&self, _icr: u64) -> Result<(), SvsmError> {


### PR DESCRIPTION
The current Alternate Injection specification describes the use of a count-based registration mechanism for tracking the enablement of APIC emulation, but the previous implementation of the code use the older locking-based design.  The code must be revised to match the current spec.