### PR TITLE
console: minor cleanups

### DIFF
--- a/kernel/src/console.rs
+++ b/kernel/src/console.rs
@@ -9,7 +9,7 @@ use crate::serial::{Terminal, DEFAULT_SERIAL_PORT};
 use crate::utils::immut_after_init::{ImmutAfterInitCell, ImmutAfterInitResult};
 use core::fmt;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 struct Console {
     writer: &'static dyn Terminal,
 }
@@ -20,14 +20,6 @@ impl fmt::Write for Console {
             self.writer.put_byte(ch);
         }
         Ok(())
-    }
-}
-
-impl fmt::Debug for Console {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Console")
-            .field("writer", &format_args!("{:?}", self.writer as *const _,))
-            .finish()
     }
 }
 

--- a/kernel/src/console.rs
+++ b/kernel/src/console.rs
@@ -51,20 +51,13 @@ pub fn _print(args: fmt::Arguments<'_>) {
 }
 
 #[derive(Clone, Copy, Debug)]
-struct ConsoleLoggerComponent {
+struct ConsoleLogger {
     name: &'static str,
 }
 
-#[derive(Clone, Copy, Debug)]
-struct ConsoleLogger {
-    component: ConsoleLoggerComponent,
-}
-
 impl ConsoleLogger {
-    fn new(component: &'static str) -> ConsoleLogger {
-        ConsoleLogger {
-            component: ConsoleLoggerComponent { name: component },
-        }
+    const fn new(name: &'static str) -> Self {
+        Self { name }
     }
 }
 
@@ -80,26 +73,25 @@ impl log::Log for ConsoleLogger {
 
         // The logger being uninitialized is impossible, as that would mean it
         // wouldn't have been registered with the log library.
-        let component = self.component.name;
         // Log format/detail depends on the level.
         match record.metadata().level() {
             log::Level::Error | log::Level::Warn => {
                 _print(format_args!(
                     "[{}] {}: {}\n",
-                    component,
+                    self.name,
                     record.metadata().level().as_str(),
                     record.args()
                 ));
             }
 
             log::Level::Info => {
-                _print(format_args!("[{}] {}\n", component, record.args()));
+                _print(format_args!("[{}] {}\n", self.name, record.args()));
             }
 
             log::Level::Debug | log::Level::Trace => {
                 _print(format_args!(
                     "[{}/{}] {} {}\n",
-                    component,
+                    self.name,
                     record.metadata().target(),
                     record.metadata().level().as_str(),
                     record.args()

--- a/kernel/src/serial.rs
+++ b/kernel/src/serial.rs
@@ -5,6 +5,7 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 
 use super::io::{IOPort, DEFAULT_IO_DRIVER};
+use core::fmt::Debug;
 
 pub const SERIAL_PORT: u16 = 0x3f8;
 const BAUD: u32 = 9600;
@@ -25,7 +26,7 @@ pub const DLH: u16 = 1; // Divisor Latch High
 pub const RCVRDY: u8 = 0x01;
 pub const XMTRDY: u8 = 0x20;
 
-pub trait Terminal: Sync {
+pub trait Terminal: Sync + Debug {
     fn put_byte(&self, _ch: u8) {}
     fn get_byte(&self) -> u8 {
         0


### PR DESCRIPTION
* Remove an unnecessary type.
* Remove an unnecessary `Debug` manual implementation.