### PR TITLE
boot_stage2: avoid modifying EFER if possible

### DIFF
--- a/kernel/src/boot_stage2.rs
+++ b/kernel/src/boot_stage2.rs
@@ -88,7 +88,9 @@ global_asm!(
         movl $0xc0000080, %ecx
         rdmsr
         bts $8, %eax
+        jc 2f
         wrmsr
+        2:
 
         /* Load the static page table root. */
         movl $pgtable, %eax


### PR DESCRIPTION
TDX does not permit writing to the EFER register.  Instead, EFER.LME is set as part of the reset state so long mode can be activated once paging is enabled.  Since EFER.LME is already set by the hardware, any attempt to set EFER.LME should not write the EFER MSR if EFER.LME is already set.