### PR TITLE
error: subsume ApicError into SvsmError

### DIFF
--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -9,7 +9,6 @@ extern crate alloc;
 use super::gdt_mut;
 use super::tss::{X86Tss, IST_DF};
 use crate::address::{Address, PhysAddr, VirtAddr};
-use crate::cpu::apic::ApicError;
 use crate::cpu::idt::common::INT_INJ_VECTOR;
 use crate::cpu::tss::TSS_LIMIT;
 use crate::cpu::vmsa::{init_guest_vmsa, init_svsm_vmsa, vmsa_mut_ref_from_vaddr};
@@ -732,7 +731,7 @@ impl PerCpu {
         self.apic().is_some()
     }
 
-    pub fn read_apic_register(&self, register: u64) -> Result<u64, ApicError> {
+    pub fn read_apic_register(&self, register: u64) -> Result<u64, SvsmError> {
         let mut vmsa_ref = self.guest_vmsa_ref();
         let caa_addr = vmsa_ref.caa_addr();
         let vmsa = vmsa_ref.vmsa();
@@ -743,7 +742,7 @@ impl PerCpu {
             .read_register(self.shared(), vmsa, caa_addr, register)
     }
 
-    pub fn write_apic_register(&self, register: u64, value: u64) -> Result<(), ApicError> {
+    pub fn write_apic_register(&self, register: u64, value: u64) -> Result<(), SvsmError> {
         let mut vmsa_ref = self.guest_vmsa_ref();
         let caa_addr = vmsa_ref.caa_addr();
         let vmsa = vmsa_ref.vmsa();

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -28,6 +28,17 @@ use crate::sev::SevSnpError;
 use crate::task::TaskError;
 use elf::ElfError;
 
+/// Errors related to APIC handling.  These may originate from multiple
+/// layers in the system.
+#[derive(Clone, Copy, Debug)]
+pub enum ApicError {
+    /// An error related to APIC emulation.
+    Emulation,
+
+    /// An error related to APIC registration.
+    Registration,
+}
+
 /// A generic error during SVSM operation.
 #[derive(Clone, Copy, Debug)]
 pub enum SvsmError {
@@ -72,11 +83,17 @@ pub enum SvsmError {
     /// The operation is not supported.
     NotSupported,
     /// Generic errors related to APIC emulation.
-    Apic,
+    Apic(ApicError),
 }
 
 impl From<ElfError> for SvsmError {
     fn from(err: ElfError) -> Self {
         Self::Elf(err)
+    }
+}
+
+impl From<ApicError> for SvsmError {
+    fn from(err: ApicError) -> Self {
+        Self::Apic(err)
     }
 }

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -7,6 +7,7 @@
 use crate::address::{PhysAddr, VirtAddr};
 use crate::cpu::cpuid::cpuid_table;
 use crate::cpu::percpu::{current_ghcb, PerCpu};
+use crate::error::ApicError::Registration;
 use crate::error::SvsmError;
 use crate::io::IOPort;
 use crate::platform::{PageEncryptionMasks, PageStateChangeOp, SvsmPlatform};
@@ -145,9 +146,11 @@ impl SvsmPlatform for SnpPlatform {
                 // has not already dropped to zero, and only if the
                 // registration count will not wrap around.
                 if current == 0 {
-                    return Err(SvsmError::Apic);
+                    return Err(SvsmError::Apic(Registration));
                 }
-                current.checked_add(1).ok_or(SvsmError::Apic)?
+                current
+                    .checked_add(1)
+                    .ok_or(SvsmError::Apic(Registration))?
             } else {
                 // An attempt to decrement when the count is already zero is
                 // considered a benign race, which will not result in any

--- a/kernel/src/protocols/errors.rs
+++ b/kernel/src/protocols/errors.rs
@@ -4,6 +4,7 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
+use crate::error::ApicError;
 use crate::error::SvsmError;
 
 #[derive(Debug, Clone, Copy)]
@@ -37,6 +38,8 @@ impl From<SvsmResultCode> for u64 {
         }
     }
 }
+
+const SVSM_ERR_APIC_CANNOT_REGISTER: u64 = 0;
 
 #[derive(Debug, Clone, Copy)]
 pub enum SvsmReqError {
@@ -75,6 +78,10 @@ impl From<SvsmError> for SvsmReqError {
             // to the guest as protocol-specific errors.
             SvsmError::SevSnp(e) => Self::protocol(e.ret()),
             SvsmError::InvalidAddress => Self::invalid_address(),
+            SvsmError::Apic(e) => match e {
+                ApicError::Emulation => Self::invalid_parameter(),
+                ApicError::Registration => Self::protocol(SVSM_ERR_APIC_CANNOT_REGISTER),
+            },
             // Use a fatal error for now
             _ => Self::FatalError(err),
         }


### PR DESCRIPTION
This change removes `ApicError` as a type associated with APIC emulation and defines it as a subordinate type of `SvsmError`, with variants describing the types of errors that may be associated with APIC handling (emulation or otherwise).  This permits unification of error types across different components so they can all use `SvsmError`.