### PR TITLE
platform/snp: enable alternate injection only if requested

### DIFF
--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -126,11 +126,13 @@ impl SvsmPlatform for SnpPlatform {
     }
 
     fn configure_alternate_injection(&mut self, alt_inj_requested: bool) -> Result<(), SvsmError> {
+        if !alt_inj_requested {
+            return Ok(());
+        }
+
         // If alternate injection was requested, then it must be supported by
         // the hypervisor.
-        if alt_inj_requested
-            && !hypervisor_ghcb_features().contains(GHCBHvFeatures::SEV_SNP_EXT_INTERRUPTS)
-        {
+        if !hypervisor_ghcb_features().contains(GHCBHvFeatures::SEV_SNP_EXT_INTERRUPTS) {
             return Err(SvsmError::NotSupported);
         }
 


### PR DESCRIPTION
The current logic for enabling alternate injection is broken, as it will enable it always. This is causing a crash during boot when running under a hypervisor that does not support the feature:

```
[SVSM] ERROR: Panic: CPU[0] panicked at kernel/src/svsm.rs:449:36:
Failed to setup guest VMSA/CAA: Ghcb(VmgexitError(2, 6))
[SVSM] ---BACKTRACE---:
[SVSM]   [0xffffff8000128445]
[SVSM]   Invalid frame
[SVSM] ---END---
```

Fix this by checking upfront if the feature was requested.

Fixes: 978aef5a9d75 ("protocols/apic: update the registration-based APIC protocol")