### PR TITLE
libmstpm: disable red zone

### DIFF
--- a/libmstpm/Makefile
+++ b/libmstpm/Makefile
@@ -103,7 +103,7 @@ $(LIBTPM): $(MSTPM_MAKEFILE) $(LIBCRYPTO)
 $(LIBPLATFORM): $(MSTPM_MAKEFILE) $(LIBCRYPTO)
 	$(MAKE) -C $(MSTPM_DIR) $(LIBPLATFORM_A)
 
-MSTPM_CFLAGS += -static -nostdinc -fno-stack-protector -fPIE -mno-sse
+MSTPM_CFLAGS += -static -nostdinc -fno-stack-protector -fPIE -mno-sse -mno-red-zone
 MSTPM_CFLAGS += -DSIMULATION=NO -DFILE_BACKED_NV=NO
 MSTPM_CFLAGS += -I$(LIBCRT_DIR)/include
 MSTPM_CFLAGS += -I$(OPENSSL_DIR)/include

--- a/libmstpm/deps/libcrt/Makefile
+++ b/libmstpm/deps/libcrt/Makefile
@@ -6,7 +6,7 @@ else
 CFLAGS = -g -O0
 endif
 
-CFLAGS += -I./include -nostdinc -nostdlib
+CFLAGS += -I./include -nostdinc -nostdlib -mno-red-zone
 CFLAGS += -m64 -march=x86-64 -mno-sse2 -fPIE
 CFLAGS += -fno-stack-protector
 CFLAGS += -ffreestanding

--- a/libmstpm/deps/openssl_svsm.conf
+++ b/libmstpm/deps/openssl_svsm.conf
@@ -18,7 +18,7 @@ my %targets = (
                                           # exception 6 (invalid opcode) usually in:
                                           # vtpm_init()->libtpm:manufacture()->libcrypto:BN_CTX_new()
                                           release => "-O0"),
-                                   "-fPIE -m64 -nostdinc -nostdlib -static -fno-stack-protector")),
+                                   "-fPIE -m64 -nostdinc -nostdlib -static -fno-stack-protector -mno-red-zone")),
         bn_ops          => "SIXTY_FOUR_BIT_LONG",
         lib_cppflags    => add("-DL_ENDIAN -DNO_SYSLOG -DOPENSSL_SMALL_FOOTPRINT -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE"),
         sys_id          => "SVSM"


### PR DESCRIPTION
As reported by Jiewen Yao, OpenSSL is built using a stack red zone, which causes issues when returning from an interrupt. Disable it in the OpenSSL build flags, as well as in libmstpm and libcrt.

Fixes: #404