### PR TITLE
errors: introduce APIC disabled error

### DIFF
--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -32,6 +32,9 @@ use elf::ElfError;
 /// layers in the system.
 #[derive(Clone, Copy, Debug)]
 pub enum ApicError {
+    /// An error arising because APIC emulation is disabled.
+    Disabled,
+
     /// An error related to APIC emulation.
     Emulation,
 

--- a/kernel/src/protocols/apic.rs
+++ b/kernel/src/protocols/apic.rs
@@ -62,9 +62,6 @@ fn apic_configure(params: &RequestParams) -> Result<(), SvsmReqError> {
 
 fn apic_read_register(params: &mut RequestParams) -> Result<(), SvsmReqError> {
     let cpu = this_cpu();
-    if !cpu.use_apic_emulation() {
-        return Err(SvsmReqError::invalid_request());
-    }
     let value = cpu.read_apic_register(params.rcx)?;
     params.rdx = value;
     Ok(())
@@ -72,19 +69,19 @@ fn apic_read_register(params: &mut RequestParams) -> Result<(), SvsmReqError> {
 
 fn apic_write_register(params: &RequestParams) -> Result<(), SvsmReqError> {
     let cpu = this_cpu();
-    if !cpu.use_apic_emulation() {
-        return Err(SvsmReqError::invalid_request());
-    }
     cpu.write_apic_register(params.rcx, params.rdx)?;
     Ok(())
 }
 
 fn apic_configure_vector(params: &RequestParams) -> Result<(), SvsmReqError> {
     let cpu = this_cpu();
+    if !cpu.use_apic_emulation() {
+        return Err(SvsmReqError::invalid_request());
+    }
     if params.rcx <= 0x1FF {
         let vector: u8 = (params.rcx & 0xFF) as u8;
         let allowed = (params.rcx & 0x100) != 0;
-        cpu.configure_apic_vector(vector, allowed);
+        cpu.configure_apic_vector(vector, allowed)?;
         Ok(())
     } else {
         Err(SvsmReqError::invalid_parameter())

--- a/kernel/src/protocols/errors.rs
+++ b/kernel/src/protocols/errors.rs
@@ -79,6 +79,7 @@ impl From<SvsmError> for SvsmReqError {
             SvsmError::SevSnp(e) => Self::protocol(e.ret()),
             SvsmError::InvalidAddress => Self::invalid_address(),
             SvsmError::Apic(e) => match e {
+                ApicError::Disabled => Self::unsupported_protocol(),
                 ApicError::Emulation => Self::invalid_parameter(),
                 ApicError::Registration => Self::protocol(SVSM_ERR_APIC_CANNOT_REGISTER),
             },


### PR DESCRIPTION
Introducing `Disabled` to `SvsmError(Apic)` simplifies error handling in many of the paths that involve determining whether APIC emulation is active.