### PR TITLE
stage2: add TD Partitioning support to boot_stage2

### DIFF
--- a/kernel/src/boot_stage2.rs
+++ b/kernel/src/boot_stage2.rs
@@ -16,8 +16,8 @@ global_asm!(
         .globl startup_32
         startup_32:
 
-        /* Save pointer to startup structure in ESI */
-        movl %esp, %esi
+        /* Save pointer to startup structure in EBP */
+        movl %esp, %ebp
         /*
          * Load a GDT. Despite the naming, it contains valid
          * entries for both, "legacy" 32bit and long mode each.
@@ -113,7 +113,7 @@ global_asm!(
         /*
          * Check if this is an SNP platform.  If not, there is no C bit.
          */
-        cmpl $1, 8(%esi)
+        cmpl $1, 8(%ebp)
         jnz .Lvtom
 
         /*
@@ -215,7 +215,7 @@ global_asm!(
         shrq $3, %rcx
         rep stosq
 
-        movq %rsi, %rdi
+        movl %ebp, %edi
         jmp stage2_main
 
         .data

--- a/kernel/src/boot_stage2.rs
+++ b/kernel/src/boot_stage2.rs
@@ -170,7 +170,7 @@ global_asm!(
         jmp .Lfound_entry
 
     .Lwrong_entry:
-        /* 
+        /*
          * The current entry doesn't contain the correct input
          * parameters. Try the next one.
          */
@@ -216,6 +216,14 @@ global_asm!(
         movw %ax, %gs
         movw %ax, %ss
 
+        test %esi, %esi
+        jz .Lbsp_main
+
+    .Lcheck_command:
+        /* TODO */
+        jmp .Lcheck_command
+
+    .Lbsp_main:
         /* Clear out .bss and transfer control to the main stage2 code. */
         xorq %rax, %rax
         leaq _bss(%rip), %rdi

--- a/kernel/src/boot_stage2.rs
+++ b/kernel/src/boot_stage2.rs
@@ -32,13 +32,9 @@ global_asm!(
         movw %ax, %gs
         movw %ax, %ss
 
-        pushl $0x8
-        movl $.Lon_svsm32_cs, %eax
-        pushl %eax
-        lret
+        ljmpl $0x8, $.Lon_svsm32_cs
 
     .Lon_svsm32_cs:
-        push    %edi
 
         /* Clear out the static page table pages. */
         movl $pgtable_end, %ecx
@@ -101,13 +97,7 @@ global_asm!(
         bts $31, %eax
         movl %eax, %cr0
 
-        popl    %edi
-
-        pushl $0x18
-        movl $startup_64, %eax
-        pushl %eax
-
-        lret
+        ljmpl $0x18, $startup_64
 
     get_pte_c_bit:
         /*


### PR DESCRIPTION
This is the first half of the TDX enabling work in stage2. It focuses on boot_stage2.rs, before reaching stage2_main(). The main goal of this patchset is to lay the groundwork for TD SMP support. TD SMP boot flow is different from traditional x86 SMP in that all TD vCPUs start execution in 32-bit non-paged mode concurrently and the INIT/SIPI protocol is not used.