### PR TITLE
workspace: remove `missing_copy_implementations` workspace lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ packit = { git = "https://github.com/coconut-svsm/packit", version = "0.1.1" }
 future_incompatible = "deny"
 nonstandard_style = "deny"
 rust_2018_idioms = "deny"
-missing_copy_implementations = "deny"
 missing_debug_implementations = "deny"
 single_use_lifetimes = "warn"
 trivial-numeric-casts = "deny"


### PR DESCRIPTION
Do not require `Copy` for all structures that can derive it, as this can be error prone and can inadvertently increase stack usage. For now, remove the related lint, as introducing `Copy` for in the future should not require too much work if necessary.