### PR TITLE
Prepare for update to COCONUT linux host and QEMU 9.0

### DIFF
--- a/kernel/src/cpu/vc.rs
+++ b/kernel/src/cpu/vc.rs
@@ -510,14 +510,12 @@ mod tests {
         assert_eq!(apic_base & APIC_BASE_PHYS_ADDR_MASK, APIC_DEFAULT_PHYS_BASE);
     }
 
-    const MSR_TSC_AUX: u32 = 0xc0000103;
-
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
-    fn test_wrmsr_tsc_aux() {
-        let test_val = 0x1234;
-        verify_ghcb_gets_altered(|| write_msr(MSR_TSC_AUX, test_val));
-        let readback = verify_ghcb_gets_altered(|| read_msr(MSR_TSC_AUX));
+    fn test_wrmsr_apic_base() {
+        let test_val = read_msr(MSR_APIC_BASE);
+        verify_ghcb_gets_altered(|| write_msr(MSR_APIC_BASE, test_val));
+        let readback = verify_ghcb_gets_altered(|| read_msr(MSR_APIC_BASE));
         assert_eq!(test_val, readback);
     }
 
@@ -569,8 +567,8 @@ mod tests {
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn test_rdtscp() {
-        let expected_pid = u32::try_from(verify_ghcb_gets_altered(|| read_msr(MSR_TSC_AUX)))
-            .expect("pid should be 32 bits");
+        const MSR_TSC_AUX: u32 = 0xc0000103;
+        let expected_pid = u32::try_from(read_msr(MSR_TSC_AUX)).expect("pid should be 32 bits");
         let RdtscpOut {
             timestamp: mut prev,
             pid,

--- a/kernel/src/cpu/vc.rs
+++ b/kernel/src/cpu/vc.rs
@@ -510,14 +510,6 @@ mod tests {
         assert_eq!(apic_base & APIC_BASE_PHYS_ADDR_MASK, APIC_DEFAULT_PHYS_BASE);
     }
 
-    #[test]
-    #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
-    fn test_rdmsr_debug_ctl() {
-        const MSR_DEBUG_CTL: u32 = 0x1d9;
-        let apic_base = verify_ghcb_gets_altered(|| read_msr(MSR_DEBUG_CTL));
-        assert_eq!(apic_base, 0);
-    }
-
     const MSR_TSC_AUX: u32 = 0xc0000103;
 
     #[test]

--- a/scripts/launch_guest.sh
+++ b/scripts/launch_guest.sh
@@ -62,12 +62,24 @@ QEMU_MINOR=${QEMU_MINOR%%.$QEMU_BUILD}
 
 # The QEMU machine and memory command line changed after QEMU 8.2.0 from
 # the coconut-svsm git repository.
-if (( (QEMU_MAJOR > 8) || ((QEMU_MAJOR == 8) && (QEMU_MINOR >= 2)) )); then
+if (( QEMU_MAJOR >= 9 )); then
+  MACHINE=q35,confidential-guest-support=sev0,memory-backend=mem0,igvm-cfg=igvm0
+  IGVM_OBJECT=
+  MEMORY=memory-backend-memfd,size=8G,id=mem0,share=true,prealloc=false,reserve=false
+  IGVM_OBJECT="-object igvm-cfg,id=igvm0,file=$IGVM"
+  INIT_FLAGS=
+  IGVM_FILE=
+elif (( (QEMU_MAJOR > 8) || ((QEMU_MAJOR == 8) && (QEMU_MINOR >= 2)) )); then
   MACHINE=q35,confidential-guest-support=sev0,memory-backend=mem0
   MEMORY=memory-backend-memfd,size=8G,id=mem0,share=true,prealloc=false,reserve=false
+  IGVM_FILE=",igvm-file=$IGVM"
+  IGVM_OBJECT=
+  INIT_FLAGS=,init-flags=5
 else
   MACHINE=q35,confidential-guest-support=sev0,memory-backend=mem0,kvm-type=protected
   MEMORY=memory-backend-memfd-private,size=8G,id=mem0,share=true
+  IGVM_OBJECT=
+  INIT_FLAGS=,init-flags=5
 fi
 
 # Setup a disk if an image has been specified
@@ -103,7 +115,8 @@ $SUDO_CMD \
     -cpu EPYC-v4 \
     -machine $MACHINE \
     -object $MEMORY \
-    -object sev-snp-guest,id=sev0,cbitpos=$C_BIT_POS,reduced-phys-bits=1,init-flags=5,igvm-file=$IGVM \
+    -object sev-snp-guest,id=sev0,cbitpos=$C_BIT_POS,reduced-phys-bits=1$INIT_FLAGS$IGVM_FILE \
+    $IGVM_OBJECT \
     -smp 4 \
     -no-reboot \
     -netdev user,id=vmnic -device e1000,netdev=vmnic,romfile= \


### PR DESCRIPTION
This PR consists of commits that are required to launch and run tests when hosted on a system with the following kernel and QEMU versions:

Linux-6.10-rc2:
https://github.com/coconut-svsm/linux/pull/6

QEMU 9.0:
https://github.com/coconut-svsm/qemu/pull/15

The intercept behaviour of some MSRs has changed since the previous COCONUT linux version, hence tests needed to be updated. Also, the QEMU command line has changed requiring a change in the launch script. The script is still compatible with early versions of QEMU/kernel.

I've also added an extra commit that fixes failing test-in-svsm cases when run on a Genoa system.