### PR TITLE
igvmbuilder: fix incorrect CPUID table construction

### DIFF
--- a/igvmbuilder/src/cpuid.rs
+++ b/igvmbuilder/src/cpuid.rs
@@ -79,7 +79,7 @@ impl SnpCpuidPage {
     pub fn new() -> Result<Self, Box<dyn Error>> {
         let mut cpuid_page = SnpCpuidPage::default();
         cpuid_page.add(SnpCpuidLeaf::new1(0x8000001f))?;
-        cpuid_page.add(SnpCpuidLeaf::new2(1, 1))?;
+        cpuid_page.add(SnpCpuidLeaf::new1(1))?;
         cpuid_page.add(SnpCpuidLeaf::new1(2))?;
         cpuid_page.add(SnpCpuidLeaf::new1(4))?;
         cpuid_page.add(SnpCpuidLeaf::new2(4, 1))?;


### PR DESCRIPTION
The IGVM file specifies the set of CPUID leaves that are expected to be provided when the IGVM file is loaded.  The builder was erroneously specifying leaf EAX=1 with subleaf ECX=1, which is not architecturally defined.  This caused the subsequent CPUID lookup to fail when the SVSM would execute its CPUID lookup code.