### PR TITLE
cpu/tlb: do not broadcast per-cpu TLB flushes

### DIFF
--- a/kernel/src/cpu/control_regs.rs
+++ b/kernel/src/cpu/control_regs.rs
@@ -24,10 +24,12 @@ pub fn cr4_init() {
 
     cr4.insert(CR4Flags::PSE); // Enable Page Size Extensions
 
-    if cpu_has_pge() {
-        cr4.insert(CR4Flags::PGE); // Enable Global Pages
-    }
+    // All processors that are capable of virtualization will support global
+    // page table entries, so there is no reason to support any processor that
+    // does not enumerate PGE capability.
+    assert!(cpu_has_pge(), "CPU does not support PGE");
 
+    cr4.insert(CR4Flags::PGE); // Enable Global Pages
     write_cr4(cr4);
 }
 

--- a/kernel/src/cpu/control_regs.rs
+++ b/kernel/src/cpu/control_regs.rs
@@ -34,6 +34,7 @@ pub fn cr4_init() {
 }
 
 bitflags! {
+    #[derive(Debug, Clone, Copy)]
     pub struct CR0Flags: u64 {
         const PE = 1 << 0;  // Protection Enabled
         const MP = 1 << 1;  // Monitor Coprocessor
@@ -108,6 +109,7 @@ pub fn write_cr3(cr3: PhysAddr) {
 }
 
 bitflags! {
+    #[derive(Debug, Clone, Copy)]
     pub struct CR4Flags: u64 {
         const VME       = 1 << 0;  // Virtual-8086 Mode Extensions
         const PVI       = 1 << 1;  // Protected-Mode Virtual Interrupts

--- a/kernel/src/cpu/efer.rs
+++ b/kernel/src/cpu/efer.rs
@@ -36,9 +36,11 @@ pub fn write_efer(efer: EFERFlags) {
 pub fn efer_init() {
     let mut efer = read_efer();
 
-    if cpu_has_nx() {
-        efer.insert(EFERFlags::NXE);
-    }
+    // All processors that are capable of virtualization will support
+    // no-execute table entries, so there is no reason to support any processor
+    // that does not enumerate NX capability.
+    assert!(cpu_has_nx(), "CPU does not support NX");
 
+    efer.insert(EFERFlags::NXE);
     write_efer(efer);
 }

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -323,7 +323,12 @@ impl PerCpu {
             tss: Cell::new(X86Tss::new()),
             svsm_vmsa: OnceCell::new(),
             reset_ip: Cell::new(0xffff_fff0),
-            vm_range: VMR::new(SVSM_PERCPU_BASE, SVSM_PERCPU_END, PTEntryFlags::GLOBAL),
+            vm_range: {
+                let mut vmr = VMR::new(SVSM_PERCPU_BASE, SVSM_PERCPU_END, PTEntryFlags::GLOBAL);
+                vmr.set_per_cpu(true);
+                vmr
+            },
+
             vrange_4k: RefCell::new(VirtualRange::new()),
             vrange_2m: RefCell::new(VirtualRange::new()),
             runqueue: RefCell::new(RunQueue::new()),

--- a/kernel/src/mm/pagetable.rs
+++ b/kernel/src/mm/pagetable.rs
@@ -6,7 +6,6 @@
 
 use crate::address::{Address, PhysAddr, VirtAddr};
 use crate::cpu::control_regs::write_cr3;
-use crate::cpu::features::{cpu_has_nx, cpu_has_pge};
 use crate::cpu::flush_tlb_global_sync;
 use crate::error::SvsmError;
 use crate::locking::{LockGuard, SpinLock};
@@ -57,13 +56,7 @@ pub fn paging_init_early(platform: &dyn SvsmPlatform, vtom: u64) -> ImmutAfterIn
 pub fn paging_init(platform: &dyn SvsmPlatform, vtom: u64) -> ImmutAfterInitResult<()> {
     init_encrypt_mask(platform, vtom.try_into().unwrap())?;
 
-    let mut feature_mask = PTEntryFlags::all();
-    if !cpu_has_nx() {
-        feature_mask.remove(PTEntryFlags::NX);
-    }
-    if !cpu_has_pge() {
-        feature_mask.remove(PTEntryFlags::GLOBAL);
-    }
+    let feature_mask = PTEntryFlags::all();
     FEATURE_MASK.reinit(&feature_mask)
 }
 


### PR DESCRIPTION
VM ranges that are specific to a single CPU do not require TLB invalidations to be broadcast to multiple processors.  This is especially important during the early boot phase when no other processors are online and when the infrastructure required to broadcast TLB invalidations may not yet be fully initialized.  The same is true for temporary mappings established in a per-CPU address range.