### PR TITLE
build: Allow building without mstpm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,8 @@
-FEATURES ?= "default"
-SVSM_ARGS = --features ${FEATURES}
+FEATURES ?= mstpm
+SVSM_ARGS += --features ${FEATURES}
 
-SVSM_ARGS_TEST = --no-default-features
-ifdef FEATURES_TEST
-	SVSM_ARGS_TEST += --features ${FEATURES_TEST}
-endif
+FEATURES_TEST ?= mstpm
+SVSM_ARGS_TEST += --no-default-features --features ${FEATURES_TEST}
 
 ifdef RELEASE
 TARGET_PATH=release
@@ -112,7 +110,7 @@ bin/meta.bin: utils/gen_meta utils/print-meta bin
 	./utils/gen_meta $@
 
 bin/stage2.bin: bin
-	cargo build --manifest-path kernel/Cargo.toml ${CARGO_ARGS} --no-default-features --bin stage2
+	cargo build --manifest-path kernel/Cargo.toml ${CARGO_ARGS} --bin stage2
 	objcopy -O binary ${STAGE2_ELF} $@
 
 bin/svsm-kernel.elf: bin
@@ -120,7 +118,7 @@ bin/svsm-kernel.elf: bin
 	objcopy -O elf64-x86-64 --strip-unneeded ${SVSM_KERNEL_ELF} $@
 
 bin/test-kernel.elf: bin
-	LINK_TEST=1 cargo +nightly test ${CARGO_ARGS} -p svsm --config 'target.x86_64-unknown-none.runner=["sh", "-c", "cp $$0 ../${TEST_KERNEL_ELF}"]'
+	LINK_TEST=1 cargo +nightly test ${CARGO_ARGS} ${SVSM_ARGS_TEST} -p svsm --config 'target.x86_64-unknown-none.runner=["sh", "-c", "cp $$0 ../${TEST_KERNEL_ELF}"]'
 	objcopy -O elf64-x86-64 --strip-unneeded ${TEST_KERNEL_ELF} bin/test-kernel.elf
 
 ${FS_BIN}: bin

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -38,7 +38,7 @@ libmstpm = { workspace = true, optional = true }
 test.workspace = true
 
 [features]
-default = ["mstpm"]
+default = []
 enable-gdb = ["dep:gdbstub", "dep:gdbstub_arch"]
 mstpm = ["dep:libmstpm"]
 


### PR DESCRIPTION
The svsm crate allows the libmstpm dependency to be optional, but since it's a default feature there's no actual way to use make to compile it that disables the feature. Add the necessary parts so that it can be compiled out. This allows running FEATURES='""' make to not build the mstpm.

If there's an existing or better way to do this, please let me know!