### PR TITLE
kernel/task/schedule: Disable interrupt during context switching

### DIFF
--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -388,6 +388,9 @@ global_asm!(
         movq    %rsp, (%rsi)
 
     1:
+        // Disable interrupt
+        cli
+
         // Switch to the new task state
         mov     %rdx, %cr3
 


### PR DESCRIPTION
The instructions "mov %rdx, %cr3" and "movq (%rdi), %rsp" will switch the page table and stack. An interrupt happening in the middle of the switching can corrupt the stack, as it will push data to the old rsp address but is translated by the new page table. To avoid such stack corruption, disable interrupt before the switching the page table and stack. The interrupt will be restored by the popfq.