### PR TITLE
stage2: relocate stage2 and boot data to 8 MB

### DIFF
--- a/bootlib/src/igvm_params.rs
+++ b/bootlib/src/igvm_params.rs
@@ -106,12 +106,6 @@ pub struct IgvmParamBlock {
     /// context is present.
     pub guest_context_offset: u32,
 
-    /// The guest physical address of the CPUID page.
-    pub cpuid_page: u32,
-
-    /// The guest physical address of the SVSM secrets page.
-    pub secrets_page: u32,
-
     /// The port number of the serial port to use for debugging.
     pub debug_serial_port: u16,
 

--- a/bootlib/src/kernel_launch.rs
+++ b/bootlib/src/kernel_launch.rs
@@ -53,6 +53,12 @@ pub struct Stage2LaunchInfo {
     // platform_type must be the second field.
     pub platform_type: u32,
 
+    // cpuid_page must be the third field.
+    pub cpuid_page: u32,
+
+    // secrets_page must be the fourth field.
+    pub secrets_page: u32,
+
     pub kernel_elf_start: u32,
     pub kernel_elf_end: u32,
     pub kernel_fs_start: u32,

--- a/bootlib/src/kernel_launch.rs
+++ b/bootlib/src/kernel_launch.rs
@@ -61,9 +61,11 @@ pub struct Stage2LaunchInfo {
     // secrets_page must be the fourth field.
     pub secrets_page: u32,
 
+    pub stage2_end: u32,
     pub kernel_elf_start: u32,
     pub kernel_elf_end: u32,
     pub kernel_fs_start: u32,
     pub kernel_fs_end: u32,
     pub igvm_params: u32,
+    pub _reserved: u32,
 }

--- a/bootlib/src/kernel_launch.rs
+++ b/bootlib/src/kernel_launch.rs
@@ -23,6 +23,8 @@ pub struct KernelLaunchInfo {
     pub kernel_elf_stage2_virt_end: u64,
     pub kernel_fs_start: u64,
     pub kernel_fs_end: u64,
+    pub stage2_start: u64,
+    pub stage2_end: u64,
     pub cpuid_page: u64,
     pub secrets_page: u64,
     pub stage2_igvm_params_phys_addr: u64,

--- a/igvmbuilder/src/gpa_map.rs
+++ b/igvmbuilder/src/gpa_map.rs
@@ -55,7 +55,6 @@ pub struct GpaMap {
     pub stage1_image: GpaRange,
     pub stage2_stack: GpaRange,
     pub stage2_image: GpaRange,
-    pub stage2_free: GpaRange,
     pub secrets_page: GpaRange,
     pub cpuid_page: GpaRange,
     pub kernel_elf: GpaRange,
@@ -108,9 +107,9 @@ impl GpaMap {
 
         let stage2_image = GpaRange::new(0x808000, stage2_len as u64)?;
 
-        // The kernel image is loaded beyond the end of the stage2 heap,
-        // at 0x8A0000.
-        let kernel_address = 0x8A0000;
+        // The kernel image is loaded beyond the end of the stage2 image,
+        // rounded up to a 4 KB boundary.
+        let kernel_address = stage2_image.get_end().next_multiple_of(0x1000);
         let kernel_elf = GpaRange::new(kernel_address, kernel_elf_len as u64)?;
         let kernel_fs = GpaRange::new(kernel_elf.get_end(), kernel_fs_len as u64)?;
 
@@ -153,7 +152,6 @@ impl GpaMap {
             stage1_image,
             stage2_stack: GpaRange::new_page(0x805000)?,
             stage2_image,
-            stage2_free: GpaRange::new(stage2_image.get_end(), 0x8a0000 - &stage2_image.get_end())?,
             secrets_page: GpaRange::new_page(0x806000)?,
             cpuid_page: GpaRange::new_page(0x807000)?,
             kernel_elf,

--- a/igvmbuilder/src/igvm_builder.rs
+++ b/igvmbuilder/src/igvm_builder.rs
@@ -419,14 +419,6 @@ impl IgvmBuilder {
             IgvmPageDataType::NORMAL,
         )?;
 
-        // Populate the empty region above the stage 2 binary.
-        self.add_empty_pages(
-            self.gpa_map.stage2_free.get_start(),
-            self.gpa_map.stage2_free.get_size(),
-            COMPATIBILITY_MASK.get(),
-            IgvmPageDataType::NORMAL,
-        )?;
-
         // Populate the stage 2 binary.
         self.add_data_pages_from_file(
             &self.options.stage2.clone(),

--- a/igvmbuilder/src/igvm_builder.rs
+++ b/igvmbuilder/src/igvm_builder.rs
@@ -210,8 +210,6 @@ impl IgvmBuilder {
             param_page_offset,
             memory_map_offset,
             guest_context_offset,
-            cpuid_page: self.gpa_map.cpuid_page.get_start() as u32,
-            secrets_page: self.gpa_map.secrets_page.get_start() as u32,
             debug_serial_port: self.options.get_port_address(),
             firmware: fw_info,
             stage1_size: self.gpa_map.stage1_image.get_size() as u32,

--- a/igvmbuilder/src/stage2_stack.rs
+++ b/igvmbuilder/src/stage2_stack.rs
@@ -26,6 +26,7 @@ const _: () = assert!((size_of::<Stage2Stack>() as u64) <= PAGE_SIZE_4K);
 impl Stage2Stack {
     pub fn new(gpa_map: &GpaMap, vtom: u64) -> Self {
         let stage2_stack = Stage2LaunchInfo {
+            stage2_end: gpa_map.kernel_elf.get_start() as u32,
             kernel_elf_start: gpa_map.kernel_elf.get_start() as u32,
             kernel_elf_end: (gpa_map.kernel_elf.get_start() + gpa_map.kernel_elf.get_size()) as u32,
             kernel_fs_start: gpa_map.kernel_fs.get_start() as u32,
@@ -35,6 +36,7 @@ impl Stage2Stack {
             platform_type: 0,
             cpuid_page: gpa_map.cpuid_page.get_start() as u32,
             secrets_page: gpa_map.secrets_page.get_start() as u32,
+            _reserved: 0,
         };
         Self { stage2_stack }
     }

--- a/igvmbuilder/src/stage2_stack.rs
+++ b/igvmbuilder/src/stage2_stack.rs
@@ -33,6 +33,8 @@ impl Stage2Stack {
             igvm_params: gpa_map.igvm_param_block.get_start() as u32,
             vtom,
             platform_type: 0,
+            cpuid_page: gpa_map.cpuid_page.get_start() as u32,
+            secrets_page: gpa_map.secrets_page.get_start() as u32,
         };
         Self { stage2_stack }
     }

--- a/igvmbuilder/src/vmsa.rs
+++ b/igvmbuilder/src/vmsa.rs
@@ -4,17 +4,14 @@
 //
 // Author: Roy Hopkins <roy.hopkins@suse.com>
 
-use std::mem::size_of;
-
 use igvm::snp_defs::{SevFeatures, SevVmsa};
 use igvm::IgvmDirectiveHeader;
 use igvm_defs::IgvmNativeVpContextX64;
 use zerocopy::FromZeroes;
 
 use crate::cmd_options::SevExtraFeatures;
-use crate::stage2_stack::Stage2Stack;
 
-pub fn construct_start_context() -> Box<IgvmNativeVpContextX64> {
+pub fn construct_start_context(start_rip: u64, start_rsp: u64) -> Box<IgvmNativeVpContextX64> {
     let mut context_box = IgvmNativeVpContextX64::new_box_zeroed();
     let context = context_box.as_mut();
 
@@ -35,8 +32,8 @@ pub fn construct_start_context() -> Box<IgvmNativeVpContextX64> {
     context.cr4 = 0x40;
 
     context.rflags = 2;
-    context.rip = 0x10000;
-    context.rsp = context.rip - size_of::<Stage2Stack>() as u64;
+    context.rip = start_rip;
+    context.rsp = start_rsp;
 
     context_box
 }

--- a/kernel/src/boot_stage2.rs
+++ b/kernel/src/boot_stage2.rs
@@ -142,10 +142,13 @@ global_asm!(
 
         /* Determine the PTE C-bit position from the CPUID page. */
 
+        /* Locate the table.  The pointer to the CPUID page is 12 bytes into
+         * the stage2 startup structure. */
+        movl 12(%ebp), %ecx
         /* Read the number of entries. */
-        mov CPUID_PAGE, %eax
+        movl (%ecx), %eax
         /* Create a pointer to the first entry. */
-        leal CPUID_PAGE + 16, %ecx
+        leal 16(%ecx), %ecx
 
     .Lcheck_entry:
         /* Check that there is another entry. */

--- a/kernel/src/config.rs
+++ b/kernel/src/config.rs
@@ -71,18 +71,6 @@ impl SvsmConfig<'_> {
             SvsmConfig::IgvmConfig(igvm_params) => igvm_params.find_kernel_region(),
         }
     }
-    pub fn get_cpuid_page_address(&self) -> u64 {
-        match self {
-            SvsmConfig::FirmwareConfig(_) => 0x9f000,
-            SvsmConfig::IgvmConfig(igvm_params) => igvm_params.get_cpuid_page_address(),
-        }
-    }
-    pub fn get_secrets_page_address(&self) -> u64 {
-        match self {
-            SvsmConfig::FirmwareConfig(_) => 0x9e000,
-            SvsmConfig::IgvmConfig(igvm_params) => igvm_params.get_secrets_page_address(),
-        }
-    }
     pub fn page_state_change_required(&self) -> bool {
         match self {
             SvsmConfig::FirmwareConfig(_) => true,

--- a/kernel/src/igvm_params.rs
+++ b/kernel/src/igvm_params.rs
@@ -93,14 +93,6 @@ impl IgvmParams<'_> {
         environment_info.memory_is_shared()
     }
 
-    pub fn get_cpuid_page_address(&self) -> u64 {
-        self.igvm_param_block.cpuid_page as u64
-    }
-
-    pub fn get_secrets_page_address(&self) -> u64 {
-        self.igvm_param_block.secrets_page as u64
-    }
-
     pub fn get_memory_regions(&self) -> Result<Vec<MemoryRegion<PhysAddr>>, SvsmError> {
         // Count the number of memory entries present.  They must be
         // non-overlapping and strictly increasing.

--- a/kernel/src/stage2.lds
+++ b/kernel/src/stage2.lds
@@ -40,7 +40,7 @@ SECTIONS
 	heap_end = .;
 	SECRETS_PAGE = .;
 	. = 636k;
-	CPUID_PAGE = .;
+	_reserved_for_cpuid_page = .;
 }
 
 ENTRY(startup_32)

--- a/kernel/src/stage2.lds
+++ b/kernel/src/stage2.lds
@@ -37,7 +37,6 @@ SECTIONS
 	heap_start = .;
 
 	. = 632k;
-	heap_end = .;
 	SECRETS_PAGE = .;
 	. = 636k;
 	_reserved_for_cpuid_page = .;

--- a/kernel/src/stage2.lds
+++ b/kernel/src/stage2.lds
@@ -24,18 +24,20 @@ SECTIONS
 	}
 	. = ALIGN(16);
 	.data : { *(.data) }
-	. = ALIGN(16);
-	.rodata : { *(.rodata) }
 	edata = .;
-	. = ALIGN(4096);
+	. = ALIGN(16);
 	.bss : {
 		_bss = .;
 		*(.bss) *(.bss.[0-9a-zA-Z_]*)
 		. = ALIGN(16);
 		_ebss = .;
 	}
-	. = ALIGN(4096);
-	heap_start = .;
+	/* Move rodata to follow bss so that the in-memory image has the same
+	 * length as the ELF image.  This is required so that the IGVM
+	 * builder does not have to parse the ELF file to know how much space
+	 * to reserve for BSS. */
+	. = ALIGN(16);
+	.rodata : { *(.rodata) }
 }
 
 ENTRY(startup_32)

--- a/kernel/src/stage2.lds
+++ b/kernel/src/stage2.lds
@@ -10,7 +10,8 @@ OUTPUT_ARCH(i386:x86-64)
 
 SECTIONS
 {
-	. = 64k;
+	/* Base address is 8 MB + 32 KB */
+	. = 8m + 32k;
 	.stext = .;
 	.text : {
 		*(.startup.*)
@@ -35,11 +36,6 @@ SECTIONS
 	}
 	. = ALIGN(4096);
 	heap_start = .;
-
-	. = 632k;
-	SECRETS_PAGE = .;
-	. = 636k;
-	_reserved_for_cpuid_page = .;
 }
 
 ENTRY(startup_32)

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -13,7 +13,7 @@ use bootlib::kernel_launch::{KernelLaunchInfo, Stage2LaunchInfo};
 use bootlib::platform::SvsmPlatformType;
 use core::arch::asm;
 use core::panic::PanicInfo;
-use core::ptr::{addr_of, addr_of_mut};
+use core::ptr::addr_of_mut;
 use core::slice;
 use cpuarch::snp_cpuid::SnpCpuidTable;
 use elf::ElfError;
@@ -28,7 +28,6 @@ use svsm::error::SvsmError;
 use svsm::fw_cfg::FwCfg;
 use svsm::igvm_params::IgvmParams;
 use svsm::mm::alloc::{memory_info, print_memory_info, root_mem_init};
-use svsm::mm::init_kernel_mapping_info;
 use svsm::mm::pagetable::{
     get_init_pgtable_locked, paging_init_early, set_init_pgtable, PTEntryFlags, PageTable,
     PageTableRef,
@@ -36,19 +35,17 @@ use svsm::mm::pagetable::{
 use svsm::mm::validate::{
     init_valid_bitmap_alloc, valid_bitmap_addr, valid_bitmap_set_valid_range,
 };
+use svsm::mm::{init_kernel_mapping_info, FixedAddressMappingRange};
 use svsm::platform::{PageStateChangeOp, SvsmPlatform, SvsmPlatformCell};
 use svsm::types::{PageSize, PAGE_SIZE, PAGE_SIZE_2M};
 use svsm::utils::{halt, is_aligned, MemoryRegion};
 
-const HEAP_AREA_END: u64 = 0x8A0000;
-
 extern "C" {
-    pub static heap_start: u8;
     pub static mut pgtable: PageTable;
 }
 
-fn setup_stage2_allocator(heap_end: u64) {
-    let vstart = unsafe { VirtAddr::from(addr_of!(heap_start)).page_align_up() };
+fn setup_stage2_allocator(heap_start: u64, heap_end: u64) {
+    let vstart = VirtAddr::from(heap_start);
     let vend = VirtAddr::from(heap_end);
     let pstart = PhysAddr::from(vstart.bits()); // Identity mapping
     let nr_pages = (vend - vstart) / PAGE_SIZE;
@@ -92,11 +89,16 @@ fn setup_env(
         .validate_page_range(region)
         .expect("failed to validate low 640 KB");
 
-    init_kernel_mapping_info(
+    // Supply the heap bounds as the kernel range, since the only virtual-to
+    // physical translations required will be on heap memory.
+    let kernel_mapping = FixedAddressMappingRange::new(
         VirtAddr::from(0x808000u64),
-        VirtAddr::from(HEAP_AREA_END),
+        VirtAddr::from(launch_info.stage2_end as u64),
         PhysAddr::from(0x808000u64),
     );
+    let heap_mapping =
+        FixedAddressMappingRange::new(region.start(), region.end(), PhysAddr::from(0u64));
+    init_kernel_mapping_info(kernel_mapping, Some(heap_mapping));
 
     let cpuid_page = unsafe { &*(launch_info.cpuid_page as *const SnpCpuidTable) };
 
@@ -105,8 +107,9 @@ fn setup_env(
 
     set_init_pgtable(PageTableRef::shared(unsafe { addr_of_mut!(pgtable) }));
 
-    // The end of the heap is the base of the kernel image.
-    setup_stage2_allocator(HEAP_AREA_END);
+    // Configure the heap to exist from 64 KB to 640 KB.
+    setup_stage2_allocator(0x10000, 0xA0000);
+
     init_percpu(platform).expect("Failed to initialize per-cpu area");
 
     // Init IDT again with handlers requiring GHCB (eg. #VC handler)
@@ -403,7 +406,7 @@ pub extern "C" fn stage2_main(launch_info: &Stage2LaunchInfo) {
         kernel_fs_start: u64::from(launch_info.kernel_fs_start),
         kernel_fs_end: u64::from(launch_info.kernel_fs_end),
         stage2_start: 0x800000u64,
-        stage2_end: HEAP_AREA_END,
+        stage2_end: launch_info.stage2_end as u64,
         cpuid_page: launch_info.cpuid_page as u64,
         secrets_page: launch_info.secrets_page as u64,
         stage2_igvm_params_phys_addr: u64::from(launch_info.igvm_params),

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -40,7 +40,7 @@ use svsm::mm::alloc::{memory_info, print_memory_info, root_mem_init};
 use svsm::mm::memory::{init_memory_map, write_guest_memory_map};
 use svsm::mm::pagetable::paging_init;
 use svsm::mm::virtualrange::virt_log_usage;
-use svsm::mm::{init_kernel_mapping_info, PerCPUPageMappingGuard};
+use svsm::mm::{init_kernel_mapping_info, FixedAddressMappingRange, PerCPUPageMappingGuard};
 use svsm::platform::{SvsmPlatformCell, SVSM_PLATFORM};
 use svsm::requests::{request_loop, request_processing_main, update_mappings};
 use svsm::sev::utils::{rmp_adjust, RMPFlags};
@@ -243,11 +243,12 @@ pub fn boot_stack_info() {
 }
 
 fn mapping_info_init(launch_info: &KernelLaunchInfo) {
-    init_kernel_mapping_info(
+    let kernel_mapping = FixedAddressMappingRange::new(
         VirtAddr::from(launch_info.heap_area_virt_start),
         VirtAddr::from(launch_info.heap_area_virt_end()),
         PhysAddr::from(launch_info.heap_area_phys_start),
     );
+    init_kernel_mapping_info(kernel_mapping, None);
 }
 
 /// # Panics

--- a/kernel/src/svsm_paging.rs
+++ b/kernel/src/svsm_paging.rs
@@ -130,9 +130,14 @@ pub fn invalidate_early_boot_memory(
     // invalidate stage 2 memory, unless firmware is loaded into low memory.
     // Also invalidate the boot data if required.
     if !config.fw_in_low_memory() {
-        let stage2_region = MemoryRegion::new(PhysAddr::null(), 640 * 1024);
-        invalidate_boot_memory_region(platform, config, stage2_region)?;
+        let lowmem_region = MemoryRegion::new(PhysAddr::null(), 640 * 1024);
+        invalidate_boot_memory_region(platform, config, lowmem_region)?;
     }
+
+    let stage2_base = usize::try_from(launch_info.stage2_start).unwrap();
+    let stage2_len = usize::try_from(launch_info.stage2_end).unwrap() - stage2_base;
+    let stage2_region = MemoryRegion::new(PhysAddr::new(stage2_base), stage2_len);
+    invalidate_boot_memory_region(platform, config, stage2_region)?;
 
     if config.invalidate_boot_data() {
         let kernel_elf_size =

--- a/kernel/src/svsm_paging.rs
+++ b/kernel/src/svsm_paging.rs
@@ -134,9 +134,9 @@ pub fn invalidate_early_boot_memory(
         invalidate_boot_memory_region(platform, config, lowmem_region)?;
     }
 
-    let stage2_base = usize::try_from(launch_info.stage2_start).unwrap();
-    let stage2_len = usize::try_from(launch_info.stage2_end).unwrap() - stage2_base;
-    let stage2_region = MemoryRegion::new(PhysAddr::new(stage2_base), stage2_len);
+    let stage2_base = PhysAddr::from(launch_info.stage2_start);
+    let stage2_end = PhysAddr::from(launch_info.stage2_end);
+    let stage2_region = MemoryRegion::from_addresses(stage2_base, stage2_end);
     invalidate_boot_memory_region(platform, config, stage2_region)?;
 
     if config.invalidate_boot_data() {

--- a/stage1/stage1.S
+++ b/stage1/stage1.S
@@ -67,6 +67,12 @@ startup_32:
 	leal	kernel_elf(%ebp), %edi
 	pushl	%edi
 
+	/* Push the location of the secrets page.  It is always at 9E000 */
+	pushl	$0x9E000
+
+	/* Push the location of the CPUID page.  It is always at 9F000 */
+	pushl	$0x9F000
+
 	/* Push the value 1 to indicate SNP */
 	pushl	$1
 
@@ -81,7 +87,7 @@ startup_32:
 	 * Stage 2 launch info has been prepared
 	 * Make sure platform type is TDP
 	 */
-	movl	$(STAGE2_START - 24), %eax
+	movl	$(STAGE1_STACK - 32), %eax
 	movl	(%eax), %eax
 	cmpl	$2, %eax
 	je	.Lsetup_td
@@ -98,7 +104,7 @@ startup_32:
 
 .Lsetup_bsp_stack:
 	/* Set up BSP stack for stage 2 */
-	movl	$(STAGE2_START - 32), %esp
+	movl	$(STAGE1_STACK - 40), %esp
 	/* %ebx is initialized with GPAW - save (1u64 << (GPAW - 1)) to vtom */
 	mov	%esp, %eax
 	/* GPAW must be either 48 or 52 */

--- a/stage1/stage1.S
+++ b/stage1/stage1.S
@@ -50,6 +50,7 @@ startup_32:
 	/* Write startup information to stage2 stack */
 	xorl	%eax, %eax
 	pushl	%eax
+	pushl	%eax
 
 	leal	kernel_fs_bin_end(%ebp), %edi
 	pushl	%edi
@@ -62,6 +63,9 @@ startup_32:
 
 	leal	kernel_elf(%ebp), %edi
 	pushl	%edi
+
+	/* The stage2 area ends at 0x8A0000. */
+	pushl	$0x8A0000
 
 	/* Push the location of the secrets page.  It is at 8 MB plus 56 KB */
 	pushl	$0x806000

--- a/stage1/stage1.S
+++ b/stage1/stage1.S
@@ -8,14 +8,10 @@
 
 #include "types.h"
 
-/* Use first 640kb of memory for stage2 loader */
-#define STAGE2_RANGE_START	0
-#define STAGE2_RANGE_PAGES	158
+/* Stage2 is loaded at 8 MB + 16 KB */
+#define STAGE2_START		0x808000
 
-/* Stage2 is loaded at 64kb */
-#define STAGE2_START		0x10000
-
-#define STAGE1_STACK		0x10000
+#define STAGE1_STACK		0x806000
 
 .text
 	.section ".startup.text","ax"
@@ -49,7 +45,7 @@ startup_32:
 	rep movsl
 
 	/* Setup stack for stage 2*/
-	movl	$STAGE2_START, %esp
+	movl	$STAGE1_STACK, %esp
 
 	/* Write startup information to stage2 stack */
 	xorl	%eax, %eax
@@ -67,11 +63,11 @@ startup_32:
 	leal	kernel_elf(%ebp), %edi
 	pushl	%edi
 
-	/* Push the location of the secrets page.  It is always at 9E000 */
-	pushl	$0x9E000
+	/* Push the location of the secrets page.  It is at 8 MB plus 56 KB */
+	pushl	$0x806000
 
-	/* Push the location of the CPUID page.  It is always at 9F000 */
-	pushl	$0x9F000
+	/* Push the location of the CPUID page.  It is at 8 MB plus 60 KB */
+	pushl	$0x807000
 
 	/* Push the value 1 to indicate SNP */
 	pushl	$1

--- a/stage1/stage1.lds
+++ b/stage1/stage1.lds
@@ -10,6 +10,7 @@ OUTPUT_ARCH(i386:x86-64)
 
 SECTIONS
 {
+	. = 0x800000;
 	.stext = ALIGN(.sdata  - SIZEOF(.text) - 4095, 4096);
 	. = .stext;
 	.text : { *(.startup.*) *(.text) *(.text.*) }

--- a/utils/gen_meta.c
+++ b/utils/gen_meta.c
@@ -175,7 +175,7 @@ void add_table(struct meta_buffer *meta, const char *uuid_str, char *table, uint
 	*meta->len += *len;
 }
 
-#define NUM_DESCS	3
+#define NUM_DESCS	4
 struct __attribute__((__packed__)) svsm_meta_data {
 	char sig[4];
 	uint32_t len;
@@ -194,17 +194,21 @@ void init_sev_meta(struct svsm_meta_data *svsm_meta)
 	svsm_meta->version  = 1;
 	svsm_meta->num_desc = NUM_DESCS;
 
-	svsm_meta->descs[0].base = 0;
-	svsm_meta->descs[0].len  = 632 * 1024;
+	svsm_meta->descs[0].base = 0x800000;
+	svsm_meta->descs[0].len  = 0x6000;
 	svsm_meta->descs[0].type = SEV_DESC_TYPE_SNP_SEC_MEM;
 
-	svsm_meta->descs[1].base = 632 * 1024;
-	svsm_meta->descs[1].len  = 4096;
+	svsm_meta->descs[1].base = 0x806000;
+	svsm_meta->descs[1].len  = 0x1000;
 	svsm_meta->descs[1].type = SEV_DESC_TYPE_SNP_SECRETS;
 
-	svsm_meta->descs[2].base = 636 * 1024;
-	svsm_meta->descs[2].len  = 4096;
+	svsm_meta->descs[2].base = 0x807000;
+	svsm_meta->descs[2].len  = 0x1000;
 	svsm_meta->descs[2].type = SEV_DESC_TYPE_CPUID;
+
+	svsm_meta->descs[3].base = 0x808000;
+	svsm_meta->descs[3].len  = 0x8A0000 - 0x808000;
+	svsm_meta->descs[3].type = SEV_DESC_TYPE_SNP_SEC_MEM;
 }
 
 uint16_t meta_data_table_size(void)
@@ -231,16 +235,6 @@ void fill_buffer(struct meta_buffer *meta)
 	secret.base = 0xdeadbeef;
 	secret.size = 0;
 	add_table(meta, SEV_SECRET_GUID, (char *)&secret, sizeof(secret));
-
-#if 0
-	boot_block.pre_validated_start = 0;
-	boot_block.pre_validated_end   = 636 * 1024;
-	boot_block.secrets_addr        = 636 * 1024;
-	boot_block.secrets_len         = 4096;
-	boot_block.cpuid_addr          = 632 * 1024;
-	boot_block.cpuid_len           = 4096;
-	add_table(meta, SEV_SNP_BOOT_BLOCK_GUID, (char *)&boot_block, sizeof(boot_block));
-#endif
 
 	svsm_info.launch_offset = 0;
 	add_table(meta, SVSM_INFO_GUID, (char *)&svsm_info, sizeof(svsm_info));


### PR DESCRIPTION
Stage2 has grown so that it cannot fit below 640 KB with enough space to provide a heap for stage2 execution.  This change relocates stage2 (and stage1 and the kernel images) up to 8 MB so that all of the memory below 640 KB can be used for the stage2 heap, and so that stage2 can continue to grow without concern for hitting any other size limits.