### PR TITLE
kernel/svsm: Increase boot time stack by 4KB

### DIFF
--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -88,7 +88,7 @@ global_asm!(
 
         .align 4096
     bsp_stack:
-        .fill 4*4096, 1, 0
+        .fill 5*4096, 1, 0
     bsp_stack_end:
         "#,
     options(att_syntax)


### PR DESCRIPTION
During early boot of svsm kernel, init page table is created via still using the boot time stack. The page table is allocated by using PageBox which will get a temporary PTPage (4KB) from the stack via the PTPage::default() method. This increases the load on the boot time stack and may cause stack overflow in the next. As the default method requires 4KB stack size, increase the boot time stack by 4KB to satisfy this.

With code increasing in the future, the boot time stack may not be large enough again, so this is not a permanent fix but just works for short term. If it conflicts with any ongoing stack unwind/overflow works, please let me know and I will close it. Thanks!