### PR TITLE
stage1: Fix boot issue where %esi was wrong on stage2 entry

### DIFF
--- a/stage1/stage1.S
+++ b/stage1/stage1.S
@@ -73,6 +73,9 @@ startup_32:
 	/* Reserve space for VTOM */
 	pushl	%eax
 	pushl	%eax
+
+	/* Clear ESI to inform stage 2 that this is the BSP */
+	xorl	%esi, %esi
 #else
 	/*
 	 * Stage 2 launch info has been prepared


### PR DESCRIPTION
The changes to support TDX from stage1 introduced an exchange of the BSP/AP index between stage1 and stage2. This was not implemented in the non-TDX case resulting in a non-zero %edi register on entry to stage2, resulting in the identity mapped page table not being configured.

This patch clears %esi on entry to stage2.