### PR TITLE
kernel/mm: Reduce stack footprint of page-table freeing

### DIFF
--- a/kernel/src/mm/pagetable.rs
+++ b/kernel/src/mm/pagetable.rs
@@ -977,8 +977,8 @@ struct RawPageTablePart {
 impl RawPageTablePart {
     /// Frees a level 1 page table.
     fn free_lvl1(page: &PTPage) {
-        for entry in page.entries {
-            if let Some(page) = PTPage::from_entry(entry) {
+        for entry in page.entries.iter() {
+            if let Some(page) = PTPage::from_entry(*entry) {
                 // SAFETY: the page comes from an entry in the page table,
                 // which we allocated using `PTPage::alloc()`, so this is
                 // safe.
@@ -989,8 +989,8 @@ impl RawPageTablePart {
 
     /// Frees a level 2 page table, including all level 1 tables beneath it.
     fn free_lvl2(page: &PTPage) {
-        for entry in page.entries {
-            if let Some(l1_page) = PTPage::from_entry(entry) {
+        for entry in page.entries.iter() {
+            if let Some(l1_page) = PTPage::from_entry(*entry) {
                 Self::free_lvl1(l1_page);
                 // SAFETY: the page comes from an entry in the page table,
                 // which we allocated using `PTPage::alloc()`, so this is


### PR DESCRIPTION
Turns out that the way the iterators are implemented in RawPageTablePart::free_lvl*() the compiler makes copies of entire pages on the stack, which overflows the 32 KiB stack pretty quickly.

Iterate over references only and significantly reduce stack usage of the page-table freeing code.