### PR TITLE
mm: always use `this_cpu().get_pgtable()` instead of `get_init_pgtable_locked()`

### DIFF
--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -440,7 +440,7 @@ impl PerCpu {
     fn allocate_page_table(&self) -> Result<(), SvsmError> {
         self.vm_range.initialize()?;
         let pgtable_ref = get_init_pgtable_locked().clone_shared()?;
-        self.set_pgtable(pgtable_ref.leak());
+        self.set_pgtable(PageBox::leak(pgtable_ref));
 
         Ok(())
     }

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -15,7 +15,7 @@ use crate::cpu::vmsa::{init_guest_vmsa, init_svsm_vmsa};
 use crate::cpu::{IrqState, LocalApic};
 use crate::error::{ApicError, SvsmError};
 use crate::locking::{LockGuard, RWLock, RWLockIrqSafe, SpinLock};
-use crate::mm::pagetable::{get_init_pgtable_locked, PTEntryFlags, PageTableRef};
+use crate::mm::pagetable::{get_init_pgtable_locked, PTEntryFlags, PageTable, PageTableRef};
 use crate::mm::virtualrange::VirtualRange;
 use crate::mm::vm::{Mapping, VMKernelStack, VMPhysMem, VMRMapping, VMReserved, VMR};
 use crate::mm::{
@@ -822,7 +822,7 @@ impl PerCpu {
     /// # Arguments
     ///
     /// * `pt` - The page table to populate the the PerCpu range into
-    pub fn populate_page_table(&self, pt: &mut PageTableRef) {
+    pub fn populate_page_table(&self, pt: &mut PageTable) {
         self.vm_range.populate(pt);
     }
 

--- a/kernel/src/mm/pagetable.rs
+++ b/kernel/src/mm/pagetable.rs
@@ -8,7 +8,6 @@ use crate::address::{Address, PhysAddr, VirtAddr};
 use crate::cpu::control_regs::write_cr3;
 use crate::cpu::flush_tlb_global_sync;
 use crate::error::SvsmError;
-use crate::locking::{LockGuard, SpinLock};
 use crate::mm::PageBox;
 use crate::mm::{phys_to_virt, virt_to_phys, PGTABLE_LVL3_IDX_SHARED};
 use crate::platform::SvsmPlatform;
@@ -879,30 +878,6 @@ impl PageTable {
             entry.set(paddr, flags);
         }
     }
-}
-
-static INIT_PGTABLE: SpinLock<PageTableRef> = SpinLock::new(PageTableRef::unset());
-
-/// Sets the initial page table unless it is already set.
-///
-/// # Parameters
-/// - `pgtable`: The page table reference to set as the initial page table.
-///
-/// # Panics
-/// Panics if the initial page table is already set.
-pub fn set_init_pgtable(pgtable: PageTableRef) {
-    let mut init_pgtable = INIT_PGTABLE.lock();
-    assert!(!init_pgtable.is_set());
-    *init_pgtable = pgtable;
-}
-
-/// Acquires a lock and returns a guard for the initial page table, which
-/// is locked for the duration of the guard's scope.
-///
-/// # Returns
-/// A `LockGuard` for the initial page table.
-pub fn get_init_pgtable_locked<'a>() -> LockGuard<'a, PageTableRef> {
-    INIT_PGTABLE.lock()
 }
 
 /// A reference wrapper for a [`PageTable`].

--- a/kernel/src/mm/pagetable.rs
+++ b/kernel/src/mm/pagetable.rs
@@ -305,8 +305,8 @@ impl PageTable {
     ///
     /// # Errors
     /// Returns [`SvsmError`] if the page cannot be allocated.
-    pub fn clone_shared(&self) -> Result<PageTableRef, SvsmError> {
-        let mut pgtable = PageTableRef::alloc()?;
+    pub fn clone_shared(&self) -> Result<PageBox<PageTable>, SvsmError> {
+        let mut pgtable = PageBox::try_new(PageTable::default())?;
         pgtable.root.entries[PGTABLE_LVL3_IDX_SHARED] = self.root.entries[PGTABLE_LVL3_IDX_SHARED];
         Ok(pgtable)
     }

--- a/kernel/src/mm/pagetable.rs
+++ b/kernel/src/mm/pagetable.rs
@@ -939,6 +939,13 @@ impl PageTableRef {
             Self::Shared(p) => !p.is_null(),
         }
     }
+
+    pub fn leak(self) -> &'static mut PageTable {
+        match self {
+            PageTableRef::Owned(p) => PageBox::leak(p),
+            PageTableRef::Shared(p) => unsafe { &mut *p },
+        }
+    }
 }
 
 impl Deref for PageTableRef {

--- a/kernel/src/mm/vm/range.rs
+++ b/kernel/src/mm/vm/range.rs
@@ -8,7 +8,7 @@ use crate::address::{Address, VirtAddr};
 use crate::cpu::{flush_tlb_global_percpu, flush_tlb_global_sync};
 use crate::error::SvsmError;
 use crate::locking::RWLock;
-use crate::mm::pagetable::{PTEntryFlags, PageTable, PageTablePart, PageTableRef};
+use crate::mm::pagetable::{PTEntryFlags, PageTable, PageTablePart};
 use crate::types::{PageSize, PAGE_SHIFT, PAGE_SIZE};
 use crate::utils::{align_down, align_up};
 
@@ -122,8 +122,8 @@ impl VMR {
     ///
     /// # Arguments
     ///
-    /// * `pgtbl` - A [`PageTableRef`] pointing to the target page-table
-    pub fn populate(&self, pgtbl: &mut PageTableRef) {
+    /// * `pgtbl` - A [`PageTable`] pointing to the target page-table
+    pub fn populate(&self, pgtbl: &mut PageTable) {
         let parts = self.pgtbl_parts.lock_read();
 
         for part in parts.iter() {
@@ -131,7 +131,7 @@ impl VMR {
         }
     }
 
-    pub fn populate_addr(&self, pgtbl: &mut PageTableRef, vaddr: VirtAddr) {
+    pub fn populate_addr(&self, pgtbl: &mut PageTable, vaddr: VirtAddr) {
         let start = VirtAddr::from(self.start_pfn << PAGE_SHIFT);
         let end = VirtAddr::from(self.end_pfn << PAGE_SHIFT);
         assert!(vaddr >= start && vaddr < end);

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -220,7 +220,8 @@ impl SvsmPlatform for SnpPlatform {
     }
 
     fn start_cpu(&self, cpu: &PerCpu, start_rip: u64) -> Result<(), SvsmError> {
-        cpu.setup(self)?;
+        let pgtable = this_cpu().get_pgtable().clone_shared()?;
+        cpu.setup(self, pgtable)?;
         let (vmsa_pa, sev_features) = cpu.alloc_svsm_vmsa(*VTOM as u64, start_rip)?;
 
         current_ghcb().ap_create(vmsa_pa, cpu.get_apic_id().into(), 0, sev_features)

--- a/kernel/src/sev/ghcb.rs
+++ b/kernel/src/sev/ghcb.rs
@@ -9,7 +9,6 @@ use crate::cpu::msr::{write_msr, SEV_GHCB};
 use crate::cpu::percpu::this_cpu;
 use crate::cpu::{flush_tlb_global_sync, X86GeneralRegs};
 use crate::error::SvsmError;
-use crate::mm::pagetable::get_init_pgtable_locked;
 use crate::mm::validate::{
     valid_bitmap_clear_valid_4k, valid_bitmap_set_valid_4k, valid_bitmap_valid_addr,
 };
@@ -151,7 +150,7 @@ impl GhcbPage {
         }
 
         // Map page unencrypted
-        get_init_pgtable_locked().set_shared_4k(vaddr)?;
+        this_cpu().get_pgtable().set_shared_4k(vaddr)?;
         flush_tlb_global_sync();
 
         // SAFETY: all zeros is a valid representation for the GHCB.
@@ -323,7 +322,7 @@ impl GHCB {
         let paddr = virt_to_phys(vaddr);
 
         // Re-encrypt page
-        get_init_pgtable_locked().set_encrypted_4k(vaddr)?;
+        this_cpu().get_pgtable().set_encrypted_4k(vaddr)?;
 
         // Unregister GHCB PA
         register_ghcb_gpa_msr(PhysAddr::null())?;

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -142,7 +142,7 @@ fn map_and_validate(
         | PTEntryFlags::ACCESSED
         | PTEntryFlags::DIRTY;
 
-    let mut pgtbl = get_init_pgtable_locked();
+    let mut pgtbl = this_cpu().get_pgtable();
     pgtbl.map_region(vregion, paddr, flags)?;
 
     if config.page_state_change_required() {

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -28,10 +28,7 @@ use svsm::error::SvsmError;
 use svsm::fw_cfg::FwCfg;
 use svsm::igvm_params::IgvmParams;
 use svsm::mm::alloc::{memory_info, print_memory_info, root_mem_init};
-use svsm::mm::pagetable::{
-    get_init_pgtable_locked, paging_init_early, set_init_pgtable, PTEntryFlags, PageTable,
-    PageTableRef,
-};
+use svsm::mm::pagetable::{paging_init_early, PTEntryFlags, PageTable};
 use svsm::mm::validate::{
     init_valid_bitmap_alloc, valid_bitmap_addr, valid_bitmap_set_valid_range,
 };
@@ -41,7 +38,7 @@ use svsm::types::{PageSize, PAGE_SIZE, PAGE_SIZE_2M};
 use svsm::utils::{halt, is_aligned, MemoryRegion};
 
 extern "C" {
-    pub static mut pgtable: PageTable;
+    static mut pgtable: PageTable;
 }
 
 fn setup_stage2_allocator(heap_start: u64, heap_end: u64) {
@@ -108,8 +105,6 @@ fn setup_env(
 
     register_cpuid_table(cpuid_page);
     paging_init_early(platform).expect("Failed to initialize early paging");
-
-    set_init_pgtable(PageTableRef::shared(unsafe { addr_of_mut!(pgtable) }));
 
     // Configure the heap to exist from 64 KB to 640 KB.
     setup_stage2_allocator(0x10000, 0xA0000);

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -344,6 +344,7 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
     let init_pgtable = get_init_pgtable_locked()
         .clone_shared()
         .expect("Failed to allocate page tables for BSP");
+    init_pgtable.load();
     bsp_percpu
         .setup(platform, init_pgtable)
         .expect("Failed to setup BSP per-cpu area");

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -338,10 +338,6 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
     paging_init(platform).expect("Failed to initialize paging");
     init_page_table(&launch_info, &kernel_elf).expect("Could not initialize the page table");
 
-    // SAFETY: this PerCpu has just been allocated and no other CPUs have been
-    // brought up, thus it cannot be aliased and we can get a mutable
-    // reference to it. We trust PerCpu::alloc() to return a valid and
-    // aligned pointer.
     let bsp_percpu = PerCpu::alloc(0).expect("Failed to allocate BSP per-cpu data");
 
     bsp_percpu

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -20,8 +20,9 @@ use crate::cpu::{irqs_enable, X86GeneralRegs};
 use crate::error::SvsmError;
 use crate::fs::FileHandle;
 use crate::locking::{RWLock, SpinLock};
-use crate::mm::pagetable::{PTEntryFlags, PageTableRef};
+use crate::mm::pagetable::{PTEntryFlags, PageTable};
 use crate::mm::vm::{Mapping, VMFileMappingFlags, VMKernelStack, VMR};
+use crate::mm::PageBox;
 use crate::mm::{
     mappings::create_anon_mapping, mappings::create_file_mapping, VMMappingGuard,
     SVSM_PERTASK_BASE, SVSM_PERTASK_END, SVSM_PERTASK_STACK_BASE, USER_MEM_END, USER_MEM_START,
@@ -119,7 +120,7 @@ pub struct Task {
     pub stack_bounds: MemoryRegion<VirtAddr>,
 
     /// Page table that is loaded when the task is scheduled
-    pub page_table: SpinLock<PageTableRef>,
+    pub page_table: SpinLock<PageBox<PageTable>>,
 
     /// Task virtual memory range for use at CPL 0
     vm_kernel_range: VMR,


### PR DESCRIPTION
`get_init_pgtable_locked()` was problematic because the returned mutable reference was aliasing the mutable reference returned in `this_cpu().get_pgtable()` in stage2.

Removing `get_init_pgtable_locked()` now will probably also make it easier to implement isolated pagetables in the future because everything is already only accessing `this_cpu().get_pgtable()`.