### PR TITLE
igvm: Add the Vanadium hypervisor to igvmbuilder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ C_BIT_POS ?= 51
 STAGE1_OBJS = stage1/stage1.o stage1/reset.o
 STAGE1_TEST_OBJS = stage1/stage1-test.o stage1/reset.o
 STAGE1_TRAMPOLINE_OBJS = stage1/stage1-trampoline.o stage1/reset.o
-IGVM_FILES = bin/coconut-qemu.igvm bin/coconut-hyperv.igvm
+IGVM_FILES = bin/coconut-qemu.igvm bin/coconut-hyperv.igvm bin/coconut-vanadium.igvm
 IGVMBUILDER = "target/x86_64-unknown-linux-gnu/${TARGET_PATH}/igvmbuilder"
 IGVMBIN = bin/igvmbld
 IGVMMEASURE = "target/x86_64-unknown-linux-gnu/${TARGET_PATH}/igvmmeasure"
@@ -80,6 +80,14 @@ bin/coconut-hyperv.igvm: $(IGVMBUILDER) $(IGVMMEASURE) bin/stage1-trampoline.bin
 bin/coconut-test-qemu.igvm: $(IGVMBUILDER) $(IGVMMEASURE) bin/stage1-trampoline.bin bin/test-kernel.elf bin/stage2.bin
 	$(IGVMBUILDER) --sort --output $@ --tdx-stage1 bin/stage1-trampoline.bin --stage2 bin/stage2.bin --kernel bin/test-kernel.elf qemu --snp --tdp
 	$(IGVMMEASURE) $@ measure
+
+bin/coconut-vanadium.igvm: $(IGVMBUILDER) $(IGVMMEASURE) bin/stage1-trampoline.bin bin/svsm-kernel.elf bin/stage2.bin ${FS_BIN}
+	$(IGVMBUILDER) --sort --policy 0x30000 --output $@ --tdx-stage1 bin/stage1-trampoline.bin --stage2 bin/stage2.bin --kernel bin/svsm-kernel.elf --filesystem ${FS_BIN} ${BUILD_FW} vanadium --snp --tdp
+	$(IGVMMEASURE) --check-kvm $@ measure
+
+bin/coconut-test-vanadium.igvm: $(IGVMBUILDER) $(IGVMMEASURE) bin/stage1-trampoline.bin bin/test-kernel.elf bin/stage2.bin
+	$(IGVMBUILDER) --sort --output $@ --tdx-stage1 bin/stage1-trampoline.bin --stage2 bin/stage2.bin --kernel bin/test-kernel.elf vanadium --snp --tdp
+	$(IGVMMEASURE) --check-kvm $@ measure
 
 test:
 	cargo test ${CARGO_ARGS} ${SVSM_ARGS_TEST} --workspace --target=x86_64-unknown-linux-gnu

--- a/igvmbuilder/src/cmd_options.rs
+++ b/igvmbuilder/src/cmd_options.rs
@@ -96,6 +96,9 @@ pub enum Hypervisor {
 
     /// Build an IGVM file compatible with Hyper-V
     HyperV,
+
+    /// Build an IGVM file compatible with Google's Vanadium
+    Vanadium,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]

--- a/igvmbuilder/src/firmware.rs
+++ b/igvmbuilder/src/firmware.rs
@@ -33,6 +33,9 @@ pub fn parse_firmware(
             crate::cmd_options::Hypervisor::HyperV => {
                 IgvmFirmware::parse(filename, parameter_count, compatibility_mask)
             }
+            crate::cmd_options::Hypervisor::Vanadium => {
+                OvmfFirmware::parse(filename, parameter_count, compatibility_mask)
+            }
         }
     } else {
         Err("No firmware filename specified".into())

--- a/igvmbuilder/src/gpa_map.rs
+++ b/igvmbuilder/src/gpa_map.rs
@@ -149,6 +149,10 @@ impl GpaMap {
                 // Place the kernel area at 64 MB with a size of 16 MB.
                 GpaRange::new(0x04000000, 0x01000000)?
             }
+            Hypervisor::Vanadium => {
+                // Place the kernel area at 8TiB-2GiB with a size of 16 MB.
+                GpaRange::new(0x7ff80000000, 0x01000000)?
+            }
         };
 
         let igvm_param_block = GpaRange::new_page(kernel_fs.get_end())?;
@@ -166,7 +170,7 @@ impl GpaMap {
         };
 
         let vmsa = match options.hypervisor {
-            Hypervisor::Qemu => {
+            Hypervisor::Qemu | Hypervisor::Vanadium => {
                 // VMSA address is currently hardcoded in kvm
                 GpaRange::new_page(0xFFFFFFFFF000)?
             }

--- a/igvmbuilder/src/igvm_builder.rs
+++ b/igvmbuilder/src/igvm_builder.rs
@@ -200,6 +200,7 @@ impl IgvmBuilder {
                     // C-bit position.
                     0x0000400000000000
                 }
+                Hypervisor::Vanadium => 0,
             };
             (fw_info, vtom)
         };


### PR DESCRIPTION
The Vanadium hypervisor is used internally by Google. It is similar to qemu in that it uses kvm.