### PR TITLE
soundness improvements around hypervisor-shared memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,6 +842,7 @@ dependencies = [
  "packit",
  "syscall",
  "test",
+ "zerocopy",
 ]
 
 [[package]]

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -34,6 +34,7 @@ intrusive-collections.workspace = true
 log = { workspace = true, features = ["max_level_info", "release_max_level_info"] }
 packit.workspace = true
 libmstpm = { workspace = true, optional = true }
+zerocopy.workspace = true
 
 [target."x86_64-unknown-none".dev-dependencies]
 test.workspace = true

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -618,13 +618,6 @@ impl PerCpu {
         self.load_tss();
     }
 
-    pub fn shutdown(&self) -> Result<(), SvsmError> {
-        if let Some(ghcb) = self.ghcb.get() {
-            ghcb.shutdown()?;
-        }
-        Ok(())
-    }
-
     pub fn set_reset_ip(&self, reset_ip: u64) {
         self.reset_ip.set(reset_ip);
     }
@@ -863,7 +856,7 @@ impl PerCpu {
 }
 
 pub fn this_cpu() -> &'static PerCpu {
-    unsafe { &*SVSM_PERCPU_BASE.as_mut_ptr::<PerCpu>() }
+    unsafe { &*SVSM_PERCPU_BASE.as_ptr::<PerCpu>() }
 }
 
 pub fn this_cpu_shared() -> &'static PerCpuShared {

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -25,7 +25,7 @@ use crate::mm::{
 };
 use crate::platform::{SvsmPlatform, SVSM_PLATFORM};
 use crate::sev::ghcb::{GhcbPage, GHCB};
-use crate::sev::hv_doorbell::{HVDoorbell, HVDoorbellPage};
+use crate::sev::hv_doorbell::{allocate_hv_doorbell_page, HVDoorbell};
 use crate::sev::msr_protocol::{hypervisor_ghcb_features, GHCBHvFeatures};
 use crate::sev::utils::RMPFlags;
 use crate::sev::vmsa::{VMSAControl, VmsaPage};
@@ -487,8 +487,7 @@ impl PerCpu {
     }
 
     fn setup_hv_doorbell(&self) -> Result<(), SvsmError> {
-        let page = HVDoorbellPage::new(current_ghcb())?;
-        let doorbell = HVDoorbellPage::leak(page);
+        let doorbell = allocate_hv_doorbell_page(current_ghcb())?;
         self.hv_doorbell
             .set(doorbell)
             .expect("Attempted to reinitialize the HV doorbell page");

--- a/kernel/src/greq/driver.rs
+++ b/kernel/src/greq/driver.rs
@@ -344,13 +344,13 @@ impl SnpGuestRequestDriver {
             command_len,
         )?;
 
-        // The SEV-SNP certificates can be used to verify the attestation report. At this point, a zeroed
-        // ext_data buffer indicates that the certificates were not imported.
-        // The VM owner can import them from the host using the virtee/snphost project
-        if self.ext_data.is_nclear(certs.len())? {
+        // The SEV-SNP certificates can be used to verify the attestation report.
+        self.ext_data.copy_to_slice(certs)?;
+        // At this point, a zeroed ext_data buffer indicates that the
+        // certificates were not imported. The VM owner can import them from the
+        // host using the virtee/snphost project
+        if certs[..24] == [0; 24] {
             log::warn!("SEV-SNP certificates not found. Make sure they were loaded from the host.");
-        } else {
-            self.ext_data.copy_to_slice(certs)?;
         }
 
         Ok(outbuf_len)

--- a/kernel/src/greq/msg.rs
+++ b/kernel/src/greq/msg.rs
@@ -12,23 +12,17 @@ use alloc::{
     alloc::{alloc_zeroed, Layout},
     boxed::Box,
 };
-use core::{
-    mem::{offset_of, size_of},
-    ptr::addr_of_mut,
-    slice::from_raw_parts_mut,
-};
+use core::mem::{offset_of, size_of};
 
 use crate::{
     address::{Address, VirtAddr},
     crypto::aead::{Aes256Gcm, Aes256GcmTrait, AUTHTAG_SIZE, IV_SIZE},
-    mm::page_visibility::{make_page_private, make_page_shared},
     protocols::errors::SvsmReqError,
     sev::secrets_page::VMPCK_SIZE,
-    types::{PageSize, PAGE_SIZE},
-    utils::MemoryRegion,
+    types::PAGE_SIZE,
 };
 
-use zerocopy::AsBytes;
+use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 /// Version of the message header
 const HDR_VERSION: u8 = 1;
@@ -76,7 +70,7 @@ pub const SNP_GUEST_REQ_MAX_DATA_SIZE: usize = 4 * PAGE_SIZE;
 
 /// `SNP_GUEST_REQUEST` message header format (AMD SEV-SNP spec. table 98)
 #[repr(C, packed)]
-#[derive(Clone, Copy, Debug, AsBytes)]
+#[derive(Clone, Copy, Debug, FromZeroes, FromBytes, AsBytes)]
 pub struct SnpGuestRequestMsgHdr {
     /// Message authentication tag
     authtag: [u8; 32],
@@ -154,11 +148,6 @@ impl SnpGuestRequestMsgHdr {
         let algo_offset = offset_of!(Self, algo);
         &self.as_bytes()[algo_offset..]
     }
-
-    /// Get [`SnpGuestRequestMsgHdr`] as a mutable slice reference
-    fn as_slice_mut(&mut self) -> &mut [u8] {
-        unsafe { from_raw_parts_mut(addr_of_mut!(*self).cast(), size_of::<Self>()) }
-    }
 }
 
 impl Default for SnpGuestRequestMsgHdr {
@@ -185,7 +174,7 @@ impl Default for SnpGuestRequestMsgHdr {
 
 /// `SNP_GUEST_REQUEST` message format
 #[repr(C, align(4096))]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, FromZeroes, FromBytes)]
 pub struct SnpGuestRequestMsg {
     hdr: SnpGuestRequestMsgHdr,
     pld: [u8; MSG_PAYLOAD_SIZE],
@@ -215,30 +204,6 @@ impl SnpGuestRequestMsg {
             let ptr = addr.cast::<Self>();
             Ok(Box::from_raw(ptr))
         }
-    }
-
-    /// Clear the C-bit (memory encryption bit) for the Self page
-    ///
-    /// # Safety
-    ///
-    /// * The caller is responsible for setting the page back to encrypted
-    ///   before the object is dropped. Shared pages should not be freed
-    ///   (returned to the allocator)
-    pub fn set_shared(&mut self) -> Result<(), SvsmReqError> {
-        let vaddr = VirtAddr::from(addr_of_mut!(*self));
-        make_page_shared(vaddr).map_err(|_| SvsmReqError::invalid_request())
-    }
-
-    /// Set the C-bit (memory encryption bit) for the Self page
-    pub fn set_encrypted(&mut self) -> Result<(), SvsmReqError> {
-        let vaddr = VirtAddr::from(addr_of_mut!(*self));
-        make_page_private(vaddr).map_err(|_| SvsmReqError::invalid_request())
-    }
-
-    /// Fill the [`SnpGuestRequestMsg`] fields with zeros
-    pub fn clear(&mut self) {
-        self.hdr.as_slice_mut().fill(0);
-        self.pld.fill(0);
     }
 
     /// Encrypt the provided `SNP_GUEST_REQUEST` command and store the result in the actual message payload
@@ -372,98 +337,9 @@ fn build_iv(msg_seqno: u64) -> [u8; IV_SIZE] {
     iv
 }
 
-/// Set to encrypted all the 4k pages of a memory range
-fn set_encrypted_region_4k(vregion: MemoryRegion<VirtAddr>) -> Result<(), SvsmReqError> {
-    for addr in vregion.iter_pages(PageSize::Regular) {
-        make_page_private(addr).map_err(|_| SvsmReqError::invalid_request())?;
-    }
-    Ok(())
-}
-
-/// Set to shared all the 4k pages of a memory range
-fn set_shared_region_4k(vregion: MemoryRegion<VirtAddr>) -> Result<(), SvsmReqError> {
-    for addr in vregion.iter_pages(PageSize::Regular) {
-        make_page_shared(addr).map_err(|_| SvsmReqError::invalid_request())?;
-    }
-    Ok(())
-}
-
 /// Data page(s) the hypervisor will use to store certificate data in
 /// an extended `SNP_GUEST_REQUEST`
-#[repr(C, align(4096))]
-#[derive(Debug)]
-pub struct SnpGuestRequestExtData {
-    /// According to the GHCB spec, the data page(s) must be contiguous pages if
-    /// supplying more than one page and all certificate pages must be
-    /// assigned to the hypervisor (shared).
-    data: [u8; SNP_GUEST_REQ_MAX_DATA_SIZE],
-}
-
-impl SnpGuestRequestExtData {
-    /// Allocate the object in the heap without going through stack as
-    /// this is a large object
-    pub fn boxed_new() -> Result<Box<Self>, SvsmReqError> {
-        let layout = Layout::new::<Self>();
-        unsafe {
-            let addr = alloc_zeroed(layout);
-            if addr.is_null() {
-                return Err(SvsmReqError::invalid_request());
-            }
-            assert!(VirtAddr::from(addr).is_page_aligned());
-
-            let ptr = addr.cast::<Self>();
-            Ok(Box::from_raw(ptr))
-        }
-    }
-
-    /// Clear the C-bit (memory encryption bit) for the Self pages
-    ///
-    /// # Safety
-    ///
-    /// * The caller is responsible for setting the page back to encrypted
-    ///   before the object is dropped. Shared pages should not be freed
-    ///   (returned to the allocator)
-    pub fn set_shared(&mut self) -> Result<(), SvsmReqError> {
-        let start = VirtAddr::from(addr_of_mut!(*self));
-        let region = MemoryRegion::new(start, size_of::<Self>());
-        set_shared_region_4k(region)
-    }
-
-    /// Set the C-bit (memory encryption bit) for the Self pages
-    pub fn set_encrypted(&mut self) -> Result<(), SvsmReqError> {
-        let start = VirtAddr::from(addr_of_mut!(*self));
-        let region = MemoryRegion::new(start, size_of::<Self>());
-        set_encrypted_region_4k(region)
-    }
-
-    /// Clear the first `n` bytes from data
-    pub fn nclear(&mut self, n: usize) -> Result<(), SvsmReqError> {
-        self.data
-            .get_mut(..n)
-            .ok_or_else(SvsmReqError::invalid_parameter)?
-            .fill(0);
-        Ok(())
-    }
-
-    /// Fill up the `outbuf` slice provided with bytes from data
-    pub fn copy_to_slice(&self, outbuf: &mut [u8]) -> Result<(), SvsmReqError> {
-        let data = self
-            .data
-            .get(..outbuf.len())
-            .ok_or_else(SvsmReqError::invalid_parameter)?;
-        outbuf.copy_from_slice(data);
-        Ok(())
-    }
-
-    /// Check if the first `n` bytes from data are zeroed
-    pub fn is_nclear(&self, n: usize) -> Result<bool, SvsmReqError> {
-        let data = self
-            .data
-            .get(..n)
-            .ok_or_else(SvsmReqError::invalid_parameter)?;
-        Ok(data.iter().all(|e| *e == 0))
-    }
-}
+pub type SnpGuestRequestExtData = [u8; SNP_GUEST_REQ_MAX_DATA_SIZE];
 
 #[cfg(test)]
 mod tests {
@@ -495,16 +371,9 @@ mod tests {
     #[test]
     fn test_requestmsg_boxed_new() {
         let _mem = TestRootMem::setup(DEFAULT_TEST_MEMORY_SIZE);
-        let mut data = SnpGuestRequestMsg::boxed_new().unwrap();
-        assert!(data.hdr.as_slice_mut().iter().all(|c| *c == 0));
+        let data = SnpGuestRequestMsg::boxed_new().unwrap();
+        assert!(data.hdr.as_bytes().iter().all(|c| *c == 0));
         assert!(data.pld.iter().all(|c| *c == 0));
-    }
-
-    #[test]
-    fn test_reqextdata_boxed_new() {
-        let _mem = TestRootMem::setup(DEFAULT_TEST_MEMORY_SIZE);
-        let data = SnpGuestRequestExtData::boxed_new().unwrap();
-        assert!(data.data.iter().all(|c| *c == 0));
     }
 
     #[test]

--- a/kernel/src/mm/page_visibility.rs
+++ b/kernel/src/mm/page_visibility.rs
@@ -4,17 +4,24 @@
 //
 // Author: Jon Lange (jlange@microsoft.com)
 
+use core::mem::MaybeUninit;
+use core::ptr::NonNull;
+
 use crate::address::VirtAddr;
 use crate::cpu::flush_tlb_global_sync;
+use crate::cpu::mem::{copy_bytes, write_bytes};
 use crate::cpu::percpu::this_cpu;
 use crate::error::SvsmError;
 use crate::mm::validate::{
     valid_bitmap_clear_valid_4k, valid_bitmap_set_valid_4k, valid_bitmap_valid_addr,
 };
-use crate::mm::virt_to_phys;
+use crate::mm::{virt_to_phys, PageBox};
 use crate::platform::{PageStateChangeOp, SVSM_PLATFORM};
+use crate::protocols::errors::SvsmReqError;
 use crate::types::{PageSize, PAGE_SIZE};
 use crate::utils::MemoryRegion;
+
+use zerocopy::{FromBytes, FromZeroes};
 
 /// Makes a virtual page shared by revoking its validation, updating the
 /// page state, and modifying the page tables accordingly.
@@ -22,7 +29,13 @@ use crate::utils::MemoryRegion;
 /// # Arguments
 ///
 /// * `vaddr` - The virtual address of the page to be made shared.
-pub fn make_page_shared(vaddr: VirtAddr) -> Result<(), SvsmError> {
+///
+/// # Safety
+///
+/// Converting the memory at `vaddr` must be safe within Rust's memory model.
+/// Notably any objects at `vaddr` must tolerate unsynchronized writes of any
+/// bit pattern.
+pub unsafe fn make_page_shared(vaddr: VirtAddr) -> Result<(), SvsmError> {
     let platform = SVSM_PLATFORM.as_dyn_ref();
 
     // Revoke page validation before changing page state.
@@ -55,7 +68,7 @@ pub fn make_page_shared(vaddr: VirtAddr) -> Result<(), SvsmError> {
 /// # Arguments
 ///
 /// * `vaddr` - The virtual address of the page to be made private.
-pub fn make_page_private(vaddr: VirtAddr) -> Result<(), SvsmError> {
+pub unsafe fn make_page_private(vaddr: VirtAddr) -> Result<(), SvsmError> {
     // Update the page tables to map the page as private.
     this_cpu().get_pgtable().set_encrypted_4k(vaddr)?;
     flush_tlb_global_sync();
@@ -77,4 +90,128 @@ pub fn make_page_private(vaddr: VirtAddr) -> Result<(), SvsmError> {
     }
 
     Ok(())
+}
+
+/// SharedBox is a safe wrapper around memory pages shared with the host.
+pub struct SharedBox<T> {
+    ptr: NonNull<T>,
+}
+
+impl<T> SharedBox<T> {
+    /// Allocate some memory and share it with the host.
+    pub fn try_new_zeroed() -> Result<Self, SvsmError> {
+        let page_box = PageBox::<T>::try_new_zeroed()?;
+        let vaddr = page_box.vaddr();
+
+        let ptr = NonNull::from(PageBox::leak(page_box)).cast::<T>();
+
+        for offset in (0..core::mem::size_of::<T>()).step_by(PAGE_SIZE) {
+            unsafe {
+                make_page_shared(vaddr + offset)?;
+            }
+        }
+
+        Ok(Self { ptr })
+    }
+
+    /// Returns the virtual address of the memory.
+    pub fn addr(&self) -> VirtAddr {
+        VirtAddr::from(self.ptr.as_ptr())
+    }
+
+    /// Read the currently stored value into `out`.
+    pub fn read_into(&self, out: &mut T)
+    where
+        T: FromBytes + Copy,
+    {
+        unsafe {
+            // SAFETY: `self.ptr` is valid. Any bitpattern is valid for `T`.
+            copy_bytes(
+                self.ptr.as_ptr() as usize,
+                out as *const T as usize,
+                size_of::<T>(),
+            );
+        }
+    }
+
+    /// Share `value` with the host.
+    pub fn write_from(&mut self, value: &T)
+    where
+        T: Copy,
+    {
+        unsafe {
+            // SAFETY: `self.ptr` is valid..
+            copy_bytes(
+                value as *const T as usize,
+                self.ptr.as_ptr() as usize,
+                size_of::<T>(),
+            );
+        }
+    }
+}
+
+impl<T, const N: usize> SharedBox<[T; N]> {
+    /// Clear the first `n` elements.
+    pub fn nclear(&mut self, n: usize) -> Result<(), SvsmReqError>
+    where
+        T: FromZeroes,
+    {
+        if n > N {
+            return Err(SvsmReqError::invalid_parameter());
+        }
+
+        unsafe {
+            // SAFETY: `self.ptr` is valid and we did a bounds check on `n`.
+            write_bytes(self.ptr.as_ptr() as usize, size_of::<T>() * n, 0);
+        }
+
+        Ok(())
+    }
+
+    /// Fill up the `outbuf` slice provided with bytes from data
+    pub fn copy_to_slice(&self, outbuf: &mut [T]) -> Result<(), SvsmReqError>
+    where
+        T: FromBytes + Copy,
+    {
+        if outbuf.len() > N {
+            return Err(SvsmReqError::invalid_parameter());
+        }
+
+        let size = core::mem::size_of_val(outbuf);
+        unsafe {
+            // SAFETY: `self.ptr` is valid.
+            copy_bytes(
+                self.ptr.as_ptr() as usize,
+                outbuf.as_mut_ptr() as usize,
+                size,
+            );
+        }
+
+        Ok(())
+    }
+}
+
+unsafe impl<T> Send for SharedBox<T> where T: Send {}
+unsafe impl<T> Sync for SharedBox<T> where T: Sync {}
+
+impl<T> Drop for SharedBox<T> {
+    fn drop(&mut self) {
+        // Re-encrypt the pages.
+        let res = (0..size_of::<Self>())
+            .step_by(PAGE_SIZE)
+            .try_for_each(|offset| unsafe { make_page_private(self.addr() + offset) });
+
+        // If re-encrypting was successful free the memory otherwise leak it.
+        if res.is_ok() {
+            drop(unsafe { PageBox::from_raw(self.ptr.cast::<MaybeUninit<T>>()) });
+        } else {
+            log::error!("failed to set pages to encrypted. Memory leak!");
+        }
+    }
+}
+
+impl<T> core::fmt::Debug for SharedBox<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SharedBox").finish_non_exhaustive()
+    }
 }

--- a/kernel/src/sev/ghcb.rs
+++ b/kernel/src/sev/ghcb.rs
@@ -23,7 +23,7 @@ use crate::utils::MemoryRegion;
 use crate::mm::PageBox;
 use core::arch::global_asm;
 use core::mem::{self, offset_of};
-use core::ops::{Deref, DerefMut};
+use core::ops::Deref;
 use core::ptr;
 use core::sync::atomic::{AtomicU16, AtomicU32, AtomicU64, AtomicU8, Ordering};
 
@@ -170,12 +170,6 @@ impl Deref for GhcbPage {
     type Target = GHCB;
     fn deref(&self) -> &Self::Target {
         self.0.deref()
-    }
-}
-
-impl DerefMut for GhcbPage {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.0.deref_mut()
     }
 }
 

--- a/kernel/src/sev/ghcb.rs
+++ b/kernel/src/sev/ghcb.rs
@@ -22,16 +22,18 @@ use crate::utils::MemoryRegion;
 
 use crate::mm::PageBox;
 use core::arch::global_asm;
-use core::cell::Cell;
 use core::mem::{self, offset_of};
 use core::ops::{Deref, DerefMut};
 use core::ptr;
+use core::sync::atomic::{AtomicU16, AtomicU32, AtomicU64, AtomicU8, Ordering};
 
 use super::msr_protocol::{invalidate_page_msr, register_ghcb_gpa_msr, validate_page_msr};
 use super::{pvalidate, PvalidateOp};
 
+use zerocopy::AsBytes;
+
 #[repr(C, packed)]
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, AsBytes)]
 pub struct PageStateChangeHeader {
     cur_entry: u16,
     end_entry: u16,
@@ -56,7 +58,7 @@ macro_rules! ghcb_getter {
         #[allow(unused)]
         fn $name(&self) -> Result<$t, GhcbError> {
             self.is_valid(offset_of!(Self, $field))
-                .then(|| self.$field.get())
+                .then(|| self.$field.load(Ordering::Relaxed))
                 .ok_or(GhcbError::VmgexitInvalid)
         }
     };
@@ -66,7 +68,7 @@ macro_rules! ghcb_setter {
     ($name:ident, $field:ident, $t:ty) => {
         #[allow(unused)]
         fn $name(&self, val: $t) {
-            self.$field.set(val);
+            self.$field.store(val, Ordering::Relaxed);
             self.set_valid(offset_of!(Self, $field));
         }
     };
@@ -178,35 +180,35 @@ impl DerefMut for GhcbPage {
 }
 
 #[repr(C)]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct GHCB {
-    reserved_1: Cell<[u8; 0xcb]>,
-    cpl: Cell<u8>,
-    reserved_2: Cell<[u8; 0x74]>,
-    xss: Cell<u64>,
-    reserved_3: Cell<[u8; 0x18]>,
-    dr7: Cell<u64>,
-    reserved_4: Cell<[u8; 0x90]>,
-    rax: Cell<u64>,
-    reserved_5: Cell<[u8; 0x100]>,
-    reserved_6: Cell<u64>,
-    rcx: Cell<u64>,
-    rdx: Cell<u64>,
-    rbx: Cell<u64>,
-    reserved_7: Cell<[u8; 0x70]>,
-    sw_exit_code: Cell<u64>,
-    sw_exit_info_1: Cell<u64>,
-    sw_exit_info_2: Cell<u64>,
-    sw_scratch: Cell<u64>,
-    reserved_8: Cell<[u8; 0x38]>,
-    xcr0: Cell<u64>,
-    valid_bitmap: Cell<[u64; 2]>,
-    x87_state_gpa: Cell<u64>,
-    reserved_9: Cell<[u8; 0x3f8]>,
-    buffer: Cell<[u8; GHCB_BUFFER_SIZE]>,
-    reserved_10: Cell<[u8; 0xa]>,
-    version: Cell<u16>,
-    usage: Cell<u32>,
+    reserved_1: [AtomicU8; 0xcb],
+    cpl: AtomicU8,
+    reserved_2: [AtomicU8; 0x74],
+    xss: AtomicU64,
+    reserved_3: [AtomicU8; 0x18],
+    dr7: AtomicU64,
+    reserved_4: [AtomicU8; 0x90],
+    rax: AtomicU64,
+    reserved_5: [AtomicU8; 0x100],
+    reserved_6: AtomicU64,
+    rcx: AtomicU64,
+    rdx: AtomicU64,
+    rbx: AtomicU64,
+    reserved_7: [AtomicU8; 0x70],
+    sw_exit_code: AtomicU64,
+    sw_exit_info_1: AtomicU64,
+    sw_exit_info_2: AtomicU64,
+    sw_scratch: AtomicU64,
+    reserved_8: [AtomicU8; 0x38],
+    xcr0: AtomicU64,
+    valid_bitmap: [AtomicU64; 2],
+    x87_state_gpa: AtomicU64,
+    reserved_9: [AtomicU8; 0x3f8],
+    buffer: [AtomicU8; GHCB_BUFFER_SIZE],
+    reserved_10: [AtomicU8; 0xa],
+    version: AtomicU16,
+    usage: AtomicU32,
 }
 
 impl GHCB {
@@ -343,7 +345,8 @@ impl GHCB {
 
     pub fn clear(&self) {
         // Clear valid bitmap
-        self.valid_bitmap.set([0, 0]);
+        self.valid_bitmap[0].store(0, Ordering::Relaxed);
+        self.valid_bitmap[1].store(0, Ordering::Relaxed);
 
         // Mark valid_bitmap valid
         let off = offset_of!(Self, valid_bitmap);
@@ -356,9 +359,7 @@ impl GHCB {
         let index: usize = (offset >> 9) & 0x1;
         let mask: u64 = 1 << bit;
 
-        let mut bitmap = self.valid_bitmap.get();
-        bitmap[index] |= mask;
-        self.valid_bitmap.set(bitmap);
+        self.valid_bitmap[index].fetch_or(mask, Ordering::Relaxed);
     }
 
     fn is_valid(&self, offset: usize) -> bool {
@@ -366,7 +367,7 @@ impl GHCB {
         let index: usize = (offset >> 9) & 0x1;
         let mask: u64 = 1 << bit;
 
-        (self.valid_bitmap.get()[index] & mask) == mask
+        (self.valid_bitmap[index].load(Ordering::Relaxed) & mask) == mask
     }
 
     fn vmgexit(
@@ -392,7 +393,7 @@ impl GHCB {
         if sw_exit_info_1 != 0 {
             return Err(GhcbError::VmgexitError(
                 sw_exit_info_1,
-                self.sw_exit_info_2.get(),
+                self.sw_exit_info_2.load(Ordering::Relaxed),
             ));
         }
 
@@ -437,22 +438,18 @@ impl GHCB {
 
     fn write_buffer<T>(&self, data: &T, offset: usize) -> Result<(), GhcbError>
     where
-        T: Copy,
+        T: AsBytes,
     {
-        offset
-            .checked_add(mem::size_of::<T>())
-            .filter(|end| *end <= GHCB_BUFFER_SIZE)
+        let src = data.as_bytes();
+        let dst = &self
+            .buffer
+            .get(offset..)
+            .ok_or(GhcbError::InvalidOffset)?
+            .get(..src.len())
             .ok_or(GhcbError::InvalidOffset)?;
-
-        // SAFETY: we have verified that the offset is within bounds and does
-        // not overflow
-        let dst = unsafe { self.buffer.as_ptr().cast::<u8>().add(offset) };
-        if dst.align_offset(mem::align_of::<T>()) != 0 {
-            return Err(GhcbError::InvalidOffset);
+        for (dst, src) in dst.iter().zip(src.iter().copied()) {
+            dst.store(src, Ordering::Relaxed);
         }
-
-        // SAFETY: we have verified the pointer is aligned and within bounds.
-        unsafe { dst.cast::<T>().copy_from_nonoverlapping(data, 1) }
         Ok(())
     }
 
@@ -592,7 +589,11 @@ impl GHCB {
 
         let sw_exit_info_2 = self.get_exit_info_2_valid()?;
         if sw_exit_info_2 != 0 {
-            return Err(GhcbError::VmgexitError(self.sw_exit_info_1.get(), sw_exit_info_2).into());
+            return Err(GhcbError::VmgexitError(
+                self.sw_exit_info_1.load(Ordering::Relaxed),
+                sw_exit_info_2,
+            )
+            .into());
         }
 
         Ok(())
@@ -622,7 +623,9 @@ impl GHCB {
         // For an extended request, if the buffer provided is too small, the hypervisor
         // will return in RBX the number of contiguous pages required
         if sw_exit_info_2 != 0 {
-            return Err(GhcbError::VmgexitError(self.rbx.get(), sw_exit_info_2).into());
+            return Err(
+                GhcbError::VmgexitError(self.rbx.load(Ordering::Relaxed), sw_exit_info_2).into(),
+            );
         }
 
         Ok(())
@@ -668,45 +671,15 @@ impl GHCB {
 
     #[inline]
     #[cfg(test)]
-    pub fn fill(&self, byte: u8) {
-        let mut other = mem::MaybeUninit::<Self>::uninit();
-        let other = unsafe {
-            other.as_mut_ptr().write_bytes(byte, 1);
-            other.assume_init()
+    pub fn fill(&self, val: u8) {
+        let bytes = unsafe {
+            // SAFETY: All bytes in `Self` are part of an atomic integer type.
+            // This allows us to cast `Self` to a slice of `AtomicU8`s.
+            core::slice::from_raw_parts(self as *const _ as *const AtomicU8, size_of::<Self>())
         };
-        self.copy_from(&other);
-    }
-
-    #[inline]
-    #[cfg(test)]
-    fn copy_from(&self, other: &Self) {
-        self.reserved_1.set(other.reserved_1.get());
-        self.cpl.set(other.cpl.get());
-        self.reserved_2.set(other.reserved_2.get());
-        self.xss.set(other.xss.get());
-        self.reserved_3.set(other.reserved_3.get());
-        self.dr7.set(other.dr7.get());
-        self.reserved_4.set(other.reserved_4.get());
-        self.rax.set(other.rax.get());
-        self.reserved_5.set(other.reserved_5.get());
-        self.reserved_6.set(other.reserved_6.get());
-        self.rcx.set(other.rcx.get());
-        self.rdx.set(other.rdx.get());
-        self.rbx.set(other.rbx.get());
-        self.reserved_7.set(other.reserved_7.get());
-        self.sw_exit_code.set(other.sw_exit_code.get());
-        self.sw_exit_info_1.set(other.sw_exit_info_1.get());
-        self.sw_exit_info_2.set(other.sw_exit_info_2.get());
-        self.sw_scratch.set(other.sw_scratch.get());
-        self.reserved_8.set(other.reserved_8.get());
-        self.xcr0.set(other.xcr0.get());
-        self.valid_bitmap.set(other.valid_bitmap.get());
-        self.x87_state_gpa.set(other.x87_state_gpa.get());
-        self.reserved_9.set(other.reserved_9.get());
-        self.buffer.set(other.buffer.get());
-        self.reserved_10.set(other.reserved_10.get());
-        self.version.set(other.version.get());
-        self.usage.set(other.usage.get());
+        for byte in bytes {
+            byte.store(val, Ordering::Relaxed);
+        }
     }
 }
 

--- a/kernel/src/sev/hv_doorbell.rs
+++ b/kernel/src/sev/hv_doorbell.rs
@@ -61,7 +61,9 @@ impl HVDoorbellPage {
         let paddr = virt_to_phys(page.vaddr());
 
         // The #HV doorbell page must be shared before it can be used.
-        make_page_shared(page.vaddr())?;
+        unsafe {
+            make_page_shared(page.vaddr())?;
+        }
 
         // Now Drop will have correct behavior, so construct the new type.
         // SAFETY: all zeros is a valid representation of the HV doorbell page.
@@ -91,7 +93,10 @@ impl Deref for HVDoorbellPage {
 
 impl Drop for HVDoorbellPage {
     fn drop(&mut self) {
-        make_page_private(self.0.vaddr()).expect("Failed to restore HV doorbell page visibility");
+        unsafe {
+            make_page_private(self.0.vaddr())
+                .expect("Failed to restore HV doorbell page visibility");
+        }
     }
 }
 

--- a/kernel/src/sev/hv_doorbell.rs
+++ b/kernel/src/sev/hv_doorbell.rs
@@ -4,14 +4,12 @@
 use crate::cpu::idt::svsm::common_isr_handler;
 use crate::cpu::percpu::this_cpu;
 use crate::error::SvsmError;
-use crate::mm::page_visibility::{make_page_private, make_page_shared};
-use crate::mm::{virt_to_phys, PageBox};
+use crate::mm::page_visibility::SharedBox;
+use crate::mm::virt_to_phys;
 use crate::sev::ghcb::GHCB;
 
 use bitfield_struct::bitfield;
 use core::cell::UnsafeCell;
-use core::mem::ManuallyDrop;
-use core::ops::Deref;
 use core::sync::atomic::{AtomicU32, AtomicU8, Ordering};
 
 #[bitfield(u8)]
@@ -48,56 +46,24 @@ pub struct HVExtIntInfo {
     pub isr: [AtomicU32; 8],
 }
 
-/// An allocation containing the `#HV` doorbell page.
-#[derive(Debug)]
-pub struct HVDoorbellPage(PageBox<HVDoorbell>);
+/// Allocates a new HV doorbell page and registers it on the hypervisor
+/// using the given GHCB.
+pub fn allocate_hv_doorbell_page(ghcb: &GHCB) -> Result<&'static HVDoorbell, SvsmError> {
+    let page = SharedBox::<HVDoorbell>::try_new_zeroed()?;
 
-impl HVDoorbellPage {
-    /// Allocates a new HV doorbell page and registers it on the hypervisor
-    /// using the given GHCB.
-    pub fn new(ghcb: &GHCB) -> Result<Self, SvsmError> {
-        // SAFETY: all zeroes is a valid representation for `HVDoorbell`.
-        let page = PageBox::try_new_zeroed()?;
-        let paddr = virt_to_phys(page.vaddr());
+    let vaddr = page.addr();
+    let paddr = virt_to_phys(vaddr);
+    ghcb.register_hv_doorbell(paddr)?;
 
-        // The #HV doorbell page must be shared before it can be used.
-        unsafe {
-            make_page_shared(page.vaddr())?;
-        }
+    // Create a static shared reference.
+    let ptr = page.leak();
+    let doorbell = unsafe {
+        // SAFETY: Any bit-pattern is valid for `HVDoorbell` and it tolerates
+        // unsynchronized writes from the host.
+        ptr.as_ref()
+    };
 
-        // Now Drop will have correct behavior, so construct the new type.
-        // SAFETY: all zeros is a valid representation of the HV doorbell page.
-        let page = unsafe { Self(page.assume_init()) };
-        ghcb.register_hv_doorbell(paddr)?;
-        Ok(page)
-    }
-
-    /// Leaks the page allocation, ensuring it will never be freed.
-    pub fn leak(self) -> &'static HVDoorbell {
-        let mut doorbell = ManuallyDrop::new(self);
-        let ptr = core::ptr::from_mut(&mut doorbell);
-        // SAFETY: this pointer will never be freed because of ManuallyDrop,
-        // so we can create a static mutable reference. We go through a raw
-        // pointer to promote the lifetime to static.
-        unsafe { &mut *ptr }
-    }
-}
-
-impl Deref for HVDoorbellPage {
-    type Target = HVDoorbell;
-
-    fn deref(&self) -> &Self::Target {
-        self.0.deref()
-    }
-}
-
-impl Drop for HVDoorbellPage {
-    fn drop(&mut self) {
-        unsafe {
-            make_page_private(self.0.vaddr())
-                .expect("Failed to restore HV doorbell page visibility");
-        }
-    }
+    Ok(doorbell)
 }
 
 #[repr(C)]

--- a/kernel/src/sev/hv_doorbell.rs
+++ b/kernel/src/sev/hv_doorbell.rs
@@ -9,6 +9,7 @@ use crate::mm::{virt_to_phys, PageBox};
 use crate::sev::ghcb::GHCB;
 
 use bitfield_struct::bitfield;
+use core::cell::UnsafeCell;
 use core::mem::ManuallyDrop;
 use core::ops::Deref;
 use core::sync::atomic::{AtomicU32, AtomicU8, Ordering};
@@ -101,7 +102,7 @@ pub struct HVDoorbell {
     pub flags: AtomicU8,
     pub no_eoi_required: AtomicU8,
     pub per_vmpl_events: AtomicU8,
-    reserved_63_4: [u8; 60],
+    reserved_63_4: UnsafeCell<[u8; 60]>,
     pub per_vmpl: [HVExtIntInfo; 3],
 }
 


### PR DESCRIPTION
This PR improves the soundness of code around hypervisor-shared memory.

~The first patch, 174274d0e8ffb7757b74a42eef1082b05b8ea0a9, is blocked on https://github.com/google/zerocopy/pull/1601. Let me know if you want me to drop that patch if we don't want to wait on a new zerocopy release. I used the following patch to override zerocopy for testing:~
```diff
diff --git a/Cargo.toml b/Cargo.toml
index b7bdb46..d87444d 100644
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,9 @@ zerocopy = { version = "0.7.32", features = ["alloc", "derive"] }
 # other repos
 packit = { git = "https://github.com/coconut-svsm/packit", version = "0.1.1" }
 
+[patch.crates-io]
+zerocopy = { git = "https://github.com/Freax13/zerocopy.git", rev = "68e1cc8" }
+
 [workspace.lints.rust]
 future_incompatible = { level = "deny", priority = 127 }
 nonstandard_style = { level = "deny", priority = 126 }
```