### PR TITLE
kernel/requests: Ensure guest VMSA mapping is updated on switch from VMPL2

### DIFF
--- a/kernel/src/requests.rs
+++ b/kernel/src/requests.rs
@@ -174,14 +174,14 @@ pub fn request_loop() {
 
             switch_to_vmpl(GUEST_VMPL as u32);
         } else {
-            loop {
-                log::debug!("No VMSA or CAA! Halting");
-                halt();
+            log::debug!("No VMSA or CAA! Halting");
+            halt();
+        }
 
-                if update_mappings().is_ok() {
-                    break;
-                }
-            }
+        // Update mappings again on return from the guest VMPL or halt. If this
+        // is an AP it may have been created from the context of another CPU.
+        if update_mappings().is_err() {
+            continue;
         }
 
         // Obtain a reference to the VMSA just long enough to extract the


### PR DESCRIPTION
Currently, when the guest running at VMPL2 switches back to the SVSM it is assumed that the guest VMSA virtual memory mapping is correct. However, it is possible for the VMPL2 AP to be destroyed and recreated while the AP request loop is blocked on waiting for the guest VMPL to call back to the SVSM. In this case the VMSA mapping is incorrect and the SVSM call fails.

This is fixed by updating the mappings on returning to the SVSM from the guest VMPL.