### PR TITLE
update to zerocopy 0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 name = "bootlib"
 version = "0.1.0"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.8.2",
 ]
 
 [[package]]
@@ -490,7 +490,7 @@ dependencies = [
  "range_map_vec",
  "thiserror",
  "tracing",
- "zerocopy",
+ "zerocopy 0.7.34",
 ]
 
 [[package]]
@@ -502,7 +502,7 @@ dependencies = [
  "bitfield-struct",
  "open-enum",
  "static_assertions",
- "zerocopy",
+ "zerocopy 0.7.34",
 ]
 
 [[package]]
@@ -514,7 +514,8 @@ dependencies = [
  "igvm",
  "igvm_defs",
  "uuid",
- "zerocopy",
+ "zerocopy 0.7.34",
+ "zerocopy 0.8.2",
 ]
 
 [[package]]
@@ -526,7 +527,8 @@ dependencies = [
  "igvm_defs",
  "p384",
  "sha2",
- "zerocopy",
+ "zerocopy 0.7.34",
+ "zerocopy 0.8.2",
 ]
 
 [[package]]
@@ -662,7 +664,7 @@ name = "packit"
 version = "0.1.1"
 source = "git+https://github.com/coconut-svsm/packit#e2508f686440f6a703fb6c5c0c2fd338e55f1d38"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.34",
 ]
 
 [[package]]
@@ -842,7 +844,7 @@ dependencies = [
  "packit",
  "syscall",
  "test",
- "zerocopy",
+ "zerocopy 0.8.2",
 ]
 
 [[package]]
@@ -1050,7 +1052,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.34",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf8d0ac51277f0e70d6dcb000b7bfa817968d66df9f5772e731a1d1bc6fc5c6"
+dependencies = [
+ "zerocopy-derive 0.8.2",
 ]
 
 [[package]]
@@ -1058,6 +1069,17 @@ name = "zerocopy-derive"
 version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cf1fea9437ee18b719f41c597b00c1745d7ff77184daf6ac8c61110a0115161"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,7 @@ name = "cpuarch"
 version = "0.1.0"
 dependencies = [
  "bitfield-struct",
+ "zerocopy 0.8.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ log = "0.4.17"
 p384 = { version = "0.13.0" }
 uuid = "1.6.1"
 # Add the derive feature by default because all crates use it.
-zerocopy = { version = "0.8.2", features = ["derive"] }
+zerocopy = { version = "0.8.2", features = ["alloc", "derive"] }
 
 # other repos
 packit = { git = "https://github.com/coconut-svsm/packit", version = "0.1.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ log = "0.4.17"
 p384 = { version = "0.13.0" }
 uuid = "1.6.1"
 # Add the derive feature by default because all crates use it.
-zerocopy = { version = "0.7.32", features = ["derive"] }
+zerocopy = { version = "0.8.2", features = ["derive"] }
 
 # other repos
 packit = { git = "https://github.com/coconut-svsm/packit", version = "0.1.1" }

--- a/bootlib/src/igvm_params.rs
+++ b/bootlib/src/igvm_params.rs
@@ -7,12 +7,12 @@
 //! This crate provides definitions of IGVM parameters to be parsed by
 //! COCONUT-SVSM to determine its configuration.
 
-use zerocopy::AsBytes;
+use zerocopy::{Immutable, IntoBytes};
 
 /// The IGVM parameter page is an unmeasured page containing individual
 /// parameters that are provided by the host loader.
 #[repr(C, packed)]
-#[derive(AsBytes, Clone, Copy, Debug, Default)]
+#[derive(IntoBytes, Clone, Copy, Debug, Default)]
 pub struct IgvmParamPage {
     /// The number of vCPUs that are configured for the guest VM.
     pub cpu_count: u32,
@@ -26,7 +26,7 @@ pub struct IgvmParamPage {
 /// An entry that represents an area of pre-validated memory defined by the
 /// firmware in the IGVM file.
 #[repr(C, packed)]
-#[derive(AsBytes, Clone, Copy, Debug, Default)]
+#[derive(IntoBytes, Immutable, Clone, Copy, Debug, Default)]
 pub struct IgvmParamBlockFwMem {
     /// The base physical address of the prevalidated memory region.
     pub base: u32,
@@ -38,7 +38,7 @@ pub struct IgvmParamBlockFwMem {
 /// The portion of the IGVM parameter block that describes metadata about
 /// the firmware image embedded in the IGVM file.
 #[repr(C, packed)]
-#[derive(AsBytes, Clone, Copy, Debug, Default)]
+#[derive(IntoBytes, Immutable, Clone, Copy, Debug, Default)]
 pub struct IgvmParamBlockFwInfo {
     /// The guest physical address of the start of the guest firmware. The
     /// permissions on the pages in the firmware range are adjusted to the guest
@@ -88,7 +88,7 @@ pub struct IgvmParamBlockFwInfo {
 /// builder which describes where the additional IGVM parameter information
 /// has been placed into the guest address space.
 #[repr(C, packed)]
-#[derive(AsBytes, Clone, Copy, Debug, Default)]
+#[derive(IntoBytes, Immutable, Clone, Copy, Debug, Default)]
 pub struct IgvmParamBlock {
     /// The total size of the parameter area, beginning with the parameter
     /// block itself and including any additional parameter pages which follow.
@@ -145,7 +145,7 @@ pub struct IgvmParamBlock {
 /// The IGVM context page is a measured page that is used to specify the start
 /// context for the guest VMPL.  If present, it overrides the processor state
 /// initialized at reset.
-#[derive(AsBytes, Copy, Debug, Clone, Default)]
+#[derive(IntoBytes, Immutable, Copy, Debug, Clone, Default)]
 #[repr(C, packed)]
 pub struct IgvmGuestContext {
     pub cr0: u64,

--- a/bootlib/src/kernel_launch.rs
+++ b/bootlib/src/kernel_launch.rs
@@ -6,7 +6,7 @@
 
 use crate::platform::SvsmPlatformType;
 
-use zerocopy::AsBytes;
+use zerocopy::{Immutable, IntoBytes};
 
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]
@@ -46,7 +46,7 @@ impl KernelLaunchInfo {
 // Stage 2 launch info from stage1
 // The layout has to match the order in which the parts are pushed to the stack
 // in stage1/stage1.S
-#[derive(AsBytes, Default, Debug, Clone, Copy)]
+#[derive(IntoBytes, Immutable, Default, Debug, Clone, Copy)]
 #[repr(C, packed)]
 pub struct Stage2LaunchInfo {
     // VTOM must be the first field.

--- a/cpuarch/Cargo.toml
+++ b/cpuarch/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 bitfield-struct.workspace = true
+zerocopy.workspace = true
 
 [lints]
 workspace = true

--- a/cpuarch/src/vmsa.rs
+++ b/cpuarch/src/vmsa.rs
@@ -4,14 +4,18 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
+#![allow(non_camel_case_types)]
+
 use bitfield_struct::bitfield;
+use zerocopy::FromZeros;
 
 // AE Exitcodes
 // Table 15-35, AMD64 Architecture Programmer’s Manual, Vol. 2
 #[repr(u64)]
-#[derive(Clone, Copy, Default, Debug)]
-#[allow(dead_code, non_camel_case_types)]
+#[derive(Clone, Copy, Default, Debug, FromZeros)]
+#[allow(dead_code)]
 pub enum GuestVMExit {
+    CR0_READ = 0,
     MC = 0x52,
     INTR = 0x60,
     NMI = 0x61,
@@ -46,6 +50,7 @@ pub enum GuestVMExit {
 }
 
 #[bitfield(u64)]
+#[derive(FromZeros)]
 pub struct VIntrCtrl {
     pub v_tpr: u8,
     pub v_irq: bool,
@@ -92,6 +97,7 @@ impl VmsaEventType {
 }
 
 #[bitfield(u64)]
+#[derive(FromZeros)]
 pub struct VmsaEventInject {
     pub vector: u8,
     #[bits(3)]
@@ -104,7 +110,7 @@ pub struct VmsaEventInject {
 }
 
 #[repr(C, packed)]
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, FromZeros)]
 pub struct VMSASegment {
     pub selector: u16,
     pub flags: u16,
@@ -113,7 +119,7 @@ pub struct VMSASegment {
 }
 
 #[repr(C, packed)]
-#[derive(Debug)]
+#[derive(Debug, FromZeros)]
 pub struct VMSA {
     pub es: VMSASegment,
     pub cs: VMSASegment,

--- a/igvmbuilder/Cargo.toml
+++ b/igvmbuilder/Cargo.toml
@@ -13,6 +13,7 @@ igvm_defs.workspace = true
 igvm.workspace = true
 uuid.workspace = true
 zerocopy.workspace = true
+zerocopy07 = { package = "zerocopy", version = "0.7" }
 
 [lints]
 workspace = true

--- a/igvmbuilder/src/cpuid.rs
+++ b/igvmbuilder/src/cpuid.rs
@@ -9,10 +9,10 @@ use std::mem::size_of;
 
 use igvm::IgvmDirectiveHeader;
 use igvm_defs::{IgvmPageDataFlags, IgvmPageDataType, PAGE_SIZE_4K};
-use zerocopy::AsBytes;
+use zerocopy::{Immutable, IntoBytes};
 
 #[repr(C, packed(1))]
-#[derive(AsBytes, Copy, Clone, Default)]
+#[derive(IntoBytes, Immutable, Copy, Clone, Default)]
 struct SnpCpuidLeaf {
     eax_in: u32,
     ecx_in: u32,
@@ -56,7 +56,7 @@ impl SnpCpuidLeaf {
 }
 
 #[repr(C, packed(1))]
-#[derive(AsBytes)]
+#[derive(IntoBytes, Immutable)]
 pub struct SnpCpuidPage {
     count: u32,
     reserved: [u32; 3],

--- a/igvmbuilder/src/igvm_builder.rs
+++ b/igvmbuilder/src/igvm_builder.rs
@@ -20,7 +20,7 @@ use igvm_defs::{
     IgvmNativeVpContextX64, IgvmPageDataFlags, IgvmPageDataType, IgvmPlatformType,
     IGVM_VHS_PARAMETER, IGVM_VHS_PARAMETER_INSERT, IGVM_VHS_SUPPORTED_PLATFORM, PAGE_SIZE_4K,
 };
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::cmd_options::{CmdOptions, Hypervisor};
 use crate::cpuid::SnpCpuidPage;

--- a/igvmbuilder/src/igvm_firmware.rs
+++ b/igvmbuilder/src/igvm_firmware.rs
@@ -15,7 +15,7 @@ use igvm_defs::{
     IgvmPageDataType, IgvmVariableHeaderType, IGVM_VHS_PARAMETER, IGVM_VHS_PARAMETER_INSERT,
     PAGE_SIZE_4K,
 };
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::firmware::Firmware;
 

--- a/igvmbuilder/src/stage2_stack.rs
+++ b/igvmbuilder/src/stage2_stack.rs
@@ -10,7 +10,7 @@ use bootlib::kernel_launch::Stage2LaunchInfo;
 use bootlib::platform::SvsmPlatformType;
 use igvm::IgvmDirectiveHeader;
 use igvm_defs::{IgvmPageDataFlags, IgvmPageDataType, PAGE_SIZE_4K};
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::gpa_map::GpaMap;
 use crate::igvm_builder::{

--- a/igvmbuilder/src/vmsa.rs
+++ b/igvmbuilder/src/vmsa.rs
@@ -7,7 +7,7 @@
 use igvm::snp_defs::{SevFeatures, SevVmsa};
 use igvm::IgvmDirectiveHeader;
 use igvm_defs::IgvmNativeVpContextX64;
-use zerocopy::FromZeroes;
+use zerocopy07::FromZeroes;
 
 use crate::cmd_options::SevExtraFeatures;
 

--- a/igvmmeasure/Cargo.toml
+++ b/igvmmeasure/Cargo.toml
@@ -12,6 +12,8 @@ igvm.workspace = true
 igvm_defs.workspace = true
 p384.workspace = true
 zerocopy.workspace = true
+# igvm_defs still uses 0.7, so we need to import the zerocopy 0.7 traits to use them.
+zerocopy07 = { package = "zerocopy", version = "0.7" }
 
 [lints]
 workspace = true

--- a/igvmmeasure/src/id_block.rs
+++ b/igvmmeasure/src/id_block.rs
@@ -15,13 +15,14 @@ use p384::ecdsa::signature::Signer;
 use p384::ecdsa::{Signature, SigningKey};
 use p384::elliptic_curve::bigint::ArrayEncoding;
 use p384::{EncodedPoint, SecretKey};
-use zerocopy::{AsBytes, FromZeroes};
+use zerocopy::{Immutable, IntoBytes};
+use zerocopy07::FromZeroes;
 
 use crate::igvm_measure::IgvmMeasure;
 use crate::utils::{get_compatibility_mask, get_policy};
 
 #[repr(C, packed)]
-#[derive(AsBytes, Clone, Copy, Debug)]
+#[derive(IntoBytes, Immutable, Clone, Copy, Debug)]
 pub struct SevIdBlock {
     pub ld: [u8; 48],
     pub family_id: [u8; 16],

--- a/igvmmeasure/src/igvm_measure.rs
+++ b/igvmmeasure/src/igvm_measure.rs
@@ -10,7 +10,7 @@ use igvm::snp_defs::SevVmsa;
 use igvm::{IgvmDirectiveHeader, IgvmFile};
 use igvm_defs::{IgvmPageDataFlags, IgvmPageDataType, IgvmPlatformType, PAGE_SIZE_4K};
 use sha2::{Digest, Sha256};
-use zerocopy::AsBytes;
+use zerocopy07::AsBytes;
 
 use crate::page_info::PageInfo;
 

--- a/igvmmeasure/src/main.rs
+++ b/igvmmeasure/src/main.rs
@@ -14,7 +14,7 @@ use igvm::IgvmFile;
 use igvm_defs::IgvmPlatformType;
 use igvm_measure::IgvmMeasure;
 use utils::get_compatibility_mask;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::id_block::SevIdBlockBuilder;
 

--- a/igvmmeasure/src/page_info.rs
+++ b/igvmmeasure/src/page_info.rs
@@ -5,10 +5,10 @@
 // Author: Roy Hopkins <roy.hopkins@suse.com>
 
 use sha2::{Digest, Sha384};
-use zerocopy::AsBytes;
+use zerocopy::{Immutable, IntoBytes};
 
 #[repr(u8)]
-#[derive(AsBytes, Debug, Copy, Clone)]
+#[derive(IntoBytes, Immutable, Debug, Copy, Clone)]
 pub enum PageType {
     Normal = 1,
     Vmsa = 2,
@@ -19,7 +19,7 @@ pub enum PageType {
 }
 
 #[repr(C, packed)]
-#[derive(AsBytes, Debug, Copy, Clone)]
+#[derive(IntoBytes, Immutable, Debug, Copy, Clone)]
 pub struct PageInfo {
     digest_cur: [u8; 48],
     contents: [u8; 48],

--- a/kernel/src/greq/driver.rs
+++ b/kernel/src/greq/driver.rs
@@ -12,7 +12,9 @@ extern crate alloc;
 
 use alloc::boxed::Box;
 use core::{cell::OnceCell, mem::size_of};
+use zerocopy::FromZeros;
 
+use crate::mm::alloc::AllocError;
 use crate::mm::page_visibility::SharedBox;
 use crate::{
     cpu::percpu::current_ghcb,
@@ -81,7 +83,8 @@ impl SnpGuestRequestDriver {
     pub fn new() -> Result<Self, SvsmReqError> {
         let request = SharedBox::try_new_zeroed()?;
         let response = SharedBox::try_new_zeroed()?;
-        let staging = SnpGuestRequestMsg::boxed_new()?;
+        let staging = SnpGuestRequestMsg::new_box_zeroed()
+            .map_err(|_| SvsmError::Alloc(AllocError::OutOfMemory))?;
         let ext_data = SharedBox::try_new_zeroed()?;
 
         Ok(Self {

--- a/kernel/src/greq/msg.rs
+++ b/kernel/src/greq/msg.rs
@@ -22,7 +22,7 @@ use crate::{
     types::PAGE_SIZE,
 };
 
-use zerocopy::{AsBytes, FromBytes, FromZeroes};
+use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 /// Version of the message header
 const HDR_VERSION: u8 = 1;
@@ -70,7 +70,7 @@ pub const SNP_GUEST_REQ_MAX_DATA_SIZE: usize = 4 * PAGE_SIZE;
 
 /// `SNP_GUEST_REQUEST` message header format (AMD SEV-SNP spec. table 98)
 #[repr(C, packed)]
-#[derive(Clone, Copy, Debug, FromZeroes, FromBytes, AsBytes)]
+#[derive(Clone, Copy, Debug, FromBytes, IntoBytes, Immutable)]
 pub struct SnpGuestRequestMsgHdr {
     /// Message authentication tag
     authtag: [u8; 32],
@@ -174,7 +174,7 @@ impl Default for SnpGuestRequestMsgHdr {
 
 /// `SNP_GUEST_REQUEST` message format
 #[repr(C, align(4096))]
-#[derive(Clone, Copy, Debug, FromZeroes, FromBytes)]
+#[derive(Clone, Copy, Debug, FromBytes)]
 pub struct SnpGuestRequestMsg {
     hdr: SnpGuestRequestMsgHdr,
     pld: [u8; MSG_PAYLOAD_SIZE],

--- a/kernel/src/mm/page_visibility.rs
+++ b/kernel/src/mm/page_visibility.rs
@@ -21,7 +21,7 @@ use crate::protocols::errors::SvsmReqError;
 use crate::types::{PageSize, PAGE_SIZE};
 use crate::utils::MemoryRegion;
 
-use zerocopy::{FromBytes, FromZeroes};
+use zerocopy::{FromBytes, FromZeros};
 
 /// Makes a virtual page shared by revoking its validation, updating the
 /// page state, and modifying the page tables accordingly.
@@ -167,7 +167,7 @@ impl<T, const N: usize> SharedBox<[T; N]> {
     /// Clear the first `n` elements.
     pub fn nclear(&mut self, n: usize) -> Result<(), SvsmReqError>
     where
-        T: FromZeroes,
+        T: FromZeros,
     {
         if n > N {
             return Err(SvsmReqError::invalid_parameter());

--- a/kernel/src/mm/page_visibility.rs
+++ b/kernel/src/mm/page_visibility.rs
@@ -106,7 +106,7 @@ pub struct SharedBox<T> {
 impl<T> SharedBox<T> {
     /// Allocate some memory and share it with the host.
     pub fn try_new_zeroed() -> Result<Self, SvsmError> {
-        let page_box = PageBox::<T>::try_new_zeroed()?;
+        let page_box = PageBox::<MaybeUninit<T>>::try_new_zeroed()?;
         let vaddr = page_box.vaddr();
 
         let ptr = NonNull::from(PageBox::leak(page_box)).cast::<T>();

--- a/kernel/src/sev/ghcb.rs
+++ b/kernel/src/sev/ghcb.rs
@@ -30,10 +30,10 @@ use core::sync::atomic::{AtomicU16, AtomicU32, AtomicU64, AtomicU8, Ordering};
 use super::msr_protocol::{invalidate_page_msr, register_ghcb_gpa_msr, validate_page_msr};
 use super::{pvalidate, PvalidateOp};
 
-use zerocopy::AsBytes;
+use zerocopy::{Immutable, IntoBytes};
 
 #[repr(C, packed)]
-#[derive(Debug, Default, Clone, Copy, AsBytes)]
+#[derive(Debug, Default, Clone, Copy, IntoBytes, Immutable)]
 pub struct PageStateChangeHeader {
     cur_entry: u16,
     end_entry: u16,
@@ -429,7 +429,7 @@ impl GHCB {
 
     fn write_buffer<T>(&self, data: &T, offset: usize) -> Result<(), GhcbError>
     where
-        T: AsBytes,
+        T: IntoBytes + Immutable,
     {
         let src = data.as_bytes();
         let dst = &self

--- a/kernel/src/sev/vmsa.rs
+++ b/kernel/src/sev/vmsa.rs
@@ -31,7 +31,7 @@ impl VmsaPage {
     pub fn new(vmpl: RMPFlags) -> Result<Self, SvsmError> {
         assert!(vmpl.bits() < (VMPL_MAX as u64));
 
-        let page = PageBox::try_new_zeroed()?;
+        let page = PageBox::<[VMSA; 2]>::try_new_zeroed()?;
         // Make sure the VMSA page is not 2M-aligned, as some hardware
         // generations can't handle this properly. To ensure this property, we
         // allocate 2 VMSAs and choose whichever is not 2M-aligned.
@@ -43,8 +43,6 @@ impl VmsaPage {
 
         let vaddr = page.vaddr() + idx * size_of::<VMSA>();
         rmp_adjust(vaddr, RMPFlags::VMSA | vmpl, PageSize::Regular)?;
-        // SAFETY: all zeros is a valid representation for the VMSA.
-        let page = unsafe { page.assume_init() };
         Ok(Self { page, idx })
     }
 


### PR DESCRIPTION
The new version allows us to get rid of even more unsafe code :)

~This patch was split out from #451.
This PR is blocked on a new [zerocopy release](https://github.com/google/zerocopy/pull/1604).~