### PR TITLE
Implement object management

### DIFF
--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -25,6 +25,7 @@ use crate::mm::alloc::AllocError;
 use crate::sev::ghcb::GhcbError;
 use crate::sev::msr_protocol::GhcbMsrError;
 use crate::sev::SevSnpError;
+use crate::syscall::ObjError;
 use crate::task::TaskError;
 use elf::ElfError;
 
@@ -83,6 +84,8 @@ pub enum SvsmError {
     Acpi,
     /// Errors from the filesystem.
     FileSystem(FsError),
+    /// Obj related error
+    Obj(ObjError),
     /// Task management errors,
     Task(TaskError),
     /// Errors from #VC handler
@@ -102,5 +105,11 @@ impl From<ElfError> for SvsmError {
 impl From<ApicError> for SvsmError {
     fn from(err: ApicError) -> Self {
         Self::Apic(err)
+    }
+}
+
+impl From<ObjError> for SvsmError {
+    fn from(err: ObjError) -> Self {
+        Self::Obj(err)
     }
 }

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -5,5 +5,7 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 
 mod handlers;
+mod obj;
 
 pub use handlers::*;
+pub use obj::{Obj, ObjHandle};

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -8,4 +8,4 @@ mod handlers;
 mod obj;
 
 pub use handlers::*;
-pub use obj::{Obj, ObjHandle};
+pub use obj::{Obj, ObjError, ObjHandle};

--- a/kernel/src/syscall/obj.rs
+++ b/kernel/src/syscall/obj.rs
@@ -4,6 +4,18 @@
 //
 // Author: Chuanxiao Dong <chuanxiao.dong@intel.com>
 
+extern crate alloc;
+
+use crate::cpu::percpu::current_task;
+use crate::error::SvsmError;
+use alloc::sync::Arc;
+
+#[derive(Clone, Copy, Debug)]
+pub enum ObjError {
+    InvalidHandle,
+    NotFound,
+}
+
 /// An object represents the type of resource like file, VM, vCPU in the
 /// COCONUT-SVSM kernel which can be accessible by the user mode. The Obj
 /// trait is defined for such type of resource, which can be used to define
@@ -38,4 +50,64 @@ impl From<ObjHandle> for u32 {
     fn from(obj_handle: ObjHandle) -> Self {
         obj_handle.0
     }
+}
+
+/// Add an object to the current process and assigns it an `ObjHandle`.
+///
+/// # Arguments
+///
+/// * `obj` - An `Arc<dyn Obj>` representing the object to be added.
+///
+/// # Returns
+///
+/// * `Result<ObjHandle, SvsmError>` - Returns the object handle of the
+///   added object if successful, or an `SvsmError` on failure.
+///
+/// # Errors
+///
+/// This function will return an error if adding the object to the
+/// current task fails.
+#[allow(dead_code)]
+pub fn obj_add(obj: Arc<dyn Obj>) -> Result<ObjHandle, SvsmError> {
+    current_task().add_obj(obj)
+}
+
+/// Closes an object identified by its ObjHandle.
+///
+/// # Arguments
+///
+/// * `id` - The ObjHandle for the object to be closed.
+///
+/// # Returns
+///
+/// * `Result<Arc<dyn Obj>>, SvsmError>` - Returns the `Arc<dyn Obj>`
+///   on success, or an `SvsmError` on failure.
+///
+/// # Errors
+///
+/// This function will return an error if removing the object from the
+/// current task fails.
+#[allow(dead_code)]
+pub fn obj_close(id: ObjHandle) -> Result<Arc<dyn Obj>, SvsmError> {
+    current_task().remove_obj(id)
+}
+
+/// Retrieves an object by its ObjHandle.
+///
+/// # Arguments
+///
+/// * `id` - The ObjHandle for the object to be retrieved.
+///
+/// # Returns
+///
+/// * `Result<Arc<dyn Obj>>, SvsmError>` - Returns the `Arc<dyn Obj>` on
+///   success, or an `SvsmError` on failure.
+///
+/// # Errors
+///
+/// This function will return an error if retrieving the object from the
+/// current task fails.
+#[allow(dead_code)]
+pub fn obj_get(id: ObjHandle) -> Result<Arc<dyn Obj>, SvsmError> {
+    current_task().get_obj(id)
 }

--- a/kernel/src/syscall/obj.rs
+++ b/kernel/src/syscall/obj.rs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 Intel Corporation.
+//
+// Author: Chuanxiao Dong <chuanxiao.dong@intel.com>
+
+/// An object represents the type of resource like file, VM, vCPU in the
+/// COCONUT-SVSM kernel which can be accessible by the user mode. The Obj
+/// trait is defined for such type of resource, which can be used to define
+/// the common functionalities of the objects. With the trait bounds of Send
+/// and Sync, the objects implementing Obj trait could be sent to another
+/// thread and shared between threads safely.
+pub trait Obj: Send + Sync + core::fmt::Debug {}
+
+/// ObjHandle is a unique identifier for an object in the current process.
+/// An ObjHandle can be converted to a u32 id which can be used by the user
+/// mode to access this object. The passed id from the user mode by syscalls
+/// can be converted to an `ObjHandle`, which is used to access the object in
+/// the COCONUT-SVSM kernel.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct ObjHandle(u32);
+
+impl ObjHandle {
+    pub fn new(id: u32) -> Self {
+        Self(id)
+    }
+}
+
+impl From<u32> for ObjHandle {
+    #[inline]
+    fn from(id: u32) -> Self {
+        Self(id)
+    }
+}
+
+impl From<ObjHandle> for u32 {
+    #[inline]
+    fn from(obj_handle: ObjHandle) -> Self {
+        obj_handle.0
+    }
+}

--- a/syscall/src/lib.rs
+++ b/syscall/src/lib.rs
@@ -6,5 +6,7 @@
 #![no_std]
 
 mod numbers;
+mod obj;
 
 pub use numbers::*;
+pub use obj::*;

--- a/syscall/src/obj.rs
+++ b/syscall/src/obj.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 Intel Corporation.
+//
+// Author: Chuanxiao Dong <chuanxiao.dong@intel.com>
+
+/// The object is exposed to the user mode via the object-opening related
+/// syscalls, which returns the id of the object created by the COCONUT-SVSM
+/// kernel. The user mode can make use this id to access the corresponding
+/// object via other syscalls. From the user mode's point of view, an
+/// ObjHanle is defined to wrap a u32 which is the value returned by an
+/// object-opening syscall. This u32 value can be used as the input for the
+/// syscalls to access the corresponding kernel object.
+#[derive(Debug)]
+pub struct ObjHandle(u32);
+
+impl ObjHandle {
+    #[allow(dead_code)]
+    pub(crate) fn new(id: u32) -> Self {
+        Self(id)
+    }
+}
+
+impl From<&ObjHandle> for u32 {
+    #[inline]
+    fn from(obj_handle: &ObjHandle) -> Self {
+        obj_handle.0
+    }
+}


### PR DESCRIPTION
This is the code implementation for the object management. It includes 3 patches, two patches are for the COCONUT-SVSM kernel, which add the Obj trait, ObjHandle and object management. One patch is for the user mode, which add the equivalent ObjHandle define.

The implementation is made according to the object management design code, which has been reviewed at the [PR 4530](https://github.com/coconut-svsm/svsm/pull/453). Thanks to @Freax13 for the invaluable reviews!