### PR TITLE
tpm: Remove need for libssl build dependency

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -28,7 +28,7 @@ jobs:
             override: true
 
       - name: Install Microsoft TPM build dependencies
-        run: sudo apt install -y autoconf autoconf-archive pkg-config build-essential automake libssl-dev
+        run: sudo apt install -y autoconf autoconf-archive pkg-config build-essential automake
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,7 +29,7 @@ jobs:
             components: rustfmt, rust-src, clippy
 
       - name: Install Microsoft TPM build dependencies
-        run: sudo apt install -y autoconf autoconf-archive pkg-config build-essential automake libssl-dev
+        run: sudo apt install -y autoconf autoconf-archive pkg-config build-essential automake
 
       # ubuntu-latest does not have binutils 2.39, which we need for
       # ld to work, so build all the objects without performing the

--- a/Documentation/docs/installation/INSTALL.md
+++ b/Documentation/docs/installation/INSTALL.md
@@ -199,7 +199,7 @@ you can do this by:
 ```
 $ sudo zypper in system-user-mail make gcc curl patterns-devel-base-devel_basis \
       glibc-devel-static git libclang13 autoconf autoconf-archive pkg-config \
-      automake libopenssl-devel perl
+      automake perl
 ```
 
 Then checkout the SVSM repository and build the SVSM binary:

--- a/libmstpm/Makefile
+++ b/libmstpm/Makefile
@@ -116,7 +116,8 @@ $(MSTPM_MAKEFILE):
 		./bootstrap && \
 		./configure \
 			CFLAGS="${MSTPM_CFLAGS}" \
-			LIBCRYPTO_LIBS="${$(LIBCRT) $(LIBCRYPTO)}")
+			LIBCRYPTO_LIBS="$(LIBCRT) $(LIBCRYPTO)" \
+			LIBCRYPTO_CFLAGS="${MSTPM_CFLAGS}")
 
 # bindings.rs
 BINDGEN_FLAGS = --use-core

--- a/scripts/container/opensuse-rust.docker
+++ b/scripts/container/opensuse-rust.docker
@@ -25,7 +25,7 @@ SHELL ["/bin/bash", "-c"]
 RUN zypper ref && \
     zypper install -y system-user-mail make gcc curl \
         patterns-devel-base-devel_basis glibc-devel-static git libclang13 \
-        autoconf autoconf-archive pkg-config automake libopenssl-devel perl && \
+        autoconf autoconf-archive pkg-config automake perl && \
     useradd -u $USER_ID -m $USER_NAME && \
        mkdir -p "${CARGO_HOME}" "${RUSTUP_HOME}" && \
        chown "${USER_NAME}" "${CARGO_HOME}" "${RUSTUP_HOME}"


### PR DESCRIPTION
Coconut-SVSM vendors its own copy of openssl (via git submodule), but previously it didn't pass in the right variables to libmstpm's configure script to tell it to use it. This meant that libssl-dev must be installed on the build system in order to build Coconut.

This can be bypassed by passing LIBCRYPTO_LIBS and LIBCRYPTO_CFLAGS to configure. Coconut-SVSM was previously passing in LIBCRYPTO_LIBS only, but it would double-expanding the variables meaning that it was actually passing LIBCRYPTO_LIBS="", which was not enough for configure. Fix this, and also pass LIBCRYPTO_CFLAGS so that configure realizes the libcrypto dependency is satisfied without needing it installed on the build system.

Tested by building in a docker container based on debian12 without libssl-dev.

This commit also modifies the documentation and github workers to remove this dependency, but I have no way of directly testing these.