### PR TITLE
platform: extend the way pages are identified for validation/invalidation

### DIFF
--- a/kernel/src/boot_stage2.rs
+++ b/kernel/src/boot_stage2.rs
@@ -99,11 +99,13 @@ global_asm!(
         bts $5, %eax
         movl %eax, %cr4
 
-        /* Enable long mode, EFER.LME. */
+        /* Enable long mode, EFER.LME. Also ensure NXE is set. */
         movl $0xc0000080, %ecx
         rdmsr
-        bts $8, %eax
-        jc 2f
+        movl %eax, %ebx
+        orl $0x900, %eax
+        cmp %eax, %ebx
+        jz 2f
         wrmsr
         2:
 

--- a/kernel/src/boot_stage2.rs
+++ b/kernel/src/boot_stage2.rs
@@ -81,6 +81,16 @@ global_asm!(
         decl %ecx
         jnz 1b
 
+        /* Insert a self-map entry */
+        movl $pgtable, %edi
+        movl %edi, %eax
+        orl $0x63, %eax
+        /* The value 0xF68 is equivalent to 8 * PGTABLE_LVL3_IDX_PTE_SELFMAP */
+        movl %eax, 0xF68(%edi)
+        movl $0x80000000, %eax
+        orl %edx, %eax
+        movl %eax, 0xF6C(%edi)
+
         /* Signal APs */
         movl $setup_flag, %edi
         movl $1, (%edi)

--- a/kernel/src/cpu/efer.rs
+++ b/kernel/src/cpu/efer.rs
@@ -4,9 +4,7 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
-use super::features::cpu_has_nx;
 use super::msr::{read_msr, write_msr, EFER};
-use crate::platform::SvsmPlatform;
 use bitflags::bitflags;
 
 bitflags! {
@@ -33,16 +31,4 @@ pub fn read_efer() -> EFERFlags {
 pub fn write_efer(efer: EFERFlags) {
     let val = efer.bits();
     write_msr(EFER, val);
-}
-
-pub fn efer_init(platform: &dyn SvsmPlatform) {
-    let mut efer = read_efer();
-
-    // All processors that are capable of virtualization will support
-    // no-execute table entries, so there is no reason to support any processor
-    // that does not enumerate NX capability.
-    assert!(cpu_has_nx(platform), "CPU does not support NX");
-
-    efer.insert(EFERFlags::NXE);
-    write_efer(efer);
 }

--- a/kernel/src/cpu/features.rs
+++ b/kernel/src/cpu/features.rs
@@ -6,17 +6,7 @@
 
 use crate::platform::SvsmPlatform;
 
-const X86_FEATURE_NX: u32 = 20;
 const X86_FEATURE_PGE: u32 = 13;
-
-pub fn cpu_has_nx(platform: &dyn SvsmPlatform) -> bool {
-    let ret = platform.cpuid(0x80000001);
-
-    match ret {
-        None => false,
-        Some(c) => (c.edx >> X86_FEATURE_NX) & 1 == 1,
-    }
-}
 
 pub fn cpu_has_pge(platform: &dyn SvsmPlatform) -> bool {
     let ret = platform.cpuid(0x00000001);

--- a/kernel/src/igvm_params.rs
+++ b/kernel/src/igvm_params.rs
@@ -12,7 +12,7 @@ use crate::cpu::efer::EFERFlags;
 use crate::error::SvsmError;
 use crate::fw_meta::SevFWMetaData;
 use crate::mm::{GuestPtr, PerCPUPageMappingGuard, PAGE_SIZE};
-use crate::platform::{PageStateChangeOp, SVSM_PLATFORM};
+use crate::platform::{PageStateChangeOp, PageValidateOp, SVSM_PLATFORM};
 use crate::types::PageSize;
 use crate::utils::MemoryRegion;
 use alloc::vec::Vec;
@@ -173,7 +173,7 @@ impl IgvmParams<'_> {
         }
 
         let mem_map_va_region = MemoryRegion::<VirtAddr>::new(mem_map_va, mem_map_region.len());
-        platform.validate_page_range(mem_map_va_region)?;
+        platform.validate_virtual_page_range(mem_map_va_region, PageValidateOp::Validate)?;
 
         // Calculate the maximum number of entries that can be inserted.
         let max_entries = fw_info.memory_map_page_count as usize * PAGE_SIZE

--- a/kernel/src/mm/pagetable.rs
+++ b/kernel/src/mm/pagetable.rs
@@ -53,7 +53,6 @@ pub fn paging_init_early(platform: &dyn SvsmPlatform) -> ImmutAfterInitResult<()
     init_encrypt_mask(platform)?;
 
     let mut feature_mask = PTEntryFlags::all();
-    feature_mask.remove(PTEntryFlags::NX);
     feature_mask.remove(PTEntryFlags::GLOBAL);
     FEATURE_MASK.reinit(&feature_mask)
 }

--- a/kernel/src/mm/pagetable.rs
+++ b/kernel/src/mm/pagetable.rs
@@ -11,8 +11,10 @@ use crate::cpu::flush_tlb_global_sync;
 use crate::cpu::idt::common::PageFaultError;
 use crate::cpu::registers::RFlags;
 use crate::error::SvsmError;
-use crate::mm::PageBox;
-use crate::mm::{phys_to_virt, virt_to_phys, PGTABLE_LVL3_IDX_SHARED};
+use crate::mm::{
+    phys_to_virt, virt_to_phys, PageBox, PGTABLE_LVL3_IDX_PTE_SELFMAP, PGTABLE_LVL3_IDX_SHARED,
+    SVSM_PTE_BASE,
+};
 use crate::platform::SvsmPlatform;
 use crate::types::{PageSize, PAGE_SIZE, PAGE_SIZE_2M};
 use crate::utils::immut_after_init::{ImmutAfterInitCell, ImmutAfterInitResult};
@@ -360,6 +362,17 @@ impl PTEntry {
         let addr = PhysAddr::from(self.0.bits() & 0x000f_ffff_ffff_f000);
         strip_confidentiality_bits(addr)
     }
+
+    /// Read a page table entry from the specified virtual address.
+    ///
+    /// # Safety
+    ///
+    /// Reads from an arbitrary virtual address, making this essentially a
+    /// raw pointer read.  The caller must be certain to calculate the correct
+    /// address.
+    pub unsafe fn read_pte(vaddr: VirtAddr) -> Self {
+        *vaddr.as_ptr::<Self>()
+    }
 }
 
 /// A pagetable page with multiple entries.
@@ -456,13 +469,33 @@ impl PageTable {
         virt_to_phys(pgtable)
     }
 
+    /// Allocate a new page table root.
+    ///
+    /// # Errors
+    /// Returns [`SvsmError`] if the page cannot be allocated.
+    pub fn allocate_new() -> Result<PageBox<Self>, SvsmError> {
+        let mut pgtable = PageBox::try_new(PageTable::default())?;
+        let paddr = virt_to_phys(pgtable.vaddr());
+
+        // Set the self-map entry.
+        let entry = &mut pgtable.root[PGTABLE_LVL3_IDX_PTE_SELFMAP];
+        let flags = PTEntryFlags::PRESENT
+            | PTEntryFlags::WRITABLE
+            | PTEntryFlags::ACCESSED
+            | PTEntryFlags::DIRTY
+            | PTEntryFlags::NX;
+        entry.set(make_private_address(paddr), flags);
+
+        Ok(pgtable)
+    }
+
     /// Clone the shared part of the page table; excluding the private
     /// parts.
     ///
     /// # Errors
     /// Returns [`SvsmError`] if the page cannot be allocated.
     pub fn clone_shared(&self) -> Result<PageBox<PageTable>, SvsmError> {
-        let mut pgtable = PageBox::try_new(PageTable::default())?;
+        let mut pgtable = Self::allocate_new()?;
         pgtable.root.entries[PGTABLE_LVL3_IDX_SHARED] = self.root.entries[PGTABLE_LVL3_IDX_SHARED];
         Ok(pgtable)
     }
@@ -560,6 +593,72 @@ impl PageTable {
         Self::walk_addr_lvl3(&mut self.root, vaddr)
     }
 
+    /// Calculate the virtual address of a PTE in the self-map, which maps a
+    /// specified virtual address.
+    ///
+    /// # Parameters
+    /// - `vaddr': The virtual address whose PTE should be located.
+    ///
+    /// # Returns
+    /// The virtual address of the PTE.
+    fn get_pte_address(vaddr: VirtAddr) -> VirtAddr {
+        SVSM_PTE_BASE + ((usize::from(vaddr) & 0x0000_FFFF_FFFF_F000) >> 9)
+    }
+
+    /// Perform a virtual to physical translation using the self-map.
+    ///
+    /// # Parameters
+    /// - `vaddr': The virtual address to transalte.
+    ///
+    /// # Returns
+    /// Some(PhysAddr) if the virtual address is valid.
+    /// None if the virtual address is not valid.
+    pub fn virt_to_phys(vaddr: VirtAddr) -> Option<PhysAddr> {
+        // Calculate the virtual addresses of each level of the paging
+        // hierarchy in the self-map.
+        let pte_addr = Self::get_pte_address(vaddr);
+        let pde_addr = Self::get_pte_address(pte_addr);
+        let pdpe_addr = Self::get_pte_address(pde_addr);
+        let pml4e_addr = Self::get_pte_address(pdpe_addr);
+
+        // Check each entry in the paging hierarchy to determine whether this
+        // address is mapped.  Because the hierarchy is read from the top
+        // down using self-map addresses that were calculated correctly,
+        // the reads are safe to perform.
+        let pml4e = unsafe { PTEntry::read_pte(pml4e_addr) };
+        if !pml4e.present() {
+            return None;
+        }
+
+        // There is no need to check for a large page in the PML4E because
+        // the architecture does not support the large bit at the top-level
+        // entry.  If a large page is detected at a lower level of the
+        // hierarchy, the low bits from the virtual address must be combined
+        // with the physical address from the PDE/PDPE.
+        let pdpe = unsafe { PTEntry::read_pte(pdpe_addr) };
+        if !pdpe.present() {
+            return None;
+        }
+        if pdpe.huge() {
+            return Some(pdpe.address() + (usize::from(vaddr) & 0x3FFF_FFFF));
+        }
+
+        let pde = unsafe { PTEntry::read_pte(pde_addr) };
+        if !pde.present() {
+            return None;
+        }
+        if pde.huge() {
+            return Some(pde.address() + (usize::from(vaddr) & 0x001F_FFFF));
+        }
+
+        let pte = unsafe { PTEntry::read_pte(pte_addr) };
+        if pte.present() {
+            Some(pte.address() + (usize::from(vaddr) & 0xFFF))
+        } else {
+            None
+        }
+    }
+
     fn alloc_pte_lvl3(entry: &mut PTEntry, vaddr: VirtAddr, size: PageSize) -> Mapping<'_> {
         let flags = entry.flags();
 
@@ -575,7 +674,7 @@ impl PageTable {
             | PTEntryFlags::WRITABLE
             | PTEntryFlags::USER
             | PTEntryFlags::ACCESSED;
-        entry.set(paddr, flags);
+        entry.set(make_private_address(paddr), flags);
 
         let idx = Self::index::<2>(vaddr);
         Self::alloc_pte_lvl2(&mut page[idx], vaddr, size)
@@ -596,7 +695,7 @@ impl PageTable {
             | PTEntryFlags::WRITABLE
             | PTEntryFlags::USER
             | PTEntryFlags::ACCESSED;
-        entry.set(paddr, flags);
+        entry.set(make_private_address(paddr), flags);
 
         let idx = Self::index::<1>(vaddr);
         Self::alloc_pte_lvl1(&mut page[idx], vaddr, size)
@@ -617,7 +716,7 @@ impl PageTable {
             | PTEntryFlags::WRITABLE
             | PTEntryFlags::USER
             | PTEntryFlags::ACCESSED;
-        entry.set(paddr, flags);
+        entry.set(make_private_address(paddr), flags);
 
         let idx = Self::index::<0>(vaddr);
         Mapping::Level0(&mut page[idx])
@@ -1030,9 +1129,7 @@ impl PageTable {
                 | PTEntryFlags::USER
                 | PTEntryFlags::ACCESSED;
             let entry = &mut self.root[idx];
-            // The C bit is not required here because all page table fetches are
-            // made as C=1.
-            entry.set(paddr, flags);
+            entry.set(make_private_address(paddr), flags);
         }
     }
 }

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -41,6 +41,12 @@ pub enum PageStateChangeOp {
     Unsmash,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub enum PageValidateOp {
+    Validate,
+    Invalidate,
+}
+
 /// This defines a platform abstraction to permit the SVSM to run on different
 /// underlying architectures.
 pub trait SvsmPlatform {
@@ -82,11 +88,22 @@ pub trait SvsmPlatform {
         op: PageStateChangeOp,
     ) -> Result<(), SvsmError>;
 
-    /// Marks a range of pages as valid for use as private pages.
-    fn validate_page_range(&self, region: MemoryRegion<VirtAddr>) -> Result<(), SvsmError>;
+    /// Marks a physical range of pages as valid or invalid for use as private
+    /// pages.  Not usable in stage2.
+    fn validate_physical_page_range(
+        &self,
+        region: MemoryRegion<PhysAddr>,
+        op: PageValidateOp,
+    ) -> Result<(), SvsmError>;
 
-    /// Marks a range of pages as invalid for use as private pages.
-    fn invalidate_page_range(&self, region: MemoryRegion<VirtAddr>) -> Result<(), SvsmError>;
+    /// Marks a virtual range of pages as valid or invalid for use as private
+    /// pages.  Provided primarily for use in stage2 where validation by
+    /// physical address cannot e supported.
+    fn validate_virtual_page_range(
+        &self,
+        region: MemoryRegion<VirtAddr>,
+        op: PageValidateOp,
+    ) -> Result<(), SvsmError>;
 
     /// Configures the use of alternate injection as requested.
     fn configure_alternate_injection(&mut self, alt_inj_requested: bool) -> Result<(), SvsmError>;

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -11,7 +11,7 @@ use crate::cpu::msr::write_msr;
 use crate::cpu::percpu::PerCpu;
 use crate::error::SvsmError;
 use crate::io::IOPort;
-use crate::platform::{PageEncryptionMasks, PageStateChangeOp, SvsmPlatform};
+use crate::platform::{PageEncryptionMasks, PageStateChangeOp, PageValidateOp, SvsmPlatform};
 use crate::serial::SerialPort;
 use crate::svsm_console::NativeIOPort;
 use crate::types::PageSize;
@@ -95,13 +95,19 @@ impl SvsmPlatform for NativePlatform {
         Ok(())
     }
 
-    /// Marks a range of pages as valid for use as private pages.
-    fn validate_page_range(&self, _region: MemoryRegion<VirtAddr>) -> Result<(), SvsmError> {
+    fn validate_physical_page_range(
+        &self,
+        _region: MemoryRegion<PhysAddr>,
+        _op: PageValidateOp,
+    ) -> Result<(), SvsmError> {
         Ok(())
     }
 
-    /// Marks a range of pages as invalid for use as private pages.
-    fn invalidate_page_range(&self, _region: MemoryRegion<VirtAddr>) -> Result<(), SvsmError> {
+    fn validate_virtual_page_range(
+        &self,
+        _region: MemoryRegion<VirtAddr>,
+        _op: PageValidateOp,
+    ) -> Result<(), SvsmError> {
         Ok(())
     }
 

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -4,7 +4,7 @@
 //
 // Author: Jon Lange <jlange@microsoft.com>
 
-use crate::address::{PhysAddr, VirtAddr};
+use crate::address::{Address, PhysAddr, VirtAddr};
 use crate::console::init_console;
 use crate::cpu::cpuid::{cpuid_table, CpuidResult};
 use crate::cpu::percpu::{current_ghcb, this_cpu, PerCpu};
@@ -12,7 +12,8 @@ use crate::error::ApicError::Registration;
 use crate::error::SvsmError;
 use crate::greq::driver::guest_request_driver_init;
 use crate::io::IOPort;
-use crate::platform::{PageEncryptionMasks, PageStateChangeOp, SvsmPlatform};
+use crate::mm::{PerCPUPageMappingGuard, PAGE_SIZE, PAGE_SIZE_2M};
+use crate::platform::{PageEncryptionMasks, PageStateChangeOp, PageValidateOp, SvsmPlatform};
 use crate::serial::SerialPort;
 use crate::sev::hv_doorbell::current_hv_doorbell;
 use crate::sev::msr_protocol::{hypervisor_ghcb_features, verify_ghcb_version, GHCBHvFeatures};
@@ -33,6 +34,36 @@ static CONSOLE_SERIAL: ImmutAfterInitCell<SerialPort<'_>> = ImmutAfterInitCell::
 static VTOM: ImmutAfterInitCell<usize> = ImmutAfterInitCell::uninit();
 
 static APIC_EMULATION_REG_COUNT: AtomicU32 = AtomicU32::new(0);
+
+fn pvalidate_page_range(range: MemoryRegion<PhysAddr>, op: PvalidateOp) -> Result<(), SvsmError> {
+    // In the future, it is likely that this function will need to be prepared
+    // to execute both PVALIDATE and RMPADJUST over the same set of addresses,
+    // so the loop is structured to anticipate that possibility.
+    let mut paddr = range.start();
+    let paddr_end = range.end();
+    while paddr < paddr_end {
+        // Check whether a 2 MB page can be attempted.
+        let len = if paddr.is_aligned(PAGE_SIZE_2M) && paddr + PAGE_SIZE_2M <= paddr_end {
+            PAGE_SIZE_2M
+        } else {
+            PAGE_SIZE
+        };
+        let mapping = PerCPUPageMappingGuard::create(paddr, paddr + len, 0)?;
+        pvalidate_range(MemoryRegion::new(mapping.virt_addr(), len), op)?;
+        paddr = paddr + len;
+    }
+
+    Ok(())
+}
+
+impl From<PageValidateOp> for PvalidateOp {
+    fn from(op: PageValidateOp) -> PvalidateOp {
+        match op {
+            PageValidateOp::Validate => PvalidateOp::Valid,
+            PageValidateOp::Invalidate => PvalidateOp::Invalid,
+        }
+    }
+}
 
 #[derive(Clone, Copy, Debug)]
 pub struct SnpPlatform {}
@@ -141,14 +172,20 @@ impl SvsmPlatform for SnpPlatform {
         current_ghcb().page_state_change(region, size, op)
     }
 
-    /// Marks a range of pages as valid for use as private pages.
-    fn validate_page_range(&self, region: MemoryRegion<VirtAddr>) -> Result<(), SvsmError> {
-        pvalidate_range(region, PvalidateOp::Valid)
+    fn validate_physical_page_range(
+        &self,
+        region: MemoryRegion<PhysAddr>,
+        op: PageValidateOp,
+    ) -> Result<(), SvsmError> {
+        pvalidate_page_range(region, PvalidateOp::from(op))
     }
 
-    /// Marks a range of pages as invalid for use as private pages.
-    fn invalidate_page_range(&self, region: MemoryRegion<VirtAddr>) -> Result<(), SvsmError> {
-        pvalidate_range(region, PvalidateOp::Invalid)
+    fn validate_virtual_page_range(
+        &self,
+        region: MemoryRegion<VirtAddr>,
+        op: PageValidateOp,
+    ) -> Result<(), SvsmError> {
+        pvalidate_range(region, PvalidateOp::from(op))
     }
 
     fn configure_alternate_injection(&mut self, alt_inj_requested: bool) -> Result<(), SvsmError> {

--- a/kernel/src/platform/tdp.rs
+++ b/kernel/src/platform/tdp.rs
@@ -10,7 +10,7 @@ use crate::cpu::cpuid::CpuidResult;
 use crate::cpu::percpu::PerCpu;
 use crate::error::SvsmError;
 use crate::io::IOPort;
-use crate::platform::{PageEncryptionMasks, PageStateChangeOp, SvsmPlatform};
+use crate::platform::{PageEncryptionMasks, PageStateChangeOp, PageValidateOp, SvsmPlatform};
 use crate::serial::SerialPort;
 use crate::svsm_console::SVSMIOPort;
 use crate::types::PageSize;
@@ -95,11 +95,19 @@ impl SvsmPlatform for TdpPlatform {
         Err(SvsmError::Tdx)
     }
 
-    fn validate_page_range(&self, _region: MemoryRegion<VirtAddr>) -> Result<(), SvsmError> {
+    fn validate_physical_page_range(
+        &self,
+        _region: MemoryRegion<PhysAddr>,
+        _op: PageValidateOp,
+    ) -> Result<(), SvsmError> {
         Err(SvsmError::Tdx)
     }
 
-    fn invalidate_page_range(&self, _region: MemoryRegion<VirtAddr>) -> Result<(), SvsmError> {
+    fn validate_virtual_page_range(
+        &self,
+        _region: MemoryRegion<VirtAddr>,
+        _op: PageValidateOp,
+    ) -> Result<(), SvsmError> {
         Err(SvsmError::Tdx)
     }
 

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -20,7 +20,6 @@ use svsm::config::SvsmConfig;
 use svsm::console::install_console_logger;
 use svsm::cpu::control_regs::{cr0_init, cr4_init};
 use svsm::cpu::cpuid::{dump_cpuid_table, register_cpuid_table};
-use svsm::cpu::efer::efer_init;
 use svsm::cpu::gdt;
 use svsm::cpu::idt::svsm::{early_idt_init, idt_init};
 use svsm::cpu::percpu::current_ghcb;
@@ -311,7 +310,6 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
 
     cr0_init();
     cr4_init(platform);
-    efer_init(platform);
     install_console_logger("SVSM").expect("Console logger already initialized");
     platform
         .env_setup(debug_serial_port, launch_info.vtom.try_into().unwrap())

--- a/kernel/src/svsm_paging.rs
+++ b/kernel/src/svsm_paging.rs
@@ -9,10 +9,9 @@ use crate::config::SvsmConfig;
 use crate::error::SvsmError;
 use crate::igvm_params::IgvmParams;
 use crate::mm::pagetable::{PTEntryFlags, PageTable};
-use crate::mm::{PageBox, PerCPUPageMappingGuard};
-use crate::platform::PageStateChangeOp;
-use crate::platform::SvsmPlatform;
-use crate::types::{PageSize, PAGE_SIZE};
+use crate::mm::PageBox;
+use crate::platform::{PageStateChangeOp, PageValidateOp, SvsmPlatform};
+use crate::types::PageSize;
 use crate::utils::MemoryRegion;
 use bootlib::kernel_launch::KernelLaunchInfo;
 
@@ -105,15 +104,12 @@ fn invalidate_boot_memory_region(
         region.end()
     );
 
-    for paddr in region.iter_pages(PageSize::Regular) {
-        let guard = PerCPUPageMappingGuard::create_4k(paddr)?;
-        let vaddr = guard.virt_addr();
+    if !region.is_empty() {
+        platform.validate_physical_page_range(region, PageValidateOp::Invalidate)?;
 
-        platform.invalidate_page_range(MemoryRegion::new(vaddr, PAGE_SIZE))?;
-    }
-
-    if config.page_state_change_required() && !region.is_empty() {
-        platform.page_state_change(region, PageSize::Regular, PageStateChangeOp::Shared)?;
+        if config.page_state_change_required() {
+            platform.page_state_change(region, PageSize::Regular, PageStateChangeOp::Shared)?;
+        }
     }
 
     Ok(())

--- a/kernel/src/svsm_paging.rs
+++ b/kernel/src/svsm_paging.rs
@@ -24,7 +24,8 @@ pub fn init_page_table(
     launch_info: &KernelLaunchInfo,
     kernel_elf: &elf::Elf64File<'_>,
 ) -> Result<PageBox<PageTable>, SvsmError> {
-    let mut pgtable = PageBox::try_new(PageTable::default())?;
+    let mut pgtable = PageTable::allocate_new()?;
+
     let igvm_param_info = if launch_info.igvm_params_virt_addr != 0 {
         let addr = VirtAddr::from(launch_info.igvm_params_virt_addr);
         IgvmParamInfo {


### PR DESCRIPTION
SNP validates pages by virtual address while TDX validates pages by physical address.  This PR makes it possible for code to request validation changes based on either.  This ensures that virtual mappings are not created unnecessarily on platforms that do not require them, and ensures that it can be possible to correctly obtain the physical address for validation in those cases where the caller has only a virtual address.