### PR TITLE
Fix container build script

### DIFF
--- a/scripts/container/build.sh
+++ b/scripts/container/build.sh
@@ -4,6 +4,7 @@
 # Copyright (C) 2023 IBM
 #
 # Author: Claudio Carvalho <cclaudio@linux.ibm.com>
+set -e
 
 CURDIR=$(dirname "$(realpath "$0")")
 WORKDIR=$(realpath "${CURDIR}/../..")

--- a/scripts/container/opensuse-rust.docker
+++ b/scripts/container/opensuse-rust.docker
@@ -22,7 +22,7 @@ ENV RUSTUP_HOME=/opt/rustup
 
 SHELL ["/bin/bash", "-c"]
 
-RUN zypper ref && \
+RUN zypper ref && zypper dup -y && \
     zypper install -y system-user-mail make gcc curl \
         patterns-devel-base-devel_basis glibc-devel-static git libclang13 \
         autoconf autoconf-archive pkg-config automake libopenssl-devel perl && \


### PR DESCRIPTION
With some recent images, the container build can fail this way if the system has incompatible packages:
    
        Resolving package dependencies...
    
        Problem: 1: the to be installed patterns-devel-base-devel_basis-20170319-12.5.x86_64 requires 'ncurses-devel', but this requirement cannot be provided
        not installable providers: ncurses-devel-6.5.20240824-44.1.x86_64[repo-oss]
    
         Solution 1: downgrade of libncurses6-6.5.20240922-45.1.x86_64 to libncurses6-6.5.20240824-44.1.x86_64
         Solution 2: do not install patterns-devel-base-devel_basis-20170319-12.5.x86_64
         Solution 3: break patterns-devel-base-devel_basis-20170319-12.5.x86_64 by ignoring some of its dependencies
    
Do an update before installing packages to make sure we don't have any potential conflicts, and also use `set -x` in `build.sh` to make sure that if any command fails, we get out immediately since each step is strictly dependent on the previous one.