### PR TITLE
platform: move greq driver initialization to the SNP platform

### DIFF
--- a/kernel/src/igvm_params.rs
+++ b/kernel/src/igvm_params.rs
@@ -226,6 +226,7 @@ impl IgvmParams<'_> {
 
     pub fn load_cpu_info(&self) -> Result<Vec<ACPICPUInfo>, SvsmError> {
         let mut cpus: Vec<ACPICPUInfo> = Vec::new();
+        log::info!("CPU count is {}", { self.igvm_param_page.cpu_count });
         for i in 0..self.igvm_param_page.cpu_count {
             let cpu = ACPICPUInfo {
                 apic_id: i,

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -10,6 +10,7 @@ use crate::cpu::cpuid::{cpuid_table, CpuidResult};
 use crate::cpu::percpu::{current_ghcb, this_cpu, PerCpu};
 use crate::error::ApicError::Registration;
 use crate::error::SvsmError;
+use crate::greq::driver::guest_request_driver_init;
 use crate::io::IOPort;
 use crate::platform::{PageEncryptionMasks, PageStateChangeOp, SvsmPlatform};
 use crate::serial::SerialPort;
@@ -67,7 +68,9 @@ impl SvsmPlatform for SnpPlatform {
     }
 
     fn env_setup_svsm(&self) -> Result<(), SvsmError> {
-        this_cpu().configure_hv_doorbell()
+        this_cpu().configure_hv_doorbell()?;
+        guest_request_driver_init();
+        Ok(())
     }
 
     fn setup_percpu(&self, cpu: &PerCpu) -> Result<(), SvsmError> {

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -32,7 +32,6 @@ use svsm::debug::stacktrace::print_stack;
 use svsm::error::SvsmError;
 use svsm::fs::{initialize_fs, populate_ram_fs};
 use svsm::fw_cfg::FwCfg;
-use svsm::greq::driver::guest_request_driver_init;
 use svsm::igvm_params::IgvmParams;
 use svsm::kernel_region::new_kernel_region;
 use svsm::mm::alloc::{memory_info, print_memory_info, root_mem_init};
@@ -441,8 +440,6 @@ pub extern "C" fn svsm_main() {
         copy_tables_to_fw(fw_meta).expect("Failed to copy firmware tables");
         validate_fw(&config, &LAUNCH_INFO).expect("Failed to validate flash memory");
     }
-
-    guest_request_driver_init();
 
     if let Some(ref fw_meta) = fw_metadata {
         prepare_fw_launch(fw_meta).expect("Failed to setup guest VMSA/CAA");


### PR DESCRIPTION
The notion of "guest request" is specific to the SNP platform. Therefore, the global `SnpGuestRequestDriver` object should only be initialized on the SNP platform.