### PR TITLE
cpu: process pending #HV events when enabling interrupts

### DIFF
--- a/kernel/src/sev/hv_doorbell.rs
+++ b/kernel/src/sev/hv_doorbell.rs
@@ -140,6 +140,13 @@ impl HVDoorbell {
         // is performed.
     }
 
+    pub fn process_if_required(&self) {
+        let flags = HVDoorbellFlags::from(self.flags.load(Ordering::Relaxed));
+        if flags.no_further_signal() {
+            self.process_pending_events();
+        }
+    }
+
     pub fn no_eoi_required(&self) -> bool {
         // Check to see if the "no EOI required" flag is set to determine
         // whether an explicit EOI can be avoided.


### PR DESCRIPTION
Interrupts delivered via #HV are ignored when EFLAGS.IF=0.  When enabling interrupts, the #HV doorbell page must be checked for pending events that were suppressed while interrupts were disabled so that they do not remain pending indefinitely.