### PR TITLE
igmvbuilder: support VSM isolation platform type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ bin/coconut-qemu.igvm: $(IGVMBUILDER) $(IGVMMEASURE) bin/stage1-trampoline.bin b
 	$(IGVMMEASURE) --check-kvm $@ measure
 
 bin/coconut-hyperv.igvm: $(IGVMBUILDER) $(IGVMMEASURE) bin/stage1-trampoline.bin bin/svsm-kernel.elf bin/stage2.bin
-	$(IGVMBUILDER) --sort --output $@ --tdx-stage1 bin/stage1-trampoline.bin --stage2 bin/stage2.bin --kernel bin/svsm-kernel.elf --comport 3 hyper-v --native --snp --tdp
+	$(IGVMBUILDER) --sort --output $@ --tdx-stage1 bin/stage1-trampoline.bin --stage2 bin/stage2.bin --kernel bin/svsm-kernel.elf --comport 3 hyper-v --native --snp --tdp --vsm
 	$(IGVMMEASURE) $@ measure
 
 bin/coconut-test-qemu.igvm: $(IGVMBUILDER) $(IGVMMEASURE) bin/stage1-trampoline.bin bin/test-kernel.elf bin/stage2.bin
@@ -80,7 +80,7 @@ bin/coconut-test-qemu.igvm: $(IGVMBUILDER) $(IGVMMEASURE) bin/stage1-trampoline.
 	$(IGVMMEASURE) $@ measure
 
 bin/coconut-test-hyperv.igvm: $(IGVMBUILDER) $(IGVMMEASURE) bin/stage1-trampoline.bin bin/test-kernel.elf bin/stage2.bin
-	$(IGVMBUILDER) --sort --output $@ --tdx-stage1 bin/stage1-trampoline.bin --stage2 bin/stage2.bin --kernel bin/test-kernel.elf --comport 3 hyper-v --snp --tdp
+	$(IGVMBUILDER) --sort --output $@ --tdx-stage1 bin/stage1-trampoline.bin --stage2 bin/stage2.bin --kernel bin/test-kernel.elf --comport 3 hyper-v --snp --tdp --vsm
 	$(IGVMMEASURE) $@ measure
 
 bin/coconut-vanadium.igvm: $(IGVMBUILDER) $(IGVMMEASURE) bin/stage1-trampoline.bin bin/svsm-kernel.elf bin/stage2.bin ${FS_BIN}

--- a/igvmbuilder/src/cmd_options.rs
+++ b/igvmbuilder/src/cmd_options.rs
@@ -64,6 +64,10 @@ pub struct CmdOptions {
     #[arg(long, default_value_t = false)]
     pub native: bool,
 
+    /// Include VSM isolation platform target.
+    #[arg(long, default_value_t = false)]
+    pub vsm: bool,
+
     /// Enable debug features (e.g. SNP debug_swap)
     #[arg(short, long, default_value_t = false)]
     pub debug: bool,

--- a/igvmbuilder/src/igvm_builder.rs
+++ b/igvmbuilder/src/igvm_builder.rs
@@ -13,12 +13,13 @@ use std::mem::size_of;
 use bootlib::igvm_params::{IgvmGuestContext, IgvmParamBlock, IgvmParamBlockFwInfo};
 use bootlib::platform::SvsmPlatformType;
 use clap::Parser;
+use igvm::registers::X86Register;
 use igvm::{
     Arch, IgvmDirectiveHeader, IgvmFile, IgvmInitializationHeader, IgvmPlatformHeader, IgvmRevision,
 };
 use igvm_defs::{
-    IgvmNativeVpContextX64, IgvmPageDataFlags, IgvmPageDataType, IgvmPlatformType,
-    IGVM_VHS_PARAMETER, IGVM_VHS_PARAMETER_INSERT, IGVM_VHS_SUPPORTED_PLATFORM, PAGE_SIZE_4K,
+    IgvmPageDataFlags, IgvmPageDataType, IgvmPlatformType, IGVM_VHS_PARAMETER,
+    IGVM_VHS_PARAMETER_INSERT, IGVM_VHS_SUPPORTED_PLATFORM, PAGE_SIZE_4K,
 };
 use zerocopy::AsBytes;
 
@@ -27,7 +28,7 @@ use crate::cpuid::SnpCpuidPage;
 use crate::firmware::{parse_firmware, Firmware};
 use crate::platform::PlatformMask;
 use crate::stage2_stack::Stage2Stack;
-use crate::vmsa::{construct_start_context, construct_vmsa};
+use crate::vmsa::{construct_native_start_context, construct_start_context, construct_vmsa};
 use crate::GpaMap;
 
 pub const SNP_COMPATIBILITY_MASK: u32 = 1u32 << 0;
@@ -124,7 +125,7 @@ impl IgvmBuilder {
         let start_rsp = self.gpa_map.stage2_stack.get_end() - size_of::<Stage2Stack>() as u64;
         let start_context = construct_start_context(start_rip, start_rsp);
 
-        self.build_directives(&param_block, start_context)?;
+        self.build_directives(&param_block, &start_context)?;
         self.build_initialization()?;
         self.build_platforms(&param_block);
 
@@ -285,7 +286,7 @@ impl IgvmBuilder {
     fn build_directives(
         &mut self,
         param_block: &IgvmParamBlock,
-        start_context: Box<IgvmNativeVpContextX64>,
+        start_context: &[X86Register],
     ) -> Result<(), Box<dyn Error>> {
         // Populate firmware directives.
         if let Some(firmware) = &self.firmware {
@@ -348,7 +349,7 @@ impl IgvmBuilder {
         if COMPATIBILITY_MASK.contains(SNP_COMPATIBILITY_MASK) {
             // Add the VMSA.
             self.directives.push(construct_vmsa(
-                start_context.as_ref(),
+                start_context,
                 self.gpa_map.vmsa.get_start(),
                 param_block.vtom,
                 SNP_COMPATIBILITY_MASK,
@@ -358,12 +359,10 @@ impl IgvmBuilder {
 
         if COMPATIBILITY_MASK.contains(NATIVE_COMPATIBILITY_MASK) {
             // Include the native start context.
-            self.directives
-                .push(IgvmDirectiveHeader::X64NativeVpContext {
-                    compatibility_mask: NATIVE_COMPATIBILITY_MASK,
-                    context: start_context,
-                    vp_index: 0,
-                });
+            self.directives.push(construct_native_start_context(
+                start_context,
+                NATIVE_COMPATIBILITY_MASK,
+            ));
         }
 
         // Add the IGVM parameter block

--- a/igvmbuilder/src/stage2_stack.rs
+++ b/igvmbuilder/src/stage2_stack.rs
@@ -13,9 +13,6 @@ use igvm_defs::{IgvmPageDataFlags, IgvmPageDataType, PAGE_SIZE_4K};
 use zerocopy::AsBytes;
 
 use crate::gpa_map::GpaMap;
-use crate::igvm_builder::{
-    NATIVE_COMPATIBILITY_MASK, SNP_COMPATIBILITY_MASK, TDP_COMPATIBILITY_MASK,
-};
 
 pub struct Stage2Stack {
     stage2_stack: Stage2LaunchInfo,
@@ -45,14 +42,9 @@ impl Stage2Stack {
         &self,
         gpa: u64,
         platform: SvsmPlatformType,
+        compatibility_mask: u32,
         directives: &mut Vec<IgvmDirectiveHeader>,
     ) {
-        let compatibility_mask = match platform {
-            SvsmPlatformType::Snp => SNP_COMPATIBILITY_MASK,
-            SvsmPlatformType::Tdp => TDP_COMPATIBILITY_MASK,
-            SvsmPlatformType::Native => NATIVE_COMPATIBILITY_MASK,
-        };
-
         let mut stage2_stack = self.stage2_stack;
         stage2_stack.platform_type = u32::from(platform);
 


### PR DESCRIPTION
This change enables building an IGVM file that support the `VSM_ISOLATION` platform type.