### PR TITLE
Enabling SMEP and SMAP

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -43,6 +43,7 @@ default = []
 enable-gdb = ["dep:gdbstub", "dep:gdbstub_arch"]
 mstpm = ["dep:libmstpm"]
 nosmep = []
+nosmap = []
 
 [dev-dependencies]
 

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -42,6 +42,7 @@ test.workspace = true
 default = []
 enable-gdb = ["dep:gdbstub", "dep:gdbstub_arch"]
 mstpm = ["dep:libmstpm"]
+nosmep = []
 
 [dev-dependencies]
 

--- a/kernel/src/cpu/control_regs.rs
+++ b/kernel/src/cpu/control_regs.rs
@@ -6,6 +6,7 @@
 
 use super::features::cpu_has_pge;
 use crate::address::{Address, PhysAddr};
+use crate::cpu::features::cpu_has_smep;
 use crate::platform::SvsmPlatform;
 use bitflags::bitflags;
 use core::arch::asm;
@@ -31,6 +32,12 @@ pub fn cr4_init(platform: &dyn SvsmPlatform) {
     assert!(cpu_has_pge(platform), "CPU does not support PGE");
 
     cr4.insert(CR4Flags::PGE); // Enable Global Pages
+
+    if !cfg!(feature = "nosmep") {
+        assert!(cpu_has_smep(platform), "CPU does not support SMEP");
+        cr4.insert(CR4Flags::SMEP);
+    }
+
     write_cr4(cr4);
 }
 

--- a/kernel/src/cpu/control_regs.rs
+++ b/kernel/src/cpu/control_regs.rs
@@ -6,7 +6,7 @@
 
 use super::features::cpu_has_pge;
 use crate::address::{Address, PhysAddr};
-use crate::cpu::features::cpu_has_smep;
+use crate::cpu::features::{cpu_has_smap, cpu_has_smep};
 use crate::platform::SvsmPlatform;
 use bitflags::bitflags;
 use core::arch::asm;
@@ -36,6 +36,11 @@ pub fn cr4_init(platform: &dyn SvsmPlatform) {
     if !cfg!(feature = "nosmep") {
         assert!(cpu_has_smep(platform), "CPU does not support SMEP");
         cr4.insert(CR4Flags::SMEP);
+    }
+
+    if !cfg!(feature = "nosmap") {
+        assert!(cpu_has_smap(platform), "CPU does not support SMAP");
+        cr4.insert(CR4Flags::SMAP);
     }
 
     write_cr4(cr4);

--- a/kernel/src/cpu/features.rs
+++ b/kernel/src/cpu/features.rs
@@ -8,6 +8,7 @@ use crate::platform::SvsmPlatform;
 
 const X86_FEATURE_NX: u32 = 20;
 const X86_FEATURE_PGE: u32 = 13;
+const X86_FEATURE_SMEP: u32 = 7;
 
 pub fn cpu_has_nx(platform: &dyn SvsmPlatform) -> bool {
     let ret = platform.cpuid(0x80000001);
@@ -24,5 +25,14 @@ pub fn cpu_has_pge(platform: &dyn SvsmPlatform) -> bool {
     match ret {
         None => false,
         Some(c) => (c.edx >> X86_FEATURE_PGE) & 1 == 1,
+    }
+}
+
+pub fn cpu_has_smep(platform: &dyn SvsmPlatform) -> bool {
+    let ret = platform.cpuid(0x0000_0007);
+
+    match ret {
+        None => false,
+        Some(c) => (c.ebx >> X86_FEATURE_SMEP & 1) == 1,
     }
 }

--- a/kernel/src/cpu/features.rs
+++ b/kernel/src/cpu/features.rs
@@ -9,6 +9,7 @@ use crate::platform::SvsmPlatform;
 const X86_FEATURE_NX: u32 = 20;
 const X86_FEATURE_PGE: u32 = 13;
 const X86_FEATURE_SMEP: u32 = 7;
+const X86_FEATURE_SMAP: u32 = 20;
 
 pub fn cpu_has_nx(platform: &dyn SvsmPlatform) -> bool {
     let ret = platform.cpuid(0x80000001);
@@ -34,5 +35,14 @@ pub fn cpu_has_smep(platform: &dyn SvsmPlatform) -> bool {
     match ret {
         None => false,
         Some(c) => (c.ebx >> X86_FEATURE_SMEP & 1) == 1,
+    }
+}
+
+pub fn cpu_has_smap(platform: &dyn SvsmPlatform) -> bool {
+    let ret = platform.cpuid(0x0000_0007);
+
+    match ret {
+        None => false,
+        Some(c) => (c.ebx >> X86_FEATURE_SMAP & 1) == 1,
     }
 }

--- a/kernel/src/cpu/idt/common.rs
+++ b/kernel/src/cpu/idt/common.rs
@@ -45,8 +45,6 @@ pub const HV_VECTOR: usize = 28;
 pub const VC_VECTOR: usize = 29;
 pub const SX_VECTOR: usize = 30;
 
-pub const PF_ERROR_WRITE: usize = 2;
-
 pub const INT_INJ_VECTOR: usize = 0x50;
 
 bitflags::bitflags! {

--- a/kernel/src/cpu/idt/entry.S
+++ b/kernel/src/cpu/idt/entry.S
@@ -34,6 +34,8 @@ HV_DOORBELL_ADDR:
 .macro default_entry_no_ist name: req handler:req error_code:req vector:req
 	.globl asm_entry_\name
 asm_entry_\name:
+	asm_clac
+
 	.if \error_code == 0
 	pushq $0
 	.endif
@@ -47,6 +49,8 @@ asm_entry_\name:
 .macro irq_entry name:req vector:req
 	.globl asm_entry_irq_\name
 asm_entry_irq_\name:
+	asm_clac
+
 	pushq	$0
 	push_regs
 	movl	$\vector, %edi
@@ -78,6 +82,8 @@ asm_entry_irq_\name:
 //    exception.
 .globl asm_entry_hv
 asm_entry_hv:
+	asm_clac
+
 	// Push a dummy error code, and only three registers.  If no #HV
 	// processing is required, then only these three registers will need to
 	// be popped.

--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -20,7 +20,6 @@ use crate::cpu::X86ExceptionContext;
 use crate::debug::gdbstub::svsm_gdbstub::handle_debug_exception;
 use crate::platform::SVSM_PLATFORM;
 use crate::task::{is_task_fault, terminate};
-
 use core::arch::global_asm;
 
 use crate::syscall::*;
@@ -265,4 +264,13 @@ pub extern "C" fn common_isr_handler(_vector: usize) {
     SVSM_PLATFORM.as_dyn_ref().eoi();
 }
 
-global_asm!(include_str!("entry.S"), options(att_syntax));
+global_asm!(
+    r#"
+        .set const_false, 0
+        .set const_true, 1
+    "#,
+    concat!(".set CFG_NOSMAP, const_", cfg!(feature = "nosmap")),
+    include_str!("../x86/smap.S"),
+    include_str!("entry.S"),
+    options(att_syntax)
+);

--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -10,10 +10,10 @@ use super::super::percpu::{current_task, this_cpu};
 use super::super::tss::IST_DF;
 use super::super::vc::handle_vc_exception;
 use super::common::{
-    idt_mut, user_mode, IdtEntry, AC_VECTOR, BP_VECTOR, BR_VECTOR, CP_VECTOR, DB_VECTOR, DE_VECTOR,
-    DF_VECTOR, GP_VECTOR, HV_VECTOR, INT_INJ_VECTOR, MCE_VECTOR, MF_VECTOR, NMI_VECTOR, NM_VECTOR,
-    NP_VECTOR, OF_VECTOR, PF_ERROR_WRITE, PF_VECTOR, SS_VECTOR, SX_VECTOR, TS_VECTOR, UD_VECTOR,
-    VC_VECTOR, XF_VECTOR,
+    idt_mut, user_mode, IdtEntry, PageFaultError, AC_VECTOR, BP_VECTOR, BR_VECTOR, CP_VECTOR,
+    DB_VECTOR, DE_VECTOR, DF_VECTOR, GP_VECTOR, HV_VECTOR, INT_INJ_VECTOR, MCE_VECTOR, MF_VECTOR,
+    NMI_VECTOR, NM_VECTOR, NP_VECTOR, OF_VECTOR, PF_VECTOR, SS_VECTOR, SX_VECTOR, TS_VECTOR,
+    UD_VECTOR, VC_VECTOR, XF_VECTOR,
 };
 use crate::address::VirtAddr;
 use crate::cpu::X86ExceptionContext;
@@ -178,7 +178,7 @@ extern "C" fn ex_handler_page_fault(ctxt: &mut X86ExceptionContext, vector: usiz
     if user_mode(ctxt) {
         let kill_task: bool = if is_task_fault(vaddr) {
             current_task()
-                .fault(vaddr, (err & PF_ERROR_WRITE) != 0)
+                .fault(vaddr, (err & PageFaultError::W.bits() as usize) != 0)
                 .is_err()
         } else {
             true
@@ -190,7 +190,10 @@ extern "C" fn ex_handler_page_fault(ctxt: &mut X86ExceptionContext, vector: usiz
             terminate();
         }
     } else if this_cpu()
-        .handle_pf(VirtAddr::from(cr2), (err & PF_ERROR_WRITE) != 0)
+        .handle_pf(
+            VirtAddr::from(cr2),
+            (err & PageFaultError::W.bits() as usize) != 0,
+        )
         .is_err()
         && !handle_exception_table(ctxt)
     {

--- a/kernel/src/cpu/mod.rs
+++ b/kernel/src/cpu/mod.rs
@@ -22,6 +22,7 @@ pub mod tlb;
 pub mod tss;
 pub mod vc;
 pub mod vmsa;
+pub mod x86;
 
 pub use apic::LocalApic;
 pub use gdt::{gdt, gdt_mut};

--- a/kernel/src/cpu/x86/mod.rs
+++ b/kernel/src/cpu/x86/mod.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2024 SUSE LLC
+//
+// Authors: Thomas Leroy <tleroy@suse.de>
+
+pub mod smap;

--- a/kernel/src/cpu/x86/smap.S
+++ b/kernel/src/cpu/x86/smap.S
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2024 SUSE LLC
+//
+// Authors: Thomas Leroy <tleroy@suse.de>
+
+.code64
+
+.section .text
+.macro asm_clac
+        .if !CFG_NOSMAP
+        clac
+        .endif
+.endm
+
+.macro asm_stac
+        .if !CFG_NOSMAP
+        stac
+        .endif
+.endm

--- a/kernel/src/cpu/x86/smap.rs
+++ b/kernel/src/cpu/x86/smap.rs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2024 SUSE LLC
+//
+// Authors: Thomas Leroy <tleroy@suse.de>
+
+use core::arch::asm;
+
+/// Clears RFLAGS.AC to enable SMAP.
+/// This is currently only used when SMAP is supported and enabled.
+/// SMAP protection is effective only if CR4.SMAP is set and if RFLAGS.AC = 0.
+#[inline(always)]
+pub fn clac() {
+    if !cfg!(feature = "nosmap") {
+        unsafe { asm!("clac", options(att_syntax, nomem, nostack, preserves_flags)) }
+    }
+}
+
+/// Sets RFLAGS.AC to disable SMAP.
+/// This is currently only used when SMAP is supported and enabled.
+/// SMAP protection is effective only if CR4.SMAP is set and if RFLAGS.AC = 0.
+#[inline(always)]
+pub fn stac() {
+    if !cfg!(feature = "nosmap") {
+        unsafe { asm!("stac", options(att_syntax, nomem, nostack, preserves_flags)) }
+    }
+}


### PR DESCRIPTION
Enabling SMEP and SMAP if supported by the CPU.

To enable these, `smep` and `smap` features have to be specifically enabled, but this could be changed in the future since I think all modern CPUs support SMEP and SMAP.

I stole the way to give the CFG_SMAP bool to assembly from #455. This will likely cause a small conflict in  `kernel/src/cpu/idt/svsm.rs:265` when one of the two PR is merged.
This also conflict with the userspace PR since SMAP has to be temporary disabled to fetch user-provided pointers in syscalls arguments.
 
Finally, SMAP requires RFLAGS.AC to be unset to be enabled so I added a `clac` instruction in different entries, including #HV entry for which I don't really know if this is required, and if this could break something in the future. @msft-jlange could you please take a look? 