### PR TITLE
svsm: bump to Rust version 1.81

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install specified rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: '1.80.0'
+            toolchain: '1.81.0'
             target: x86_64-unknown-none
             profile: minimal
             override: true

--- a/igvmbuilder/src/gpa_map.rs
+++ b/igvmbuilder/src/gpa_map.rs
@@ -174,9 +174,8 @@ impl GpaMap {
     }
 
     pub fn get_metadata(path: &String) -> Result<std::fs::Metadata, Box<dyn Error>> {
-        let meta = metadata(path).map_err(|e| {
+        let meta = metadata(path).inspect_err(|_| {
             eprintln!("Failed to access {}", path);
-            e
         })?;
         Ok(meta)
     }

--- a/igvmbuilder/src/igvm_builder.rs
+++ b/igvmbuilder/src/igvm_builder.rs
@@ -160,21 +160,18 @@ impl IgvmBuilder {
             self.initialization,
             self.directives,
         )
-        .map_err(|e| {
+        .inspect_err(|_| {
             eprintln!("Failed to create output file");
-            e
         })?;
 
         let mut binary_file = Vec::new();
         file.serialize(&mut binary_file)?;
 
-        let mut output = File::create(&self.options.output).map_err(|e| {
+        let mut output = File::create(&self.options.output).inspect_err(|_| {
             eprintln!("Failed to create output file {}", self.options.output);
-            e
         })?;
-        output.write_all(binary_file.as_slice()).map_err(|e| {
+        output.write_all(binary_file.as_slice()).inspect_err(|_| {
             eprintln!("Failed to write output file {}", self.options.output);
-            e
         })?;
         Ok(())
     }
@@ -472,9 +469,8 @@ impl IgvmBuilder {
         compatibility_mask: u32,
     ) -> Result<(), Box<dyn Error>> {
         let mut gpa = gpa_start;
-        let mut in_file = File::open(path).map_err(|e| {
+        let mut in_file = File::open(path).inspect_err(|_| {
             eprintln!("Could not open input file {}", path);
-            e
         })?;
         let mut buf = vec![0; 4096];
 

--- a/igvmbuilder/src/igvm_firmware.rs
+++ b/igvmbuilder/src/igvm_firmware.rs
@@ -63,9 +63,8 @@ impl IgvmFirmware {
     ) -> Result<Box<dyn Firmware>, Box<dyn Error>> {
         // Read and parse Hyper-V firmware.
         let mut igvm_fw = IgvmFirmware::new();
-        let igvm_buffer = fs::read(filename).map_err(|e| {
+        let igvm_buffer = fs::read(filename).inspect_err(|_| {
             eprintln!("Failed to open firmware file {}", filename);
-            e
         })?;
         let igvm = IgvmFile::new_from_binary(igvm_buffer.as_bytes(), None)?;
         let mut parameters = IgvmParameterList::new();

--- a/igvmbuilder/src/ovmf_firmware.rs
+++ b/igvmbuilder/src/ovmf_firmware.rs
@@ -240,9 +240,8 @@ impl OvmfFirmware {
         _parameter_count: u32,
         compatibility_mask: u32,
     ) -> Result<Box<dyn Firmware>, Box<dyn Error>> {
-        let mut in_file = File::open(filename).map_err(|e| {
+        let mut in_file = File::open(filename).inspect_err(|_| {
             eprintln!("Failed to open firmware file {}", filename);
-            e
         })?;
         let len = in_file.metadata()?.len() as usize;
         if len > 0xffffffff {

--- a/igvmmeasure/src/main.rs
+++ b/igvmmeasure/src/main.rs
@@ -27,9 +27,8 @@ mod utils;
 fn main() -> Result<(), Box<dyn Error>> {
     let options = CmdOptions::parse();
 
-    let igvm_buffer = fs::read(&options.input).map_err(|e| {
+    let igvm_buffer = fs::read(&options.input).inspect_err(|_| {
         eprintln!("Failed to open firmware file {}", options.input);
-        e
     })?;
     let igvm = IgvmFile::new_from_binary(igvm_buffer.as_bytes(), None)?;
     let platform = match options.platform {
@@ -121,20 +120,17 @@ fn sign_command(
         igvm.initializations().to_vec(),
         directives,
     )
-    .map_err(|e| {
+    .inspect_err(|_| {
         eprintln!("Failed to create signed IGVM output file");
-        e
     })?;
     let mut binary_file = Vec::new();
     signed_file.serialize(&mut binary_file)?;
 
-    let mut file = File::create(output).map_err(|e| {
+    let mut file = File::create(output).inspect_err(|_| {
         eprintln!("Failed to create output file {}", output);
-        e
     })?;
-    file.write_all(binary_file.as_slice()).map_err(|e| {
+    file.write_all(binary_file.as_slice()).inspect_err(|_| {
         eprintln!("Failed to write output file {}", output);
-        e
     })?;
 
     println!("Successfully created signed file: {}", output);

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -2,7 +2,7 @@
 name = "svsm"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.80.0"
+rust-version = "1.81.0"
 
 [[bin]]
 name = "stage2"

--- a/kernel/src/protocols/core.rs
+++ b/kernel/src/protocols/core.rs
@@ -122,9 +122,8 @@ fn core_create_vcpu(params: &RequestParams) -> Result<(), SvsmReqError> {
     let lock = PVALIDATE_LOCK.lock_write();
 
     // Make sure the guest can't make modifications to the VMSA page
-    rmp_revoke_guest_access(vaddr, PageSize::Regular).map_err(|err| {
+    rmp_revoke_guest_access(vaddr, PageSize::Regular).inspect_err(|_| {
         core_create_vcpu_error_restore(Some(paddr), None);
-        err
     })?;
 
     // TLB flush needed to propagate new permissions
@@ -140,9 +139,8 @@ fn core_create_vcpu(params: &RequestParams) -> Result<(), SvsmReqError> {
     }
 
     // Set the VMSA bit
-    rmp_set_guest_vmsa(vaddr).map_err(|err| {
+    rmp_set_guest_vmsa(vaddr).inspect_err(|_| {
         core_create_vcpu_error_restore(Some(paddr), Some(vaddr));
-        err
     })?;
 
     drop(lock);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.80.0"
+channel = "1.81.0"
 targets = [ "x86_64-unknown-none" ]


### PR DESCRIPTION
So as not to fall behind the Rust toolchain developments, update to the latest stable version.

This PR also includes changes to fix would-be clippy warnings in version 1.81.