### PR TITLE
igvmbuilder, igvmmeasure: forbid unsafe code

### DIFF
--- a/igvmbuilder/src/main.rs
+++ b/igvmbuilder/src/main.rs
@@ -3,6 +3,7 @@
 // Copyright (c) 2023 SUSE LLC
 //
 // Author: Roy Hopkins <rhopkins@suse.de>
+#![forbid(unsafe_code)]
 
 use gpa_map::GpaMap;
 use igvm_builder::IgvmBuilder;

--- a/igvmmeasure/src/main.rs
+++ b/igvmmeasure/src/main.rs
@@ -3,6 +3,7 @@
 // Copyright (c) 2024 SUSE LLC
 //
 // Author: Roy Hopkins <roy.hopkins@suse.com>
+#![forbid(unsafe_code)]
 
 use std::error::Error;
 use std::fs::{self, File};


### PR DESCRIPTION
igvmbuilder and igvmmeasure are both userspace applications that do not deal with low level details like the SVSM kernel. Thus, there is no reason to allow unsafe code in them. Add a lint to prevent future additions of unsafe code.