### PR TITLE
kernel/idt: Ensure #HV handler RIP checks are executed when interrupts are enabled

### DIFF
--- a/kernel/src/cpu/idt/entry.S
+++ b/kernel/src/cpu/idt/entry.S
@@ -84,11 +84,7 @@ asm_entry_hv:
 	pushq	$0
 	pushq	%rax
 	pushq 	%rbx
-        pushq   %rcx
-	// Check whether interrupts were enabled at the time of #HV.  If so,
-	// commit to processing all #HV events immediately.
-	testl 	$0x200, 0x30(%rsp)
-	jnz	continue_hv
+	pushq   %rcx
 	// Check whether the trap RIP is within the guest VMPL return window.
 	movq	0x20(%rsp), %rax // fetch RIP from the trap frame.
 	leaq	switch_vmpl_window_start(%rip), %rbx
@@ -100,18 +96,19 @@ asm_entry_hv:
 	// RIP is in the return window, so update RIP to the cancel point.
 	leaq	switch_vmpl_cancel(%rip), %rbx
 	movq	%rbx, 0x20(%rsp)
-	// Defer any further processing until interrupts can be processed.
-	jmp	postpone_hv
+	// Continue processing the #HV
+	jmp	hv_check_if
+
 hv_not_vmpl_switch:
 	// Load the RSP value that was live at the time of the #HV.
 	movq	0x38(%rsp), %rcx
 	// Check to see whether this interrupt occurred on the IRET path
 	leaq	iret_return_window(%rip), %rbx
 	cmp	%rbx, %rax
-	jb	postpone_hv
+	jb	hv_check_if
 	leaq	default_iret(%rip), %rbx
 	cmp	%rbx, %rax
-	ja	postpone_hv
+	ja	hv_check_if
 	// RIP is within the IRET sequence, so the IRET should be aborted, and
 	// the previous exception should be handled as if it were #HV.  At this
 	// point, there are two possibilities.  If RIP is before the IRET
@@ -141,6 +138,12 @@ hv_not_vmpl_switch:
 	// processing.
 	movq	%rcx, %rsp
 	jmp	handle_as_hv
+
+hv_check_if:
+	// Check whether interrupts were enabled at the time of #HV.  If so,
+	// commit to processing all #HV events immediately.
+	testl 	$0x200, 0x30(%rsp)
+	jnz	continue_hv
 
 postpone_hv:
 	popq	%rcx


### PR DESCRIPTION
When testing restricted injection using an APIC timer firing into VMPL0 I experienced errors reported by the GHCB.rs in the code that detects whether the switch to VMPL2 was successful. This was down to a couple of separate issues. One of which is fixed by this PR. 

The current #HV handler checks EFLAGS.IF=1 at the start of the handler and immediately processes the #HV events if enabled without performing checks to see if RIP is within the VMPL switch or the iret window. The RIP windows are only checked if EFLAGS.IF=0. This means that if interrupts are enabled during either of these windows and a #HV occurs then the behaviour is undefined.