### PR TITLE
platform: move AP page table construction into common code

### DIFF
--- a/kernel/src/cpu/smp.rs
+++ b/kernel/src/cpu/smp.rs
@@ -16,6 +16,8 @@ use crate::utils::immut_after_init::immut_after_init_set_multithreaded;
 fn start_cpu(platform: &dyn SvsmPlatform, apic_id: u32) -> Result<(), SvsmError> {
     let start_rip: u64 = (start_ap as *const u8) as u64;
     let percpu = PerCpu::alloc(apic_id)?;
+    let pgtable = this_cpu().get_pgtable().clone_shared()?;
+    percpu.setup(platform, pgtable)?;
     platform.start_cpu(percpu, start_rip)?;
 
     let percpu_shared = percpu.shared();

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -271,8 +271,6 @@ impl SvsmPlatform for SnpPlatform {
     }
 
     fn start_cpu(&self, cpu: &PerCpu, start_rip: u64) -> Result<(), SvsmError> {
-        let pgtable = this_cpu().get_pgtable().clone_shared()?;
-        cpu.setup(self, pgtable)?;
         let (vmsa_pa, sev_features) = cpu.alloc_svsm_vmsa(*VTOM as u64, start_rip)?;
 
         current_ghcb().ap_create(vmsa_pa, cpu.get_apic_id().into(), 0, sev_features)


### PR DESCRIPTION
The process of cloning page tables to create the page table hierarchy for a new processor does not include platform-specific logic.  Therefore it should not be implemented in the platform object.