### PR TITLE
scripts/launch_guest.sh: fix restoring of terminal settings

### DIFF
--- a/scripts/launch_guest.sh
+++ b/scripts/launch_guest.sh
@@ -99,6 +99,10 @@ echo "============================="
 echo "Press Ctrl-] to interrupt"
 echo "============================="
 
+# Store original terminal settings and restore it on exit
+STTY_ORIGINAL=$(stty -g)
+trap 'stty "$STTY_ORIGINAL"' EXIT
+
 # Remap Ctrl-C to Ctrl-] to allow the guest to handle Ctrl-C.
 stty intr ^]
 
@@ -121,5 +125,3 @@ $SUDO_CMD \
     $COM4_SERIAL \
     $QEMU_EXIT_DEVICE \
     $QEMU_TEST_IO_DEVICE
-
-stty intr ^C


### PR DESCRIPTION
The script runs with `set -e`, so if QEMU fails, we never restore Ctrl-C remapping to Ctrl-].

For example, this happens all the time when we run `scripts/test-in-svsm.sh` because QEMU exits with a value other than 0 (perhaps due to exit via isa-debug-exit).

To solve it, set a handler to re-install them when the script exits, also save the original values to restore exactly the initial configuration.