### PR TITLE
sev: remove SNP/ES checks

### DIFF
--- a/kernel/src/sev/mod.rs
+++ b/kernel/src/sev/mod.rs
@@ -17,6 +17,5 @@ pub use msr_protocol::init_hypervisor_ghcb_features;
 pub use secrets_page::{secrets_page, secrets_page_mut, SecretsPage, VMPCK_SIZE};
 pub use status::sev_status_init;
 pub use status::sev_status_verify;
-pub use status::{sev_es_enabled, sev_snp_enabled};
 pub use utils::{pvalidate, pvalidate_range, PvalidateOp, SevSnpError};
 pub use utils::{rmp_adjust, RMPFlags};

--- a/kernel/src/sev/status.rs
+++ b/kernel/src/sev/status.rs
@@ -146,14 +146,6 @@ pub fn sev_status_init() {
         .expect("Already initialized SEV flags");
 }
 
-pub fn sev_es_enabled() -> bool {
-    sev_flags().contains(SEVStatusFlags::SEV_ES)
-}
-
-pub fn sev_snp_enabled() -> bool {
-    sev_flags().contains(SEVStatusFlags::SEV_SNP)
-}
-
 pub fn vtom_enabled() -> bool {
     sev_flags().contains(SEVStatusFlags::VTOM)
 }


### PR DESCRIPTION
The use of the SNP platform assumes that SEV-ES and SEV-SNP are always enabled (this is enforced during SEV status register checks).  There is no longer any reason to make decisions at runtime based on whether ES or SNP is available.