### PR TITLE
Introduce Syscall Interface and Error Codes

### DIFF
--- a/syscall/src/call.rs
+++ b/syscall/src/call.rs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 Intel Corporation.
+//
+// Author: Chuanxiao Dong <chuanxiao.dong@intel.com>
+
+use core::arch::asm;
+
+/// Macro to generate system call functions with varying numbers of arguments.
+macro_rules! syscall {
+    ($($name:ident($a:ident, $($b:ident, $($c:ident, $($d:ident, $($e:ident, $($f:ident, )?)?)?)?)?);)+) => {
+        $(
+            /// Performs a system call with arguments.
+            ///
+            /// # Safety
+            ///
+            /// This function is unsafe because it performs a system call.
+            /// The kernel should check the syscall number and return the
+            /// expected result back.
+            #[allow(dead_code)]
+            pub unsafe fn $name($a: u64, $($b: u64, $($c: u64, $($d: u64, $($e: u64, $($f: u64)?)?)?)?)?) -> u64 {
+                let mut ret = $a;
+                asm!(
+                    "int 0x80",
+                    inout("rax") ret,
+                    $(
+                        in("rdi") $b,
+                        $(
+                            in("rsi") $c,
+                            $(
+                                in("r8") $d,
+                                $(
+                                    in("r9") $e,
+                                    $(
+                                        in("r10") $f,
+                                    )?
+                                )?
+                            )?
+                        )?
+                    )?
+                    out("rcx") _,
+                    out("r11") _,
+                    options(nostack),
+                );
+
+                ret
+            }
+        )+
+    };
+}
+
+syscall! {
+    syscall0(a,);
+    syscall1(a, b,);
+    syscall2(a, b, c,);
+    syscall3(a, b, c, d,);
+    syscall4(a, b, c, d, e,);
+    syscall5(a, b, c, d, e, f,);
+}

--- a/syscall/src/lib.rs
+++ b/syscall/src/lib.rs
@@ -5,6 +5,7 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 #![no_std]
 
+mod call;
 mod numbers;
 mod obj;
 

--- a/syscall/src/lib.rs
+++ b/syscall/src/lib.rs
@@ -9,5 +9,6 @@ mod call;
 mod numbers;
 mod obj;
 
+pub use call::SysCallError;
 pub use numbers::*;
 pub use obj::*;


### PR DESCRIPTION
This PR introduces a syscall implementation that provides an interface between userspace and the kernel. Additionally, it adds syscall error codes following the syscall specification [[1]].

This is the first in a series of PRs to add initial userspace support in SVSM.

[1]: https://mail.8bytes.org/pipermail/svsm-devel/2024-June/000334.html