### PR TITLE
various improvements to libmstpm

### DIFF
--- a/kernel/build.rs
+++ b/kernel/build.rs
@@ -21,10 +21,6 @@ fn main() {
     println!("cargo:rustc-link-arg-bin=svsm=--no-relax");
     println!("cargo:rustc-link-arg-bin=svsm=-Tkernel/src/svsm.lds");
     println!("cargo:rustc-link-arg-bin=svsm=-no-pie");
-    if std::env::var("CARGO_FEATURE_MSTPM").is_ok() && std::env::var("CARGO_CFG_TEST").is_err() {
-        println!("cargo:rustc-link-arg-bin=svsm=-Llibmstpm");
-        println!("cargo:rustc-link-arg-bin=svsm=-lmstpm");
-    }
 
     // Extra linker args for tests.
     println!("cargo:rerun-if-env-changed=LINK_TEST");

--- a/libmstpm/.gitignore
+++ b/libmstpm/.gitignore
@@ -1,2 +1,1 @@
 libmstpm.a
-src/bindings.rs

--- a/libmstpm/.gitignore
+++ b/libmstpm/.gitignore
@@ -1,1 +1,0 @@
-libmstpm.a

--- a/libmstpm/Makefile
+++ b/libmstpm/Makefile
@@ -28,9 +28,9 @@ LIBS = $(LIBCRT) $(LIBCRYPTO) $(LIBTPM) $(LIBPLATFORM)
 
 OUT_DIR ?= $(CWD)
 
-all: libmstpm.a $(OUT_DIR)/bindings.rs
+all: $(OUT_DIR)/libmstpm.a $(OUT_DIR)/bindings.rs
 
-libmstpm.a: $(LIBS)
+$(OUT_DIR)/libmstpm.a: $(LIBS)
 	rm -f $@
 	ar rcsTPD $@ $^
 

--- a/libmstpm/Makefile
+++ b/libmstpm/Makefile
@@ -26,7 +26,9 @@ MSTPM_MAKEFILE = $(MSTPM_DIR)/Makefile
 
 LIBS = $(LIBCRT) $(LIBCRYPTO) $(LIBTPM) $(LIBPLATFORM)
 
-all: libmstpm.a src/bindings.rs
+OUT_DIR ?= $(CWD)
+
+all: libmstpm.a $(OUT_DIR)/bindings.rs
 
 libmstpm.a: $(LIBS)
 	rm -f $@
@@ -123,13 +125,8 @@ $(MSTPM_MAKEFILE):
 BINDGEN_FLAGS = --use-core
 CLANG_FLAGS = -Wno-incompatible-library-redeclaration
 
-src/bindings.rs: deps/libmstpm.h $(LIBTPM)
-	echo "#![allow(non_upper_case_globals)]" > $@
-	echo "#![allow(non_camel_case_types)]" >> $@
-	echo "#![allow(non_snake_case)]" >> $@
-	echo "#![allow(unused)]" >> $@
-	echo "#![allow(improper_ctypes)]" >> $@
-	bindgen $(BINDGEN_FLAGS) deps/libmstpm.h -- $(CLANG_FLAGS) >> $@
+$(OUT_DIR)/bindings.rs: deps/libmstpm.h $(LIBTPM)
+	bindgen $(BINDGEN_FLAGS) --output $@ deps/libmstpm.h -- $(CLANG_FLAGS)
 
 clean: $(OPENSSL_MAKEFILE) $(MSTPM_MAKEFILE)
 	make -C $(LIBCRT_DIR) clean

--- a/libmstpm/build.rs
+++ b/libmstpm/build.rs
@@ -4,6 +4,7 @@
 //
 // Authors: Claudio Carvalho <cclaudio@linux.ibm.com>
 
+use std::env::current_dir;
 use std::process::Command;
 use std::process::Stdio;
 
@@ -17,4 +18,10 @@ fn main() {
     if !output.status.success() {
         panic!();
     }
+
+    // Tell cargo to link libmstpm and where to find it.
+    let cwd = current_dir().unwrap();
+    let cwd = cwd.as_os_str().to_str().unwrap();
+    println!("cargo:rustc-link-search={cwd}");
+    println!("cargo:rustc-link-lib=mstpm");
 }

--- a/libmstpm/build.rs
+++ b/libmstpm/build.rs
@@ -4,6 +4,7 @@
 //
 // Authors: Claudio Carvalho <cclaudio@linux.ibm.com>
 
+use std::env::current_dir;
 use std::process::Command;
 use std::process::Stdio;
 
@@ -22,4 +23,10 @@ fn main() {
     let out_dir = std::env::var("OUT_DIR").unwrap();
     println!("cargo:rustc-link-search={out_dir}");
     println!("cargo:rustc-link-lib=mstpm");
+
+    // Tell cargo not to rerun the build-script unless anything in this
+    // directory changes.
+    let cwd = current_dir().unwrap();
+    let cwd = cwd.as_os_str().to_str().unwrap();
+    println!("cargo:rerun-if-changed={cwd}");
 }

--- a/libmstpm/build.rs
+++ b/libmstpm/build.rs
@@ -9,15 +9,13 @@ use std::process::Command;
 use std::process::Stdio;
 
 fn main() {
-    let output = Command::new("make")
+    // Build libmstpm.
+    let status = Command::new("make")
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
-        .output()
+        .status()
         .unwrap();
-
-    if !output.status.success() {
-        panic!();
-    }
+    assert!(status.success());
 
     // Tell cargo to link libmstpm and where to find it.
     let out_dir = std::env::var("OUT_DIR").unwrap();

--- a/libmstpm/build.rs
+++ b/libmstpm/build.rs
@@ -4,7 +4,6 @@
 //
 // Authors: Claudio Carvalho <cclaudio@linux.ibm.com>
 
-use std::env::current_dir;
 use std::process::Command;
 use std::process::Stdio;
 
@@ -20,8 +19,7 @@ fn main() {
     }
 
     // Tell cargo to link libmstpm and where to find it.
-    let cwd = current_dir().unwrap();
-    let cwd = cwd.as_os_str().to_str().unwrap();
-    println!("cargo:rustc-link-search={cwd}");
+    let out_dir = std::env::var("OUT_DIR").unwrap();
+    println!("cargo:rustc-link-search={out_dir}");
     println!("cargo:rustc-link-lib=mstpm");
 }

--- a/libmstpm/src/lib.rs
+++ b/libmstpm/src/lib.rs
@@ -10,4 +10,12 @@
 #![no_std]
 
 /// C bindings
-pub mod bindings;
+pub mod bindings {
+    #![allow(non_upper_case_globals)]
+    #![allow(non_camel_case_types)]
+    #![allow(non_snake_case)]
+    #![allow(unused)]
+    #![allow(improper_ctypes)]
+
+    include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+}


### PR DESCRIPTION
Among other things, this PR fixes a bug where the build script for libmstpm wouldn't rerun if the submodules in `libmstpm/deps/` were updated. It also changes the build script to only save output files in the directory specified on the `OUT_DIR` environment variable as recommended by [the cargo docs](https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script).