### PR TITLE
Introduce UserPtr wrapper around GuestPtr

### DIFF
--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -75,6 +75,8 @@ pub enum SvsmError {
     InvalidAddress,
     /// Error reported when convert a usize to Bytes
     InvalidBytes,
+    /// Error reported when converting to UTF-8
+    InvalidUtf8,
     /// Errors related to firmware parsing
     Firmware,
     /// Errors related to console operation
@@ -131,7 +133,8 @@ impl From<SvsmError> for SysCallError {
             | SvsmError::Obj(ObjError::InvalidHandle)
             | SvsmError::Mem
             | SvsmError::InvalidAddress
-            | SvsmError::InvalidBytes => SysCallError::EINVAL,
+            | SvsmError::InvalidBytes
+            | SvsmError::InvalidUtf8 => SysCallError::EINVAL,
 
             _ => SysCallError::UNKNOWN,
         }

--- a/syscall/src/call.rs
+++ b/syscall/src/call.rs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 Intel Corporation.
+//
+// Author: Chuanxiao Dong <chuanxiao.dong@intel.com>
+
+use core::arch::asm;
+
+/// Macro to generate system call functions with varying numbers of arguments.
+macro_rules! syscall {
+    ($($name:ident($a:ident, $($b:ident, $($c:ident, $($d:ident, $($e:ident, $($f:ident, )?)?)?)?)?);)+) => {
+        $(
+            /// Performs a system call with arguments.
+            ///
+            /// # Safety
+            ///
+            /// This function is unsafe because it performs a system call.
+            /// The kernel should check the syscall number and return the
+            /// expected result back.
+            #[allow(dead_code)]
+            pub unsafe fn $name($a: u64, $($b: u64, $($c: u64, $($d: u64, $($e: u64, $($f: u64)?)?)?)?)?) -> u64 {
+                let mut ret = $a;
+                asm!(
+                    "int 0x80",
+                    inout("rax") ret,
+                    $(
+                        in("rdi") $b,
+                        $(
+                            in("rsi") $c,
+                            $(
+                                in("r8") $d,
+                                $(
+                                    in("r9") $e,
+                                    $(
+                                        in("r10") $f,
+                                    )?
+                                )?
+                            )?
+                        )?
+                    )?
+                    out("rcx") _,
+                    out("r11") _,
+                    options(nostack),
+                );
+
+                ret
+            }
+        )+
+    };
+}
+
+syscall! {
+    syscall0(a,);
+    syscall1(a, b,);
+    syscall2(a, b, c,);
+    syscall3(a, b, c, d,);
+    syscall4(a, b, c, d, e,);
+    syscall5(a, b, c, d, e, f,);
+}

--- a/syscall/src/lib.rs
+++ b/syscall/src/lib.rs
@@ -5,6 +5,7 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 #![no_std]
 
+mod call;
 mod numbers;
 mod obj;
 

--- a/syscall/src/lib.rs
+++ b/syscall/src/lib.rs
@@ -9,5 +9,6 @@ mod call;
 mod numbers;
 mod obj;
 
+pub use call::SysCallError;
 pub use numbers::*;
 pub use obj::*;

--- a/syscall/src/numbers.rs
+++ b/syscall/src/numbers.rs
@@ -8,3 +8,6 @@
 
 pub const SYS_HELLO: u64 = 0;
 pub const SYS_EXIT: u64 = 1;
+
+///Maximum length of path name including null character in bytes
+pub const PATH_MAX: usize = 4096;


### PR DESCRIPTION
As suggested by @Freax13, introduce a `UserPtr` wrapper around `GuestPtr` to ensure 
- No invalid memory access is done.
- Validate the address passed from the userspace to make sure it isn't pointing to kernel memory.

This PR is next in series of PRs to add initial userspace support in SVSM. This is based on PR https://github.com/coconut-svsm/svsm/pull/502