### PR TITLE
Scrub memory before platform-specific invalidation

### DIFF
--- a/kernel/src/address.rs
+++ b/kernel/src/address.rs
@@ -5,6 +5,7 @@
 // Author: Carlos López <carlos.lopez@suse.com>
 
 use crate::types::{PAGE_SHIFT, PAGE_SIZE};
+use crate::utils::{align_down, align_up};
 use core::fmt;
 use core::ops;
 
@@ -42,7 +43,12 @@ pub trait Address:
 
     #[inline]
     fn align_up(&self, align: InnerAddr) -> Self {
-        Self::from((self.bits() + (align - 1)) & !(align - 1))
+        Self::from(align_up((*self).into(), align))
+    }
+
+    #[inline]
+    fn align_down(&self, align: InnerAddr) -> Self {
+        Self::from(align_down((*self).into(), align))
     }
 
     #[inline]
@@ -52,7 +58,7 @@ pub trait Address:
 
     #[inline]
     fn page_align(&self) -> Self {
-        Self::from(self.bits() & !(PAGE_SIZE - 1))
+        self.align_down(PAGE_SIZE)
     }
 
     #[inline]

--- a/kernel/src/config.rs
+++ b/kernel/src/config.rs
@@ -159,7 +159,7 @@ impl SvsmConfig<'_> {
         }
     }
 
-    pub fn invalidate_boot_data(&self) -> bool {
+    pub fn clean_up_boot_data(&self) -> bool {
         match self {
             SvsmConfig::FirmwareConfig(_) => false,
             SvsmConfig::IgvmConfig(_) => true,

--- a/kernel/src/mm/virtualrange.rs
+++ b/kernel/src/mm/virtualrange.rs
@@ -10,6 +10,7 @@ use crate::error::SvsmError;
 use crate::types::{PAGE_SHIFT, PAGE_SHIFT_2M, PAGE_SIZE, PAGE_SIZE_2M};
 use crate::utils::bitmap_allocator::{BitmapAllocator, BitmapAllocator1024};
 use crate::utils::MemoryRegion;
+use core::cmp::min;
 use core::fmt::Debug;
 
 use super::{
@@ -48,8 +49,9 @@ impl VirtualRange {
     }
 
     pub fn alloc(&mut self, page_count: usize, alignment: usize) -> Result<VirtAddr, SvsmError> {
-        // Always reserve an extra page to leave a guard between virtual memory allocations
-        match self.bits.alloc(page_count + 1, alignment) {
+        // Reserve an extra page, if possible, to leave a guard between virtual memory allocations
+        let npages = min(page_count + 1, self.page_count);
+        match self.bits.alloc(npages, alignment) {
             Some(offset) => Ok(self.start_virt + (offset << self.page_shift)),
             None => Err(SvsmError::Mem),
         }

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -45,7 +45,7 @@ use svsm::platform::{init_platform_type, SvsmPlatformCell, SVSM_PLATFORM};
 use svsm::requests::{request_loop, request_processing_main, update_mappings};
 use svsm::sev::utils::{rmp_adjust, RMPFlags};
 use svsm::sev::{secrets_page, secrets_page_mut};
-use svsm::svsm_paging::{init_page_table, invalidate_early_boot_memory};
+use svsm::svsm_paging::{clean_up_early_boot_memory, init_page_table};
 use svsm::task::exec_user;
 use svsm::task::{create_kernel_task, schedule_init};
 use svsm::types::{PageSize, GUEST_VMPL, PAGE_SIZE};
@@ -423,8 +423,8 @@ pub extern "C" fn svsm_main() {
     populate_ram_fs(LAUNCH_INFO.kernel_fs_start, LAUNCH_INFO.kernel_fs_end)
         .expect("Failed to unpack FS archive");
 
-    invalidate_early_boot_memory(&**SVSM_PLATFORM, &config, launch_info)
-        .expect("Failed to invalidate early boot memory");
+    clean_up_early_boot_memory(&**SVSM_PLATFORM, &config, launch_info)
+        .expect("Failed to clean up early boot memory");
 
     let cpus = config.load_cpu_info().expect("Failed to load ACPI tables");
     let mut nr_cpus = 0;

--- a/kernel/src/svsm_paging.rs
+++ b/kernel/src/svsm_paging.rs
@@ -94,13 +94,13 @@ pub fn init_page_table(
     Ok(pgtable)
 }
 
-fn invalidate_boot_memory_region(
+fn clean_up_boot_memory_region(
     platform: &dyn SvsmPlatform,
     config: &SvsmConfig<'_>,
     region: MemoryRegion<PhysAddr>,
 ) -> Result<(), SvsmError> {
     log::info!(
-        "Invalidating boot region {:018x}-{:018x}",
+        "Cleaning up boot region {:018x}-{:018x}",
         region.start(),
         region.end()
     );
@@ -116,33 +116,33 @@ fn invalidate_boot_memory_region(
     Ok(())
 }
 
-pub fn invalidate_early_boot_memory(
+pub fn clean_up_early_boot_memory(
     platform: &dyn SvsmPlatform,
     config: &SvsmConfig<'_>,
     launch_info: &KernelLaunchInfo,
 ) -> Result<(), SvsmError> {
-    // Early boot memory must be invalidated after changing to the SVSM page
-    // page table to avoid invalidating page tables currently in use.  Always
-    // invalidate stage 2 memory, unless firmware is loaded into low memory.
-    // Also invalidate the boot data if required.
+    // Early boot memory must be cleaned up after changing to the SVSM page
+    // page table to avoid destroying page tables currently in use.  Always
+    // clean up stage 2 memory, unless firmware is loaded into low memory.
+    // Also clean up the boot data if required.
     if !config.fw_in_low_memory() {
         let lowmem_region = MemoryRegion::new(PhysAddr::null(), 640 * 1024);
-        invalidate_boot_memory_region(platform, config, lowmem_region)?;
+        clean_up_boot_memory_region(platform, config, lowmem_region)?;
     }
 
     let stage2_base = PhysAddr::from(launch_info.stage2_start);
     let stage2_end = PhysAddr::from(launch_info.stage2_end);
     let stage2_region = MemoryRegion::from_addresses(stage2_base, stage2_end);
-    invalidate_boot_memory_region(platform, config, stage2_region)?;
+    clean_up_boot_memory_region(platform, config, stage2_region)?;
 
-    if config.invalidate_boot_data() {
+    if config.clean_up_boot_data() {
         let kernel_elf_size =
             launch_info.kernel_elf_stage2_virt_end - launch_info.kernel_elf_stage2_virt_start;
         let kernel_elf_region = MemoryRegion::new(
             PhysAddr::new(launch_info.kernel_elf_stage2_virt_start.try_into().unwrap()),
             kernel_elf_size.try_into().unwrap(),
         );
-        invalidate_boot_memory_region(platform, config, kernel_elf_region)?;
+        clean_up_boot_memory_region(platform, config, kernel_elf_region)?;
 
         let kernel_fs_size = launch_info.kernel_fs_end - launch_info.kernel_fs_start;
         if kernel_fs_size > 0 {
@@ -150,7 +150,7 @@ pub fn invalidate_early_boot_memory(
                 PhysAddr::new(launch_info.kernel_fs_start.try_into().unwrap()),
                 kernel_fs_size.try_into().unwrap(),
             );
-            invalidate_boot_memory_region(platform, config, kernel_fs_region)?;
+            clean_up_boot_memory_region(platform, config, kernel_fs_region)?;
         }
 
         if launch_info.stage2_igvm_params_size > 0 {
@@ -158,7 +158,7 @@ pub fn invalidate_early_boot_memory(
                 PhysAddr::new(launch_info.stage2_igvm_params_phys_addr.try_into().unwrap()),
                 launch_info.stage2_igvm_params_size as usize,
             );
-            invalidate_boot_memory_region(platform, config, igvm_params_region)?;
+            clean_up_boot_memory_region(platform, config, igvm_params_region)?;
         }
     }
 

--- a/kernel/src/utils/mod.rs
+++ b/kernel/src/utils/mod.rs
@@ -11,5 +11,6 @@ pub mod util;
 
 pub use memory_region::MemoryRegion;
 pub use util::{
-    align_down, align_up, halt, is_aligned, overlap, page_align_up, page_offset, zero_mem_region,
+    align_down, align_up, halt, is_aligned, overlap, page_align, page_align_up, page_offset,
+    zero_mem_region,
 };

--- a/kernel/src/utils/util.rs
+++ b/kernel/src/utils/util.rs
@@ -41,6 +41,10 @@ pub fn page_align_up(x: usize) -> usize {
     align_up(x, PAGE_SIZE)
 }
 
+pub fn page_align(x: usize) -> usize {
+    align_down(x, PAGE_SIZE)
+}
+
 pub fn page_offset(x: usize) -> usize {
     x & (PAGE_SIZE - 1)
 }


### PR DESCRIPTION
Instead of invalidating memory, TDP platforms only need to zero out its content before handing it over to the L2 guest. This is not equivalent to page invalidation because the page remains accepted after zeroing.

Always scrub the memory region prior to performing platform-specific invalidation (which is a no-op on TDP platforms). This should have no functional impact on SNP platforms.