### PR TITLE
igvmbuilder: Use Vanadium's register values when building an IGVM for vanadium

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,11 +85,11 @@ bin/coconut-test-hyperv.igvm: $(IGVMBUILDER) $(IGVMMEASURE) bin/stage1-trampolin
 
 bin/coconut-vanadium.igvm: $(IGVMBUILDER) $(IGVMMEASURE) bin/stage1-trampoline.bin bin/svsm-kernel.elf bin/stage2.bin ${FS_BIN}
 	$(IGVMBUILDER) --sort --policy 0x30000 --output $@ --tdx-stage1 bin/stage1-trampoline.bin --stage2 bin/stage2.bin --kernel bin/svsm-kernel.elf --filesystem ${FS_BIN} ${BUILD_FW} vanadium --snp --tdp
-	$(IGVMMEASURE) --check-kvm $@ measure
+	$(IGVMMEASURE) --check-kvm --native-zero $@ measure
 
 bin/coconut-test-vanadium.igvm: $(IGVMBUILDER) $(IGVMMEASURE) bin/stage1-trampoline.bin bin/test-kernel.elf bin/stage2.bin
 	$(IGVMBUILDER) --sort --output $@ --tdx-stage1 bin/stage1-trampoline.bin --stage2 bin/stage2.bin --kernel bin/test-kernel.elf vanadium --snp --tdp
-	$(IGVMMEASURE) --check-kvm $@ measure
+	$(IGVMMEASURE) --check-kvm --native-zero $@ measure
 
 test:
 	cargo test ${CARGO_ARGS} ${SVSM_ARGS_TEST} --workspace --target=x86_64-unknown-linux-gnu

--- a/igvmbuilder/src/igvm_builder.rs
+++ b/igvmbuilder/src/igvm_builder.rs
@@ -369,6 +369,7 @@ impl IgvmBuilder {
                 param_block.vtom,
                 SNP_COMPATIBILITY_MASK,
                 &self.options.sev_features,
+                self.options.hypervisor,
             ));
         }
 


### PR DESCRIPTION
Google's Vanadium hypervisor configures certain registers to have certain values different from KVM's defaults. These shouldn't affect execution, but they need to match in order for the launch measurement to be correct.