### PR TITLE
igvmbuilder: configure XCR0 as expected in CPUID tables

### DIFF
--- a/igvmbuilder/src/cpuid.rs
+++ b/igvmbuilder/src/cpuid.rs
@@ -27,24 +27,18 @@ struct SnpCpuidLeaf {
 
 impl SnpCpuidLeaf {
     pub fn new1(eax_in: u32) -> Self {
-        Self {
-            eax_in,
-            ecx_in: 0,
-            xcr0: 0,
-            xss: 0,
-            eax_out: 0,
-            ebx_out: 0,
-            ecx_out: 0,
-            edx_out: 0,
-            reserved: 0,
-        }
+        Self::new2(eax_in, 0)
     }
 
     pub fn new2(eax_in: u32, ecx_in: u32) -> Self {
+        Self::new3(eax_in, ecx_in, 0)
+    }
+
+    pub fn new3(eax_in: u32, ecx_in: u32, xcr0: u64) -> Self {
         Self {
             eax_in,
             ecx_in,
-            xcr0: 0,
+            xcr0,
             xss: 0,
             eax_out: 0,
             ebx_out: 0,
@@ -92,8 +86,8 @@ impl SnpCpuidPage {
         cpuid_page.add(SnpCpuidLeaf::new2(7, 1))?;
         cpuid_page.add(SnpCpuidLeaf::new1(11))?;
         cpuid_page.add(SnpCpuidLeaf::new2(11, 1))?;
-        cpuid_page.add(SnpCpuidLeaf::new1(13))?;
-        cpuid_page.add(SnpCpuidLeaf::new2(13, 1))?;
+        cpuid_page.add(SnpCpuidLeaf::new3(13, 0, 1))?;
+        cpuid_page.add(SnpCpuidLeaf::new3(13, 1, 1))?;
         cpuid_page.add(SnpCpuidLeaf::new1(0x80000000))?;
         cpuid_page.add(SnpCpuidLeaf::new1(0x80000001))?;
         cpuid_page.add(SnpCpuidLeaf::new1(0x80000002))?;

--- a/kernel/src/cpu/sse.rs
+++ b/kernel/src/cpu/sse.rs
@@ -31,13 +31,18 @@ fn legacy_sse_enable() {
 }
 
 fn extended_sse_supported() -> bool {
-    let res = CpuidResult::get(0xD, 1);
+    let res = CpuidResult::get(0xD, 0);
     (res.eax & 0x7) == 0x7
 }
 
 fn xsave_supported() -> bool {
     let res = CpuidResult::get(1, 0);
     (res.ecx & (1 << CPUID_ECX_XSAVE)) != 0
+}
+
+fn xsaveopt_supported() -> bool {
+    let res = CpuidResult::get(0xD, 1);
+    (res.eax & (1 << CPUID_EAX_XSAVEOPT)) != 0
 }
 
 fn xcr0_set() {
@@ -50,14 +55,11 @@ fn xcr0_set() {
 
 pub fn get_xsave_area_size() -> u32 {
     let res = CpuidResult::get(0xD, 0);
-    if (res.eax & (1 << CPUID_EAX_XSAVEOPT)) == 0 {
-        panic!("XSAVEOPT unsupported");
-    }
     res.ecx
 }
 
 fn extended_sse_enable() {
-    if extended_sse_supported() && xsave_supported() {
+    if extended_sse_supported() && xsave_supported() && xsaveopt_supported() {
         cr4_xsave_enable();
         xcr0_set();
     } else {


### PR DESCRIPTION
A recent change to the SVSM kernel requires XCR0 to match the value `1` when looking for CPUID[EAX=0Dh] leaves.  However, the IGVM file builder was populating the CPUID template with XCR0=0, resulting in a mismatch when the CPUID lookup was attempted.  This change sets XCR0=1 for the extended leaves in the CPUID template in the IGVM file so the constructed table matches the expected value at lookup time.