### PR TITLE
Use Packit as a git submodule

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,13 +56,13 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --workspace --exclude igvmbuilder --exclude igvmmeasure --exclude svsm-fuzz --all-features -- -D warnings
+          args: --workspace --exclude igvmbuilder --exclude igvmmeasure --exclude svsm-fuzz --exclude packit --all-features -- -D warnings
 
       - name: Clippy on std x86_64-unknown-linux-gnu
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --workspace --all-features --exclude svsm --exclude svsm-fuzz --target=x86_64-unknown-linux-gnu -- -D warnings
+          args: --workspace --all-features --exclude svsm --exclude svsm-fuzz --exclude packit --target=x86_64-unknown-linux-gnu -- -D warnings
 
       - name: Clippy on svsm-fuzz
         uses: actions-rs/cargo@v1
@@ -76,7 +76,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --workspace --all-features --tests --target=x86_64-unknown-linux-gnu -- -D warnings
+          args: --workspace --exclude packit --all-features --tests --target=x86_64-unknown-linux-gnu -- -D warnings
 
       - name: Check documentation
         run: make doc

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "libtcgtpm/deps/tpm-20-ref"]
 	path = libtcgtpm/deps/tpm-20-ref
 	url = https://github.com/TrustedComputingGroup/TPM.git
+[submodule "packit"]
+	path = packit
+	url = https://github.com/coconut-svsm/packit.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,6 +624,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
+name = "memmap2"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,8 +697,9 @@ dependencies = [
 [[package]]
 name = "packit"
 version = "0.1.1"
-source = "git+https://github.com/coconut-svsm/packit#e2508f686440f6a703fb6c5c0c2fd338e55f1d38"
 dependencies = [
+ "clap",
+ "memmap2",
  "zerocopy 0.7.34",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ members = [
     "libtcgtpm",
     # syscall interface definitions
     "syscall",
+    # PackIt library and command line utility
+    "packit"
 ]
 
 
@@ -26,6 +28,7 @@ svsm = { path = "kernel" }
 elf = { path = "elf" }
 libtcgtpm = { path = "libtcgtpm" }
 syscall = { path = "syscall" }
+packit = { path = "packit" }
 
 # crates.io
 aes-gcm = { version = "0.10.3", default-features = false }
@@ -46,9 +49,6 @@ tdx-tdcall = "0.2.1"
 uuid = "1.6.1"
 # Add the derive feature by default because all crates use it.
 zerocopy = { version = "0.8.2", features = ["alloc", "derive"] }
-
-# other repos
-packit = { git = "https://github.com/coconut-svsm/packit", version = "0.1.1" }
 
 [workspace.lints.rust]
 future_incompatible = { level = "deny", priority = 127 }

--- a/Makefile
+++ b/Makefile
@@ -175,10 +175,10 @@ bin/svsm-test.bin: bin/stage1-test
 	objcopy -O binary $< $@
 
 clippy:
-	cargo clippy --workspace --all-features --exclude svsm-fuzz --exclude igvmbuilder --exclude igvmmeasure -- -D warnings
-	cargo clippy --workspace --all-features --exclude svsm-fuzz --exclude svsm --target=x86_64-unknown-linux-gnu -- -D warnings
+	cargo clippy --workspace --all-features --exclude packit --exclude svsm-fuzz --exclude igvmbuilder --exclude igvmmeasure -- -D warnings
+	cargo clippy --workspace --all-features --exclude packit --exclude svsm-fuzz --exclude svsm --target=x86_64-unknown-linux-gnu -- -D warnings
 	RUSTFLAGS="--cfg fuzzing" cargo clippy --package svsm-fuzz --all-features --target=x86_64-unknown-linux-gnu -- -D warnings
-	cargo clippy --workspace --all-features --tests --target=x86_64-unknown-linux-gnu -- -D warnings
+	cargo clippy --workspace --all-features --exclude packit --tests --target=x86_64-unknown-linux-gnu -- -D warnings
 
 clean:
 	cargo clean


### PR DESCRIPTION
Instead of fetching PackIt as an external modules, include it into the repository as a git submodule. This will make it easier to integrate the packit command line utility into the build process.