### PR TITLE
Userspace support: Implement opendir and readdir syscalls

### DIFF
--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -296,6 +296,8 @@ extern "C" fn ex_handler_system_call(
     ctxt.regs.rax = match input {
         SYS_EXIT => sys_exit(ctxt.regs.rdi as u32),
         SYS_CLOSE => sys_close(ctxt.regs.rdi as u32),
+        SYS_OPENDIR => sys_opendir(ctxt.regs.rdi),
+        SYS_READDIR => sys_readdir(ctxt.regs.rdi as u32, ctxt.regs.rsi, ctxt.regs.r8),
         _ => Err(SysCallError::EINVAL),
     }
     .map_or_else(|e| e as usize, |v| v as usize);

--- a/kernel/src/fs/api.rs
+++ b/kernel/src/fs/api.rs
@@ -18,6 +18,7 @@ use packit::PackItError;
 /// Maximum supported length for a single filename
 const MAX_FILENAME_LENGTH: usize = 64;
 pub type FileName = FixedString<MAX_FILENAME_LENGTH>;
+pub type FileNameArray = [u8; MAX_FILENAME_LENGTH];
 
 /// Represents the type of error occured
 /// while doing SVSM filesystem operations.

--- a/kernel/src/fs/filesystem.rs
+++ b/kernel/src/fs/filesystem.rs
@@ -281,7 +281,7 @@ fn split_path(path: &str) -> Result<impl DoubleEndedIterator<Item = &str>, SvsmE
 }
 
 /// Used to perform a walk over the items in a path while checking
-/// each item is a directory.
+/// each item is a directory, starting at the given directory.
 ///
 /// # Argument
 ///
@@ -292,13 +292,11 @@ fn split_path(path: &str) -> Result<impl DoubleEndedIterator<Item = &str>, SvsmE
 /// [`Result<Arc<dyn Directory>, SvsmError>`]: [`Result`] containing the
 /// directory corresponding to the path if successful, or [`SvsmError`]
 /// if there is an error.
-fn walk_path<'a, I>(path_items: I) -> Result<Arc<dyn Directory>, SvsmError>
+fn walk_path<'a, I>(dir: Arc<dyn Directory>, path_items: I) -> Result<Arc<dyn Directory>, SvsmError>
 where
     I: Iterator<Item = &'a str>,
 {
-    let fs_root = FS_ROOT.lock_read();
-    let mut current_dir = fs_root.root_dir();
-    drop(fs_root);
+    let mut current_dir = dir;
 
     for item in path_items {
         let dir_name = FileName::from(item);
@@ -310,6 +308,29 @@ where
     }
 
     Ok(current_dir)
+}
+
+/// Used to perform a walk over the items in a path while checking
+/// each item is a directory, starting at the root directory.
+///
+/// # Argument
+///
+/// `path_items`: contains items in a path.
+///
+/// # Returns
+///
+/// [`Result<Arc<dyn Directory>, SvsmError>`]: [`Result`] containing the
+/// directory corresponding to the path if successful, or [`SvsmError`]
+/// if there is an error.
+fn walk_path_from_root<'a, I>(path_items: I) -> Result<Arc<dyn Directory>, SvsmError>
+where
+    I: Iterator<Item = &'a str>,
+{
+    let fs_root = FS_ROOT.lock_read();
+    let root = fs_root.root_dir();
+    drop(fs_root);
+
+    walk_path(root, path_items)
 }
 
 /// Used to perform a walk over the items in a path while checking
@@ -362,7 +383,7 @@ where
 pub fn open(path: &str) -> Result<FileHandle, SvsmError> {
     let mut path_items = split_path(path)?;
     let file_name = FileName::from(path_items.next_back().unwrap());
-    let current_dir = walk_path(path_items)?;
+    let current_dir = walk_path_from_root(path_items)?;
 
     let dir_entry = current_dir.lookup_entry(file_name)?;
 
@@ -370,6 +391,24 @@ pub fn open(path: &str) -> Result<FileHandle, SvsmError> {
         DirEntry::Directory(_) => Err(SvsmError::FileSystem(FsError::file_not_found())),
         DirEntry::File(f) => Ok(FileHandle::new(&f)),
     }
+}
+
+/// Used to open a directory object.
+///
+/// # Argument
+///
+/// `path_items`: contains items in a path.
+///
+/// # Returns
+///
+/// [`Result<Arc<dyn Directory>, SvsmError>`]: [`Result`] containing the
+/// directory corresponding to the path if successful, or [`SvsmError`]
+/// if there is an error.
+pub fn opendir(path: &str) -> Result<Arc<dyn Directory>, SvsmError> {
+    // Skip checking empty path since opendir walks the path from root, and even
+    // if path were empty the root directory will be returned.
+    let items = split_path_allow_empty(path);
+    walk_path_from_root(items)
 }
 
 /// Used to create a file with the given path.
@@ -385,7 +424,7 @@ pub fn open(path: &str) -> Result<FileHandle, SvsmError> {
 pub fn create(path: &str) -> Result<FileHandle, SvsmError> {
     let mut path_items = split_path(path)?;
     let file_name = FileName::from(path_items.next_back().unwrap());
-    let current_dir = walk_path(path_items)?;
+    let current_dir = walk_path_from_root(path_items)?;
     let file = current_dir.create_file(file_name)?;
 
     Ok(FileHandle::new(&file))
@@ -428,7 +467,7 @@ pub fn create_all(path: &str) -> Result<FileHandle, SvsmError> {
 pub fn mkdir(path: &str) -> Result<(), SvsmError> {
     let mut path_items = split_path(path)?;
     let dir_name = FileName::from(path_items.next_back().unwrap());
-    let current_dir = walk_path(path_items)?;
+    let current_dir = walk_path_from_root(path_items)?;
 
     current_dir.create_directory(dir_name)?;
 
@@ -448,7 +487,7 @@ pub fn mkdir(path: &str) -> Result<(), SvsmError> {
 pub fn unlink(path: &str) -> Result<(), SvsmError> {
     let mut path_items = split_path(path)?;
     let entry_name = FileName::from(path_items.next_back().unwrap());
-    let dir = walk_path(path_items)?;
+    let dir = walk_path_from_root(path_items)?;
 
     dir.unlink(entry_name)
 }
@@ -463,8 +502,7 @@ pub fn unlink(path: &str) -> Result<(), SvsmError> {
 /// [`Result<(), SvsmError>`]: [`Result`] containing the [`Vec`]
 /// of directory entries if successful,  [`SvsmError`] otherwise.
 pub fn list_dir(path: &str) -> Result<Vec<FileName>, SvsmError> {
-    let items = split_path_allow_empty(path);
-    let dir = walk_path(items)?;
+    let dir = opendir(path)?;
     Ok(dir.list())
 }
 

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -7,8 +7,10 @@
 mod api;
 mod filesystem;
 mod init;
+mod obj;
 mod ramfs;
 
 pub use api::*;
 pub use filesystem::*;
 pub use init::populate_ram_fs;
+pub use obj::FsObj;

--- a/kernel/src/fs/obj.rs
+++ b/kernel/src/fs/obj.rs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 Intel Corporation.
+//
+// Author: Peter Fang <peter.fang@intel.com>
+
+extern crate alloc;
+
+use super::{DirEntry, Directory, FileHandle, FileName};
+use crate::error::SvsmError;
+use crate::syscall::Obj;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+#[derive(Debug)]
+struct DirectoryHandle {
+    dir: Arc<dyn Directory>,
+    list: Vec<FileName>,
+    next: AtomicUsize,
+}
+
+impl DirectoryHandle {
+    fn new(dir: &Arc<dyn Directory>) -> Self {
+        DirectoryHandle {
+            dir: dir.clone(),
+            list: dir.list(),
+            next: AtomicUsize::new(0),
+        }
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+enum FsObjEntry {
+    File(FileHandle),
+    Directory(DirectoryHandle),
+}
+
+#[derive(Debug)]
+pub struct FsObj {
+    entry: FsObjEntry,
+}
+
+impl FsObj {
+    pub fn new_dir(dir: &Arc<dyn Directory>) -> Self {
+        FsObj {
+            entry: FsObjEntry::Directory(DirectoryHandle::new(dir)),
+        }
+    }
+
+    pub fn readdir(&self) -> Result<Option<(FileName, DirEntry)>, SvsmError> {
+        let FsObjEntry::Directory(ref dh) = self.entry else {
+            return Err(SvsmError::NotSupported);
+        };
+
+        let next = dh.next.fetch_add(1, Ordering::Relaxed);
+        if let Some(&name) = dh.list.get(next) {
+            let dirent = dh.dir.lookup_entry(name)?;
+            Ok(Some((name, dirent)))
+        } else {
+            dh.next.fetch_sub(1, Ordering::Relaxed);
+            Ok(None)
+        }
+    }
+}
+
+impl Obj for FsObj {
+    fn as_fs(&self) -> Option<&FsObj> {
+        Some(self)
+    }
+}

--- a/kernel/src/string.rs
+++ b/kernel/src/string.rs
@@ -50,6 +50,17 @@ impl<const N: usize> From<[u8; N]> for FixedString<N> {
     }
 }
 
+// TODO: Fix truncation of unicode characters > 0xff.
+impl<const N: usize> From<FixedString<N>> for [u8; N] {
+    fn from(src: FixedString<N>) -> [u8; N] {
+        let mut data = [0u8; N];
+        for (i, d) in data.iter_mut().enumerate().take(src.length()) {
+            *d = src.data[i] as u8;
+        }
+        data
+    }
+}
+
 impl<const N: usize> From<&str> for FixedString<N> {
     fn from(st: &str) -> FixedString<N> {
         let mut fs = FixedString::new();

--- a/kernel/src/syscall/class1.rs
+++ b/kernel/src/syscall/class1.rs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 Intel Corporation.
+//
+// Author: Peter Fang <peter.fang@intel.com>
+
+extern crate alloc;
+
+use super::obj::{obj_add, obj_get};
+use crate::address::VirtAddr;
+use crate::fs::{opendir, DirEntry, FileNameArray, FsObj};
+use crate::mm::guestmem::UserPtr;
+use alloc::sync::Arc;
+use core::ffi::c_char;
+use syscall::SysCallError::*;
+use syscall::{DirEnt, FileType, SysCallError};
+
+pub fn sys_opendir(path: usize) -> Result<u64, SysCallError> {
+    let user_path_ptr = UserPtr::<c_char>::new(VirtAddr::from(path));
+    let user_path = user_path_ptr.read_c_string()?;
+
+    let dir = opendir(&user_path)?;
+    let id = obj_add(Arc::new(FsObj::new_dir(&dir)))?;
+
+    Ok(u32::from(id).into())
+}
+
+pub fn sys_readdir(obj_id: u32, dirents: usize, size: usize) -> Result<u64, SysCallError> {
+    let fsobj = obj_get(obj_id.into())?;
+    let fsobj = fsobj.as_fs().ok_or(ENOTSUPP)?;
+    let user_dirents_ptr = UserPtr::<DirEnt>::new(VirtAddr::from(dirents));
+
+    for i in 0..size {
+        let Some((name, dirent)) = fsobj.readdir()? else {
+            return Ok(i as u64);
+        };
+
+        let mut new_entry = DirEnt::default();
+        let fname = FileNameArray::from(name);
+        new_entry.file_name[..fname.len()].copy_from_slice(&fname);
+
+        if let DirEntry::File(f) = dirent {
+            new_entry.file_type = FileType::File;
+            new_entry.file_size = f.size().try_into().unwrap();
+        } else {
+            new_entry.file_type = FileType::Directory;
+            new_entry.file_size = 0;
+        }
+
+        let user_dirents_ptr = user_dirents_ptr.offset(i.try_into().unwrap());
+        user_dirents_ptr.write(new_entry)?
+    }
+    Ok(size as u64)
+}

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -5,7 +5,9 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 
 mod class0;
+mod class1;
 mod obj;
 
 pub use class0::*;
+pub use class1::*;
 pub use obj::{Obj, ObjError, ObjHandle};

--- a/kernel/src/syscall/obj.rs
+++ b/kernel/src/syscall/obj.rs
@@ -72,7 +72,6 @@ impl From<ObjHandle> for u32 {
 ///
 /// This function will return an error if adding the object to the
 /// current task fails.
-#[expect(dead_code)]
 pub fn obj_add(obj: Arc<dyn Obj>) -> Result<ObjHandle, SvsmError> {
     current_task().add_obj(obj)
 }
@@ -111,7 +110,6 @@ pub fn obj_close(id: ObjHandle) -> Result<Arc<dyn Obj>, SvsmError> {
 ///
 /// This function will return an error if retrieving the object from the
 /// current task fails.
-#[expect(dead_code)]
 pub fn obj_get(id: ObjHandle) -> Result<Arc<dyn Obj>, SvsmError> {
     current_task().get_obj(id)
 }

--- a/kernel/src/syscall/obj.rs
+++ b/kernel/src/syscall/obj.rs
@@ -8,6 +8,7 @@ extern crate alloc;
 
 use crate::cpu::percpu::current_task;
 use crate::error::SvsmError;
+use crate::fs::FsObj;
 use alloc::sync::Arc;
 
 #[derive(Clone, Copy, Debug)]
@@ -22,7 +23,11 @@ pub enum ObjError {
 /// the common functionalities of the objects. With the trait bounds of Send
 /// and Sync, the objects implementing Obj trait could be sent to another
 /// thread and shared between threads safely.
-pub trait Obj: Send + Sync + core::fmt::Debug {}
+pub trait Obj: Send + Sync + core::fmt::Debug {
+    fn as_fs(&self) -> Option<&FsObj> {
+        None
+    }
+}
 
 /// ObjHandle is a unique identifier for an object in the current process.
 /// An ObjHandle can be converted to a u32 id which can be used by the user

--- a/syscall/src/class1.rs
+++ b/syscall/src/class1.rs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 Intel Corporation.
+//
+// Author: Peter Fang <peter.fang@intel.com>
+
+use super::call::{syscall1, syscall3, SysCallError};
+use super::def::{SYS_OPENDIR, SYS_READDIR};
+use super::{DirEnt, Obj, ObjHandle};
+use core::ffi::CStr;
+
+#[derive(Debug)]
+pub struct FsObjHandle(ObjHandle);
+
+impl Obj for FsObjHandle {
+    fn id(&self) -> u32 {
+        u32::from(&self.0)
+    }
+}
+
+pub fn opendir(path: &CStr) -> Result<FsObjHandle, SysCallError> {
+    unsafe {
+        syscall1(SYS_OPENDIR, path.as_ptr() as u64)
+            .map(|ret| FsObjHandle(ObjHandle::new(ret as u32)))
+    }
+}
+
+pub fn readdir(fs: &FsObjHandle, dirents: &mut [DirEnt]) -> Result<usize, SysCallError> {
+    unsafe {
+        syscall3(
+            SYS_READDIR,
+            fs.id().into(),
+            dirents.as_mut_ptr() as u64,
+            dirents.len() as u64,
+        )
+        .map(|ret| ret.try_into().unwrap())
+    }
+}

--- a/syscall/src/def.rs
+++ b/syscall/src/def.rs
@@ -6,10 +6,46 @@
 
 // Syscall classes
 const CLASS0: u64 = 0;
+const CLASS1: u64 = 1 << 32;
 
 // Syscall number in class0
 pub const SYS_EXIT: u64 = CLASS0;
 pub const SYS_CLOSE: u64 = CLASS0 + 10;
 
+// Syscall number in class1
+pub const SYS_OPENDIR: u64 = CLASS1 + 4;
+pub const SYS_READDIR: u64 = CLASS1 + 5;
+
 ///Maximum length of path name including null character in bytes
 pub const PATH_MAX: usize = 4096;
+
+/// Maximum length of file name in bytes
+pub const F_NAME_SIZE: usize = 256;
+
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FileType {
+    File,
+    Directory,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct DirEnt {
+    /// Entry name
+    pub file_name: [u8; F_NAME_SIZE],
+    /// Entry type
+    pub file_type: FileType,
+    /// File size - 0 for directories
+    pub file_size: u64,
+}
+
+impl Default for DirEnt {
+    fn default() -> Self {
+        DirEnt {
+            file_name: [0; F_NAME_SIZE],
+            file_type: FileType::File,
+            file_size: 0,
+        }
+    }
+}

--- a/syscall/src/lib.rs
+++ b/syscall/src/lib.rs
@@ -7,10 +7,12 @@
 
 mod call;
 mod class0;
+mod class1;
 mod def;
 mod obj;
 
 pub use call::SysCallError;
 pub use class0::*;
+pub use class1::*;
 pub use def::*;
 pub use obj::*;

--- a/syscall/src/obj.rs
+++ b/syscall/src/obj.rs
@@ -18,7 +18,6 @@ use super::SYS_CLOSE;
 pub struct ObjHandle(u32);
 
 impl ObjHandle {
-    #[expect(dead_code)]
     pub(crate) fn new(id: u32) -> Self {
         Self(id)
     }


### PR DESCRIPTION
This is 5th PR in the userspace series. This PR implements support for `OPENDIR` and `READDIR` syscalls.

