### PR TITLE
Add a rudimentary build system script

### DIFF
--- a/Documentation/docs/installation/BUILD_RECIPES.md
+++ b/Documentation/docs/installation/BUILD_RECIPES.md
@@ -1,0 +1,168 @@
+# COCONUT Build Recipes Format
+
+This document describes the format of COCONUT build recipes as consumed by the
+`scripts/build.py` script. The script takes a build recipe as input and builds
+all tooling and component to generate one or more IGVM output files.
+
+IGVM files are hypervisor specific. The COCONUT source repository ships with
+ready-to-use recipes for all supported hypervisors. IGVM files for multiple
+hypervisors can be built with on recipe.
+
+## General Format
+
+A build recipe is a text file containing a JSON object. The top-level object
+has attributes which point to sub-objects describing different parts of the
+build process.
+
+The currently recognized attributes are:
+
+* `igvm`: Parameters for creating IGVM files.
+* `kernel`: Configuration for compiling the COCONUT kernel and its boot stages.
+* `firmware`: Information on how to retrieve the guest firmware to put into the
+   IGVM output file (optional).
+
+The objects these attributes point to are described in more detail below:
+
+## `igvm`: Parameter for IGVM File Creation
+
+The `igvm` attribute points to an object where each attribute describes IGVM
+parameters for a supported hypervisor target. The following targets are
+currently supported:
+
+* `qemu`: The QEMU/KVM hypervisor.
+* `hyper-v`: Microsoft Hyper-V.
+* `vanadium`: Google Vanadium hypervisor based on KVM.
+
+Each target description is an object supporting a common set of attributes for
+invoking the `igvmbuilder` and `igvmmeasure` tools.
+
+The supported attributes are described below.
+
+### `output`: Output File Name
+
+The name of the output file to generate. The file will be placed in the `bin/`
+directory.
+
+### `platforms`: Host Platforms the IGVM File Supports
+
+This attribute takes an array with a list of platforms to support in the output
+IGVM file. The supported platforms are:
+
+* `native`: Non-confidential guest environment.
+* `snp`: AMD SEV-SNP guest environment.
+* `tdp`: Intel TDX guest environment with support for TD-Partitioning.
+* `vsm`: Hyper-V Virtual Secure Mode.
+
+### `policy`: Value of the Policy Field on the SEV-SNP Platform
+
+This is a hex value with the `policy` field used when creating an AMD SEV-SNP
+virtual machine with the IGVM file (default: `0x30000`).
+
+### `comport`: Serial Port Number to use for the Console
+
+This attribute specifies the number of the serial port COCONUT uses for console
+output.
+
+### `measure`: Expected Launch Measurement Calculation
+
+This has only one supported value for now: `print`. The build script will
+invoke the `igvmmeasure` tool on the IGVM file to print the expected SEV-SNP
+launch measurement for the specified target hypervisor.
+
+### `check-kvm`: Calculate Launch Measurement for KVM-based Hypervisors
+
+This attribute takes a boolean value which must be set to `true` if the target
+hypervisor is based on the Linux Kernel Virtual Machine (KVM). It is used to
+calculate the correct expected launch measurement for KVM-based hypervisors.
+Default value is `false`.
+
+### `measure-native-zeroes`: How to Measure Zero-Pages
+
+This is a boolean flag which defines how zero-pages are treated when
+calculating the expected launch measurement. The behavior is:
+
+* If `true`: Use native SEV-SNP zero-page type for measurement.
+* If `false`: Measure pages as data-pages containing all zeroes.
+
+The default value is `false`. Whether this setting is needed depends on how the
+hypervisor loads the IGVM file.
+
+## `kernel`: Definitions for Building COCONUT Kernel Parts
+
+The `kernel` attribute points to a JSON object whose attributes describe how to
+build the individual parts of the COCONUT kernel. The recognized attributes are:
+
+* `tdx-stage1`: Stage1 needed for TD-Partitioning platforms
+* `stage2`: The stage2 loader of the COCONUT kernel
+* `svsm`: The COCONUT kernel itself.
+
+Each attribute points to another object describing the build parameters. For
+all three parts of the kernel recognize the same build parameters. They are
+described in the following sections.
+
+### `type`: The Build Type
+
+This attribute currently has two supported values:
+
+* `cargo`: Build the component with cargo.
+* `make`: Run GNU make to build the component.
+
+The default is `cargo`. Some of the other attributes are specific to either
+build type.
+
+### `output_file`: Expected Build Output File
+
+This is the expected output filename of the build run. It is only recognized
+for `make` builds and used as the make target.
+
+### `manifest`: Build Manifest to use for Cargo.
+
+Path to the `Cargo.toml` file to pass as the build manifest when running cargo.
+Default is `None`.
+
+### `features`: Cargo Features to use for Kernel Component
+
+This attribute points to a comma-separated list of cargo features to enable
+when building the specified component. Default is empty.
+
+### `binary`: Whether to Build a Package or Binary
+
+This is a boolean value and defines the way cargo is invoked:
+
+* If `true`, the component is built with the `--bin` parameter to cargo.
+* If `false`, the component is built from the cargo workspace with the
+  `--package` parameter.
+
+### `objcopy`: Output Target for Objcopy run
+
+Each binary built using cargo or make will be processed and copied to the
+`bin/` directory using `objcopy`. This attribute specifies the output target
+used for the processing. Default is `elf64-x86-64`.
+
+## `firmware`: Retrieval Information for Guest Firmware Image
+
+This attribute is optional and points to a JSON object which allows to specify
+where the build script finds the guest firmware image to put into the IGVM file.
+It supports the following attributes.
+
+### `env`: Environment Variable with Firmware Image Location
+
+This attribute points to an environment variable name from which the path to
+the firmware image file is read.
+
+### `file`: Direct File Path of Firmware Image Location
+
+This attribute points directly to the path of the firmware image location. If
+present, it takes precedence over `env`.
+
+### `command`: Execute Command before Firmware Retrieval
+
+This optional attribute points to a JSON array describing a command to execute
+before the firmware is retrieved either via `env` or `file`. The command can be
+used to build a firmware image and place it at the expected location.
+
+## Examples
+
+For examples of working build recipe files please have a look into the
+`config/` directory of the COCONUT-SVSM source repository. It contains a number
+of build recipes to generate IGVM files for all supported hypervisors.

--- a/Documentation/docs/installation/INSTALL.md
+++ b/Documentation/docs/installation/INSTALL.md
@@ -214,13 +214,13 @@ $ cargo install bindgen-cli
 That checks out the SVSM which can be built by
 
 ```
-$ FW_FILE=/path/to/firmware/OVMF.fd make
+$ FW_FILE=/path/to/firmware/OVMF.fd ./build configs/qemu-target.json
 ```
 
 to get a debug build of the SVSM or
 
 ```
-$ FW_FILE=/path/to/firmware/OVMF.fd make RELEASE=1
+$ FW_FILE=/path/to/firmware/OVMF.fd ./build --release configs/qemu-target.json
 ```
 
 to build the SVSM with the release target. When the build is finished

--- a/Documentation/mkdocs.yml
+++ b/Documentation/mkdocs.yml
@@ -6,6 +6,8 @@ nav:
   - Documentation Home: 'index.md'
   - Building and launching:
     - 'installation/INSTALL.md'
+  - Build Recipe Documentation:
+    - 'installation/BUILD_RECIPES.md'
 
   - Developer Information:
     - 'developer/DOC-GUIDELINES.md'

--- a/build
+++ b/build
@@ -1,0 +1,1 @@
+scripts/build.py

--- a/configs/all-targets.json
+++ b/configs/all-targets.json
@@ -1,0 +1,53 @@
+{
+    "igvm": {
+        "qemu": {
+            "output": "coconut-qemu.igvm",
+            "platforms": [
+                "snp",
+                "tdp"
+            ],
+            "policy": "0x30000",
+            "measure": "print",
+            "check-kvm": true
+        },
+        "hyper-v": {
+            "output": "coconut-hyperv.igvm",
+            "platforms": [
+                "native",
+                "snp",
+                "tdp",
+                "vsm"
+            ],
+            "policy": "0x30000",
+            "comport": "3",
+            "measure": "print"
+        },
+        "vanadium": {
+            "output": "coconut-vanadium.igvm",
+            "platforms": [
+                "snp",
+                "tdp"
+            ],
+            "policy": "0x30000",
+            "measure": "print",
+            "check-kvm": true,
+            "measure-native-zeroes": true
+        }
+    },
+    "kernel": {
+        "svsm": {
+            "features": "vtpm,enable-gdb",
+            "binary": true
+        },
+        "stage2": {
+            "manifest": "kernel/Cargo.toml",
+            "binary": true,
+            "objcopy": "binary"
+        },
+        "tdx-stage1": {
+            "type": "make",
+            "output_file": "bin/stage1-trampoline",
+            "objcopy": "binary"
+        }
+    }
+}

--- a/configs/hyperv-target.json
+++ b/configs/hyperv-target.json
@@ -1,0 +1,32 @@
+{
+    "igvm": {
+        "hyper-v": {
+            "output": "coconut-hyperv.igvm",
+            "platforms": [
+                "native",
+                "snp",
+                "tdp",
+                "vsm"
+            ],
+            "policy": "0x30000",
+            "comport": "3",
+            "measure": "print"
+        }
+    },
+    "kernel": {
+        "svsm": {
+            "features": "vtpm",
+            "binary": true
+        },
+        "stage2": {
+            "manifest": "kernel/Cargo.toml",
+            "binary": true,
+            "objcopy": "binary"
+        },
+        "tdx-stage1": {
+            "type": "make",
+            "output_file": "bin/stage1-trampoline",
+            "objcopy": "binary"
+        }
+    }
+}

--- a/configs/qemu-target.json
+++ b/configs/qemu-target.json
@@ -1,0 +1,33 @@
+{
+    "igvm": {
+        "qemu": {
+            "output": "coconut-qemu.igvm",
+            "platforms": [
+                "snp",
+                "tdp"
+            ],
+            "policy": "0x30000",
+            "measure": "print",
+            "check-kvm": true
+        }
+    },
+    "kernel": {
+        "svsm": {
+            "features": "vtpm",
+            "binary": true
+        },
+        "stage2": {
+            "manifest": "kernel/Cargo.toml",
+            "binary": true,
+            "objcopy": "binary"
+        },
+        "tdx-stage1": {
+            "type": "make",
+            "output_file": "bin/stage1-trampoline",
+            "objcopy": "binary"
+        }
+    },
+    "firmware": {
+        "env": "FW_FILE"
+    }
+}

--- a/configs/vanadium-target.json
+++ b/configs/vanadium-target.json
@@ -1,0 +1,34 @@
+{
+    "igvm": {
+        "vanadium": {
+            "output": "coconut-vanadium.igvm",
+            "platforms": [
+                "snp",
+                "tdp"
+            ],
+            "policy": "0x30000",
+            "measure": "print",
+            "check-kvm": true,
+            "measure-native-zeroes": true
+        }
+    },
+    "kernel": {
+        "svsm": {
+            "features": "vtpm",
+            "binary": true
+        },
+        "stage2": {
+            "manifest": "kernel/Cargo.toml",
+            "binary": true,
+            "objcopy": "binary"
+        },
+        "tdx-stage1": {
+            "type": "make",
+            "output_file": "bin/stage1-trampoline",
+            "objcopy": "binary"
+        }
+    },
+    "firmware": {
+        "env": "FW_FILE"
+    }
+}

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1,0 +1,619 @@
+#!/usr/bin/env python3
+#
+
+import subprocess
+import argparse
+import platform
+import json
+import os
+
+SUPPORTED_IGVM_TARGETS=["qemu", "hyper-v", "vanadium"]
+
+class CargoRunner:
+    """
+    A class for running cargo to build specific packages from the workspace.
+    """
+
+    def __init__(self, package):
+        self.package = package
+        self.binary = False
+        self.features = []
+        self.release = False
+        self.target = None
+        self.manifest = None
+        self.offline = False
+        self.verbose = False
+
+    def set_package(self, package):
+        """
+        Sets the package to build.
+        """
+        self.package = package
+
+    def enable_binary(self):
+        """
+        Builds a binary instead of a package (--package vs. --bin)
+        """
+        self.binary = True
+
+    def add_feature(self, feature):
+        """
+        Adds a feature to build with.
+        """
+        self.features.append(feature)
+
+    def enable_release(self):
+        """
+        Sets whether to build in release mode.
+        """
+        self.release = True
+
+    def set_target(self, target):
+        """
+        Sets the target to build for.
+        """
+        self.target = target
+
+    def set_manifest(self, manifest):
+        """
+        Sets the manifest to build with.
+        """
+        self.manifest = manifest
+
+    def enable_offline(self):
+        """
+        Enable offline builds.
+        """
+        self.offline = True
+
+    def enable_verbose(self):
+        """
+        Enable verbosity build output
+        """
+        self.verbose = True
+
+    def execute(self):
+        """
+        Executes the cargo command.
+        """
+        if self.package is None:
+            raise ValueError("Package not set")
+
+        command = ["cargo", "build"]
+        if self.verbose:
+            command.append("-vv")
+        if self.binary:
+            command.extend(["--bin", self.package])
+        else:
+            command.extend(["--package", self.package])
+
+        if self.offline:
+            command.extend(["--locked", "--offline"])
+        if self.features:
+            command.extend(["--features", ",".join(self.features)])
+        if self.manifest:
+            command.extend(["--manifest-path", self.manifest])
+        if self.release:
+            command.append("--release")
+        if self.target:
+            command.extend(["--target", self.target])
+
+        if self.verbose:
+            print(command)
+        subprocess.run(command, check=True)
+
+    def get_binary_path(self):
+        """
+        Gets the path of the resulting binary.
+        """
+        target_dir = "target"
+        if self.target:
+            target_dir = os.path.join(target_dir, self.target)
+        binary_dir = os.path.join(target_dir, "release" if self.release else "debug")
+        return os.path.join(binary_dir, self.package)
+
+def parse_kernel(recipe):
+    """
+    Parse a recipe for a single kernel component like tdx-stage1, stage2 or svsm.
+
+    Args:
+      recipe: A build data structure from a parsed JSON document.
+
+    Returns:
+      A sanitized dictionary with component-related build parameters.
+    """
+    kernel_config = {}
+
+    for package, settings in recipe.items():
+        kernel_config[package] = {
+            "type": settings.get("type", "cargo"),
+            "file": settings.get("output_file", None),
+            "manifest": settings.get("manifest", None),
+            "features": settings.get("features", "").split(),
+            "binary": settings.get("binary", False),
+            "objcopy": settings.get("objcopy", get_svsm_elf_target())
+        }
+
+    return kernel_config
+
+def kernel_recipe(config):
+    """
+    Parses the JSON configuration for kernel components.
+
+    Args:
+      json_data: A Python dictionary representing the configuration.
+
+    Returns:
+      A dictionary with parsed build settings for each component.
+    """
+
+    kernel_json = config.get("kernel", {})
+
+    return parse_kernel(kernel_json)
+
+
+def parse_igvm_config(target, config):
+    """
+    Parses parameters for a single IGVM file to build.
+
+    Args:
+      config: A Python dictionary from a parsed JSON document.
+
+    Returns:
+      A sanitized dictionary with IGVM build parameters.
+    """
+    igvm_config = {
+        "policy": config.get("policy", "0x30000"),
+        "target": target,
+        "output": config.get("output", "default.json"),
+        "comport": config.get("comport", None),
+        "platforms": config.get("platforms", ["snp", "tdp", "vsm"]),
+        "measure": config.get("measure", "print"),
+        "measure-native-zeroes": config.get("measure-native-zeroes", False),
+        "check-kvm": config.get("check-kvm", False),
+    }
+
+    return igvm_config
+
+def igvm_recipe(config):
+    """
+    Parses parameters for all IGVM files to build
+
+    Args:
+      config: A Python dictionary from a parsed JSON document. The keys of the
+              dictionary are the hypervisor targets and the values point to
+              dictionaries with per-target IGVM parameters.
+
+    Returns:
+      A sanitized dictionary with per-target IGVM build parameters.
+    """
+    igvm_json = config.get("igvm", {})
+
+    igvm_targets = {}
+    for target, config in igvm_json.items():
+        if target not in SUPPORTED_IGVM_TARGETS:
+            raise ValueError(f"Unknown IGVM target: {target}")
+        igvm_targets[target] = parse_igvm_config(target, config)
+
+    return igvm_targets
+
+def firmware_recipe(config):
+    """
+    Parse a parameters for retrieving the firmware.
+
+    Args:
+      config: A Python dictionary from a parsed JSON document.
+
+    Returns:
+      A sanitized dictionary with firmware build/retrieval parameters.
+    """
+    firmware_json = config.get("firmware", {})
+
+    firmware_config = {
+        "env": firmware_json.get("env", None),
+        "file": firmware_json.get("file", None),
+        "command": firmware_json.get("command", None),
+    }
+
+    if firmware_config["command"] and not isinstance(firmware_config["command"], list):
+        raise ValueError("Value of firmware.command must be a JSON array")
+
+    return firmware_config
+
+def read_recipe(file_path):
+    """
+    Reads a JSON file and parses its content.
+
+    Args:
+      file_path: Path to the JSON file.
+
+    Returns:
+      A Python dictionary representing the parsed JSON data.
+    """
+    with open(file_path, 'r') as f:
+        data = json.load(f)
+    return data
+
+def get_host_target():
+    """
+    Returns the Rust target for building the helper utilities (like igvmbuilder
+    and igvmmeasure).
+    """
+    return "x86_64-unknown-linux-gnu"
+
+def get_svsm_kernel_target():
+    """
+    Returns the Rust target for building the helper utilities (like igvmbuilder
+    and igvmmeasure).
+    """
+    return "x86_64-unknown-none"
+
+def get_svsm_user_target():
+    """
+    Returns the Rust target for building the user-space components which are
+    packaged into the SVSM file-system image.
+    """
+    return "x86_64-unknown-none"
+
+def get_svsm_elf_target():
+    """
+    Returns the binutils target used in objcopy when copying the SVSM kernel
+    ELF file.
+    """
+    return "elf64-x86-64"
+
+def objcopy_kernel(binary_path, target_path, elf_target, args):
+    """
+    Execute objcopy to prepare a binary for packaging into the IGVM file.
+
+    Args:
+      binary_path: File path to source binary.
+      target_path: File path where copied binary is stored.
+      elf_target: Binary target to use for the output file.
+      args: A structure initialized from command line options.
+    """
+    command = ["objcopy", "-O", elf_target, "--strip-unneeded"]
+    command.append(binary_path)
+    command.append(target_path)
+    if args.verbose:
+        print(command)
+    subprocess.run(command, check=True)
+
+def cargo_build(package, config, target, args):
+    """
+    Run a single build step using cargo.
+
+    Args:
+      package: Name of the workspace package or binary to build.
+      config: A Python dictionary carrying the cargo specific build options.
+      target: Rust target to build for.
+      args: A structure initialized from command line options.
+
+    Returns:
+      Path to the binary built with cargo.
+    """
+    runner = CargoRunner(package)
+    runner.set_target(target)
+    for feature in config.get("features", []):
+        runner.add_feature(feature)
+    if config.get("binary"):
+        runner.enable_binary()
+    if config.get("manifest"):
+        runner.set_manifest(config.get("manifest"))
+    if args.release:
+        runner.enable_release()
+    if args.verbose:
+        runner.enable_verbose()
+    if args.offline:
+        runner.enable_offline()
+
+    runner.execute()
+
+    return runner.get_binary_path()
+
+def make_build(package, config, args):
+    """
+    Run a single build step using GNU Make.
+
+    Args:
+      package: Name of the package to build.
+      config: A Python dictionary carrying the make specific build options.
+      args: A structure initialized from command line options.
+
+    Returns:
+      Path to the make target which was built.
+    """
+    if config["file"]:
+        command = ["make", config["file"]]
+        if args.verbose:
+            command.append("V=2")
+            print(command)
+        subprocess.run(command, check=True)
+        return config["file"]
+    else:
+        raise ValueError("Build type make in package {} requires an 'output_file' attribute".format(package));
+
+def recipe_build(recipe, target, args):
+    """
+    Takes a list of package build recipes and builds them one by one.
+
+    Args:
+      recipe: A Python dictionary with package name as the key and another
+              dictionary with build options as their value.
+      target: Rust target to use for cargo builds
+      args: A structure initialized from command line options.
+
+    Returns:
+      A Python dictionary with package names as key and paths to built binaries
+      as value.
+    """
+    binaries = {}
+    for package, config in recipe.items():
+        print("Building {}...".format(package))
+        build_type = config.get("type", "cargo")
+        if build_type == "cargo":
+            binary = cargo_build(package, config, target, args)
+        elif build_type == "make":
+            binary = make_build(package, config, args)
+        else:
+            raise ValueError("Unknown build type: {}".format(build_type))
+
+        binaries[package] = binary
+        
+    return binaries
+
+def build_helpers(args):
+    """
+    Build the tooling needed to create the IGVM file and its components.
+    Currently it takes care of building the igvmbuilder and the igvmmeasure tool.
+
+    Args:
+      args: A structure initialized from command line options.
+
+    Returns:
+      A Python dictionary with build names as key and paths to their binaries
+      as value.
+    """
+    helpers = {
+        "igvmbuilder": {},
+        "igvmmeasure": {}
+    }
+    return recipe_build(helpers, get_host_target(), args)
+
+def build_kernel_parts(k_recipe, args):
+    """
+    Build all parts needed for the COCONUT kernel as specified in the JSON file.
+
+    Args:
+      k_recipe: A Python dictionary with the build options for each kernel part.
+      args: A structure initialized from command line options.
+
+    Returns:
+      A Python dictionary with kernel parts as key and paths to theor binary
+      files as value.
+    """
+    parts = {}
+    binaries = recipe_build(k_recipe, get_svsm_kernel_target(), args)
+    for binary, source_path in binaries.items():
+        bin_target = k_recipe[binary].get("objcopy", get_svsm_elf_target());
+        target_path = "bin/{}".format(binary)
+        objcopy_kernel(source_path, target_path, bin_target, args)
+        parts[binary] = target_path
+
+    return parts
+
+def build_firmware(args, firmware_config):
+    """
+    Retrieves and/or builds the firmware to package into the IGVM file.
+
+    Args:
+      args: A structure initialized from command line options.
+      firmware_config: A Python dictionary with options on how to
+                       build/retrieve the firmware.
+
+    Returns:
+      Path to the firmware file to package or None.
+    """
+    if firmware_config["command"]:
+        if args.verbose:
+            print(firmware_config["command"])
+        subprocess.run(firmware_config["command"], check=True)
+    if firmware_config["file"]:
+        return firmware_config["file"]
+    elif firmware_config["env"]:
+        return os.getenv(firmware_config["env"])
+    else:
+        return None
+
+def build_igvm_files(args, helpers, igvm_config, parts_config):
+    """
+    Iterates over the IGVM specifications and builds the hypervisor soecific
+    IGVM files.
+
+    Args:
+      args: A structure initialized from command line options.
+      helpers: A Python dictionary with the helper tools to use, as returned by
+               build_helpers().
+      igvm_config: A Python dictionary with targets as keys and specific build
+                   parameter dictionaries as values.
+      parts_config: A Python dictionary with information about the COCONUT
+                    kernel parts and firmware to include in all IGVM files.
+      
+    """
+    for target, config in igvm_config.items():
+        build_igvm_file_one(args, helpers, config, parts_config)
+
+def build_igvm_file_one(args, helpers, igvm_config, parts_config):
+    """
+    Takes the collected information and binaries and builds one hypervisor
+    specific IGVM file. It will also invoke igvmmeasure to calculate the
+    expected launch measurement.
+
+    Args:
+      args: A structure initialized from command line options.
+      helpers: A Python dictionary with the helper tools to use, as returned by
+               build_helpers().
+      igvm_config: A Python dictionary with all necessary information and
+                   parameters to build the IGVM file.
+      parts_config: A Python dictionary with information about the COCONUT
+                    kernel parts and firmware to include in all IGVM files.
+    """
+
+    output_path = "bin/{}".format(igvm_config["output"]);
+
+    ###################################################################
+    # IGVMBUILDER Command
+    ###################################################################
+    command = [
+        helpers["igvmbuilder"],
+        "--sort",
+        "--output", output_path,
+        "--policy", igvm_config["policy"],
+        "--stage2", parts_config["stage2"],
+        "--kernel", parts_config["kernel"]
+    ]
+
+    if parts_config["tdx-stage1"]:
+        command.extend(["--tdx-stage1", parts_config["tdx-stage1"]])
+
+    if igvm_config["comport"]:
+        command.extend(["--comport", igvm_config["comport"]])
+
+    for platform in igvm_config["platforms"]:
+        if platform == "native":
+            command.append("--native")
+        elif platform == "vsm":
+            command.append("--vsm")
+        elif platform == "snp":
+            command.append("--snp")
+        elif platform == "tdp":
+            command.append("--tdp")
+        else:
+            raise ValueError("Unknown IGVM platform type: {}".format(platform))
+
+    if parts_config["firmware"]:
+        command.extend(["--firmware", parts_config["firmware"]])
+
+    command.append(igvm_config["target"])
+
+    # Run igvmbuilder
+    if args.verbose:
+        print(command)
+    subprocess.run(command, check=True)
+
+    ###################################################################
+    # IGVMMEASURE Command
+    ###################################################################
+    command = [ helpers["igvmmeasure"] ]
+    if igvm_config["check-kvm"]:
+        command.append("--check-kvm")
+    if igvm_config["measure-native-zeroes"]:
+        command.append("--native-zero")
+
+    command.append(output_path)
+
+    if igvm_config["measure"] == "print":
+        command.append("measure")
+    else:
+        raise ValueError("Unknown measure type {}".format(igvm_config["measure"]))
+
+    # Run igvmmeasure
+    if args.verbose:
+        print(command)
+    subprocess.run(command, check=True)
+
+def build_one(recipe, helpers, args):
+    """
+    Builds all required components and generates the IGVM output file. From the
+    generated file it calculates and prints the expected launch measurement.
+
+    Args:
+      recipe: File path to the JSON build recipe.
+      helpers: Dictionary pointing to helper binaries.
+      args: A structure initialized from command line options.
+    """
+
+    # Load and parse JSON file with the build recipe.
+    config = read_recipe(recipe)
+
+    # Retrieve build configurations
+    k_recipe = kernel_recipe(config)
+    igvm_config = igvm_recipe(config)
+    firmware_config = firmware_recipe(config)
+
+    # Build all parts of the COCONUT kernel
+    kernel_parts = build_kernel_parts(k_recipe, args)
+
+    parts_cfg = {}
+
+    parts_cfg["stage2"] = kernel_parts.get("stage2")
+    parts_cfg["kernel"] = kernel_parts.get("svsm")
+    parts_cfg["tdx-stage1"] = kernel_parts.get("tdx-stage1", None)
+
+    # Build/Retrieve firmware to include into IGVM file
+    parts_cfg["firmware"] = build_firmware(args, firmware_config)
+
+    # Create the IGVM file
+    build_igvm_files(args, helpers, igvm_config, parts_cfg)
+
+def build(args):
+    """
+    Main build function. It builds the helpers and then calls build_one for
+    each passed recipe.
+
+    Args:
+      args: A structure initialized from command line options.
+    """
+	# Create output directory if it does not exist yet.
+    if not os.path.exists("bin"):
+        os.mkdir("bin")
+
+    try:
+        # Build required helpers
+        helpers = build_helpers(args)
+
+        for recipe in args.recipe:
+            build_one(recipe, helpers, args)
+
+    except FileNotFoundError as f:
+        print(f"Error: {f}")
+    except json.JSONDecodeError as e:
+        print(f"Error: {recipe}: {e}")
+    except subprocess.CalledProcessError as e:
+        print(f"Error: {e}")
+    except ValueError as verr:
+        print(f"Error: {verr}")
+
+def parse_arguments():
+    """Parses command-line arguments."""
+
+    parser = argparse.ArgumentParser(description="Build tool for COCONUT-SVSM.")
+    parser.add_argument(
+        "-r",
+        "--release",
+        action="store_true",
+        help="Perform a release build (default: debug)"
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable verbose output"
+    )
+    parser.add_argument(
+        "-o",
+        "--offline",
+        action="store_true",
+        help="Perform an offline build"
+    )
+    parser.add_argument(
+        "recipe",
+	nargs="+",
+        metavar="RECIPE", 
+        help="Path to the JSON build recipe file"
+    )
+    return parser.parse_args()
+
+if __name__ == "__main__":
+    build(parse_arguments())
+


### PR DESCRIPTION
Add a Python script which loads build recipes from JSON files, builds COCONUT and packages it into an IGVM file.

This script is the foundation for building user-space components and package them up into a file-system image during the build process.

**Update**: With the latest version the build script supports generating multiple IGVM files with one recipe. The use-case is mostly compile-testing, as per-target firmware files are not supported.

Closes: #65 