### PR TITLE
workspace: enable `unsafe_op_in_unsafe_fn` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ rust_2018_idioms = { level = "deny", priority = 1 }
 missing_debug_implementations = { level = "deny", priority = 50 }
 single_use_lifetimes = { level = "warn", priority = 125 }
 trivial-numeric-casts = { level = "deny", priority = 10 }
+unsafe_op_in_unsafe_fn = { level = "deny", priority = 2 }
 
 [workspace.lints.clippy]
 await_holding_lock = "warn"

--- a/fuzz/fuzz_targets/page_alloc.rs
+++ b/fuzz/fuzz_targets/page_alloc.rs
@@ -68,7 +68,7 @@ fn get_item<T>(v: &[T], idx: usize) -> Option<&T> {
 
 #[inline]
 unsafe fn fill_page(page: VirtAddr, byte: u8) {
-    page.as_mut_ptr::<u8>().write_bytes(byte, PAGE_SIZE)
+    unsafe { page.as_mut_ptr::<u8>().write_bytes(byte, PAGE_SIZE) }
 }
 
 #[inline]

--- a/kernel/src/address.rs
+++ b/kernel/src/address.rs
@@ -242,7 +242,7 @@ impl VirtAddr {
     #[inline]
     pub unsafe fn aligned_ref<'a, T>(&self) -> Option<&'a T> {
         self.is_aligned_to::<T>()
-            .then(|| self.as_ptr::<T>().as_ref())
+            .then(|| unsafe { self.as_ptr::<T>().as_ref() })
             .flatten()
     }
 
@@ -256,7 +256,7 @@ impl VirtAddr {
     #[inline]
     pub unsafe fn aligned_mut<'a, T>(&self) -> Option<&'a mut T> {
         self.is_aligned_to::<T>()
-            .then(|| self.as_mut_ptr::<T>().as_mut())
+            .then(|| unsafe { self.as_mut_ptr::<T>().as_mut() })
             .flatten()
     }
 
@@ -279,7 +279,7 @@ impl VirtAddr {
     /// All Safety requirements from [`core::slice::from_raw_parts`] for the
     /// data pointed to by the `VirtAddr` apply here as well.
     pub unsafe fn to_slice<T>(&self, len: usize) -> &[T] {
-        slice::from_raw_parts::<T>(self.as_ptr::<T>(), len)
+        unsafe { slice::from_raw_parts::<T>(self.as_ptr::<T>(), len) }
     }
 }
 

--- a/kernel/src/cpu/gdt.rs
+++ b/kernel/src/cpu/gdt.rs
@@ -79,12 +79,16 @@ impl GDT {
 
         let tss_entries = &self.entries[idx..idx + 1].as_mut_ptr();
 
-        tss_entries.add(0).write_volatile(desc0);
-        tss_entries.add(1).write_volatile(desc1);
+        unsafe {
+            tss_entries.add(0).write_volatile(desc0);
+            tss_entries.add(1).write_volatile(desc1);
+        }
     }
 
     unsafe fn clear_tss_entry(&mut self) {
-        self.set_tss_entry(GDTEntry::null(), GDTEntry::null());
+        unsafe {
+            self.set_tss_entry(GDTEntry::null(), GDTEntry::null());
+        }
     }
 
     pub fn load_tss(&mut self, tss: &X86Tss) {

--- a/kernel/src/cpu/irq_state.rs
+++ b/kernel/src/cpu/irq_state.rs
@@ -20,7 +20,9 @@ const EFLAGS_IF: u64 = 1 << 9;
 /// Callers need to take care of re-enabling IRQs.
 #[inline(always)]
 pub unsafe fn raw_irqs_disable() {
-    asm!("cli", options(att_syntax, preserves_flags, nomem));
+    unsafe {
+        asm!("cli", options(att_syntax, preserves_flags, nomem));
+    }
 }
 
 /// Unconditionally enable IRQs
@@ -32,7 +34,9 @@ pub unsafe fn raw_irqs_disable() {
 /// have been enabled.
 #[inline(always)]
 pub unsafe fn raw_irqs_enable() {
-    asm!("sti", options(att_syntax, preserves_flags, nomem));
+    unsafe {
+        asm!("sti", options(att_syntax, preserves_flags, nomem));
+    }
 
     // Now that interrupts are enabled, process any #HV events that may be
     // pending.
@@ -111,7 +115,9 @@ impl IrqState {
     pub unsafe fn disable(&self) {
         let state = irqs_enabled();
 
-        raw_irqs_disable();
+        unsafe {
+            raw_irqs_disable();
+        }
         let val = self.count.fetch_add(1, Ordering::Relaxed);
 
         assert!(val >= 0);
@@ -139,7 +145,9 @@ impl IrqState {
         if val == 1 {
             let state = self.state.load(Ordering::Relaxed);
             if state {
-                raw_irqs_enable();
+                unsafe {
+                    raw_irqs_enable();
+                }
             }
         }
     }

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -91,7 +91,7 @@ impl PerCpuAreas {
     }
 
     unsafe fn push(&self, info: PerCpuInfo) {
-        let ptr = self.areas.get().as_mut().unwrap();
+        let ptr = unsafe { self.areas.get().as_mut().unwrap() };
         ptr.push(info);
     }
 
@@ -383,7 +383,9 @@ impl PerCpu {
     /// `enable()` call.
     #[inline(always)]
     pub unsafe fn irqs_disable(&self) {
-        self.irq_state.disable();
+        unsafe {
+            self.irq_state.disable();
+        }
     }
 
     /// Reduces IRQ-disable nesting level on the current CPU and restores the
@@ -395,7 +397,9 @@ impl PerCpu {
     /// `enable()` call.
     #[inline(always)]
     pub unsafe fn irqs_enable(&self) {
-        self.irq_state.enable();
+        unsafe {
+            self.irq_state.enable();
+        }
     }
 
     /// Get IRQ-disable nesting count on the current CPU
@@ -982,7 +986,9 @@ pub fn this_cpu_shared() -> &'static PerCpuShared {
 /// `irqs_enable()` call.
 #[inline(always)]
 pub unsafe fn irqs_disable() {
-    this_cpu().irqs_disable();
+    unsafe {
+        this_cpu().irqs_disable();
+    }
 }
 
 /// Reduces IRQ-disable nesting level on the current CPU and restores the
@@ -994,7 +1000,9 @@ pub unsafe fn irqs_disable() {
 /// `irqs_enable()` call.
 #[inline(always)]
 pub unsafe fn irqs_enable() {
-    this_cpu().irqs_enable();
+    unsafe {
+        this_cpu().irqs_enable();
+    }
 }
 
 /// Get IRQ-disable nesting count on the current CPU

--- a/kernel/src/cpu/sse.rs
+++ b/kernel/src/cpu/sse.rs
@@ -79,14 +79,16 @@ pub fn sse_init() {
 /// no other part of the code is accessing this memory at the same time.
 pub unsafe fn sse_save_context(addr: u64) {
     let save_bits = XCR0_X87_ENABLE | XCR0_SSE_ENABLE | XCR0_YMM_ENABLE;
-    asm!(
-        r#"
-        xsaveopt (%rsi)
-        "#,
-        in("rsi") addr,
-        in("rax") save_bits,
-        in("rdx") 0,
-        options(att_syntax));
+    unsafe {
+        asm!(
+            r#"
+            xsaveopt (%rsi)
+            "#,
+            in("rsi") addr,
+            in("rax") save_bits,
+            in("rdx") 0,
+            options(att_syntax));
+    }
 }
 
 /// # Safety
@@ -95,12 +97,14 @@ pub unsafe fn sse_save_context(addr: u64) {
 /// no other part of the code is accessing this memory at the same time.
 pub unsafe fn sse_restore_context(addr: u64) {
     let save_bits = XCR0_X87_ENABLE | XCR0_SSE_ENABLE | XCR0_YMM_ENABLE;
-    asm!(
-        r#"
-        xrstor (%rsi)
-        "#,
-        in("rsi") addr,
-        in("rax") save_bits,
-        in("rdx") 0,
-        options(att_syntax));
+    unsafe {
+        asm!(
+            r#"
+            xrstor (%rsi)
+            "#,
+            in("rsi") addr,
+            in("rax") save_bits,
+            in("rdx") 0,
+            options(att_syntax));
+    }
 }

--- a/kernel/src/insn_decode/insn.rs
+++ b/kernel/src/insn_decode/insn.rs
@@ -334,11 +334,13 @@ pub mod test_utils {
         type Item = T;
 
         unsafe fn mem_read(&self) -> Result<Self::Item, InsnError> {
-            Ok(*(self.ptr))
+            Ok(unsafe { *(self.ptr) })
         }
 
         unsafe fn mem_write(&mut self, data: Self::Item) -> Result<(), InsnError> {
-            *(self.ptr) = data;
+            unsafe {
+                *(self.ptr) = data;
+            }
             Ok(())
         }
     }

--- a/kernel/src/mm/alloc.rs
+++ b/kernel/src/mm/alloc.rs
@@ -426,7 +426,7 @@ impl MemoryRegion {
     /// undefined, as the compiler is allowed to optimize assuming there will
     /// be no arithmetic overflows.
     unsafe fn page_info_mut_ptr(&mut self, pfn: usize) -> *mut PageStorageType {
-        self.start_virt.as_mut_ptr::<PageStorageType>().add(pfn)
+        unsafe { self.start_virt.as_mut_ptr::<PageStorageType>().add(pfn) }
     }
 
     /// Gets a pointer to the page information for a given page frame number.
@@ -437,7 +437,7 @@ impl MemoryRegion {
     /// undefined, as the compiler is allowed to optimize assuming there will
     /// be no arithmetic overflows.
     unsafe fn page_info_ptr(&self, pfn: usize) -> *const PageStorageType {
-        self.start_virt.as_ptr::<PageStorageType>().add(pfn)
+        unsafe { self.start_virt.as_ptr::<PageStorageType>().add(pfn) }
     }
 
     /// Checks if a page frame number is valid.

--- a/kernel/src/mm/guestmem.rs
+++ b/kernel/src/mm/guestmem.rs
@@ -90,18 +90,20 @@ unsafe fn read_u16(v: VirtAddr) -> Result<u16, SvsmError> {
     let mut rcx: u64;
     let mut val: u64;
 
-    asm!("1: movw ({0}), {1}",
-         "   xorq %rcx, %rcx",
-         "2:",
-         ".pushsection \"__exception_table\",\"a\"",
-         ".balign 16",
-         ".quad (1b)",
-         ".quad (2b)",
-         ".popsection",
-            in(reg) v.bits(),
-            out(reg) val,
-            out("rcx") rcx,
-            options(att_syntax, nostack));
+    unsafe {
+        asm!("1: movw ({0}), {1}",
+             "   xorq %rcx, %rcx",
+             "2:",
+             ".pushsection \"__exception_table\",\"a\"",
+             ".balign 16",
+             ".quad (1b)",
+             ".quad (2b)",
+             ".popsection",
+                in(reg) v.bits(),
+                out(reg) val,
+                out("rcx") rcx,
+                options(att_syntax, nostack));
+    }
 
     let ret: u16 = (val & 0xffff) as u16;
     if rcx == 0 {
@@ -117,18 +119,20 @@ unsafe fn read_u32(v: VirtAddr) -> Result<u32, SvsmError> {
     let mut rcx: u64;
     let mut val: u64;
 
-    asm!("1: movl ({0}), {1}",
-         "   xorq %rcx, %rcx",
-         "2:",
-         ".pushsection \"__exception_table\",\"a\"",
-         ".balign 16",
-         ".quad (1b)",
-         ".quad (2b)",
-         ".popsection",
-            in(reg) v.bits(),
-            out(reg) val,
-            out("rcx") rcx,
-            options(att_syntax, nostack));
+    unsafe {
+        asm!("1: movl ({0}), {1}",
+             "   xorq %rcx, %rcx",
+             "2:",
+             ".pushsection \"__exception_table\",\"a\"",
+             ".balign 16",
+             ".quad (1b)",
+             ".quad (2b)",
+             ".popsection",
+                in(reg) v.bits(),
+                out(reg) val,
+                out("rcx") rcx,
+                options(att_syntax, nostack));
+    }
 
     let ret: u32 = (val & 0xffffffff) as u32;
     if rcx == 0 {
@@ -144,19 +148,20 @@ unsafe fn read_u64(v: VirtAddr) -> Result<u64, SvsmError> {
     let mut rcx: u64;
     let mut val: u64;
 
-    asm!("1: movq ({0}), {1}",
-         "   xorq %rcx, %rcx",
-         "2:",
-         ".pushsection \"__exception_table\",\"a\"",
-         ".balign 16",
-         ".quad (1b)",
-         ".quad (2b)",
-         ".popsection",
-            in(reg) v.bits(),
-            out(reg) val,
-            out("rcx") rcx,
-            options(att_syntax, nostack));
-
+    unsafe {
+        asm!("1: movq ({0}), {1}",
+             "   xorq %rcx, %rcx",
+             "2:",
+             ".pushsection \"__exception_table\",\"a\"",
+             ".balign 16",
+             ".quad (1b)",
+             ".quad (2b)",
+             ".popsection",
+                in(reg) v.bits(),
+                out(reg) val,
+                out("rcx") rcx,
+                options(att_syntax, nostack));
+    }
     if rcx == 0 {
         Ok(val)
     } else {
@@ -169,18 +174,20 @@ unsafe fn do_movsb<T>(src: *const T, dst: *mut T) -> Result<(), SvsmError> {
     let size: usize = size_of::<T>();
     let mut rcx: u64;
 
-    asm!("1:cld
-            rep movsb
-          2:
-         .pushsection \"__exception_table\",\"a\"
-         .balign 16
-         .quad (1b)
-         .quad (2b)
-         .popsection",
-            inout("rsi") src => _,
-            inout("rdi") dst => _,
-            inout("rcx") size => rcx,
-            options(att_syntax, nostack));
+    unsafe {
+        asm!("1:cld
+                rep movsb
+              2:
+             .pushsection \"__exception_table\",\"a\"
+             .balign 16
+             .quad (1b)
+             .quad (2b)
+             .popsection",
+                inout("rsi") src => _,
+                inout("rdi") dst => _,
+                inout("rcx") size => rcx,
+                options(att_syntax, nostack));
+    }
 
     if rcx == 0 {
         Ok(())
@@ -269,12 +276,12 @@ impl<T: Copy> InsnMachineMem for GuestPtr<T> {
 
     /// Safety: See the GuestPtr's read() method documentation for safety requirements.
     unsafe fn mem_read(&self) -> Result<Self::Item, InsnError> {
-        self.read().map_err(|_| InsnError::MemRead)
+        unsafe { self.read().map_err(|_| InsnError::MemRead) }
     }
 
     /// Safety: See the GuestPtr's write() method documentation for safety requirements.
     unsafe fn mem_write(&mut self, data: Self::Item) -> Result<(), InsnError> {
-        self.write(data).map_err(|_| InsnError::MemWrite)
+        unsafe { self.write(data).map_err(|_| InsnError::MemWrite) }
     }
 }
 

--- a/kernel/src/mm/pagebox.rs
+++ b/kernel/src/mm/pagebox.rs
@@ -128,9 +128,11 @@ impl<T> PageBox<MaybeUninit<T>> {
     ///
     /// See the safety requirements for [`MaybeUninit::assume_init()`].
     pub unsafe fn assume_init(self) -> PageBox<T> {
-        let leaked = PageBox::leak(self).assume_init_mut();
-        let raw = NonNull::from(leaked);
-        PageBox::from_raw(raw)
+        unsafe {
+            let leaked = PageBox::leak(self).assume_init_mut();
+            let raw = NonNull::from(leaked);
+            PageBox::from_raw(raw)
+        }
     }
 }
 
@@ -179,7 +181,7 @@ impl<T> PageBox<[MaybeUninit<T>]> {
         let inited = NonNull::slice_from_raw_parts(leaked.cast(), leaked.len());
         // We obtained this pointer from a previously leaked allocation, so
         // this is safe.
-        PageBox::from_raw(inited)
+        unsafe { PageBox::from_raw(inited) }
     }
 }
 

--- a/kernel/src/mm/pagetable.rs
+++ b/kernel/src/mm/pagetable.rs
@@ -371,7 +371,7 @@ impl PTEntry {
     /// raw pointer read.  The caller must be certain to calculate the correct
     /// address.
     pub unsafe fn read_pte(vaddr: VirtAddr) -> Self {
-        *vaddr.as_ptr::<Self>()
+        unsafe { *vaddr.as_ptr::<Self>() }
     }
 }
 
@@ -402,7 +402,9 @@ impl PTPage {
     /// The given reference must correspond to a valid previously allocated
     /// page table page.
     unsafe fn free(page: &'static Self) {
-        let _ = PageBox::from_raw(NonNull::from(page));
+        unsafe {
+            let _ = PageBox::from_raw(NonNull::from(page));
+        }
     }
 
     /// Converts a pagetable entry to a mutable reference to a [`PTPage`],

--- a/kernel/src/sev/utils.rs
+++ b/kernel/src/sev/utils.rs
@@ -143,9 +143,10 @@ pub fn pvalidate(vaddr: VirtAddr, size: PageSize, valid: PvalidateOp) -> Result<
 /// See cpu vendor documentation for what this can do.
 pub unsafe fn raw_vmmcall(eax: u32, ebx: u32, ecx: u32, edx: u32) -> i32 {
     let new_eax;
-    asm!(
-            // bx register is reserved by llvm so it can't be passed in directly and must be
-            // restored
+    unsafe {
+        asm!(
+            // bx register is reserved by llvm so it can't be passed in
+            // directly and must be restored
             "xchg %rbx, {0:r}",
             "vmmcall",
             "xchg %rbx, {0:r}",
@@ -154,6 +155,7 @@ pub unsafe fn raw_vmmcall(eax: u32, ebx: u32, ecx: u32, edx: u32) -> i32 {
             in("ecx") ecx,
             in("edx") edx,
             options(att_syntax));
+    }
     new_eax
 }
 
@@ -161,7 +163,9 @@ pub unsafe fn raw_vmmcall(eax: u32, ebx: u32, ecx: u32, edx: u32) -> i32 {
 /// # Safety
 /// See cpu vendor documentation for what this can do.
 pub unsafe fn set_dr7(new_val: u64) {
-    asm!("mov {0}, %dr7", in(reg) new_val, options(att_syntax));
+    unsafe {
+        asm!("mov {0}, %dr7", in(reg) new_val, options(att_syntax));
+    }
 }
 
 pub fn get_dr7() -> u64 {
@@ -176,7 +180,9 @@ pub fn get_dr7() -> u64 {
 /// exiting to the host.  It is the caller's responsibility to ensure that
 /// interrupt handling is configured correctly for the attemtped operation.
 pub unsafe fn raw_vmgexit() {
-    asm!("rep; vmmcall", options(att_syntax));
+    unsafe {
+        asm!("rep; vmmcall", options(att_syntax));
+    }
 }
 
 bitflags::bitflags! {

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -74,7 +74,9 @@ fn init_percpu(platform: &mut dyn SvsmPlatform) -> Result<(), SvsmError> {
 /// The caller must ensure that the `PerCpu` is never used again.
 unsafe fn shutdown_percpu() {
     let ptr = SVSM_PERCPU_BASE.as_mut_ptr::<PerCpu>();
-    core::ptr::drop_in_place(ptr);
+    unsafe {
+        core::ptr::drop_in_place(ptr);
+    }
 }
 
 fn setup_env(

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -302,17 +302,19 @@ unsafe fn task_pointer(taskptr: TaskPointer) -> *const Task {
 
 #[inline(always)]
 unsafe fn switch_to(prev: *const Task, next: *const Task) {
-    let cr3: u64 = unsafe { (*next).page_table.lock().cr3_value().bits() as u64 };
+    unsafe {
+        let cr3: u64 = (*next).page_table.lock().cr3_value().bits() as u64;
 
-    // Switch to new task
-    asm!(
-        r#"
-        call switch_context
-        "#,
-        in("rsi") prev as u64,
-        in("rdi") next as u64,
-        in("rdx") cr3,
-        options(att_syntax));
+        // Switch to new task
+        asm!(
+            r#"
+            call switch_context
+            "#,
+            in("rsi") prev as u64,
+            in("rdi") next as u64,
+            in("rdx") cr3,
+            options(att_syntax));
+    }
 }
 
 /// Initializes the [RunQueue] on the current CPU. It will switch to the idle

--- a/kernel/src/utils/immut_after_init.rs
+++ b/kernel/src/utils/immut_after_init.rs
@@ -122,14 +122,16 @@ impl<T: Copy> ImmutAfterInitCell<T> {
     // The caller must check the initialization status to avoid double init bugs
     unsafe fn set_inner(&self, v: &T) {
         self.set_init();
-        (*self.data.get())
-            .as_mut_ptr()
-            .copy_from_nonoverlapping(v, 1)
+        unsafe {
+            (*self.data.get())
+                .as_mut_ptr()
+                .copy_from_nonoverlapping(v, 1)
+        }
     }
 
     // The caller must ensure that the cell is initialized
     unsafe fn get_inner(&self) -> &T {
-        (*self.data.get()).assume_init_ref()
+        unsafe { (*self.data.get()).assume_init_ref() }
     }
 
     fn try_get_inner(&self) -> ImmutAfterInitResult<&T> {

--- a/syscall/src/call.rs
+++ b/syscall/src/call.rs
@@ -20,28 +20,30 @@ macro_rules! syscall {
             #[allow(dead_code)]
             pub unsafe fn $name($a: u64, $($b: u64, $($c: u64, $($d: u64, $($e: u64, $($f: u64)?)?)?)?)?) -> Result<u64, SysCallError> {
                 let mut ret = $a;
-                asm!(
-                    "int 0x80",
-                    inout("rax") ret,
-                    $(
-                        in("rdi") $b,
+                unsafe {
+                    asm!(
+                        "int 0x80",
+                        inout("rax") ret,
                         $(
-                            in("rsi") $c,
+                            in("rdi") $b,
                             $(
-                                in("r8") $d,
+                                in("rsi") $c,
                                 $(
-                                    in("r9") $e,
+                                    in("r8") $d,
                                     $(
-                                        in("r10") $f,
+                                        in("r9") $e,
+                                        $(
+                                            in("r10") $f,
+                                        )?
                                     )?
                                 )?
                             )?
                         )?
-                    )?
-                    out("rcx") _,
-                    out("r11") _,
-                    options(nostack),
-                );
+                        out("rcx") _,
+                        out("r11") _,
+                        options(nostack),
+                    );
+                }
 
                 if ret > (u64::MAX - u64::from(u16::MAX)) {
                     return Err(SysCallError::from(ret as i32));


### PR DESCRIPTION
It is good to mark functions as `unsafe` when the safety of their behavior is not guaranteed.  It is not goot to permit these functions to perform additional unsafe operations without warning.  All uses of unsafe code should require explicit `unsafe` annotation regardless of whether they appear in safe or unsafe functions.