### PR TITLE
cpu/sse: Make use of extended SSE optional

### DIFF
--- a/kernel/src/cpu/sse.rs
+++ b/kernel/src/cpu/sse.rs
@@ -8,6 +8,7 @@ use crate::cpu::control_regs::{cr0_sse_enable, cr4_osfxsr_enable, cr4_xsave_enab
 use crate::cpu::cpuid::CpuidResult;
 use core::arch::asm;
 use core::arch::x86_64::{_xgetbv, _xsetbv};
+use core::sync::atomic::{AtomicU64, Ordering};
 
 const CPUID_EDX_SSE1: u32 = 25;
 const CPUID_ECX_XSAVE: u32 = 26;
@@ -15,6 +16,8 @@ const CPUID_EAX_XSAVEOPT: u32 = 0;
 const XCR0_X87_ENABLE: u64 = 0x1;
 const XCR0_SSE_ENABLE: u64 = 0x2;
 const XCR0_YMM_ENABLE: u64 = 0x4;
+
+static SVSM_XCR0: AtomicU64 = AtomicU64::new(XCR0_X87_ENABLE | XCR0_SSE_ENABLE);
 
 fn legacy_sse_supported() -> bool {
     let res = CpuidResult::get(1, 0);
@@ -48,7 +51,7 @@ fn xsaveopt_supported() -> bool {
 fn xcr0_set() {
     unsafe {
         // set bits [0-2] in XCR0 to enable extended SSE
-        let xr0 = _xgetbv(0) | XCR0_X87_ENABLE | XCR0_SSE_ENABLE | XCR0_YMM_ENABLE;
+        let xr0 = _xgetbv(0) | SVSM_XCR0.load(Ordering::Relaxed);
         _xsetbv(0, xr0);
     }
 }
@@ -58,19 +61,22 @@ pub fn get_xsave_area_size() -> u32 {
     res.ecx
 }
 
-fn extended_sse_enable() {
-    if extended_sse_supported() && xsave_supported() && xsaveopt_supported() {
+fn xsave_enable() {
+    if xsave_supported() && xsaveopt_supported() {
+        if extended_sse_supported() {
+            SVSM_XCR0.fetch_or(XCR0_YMM_ENABLE, Ordering::Relaxed);
+        }
         cr4_xsave_enable();
         xcr0_set();
     } else {
-        panic!("extended SSE unsupported");
+        panic!("xsave unsupported");
     }
 }
 
 // Enable media and x87 instructions
 pub fn sse_init() {
     legacy_sse_enable();
-    extended_sse_enable();
+    xsave_enable();
 }
 
 /// # Safety
@@ -78,7 +84,7 @@ pub fn sse_init() {
 /// context. This context store is specific to a task and
 /// no other part of the code is accessing this memory at the same time.
 pub unsafe fn sse_save_context(addr: u64) {
-    let save_bits = XCR0_X87_ENABLE | XCR0_SSE_ENABLE | XCR0_YMM_ENABLE;
+    let save_bits = SVSM_XCR0.load(Ordering::Relaxed);
     asm!(
         r#"
         xsaveopt (%rsi)
@@ -94,7 +100,7 @@ pub unsafe fn sse_save_context(addr: u64) {
 /// context. This context store is specific to a task and
 /// no other part of the code is accessing this memory at the same time.
 pub unsafe fn sse_restore_context(addr: u64) {
-    let save_bits = XCR0_X87_ENABLE | XCR0_SSE_ENABLE | XCR0_YMM_ENABLE;
+    let save_bits = SVSM_XCR0.load(Ordering::Relaxed);
     asm!(
         r#"
         xrstor (%rsi)


### PR DESCRIPTION
Hosts may choose to suppress the availablity of extended SSE state.  This should not prevent the SVSM from running, as it should be able to adapt to the SSE feature set that is available.