### PR TITLE
svsm: Enable CET on the target processor

### DIFF
--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -735,9 +735,6 @@ impl PerCpu {
         vmsa.tr = self.vmsa_tr_segment();
         vmsa.rip = start_rip;
         vmsa.rsp = self.get_top_of_stack().into();
-        if is_cet_ss_supported() {
-            vmsa.ssp = self.get_top_of_shadow_stack().into();
-        }
         vmsa.cr3 = self.get_pgtable().cr3_value().into();
         vmsa.enable();
 

--- a/kernel/src/cpu/shadow_stack.rs
+++ b/kernel/src/cpu/shadow_stack.rs
@@ -61,8 +61,6 @@ pub fn is_cet_ss_supported() -> bool {
 macro_rules! enable_shadow_stacks {
     ($bsp_percpu:ident) => {{
         use core::arch::asm;
-        use svsm::address::Address;
-        use svsm::cpu::shadow_stack::{SCetFlags, MODE_64BIT, S_CET};
 
         let token_addr = $bsp_percpu.get_top_of_shadow_stack();
 

--- a/kernel/src/cpu/vmsa.rs
+++ b/kernel/src/cpu/vmsa.rs
@@ -13,7 +13,6 @@ use super::control_regs::{read_cr0, read_cr3, read_cr4};
 use super::efer::read_efer;
 use super::gdt;
 use super::idt::common::idt;
-use super::shadow_stack::{is_cet_ss_supported, read_s_cet};
 
 fn svsm_code_segment() -> VMSASegment {
     VMSASegment {
@@ -67,9 +66,6 @@ pub fn init_svsm_vmsa(vmsa: &mut VMSA, vtom: u64) {
     vmsa.cr3 = read_cr3().bits() as u64;
     vmsa.cr4 = read_cr4().bits();
     vmsa.efer = read_efer().bits();
-    if is_cet_ss_supported() {
-        vmsa.s_cet = read_s_cet().bits();
-    }
 
     vmsa.rflags = 0x2;
     vmsa.dr6 = 0xffff0ff0;

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -7,32 +7,31 @@
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(not(test), no_main)]
 
-use svsm::cpu::shadow_stack::{determine_cet_support, is_cet_ss_supported};
-use svsm::enable_shadow_stacks;
-use svsm::fw_meta::{print_fw_meta, validate_fw_memory, SevFWMetaData};
-
 use bootlib::kernel_launch::KernelLaunchInfo;
 use core::arch::global_asm;
 use core::panic::PanicInfo;
 use core::slice;
 use cpuarch::snp_cpuid::SnpCpuidTable;
-use svsm::address::{PhysAddr, VirtAddr};
+use svsm::address::{Address, PhysAddr, VirtAddr};
 use svsm::config::SvsmConfig;
 use svsm::console::install_console_logger;
 use svsm::cpu::control_regs::{cr0_init, cr4_init};
 use svsm::cpu::cpuid::{dump_cpuid_table, register_cpuid_table};
 use svsm::cpu::gdt;
 use svsm::cpu::idt::svsm::{early_idt_init, idt_init};
-use svsm::cpu::percpu::current_ghcb;
-use svsm::cpu::percpu::PerCpu;
-use svsm::cpu::percpu::{this_cpu, this_cpu_shared};
+use svsm::cpu::percpu::{current_ghcb, this_cpu, this_cpu_shared, PerCpu};
+use svsm::cpu::shadow_stack::{
+    determine_cet_support, is_cet_ss_supported, SCetFlags, MODE_64BIT, S_CET,
+};
 use svsm::cpu::smp::start_secondary_cpus;
 use svsm::cpu::sse::sse_init;
 use svsm::debug::gdbstub::svsm_gdbstub::{debug_break, gdbstub_start};
 use svsm::debug::stacktrace::print_stack;
+use svsm::enable_shadow_stacks;
 use svsm::error::SvsmError;
 use svsm::fs::{initialize_fs, populate_ram_fs};
 use svsm::fw_cfg::FwCfg;
+use svsm::fw_meta::{print_fw_meta, validate_fw_memory, SevFWMetaData};
 use svsm::igvm_params::IgvmParams;
 use svsm::kernel_region::new_kernel_region;
 use svsm::mm::alloc::{memory_info, print_memory_info, root_mem_init};


### PR DESCRIPTION
The method of configuring SSP/MSR_S_CET via the VMSA only works on SNP and is not applicable to any other platform.  Enabling CET and configuring the shadow stack on the target processor is a technique that will work correctly on all platforms.