### PR TITLE
kernel/tdx: Fix TDX error codes

### DIFF
--- a/kernel/src/mm/pagetable.rs
+++ b/kernel/src/mm/pagetable.rs
@@ -453,7 +453,7 @@ pub enum Mapping<'a> {
 }
 
 /// A physical address within a page frame
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum PageFrame {
     Size4K(PhysAddr),
     Size2M(PhysAddr),

--- a/kernel/src/tdx/error.rs
+++ b/kernel/src/tdx/error.rs
@@ -41,3 +41,9 @@ pub fn tdx_result(err: u64) -> Result<TdxSuccess, TdxError> {
         }
     }
 }
+
+pub fn tdx_recoverable_error(err: u64) -> bool {
+    // Bit 63: ERROR
+    // Bit 62: NON_RECOVERABLE
+    (err >> 62) == 2
+}

--- a/kernel/src/tdx/error.rs
+++ b/kernel/src/tdx/error.rs
@@ -17,6 +17,13 @@ pub enum TdxSuccess {
 pub enum TdxError {
     PageSizeMismatch,
     Unimplemented,
+    Vmcall(TdVmcallError),
+    Unknown(u64),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum TdVmcallError {
+    OperandInvalid,
     Unknown(u64),
 }
 
@@ -46,4 +53,12 @@ pub fn tdx_recoverable_error(err: u64) -> bool {
     // Bit 63: ERROR
     // Bit 62: NON_RECOVERABLE
     (err >> 62) == 2
+}
+
+pub fn tdvmcall_result(err: u64) -> Result<(), TdxError> {
+    match err {
+        0 => Ok(()),
+        0x8000_0000_0000_0000 => Err(TdxError::Vmcall(TdVmcallError::OperandInvalid)),
+        _ => Err(TdxError::Vmcall(TdVmcallError::Unknown(err))),
+    }
 }


### PR DESCRIPTION
- Fix the definition of TdxError::PageAlreadyAccepted
- Handle TDX_OPERAND_BUSY in TDG.MEM.PAGE.ACCEPT
- Do sanity checks on status codes