### PR TITLE
kernel: remove unnecessary `unsafe`

### DIFF
--- a/kernel/src/cpu/gdt.rs
+++ b/kernel/src/cpu/gdt.rs
@@ -74,7 +74,7 @@ impl GDT {
         }
     }
 
-    unsafe fn set_tss_entry(&mut self, desc0: GDTEntry, desc1: GDTEntry) {
+    fn set_tss_entry(&mut self, desc0: GDTEntry, desc1: GDTEntry) {
         let idx = (SVSM_TSS / 8) as usize;
 
         let tss_entries = &self.entries[idx..idx + 1].as_mut_ptr();
@@ -85,10 +85,8 @@ impl GDT {
         }
     }
 
-    unsafe fn clear_tss_entry(&mut self) {
-        unsafe {
-            self.set_tss_entry(GDTEntry::null(), GDTEntry::null());
-        }
+    fn clear_tss_entry(&mut self) {
+        self.set_tss_entry(GDTEntry::null(), GDTEntry::null());
     }
 
     pub fn load_tss(&mut self, tss: &X86Tss) {

--- a/kernel/src/cpu/irq_state.rs
+++ b/kernel/src/cpu/irq_state.rs
@@ -15,11 +15,9 @@ const EFLAGS_IF: u64 = 1 << 9;
 
 /// Unconditionally disable IRQs
 ///
-/// # Safety
-///
 /// Callers need to take care of re-enabling IRQs.
 #[inline(always)]
-pub unsafe fn raw_irqs_disable() {
+pub fn raw_irqs_disable() {
     unsafe {
         asm!("cli", options(att_syntax, preserves_flags, nomem));
     }
@@ -27,13 +25,11 @@ pub unsafe fn raw_irqs_disable() {
 
 /// Unconditionally enable IRQs
 ///
-/// # Safety
-///
 /// Callers need to make sure it is safe to enable IRQs. e.g. that no data
 /// structures or locks which are accessed in IRQ handlers are used after IRQs
 /// have been enabled.
 #[inline(always)]
-pub unsafe fn raw_irqs_enable() {
+pub fn raw_irqs_enable() {
     unsafe {
         asm!("sti", options(att_syntax, preserves_flags, nomem));
     }
@@ -107,17 +103,13 @@ impl IrqState {
 
     /// Increase IRQ-disable nesting level by 1. The method will disable IRQs.
     ///
-    /// # Safety
-    ///
     /// The caller needs to make sure to match the number of `disable` calls
     /// with the number of `enable` calls.
     #[inline(always)]
-    pub unsafe fn disable(&self) {
+    pub fn disable(&self) {
         let state = irqs_enabled();
 
-        unsafe {
-            raw_irqs_disable();
-        }
+        raw_irqs_disable();
         let val = self.count.fetch_add(1, Ordering::Relaxed);
 
         assert!(val >= 0);
@@ -130,12 +122,10 @@ impl IrqState {
     /// Decrease IRQ-disable nesting level by 1. The method will restore the
     /// original IRQ state when the nesting level reaches 0.
     ///
-    /// # Safety
-    ///
     /// The caller needs to make sure to match the number of `disable` calls
     /// with the number of `enable` calls.
     #[inline(always)]
-    pub unsafe fn enable(&self) {
+    pub fn enable(&self) {
         debug_assert!(irqs_disabled());
 
         let val = self.count.fetch_sub(1, Ordering::Relaxed);
@@ -145,9 +135,7 @@ impl IrqState {
         if val == 1 {
             let state = self.state.load(Ordering::Relaxed);
             if state {
-                unsafe {
-                    raw_irqs_enable();
-                }
+                raw_irqs_enable();
             }
         }
     }
@@ -164,12 +152,10 @@ impl IrqState {
     /// Changes whether interrupts will be enabled when the nesting count
     /// drops to zero.
     ///
-    /// # Safety
-    ///
     /// The caller must ensure that the current nesting count is non-zero,
     /// and must ensure that the specified value is appropriate for the
     /// current environment.
-    pub unsafe fn set_restore_state(&self, enabled: bool) {
+    pub fn set_restore_state(&self, enabled: bool) {
         assert!(self.count.load(Ordering::Relaxed) != 0);
         self.state.store(enabled, Ordering::Relaxed);
     }
@@ -198,11 +184,9 @@ pub struct IrqGuard {
 
 impl IrqGuard {
     pub fn new() -> Self {
-        // SAFETY: Safe because the struct implements `Drop`, which
-        // restores the IRQ state saved here.
-        unsafe {
-            irqs_disable();
-        }
+        // This struct implements `Drop`, which will restore the IRQ state
+        // saved here.
+        irqs_disable();
 
         Self {
             phantom: PhantomData,
@@ -218,11 +202,9 @@ impl Default for IrqGuard {
 
 impl Drop for IrqGuard {
     fn drop(&mut self) {
-        // SAFETY: Safe because the irqs_enabled() call matches the
-        // irqs_disabled() call during struct creation.
-        unsafe {
-            irqs_enable();
-        }
+        // The irqs_enabled() call matches the irqs_disabled() call during
+        // struct creation.
+        irqs_enable();
     }
 }
 
@@ -233,52 +215,46 @@ mod tests {
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn irq_enable_disable() {
-        unsafe {
-            let was_enabled = irqs_enabled();
+        let was_enabled = irqs_enabled();
+        raw_irqs_enable();
+        assert!(irqs_enabled());
+        raw_irqs_disable();
+        assert!(irqs_disabled());
+        if was_enabled {
             raw_irqs_enable();
-            assert!(irqs_enabled());
-            raw_irqs_disable();
-            assert!(irqs_disabled());
-            if was_enabled {
-                raw_irqs_enable();
-            }
         }
     }
 
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn irq_state() {
-        unsafe {
-            let state = IrqState::new();
-            let was_enabled = irqs_enabled();
-            raw_irqs_enable();
-            state.disable();
-            assert!(irqs_disabled());
-            state.disable();
-            state.enable();
-            assert!(irqs_disabled());
-            state.enable();
-            assert!(irqs_enabled());
-            if !was_enabled {
-                raw_irqs_disable();
-            }
+        let state = IrqState::new();
+        let was_enabled = irqs_enabled();
+        raw_irqs_enable();
+        state.disable();
+        assert!(irqs_disabled());
+        state.disable();
+        state.enable();
+        assert!(irqs_disabled());
+        state.enable();
+        assert!(irqs_enabled());
+        if !was_enabled {
+            raw_irqs_disable();
         }
     }
 
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn irq_guard_test() {
-        unsafe {
-            let was_enabled = irqs_enabled();
-            raw_irqs_enable();
-            assert!(irqs_enabled());
-            let g1 = IrqGuard::new();
-            assert!(irqs_disabled());
-            drop(g1);
-            assert!(irqs_enabled());
-            if !was_enabled {
-                raw_irqs_disable();
-            }
+        let was_enabled = irqs_enabled();
+        raw_irqs_enable();
+        assert!(irqs_enabled());
+        let g1 = IrqGuard::new();
+        assert!(irqs_disabled());
+        drop(g1);
+        assert!(irqs_enabled());
+        if !was_enabled {
+            raw_irqs_disable();
         }
     }
 }

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -377,29 +377,21 @@ impl PerCpu {
     /// Disables IRQs on the current CPU. Keeps track of the nesting level and
     /// the original IRQ state.
     ///
-    /// # Safety
-    ///
     /// Caller needs to make sure to match every `disable()` call with an
     /// `enable()` call.
     #[inline(always)]
-    pub unsafe fn irqs_disable(&self) {
-        unsafe {
-            self.irq_state.disable();
-        }
+    pub fn irqs_disable(&self) {
+        self.irq_state.disable();
     }
 
     /// Reduces IRQ-disable nesting level on the current CPU and restores the
     /// original IRQ state when the level reaches 0.
     ///
-    /// # Safety
-    ///
     /// Caller needs to make sure to match every `disable()` call with an
     /// `enable()` call.
     #[inline(always)]
-    pub unsafe fn irqs_enable(&self) {
-        unsafe {
-            self.irq_state.enable();
-        }
+    pub fn irqs_enable(&self) {
+        self.irq_state.enable();
     }
 
     /// Get IRQ-disable nesting count on the current CPU
@@ -934,9 +926,7 @@ impl PerCpu {
         // be received will always observe that there is a current task and
         // not the boot thread.
         if SVSM_PLATFORM.use_interrupts() {
-            unsafe {
-                self.irq_state.set_restore_state(true);
-            }
+            self.irq_state.set_restore_state(true);
         }
         let task = self.runqueue.lock_write().schedule_init();
         self.current_stack.set(task.stack_bounds());
@@ -977,29 +967,21 @@ pub fn this_cpu_shared() -> &'static PerCpuShared {
 /// Disables IRQs on the current CPU. Keeps track of the nesting level and
 /// the original IRQ state.
 ///
-/// # Safety
-///
 /// Caller needs to make sure to match every `irqs_disable()` call with an
 /// `irqs_enable()` call.
 #[inline(always)]
-pub unsafe fn irqs_disable() {
-    unsafe {
-        this_cpu().irqs_disable();
-    }
+pub fn irqs_disable() {
+    this_cpu().irqs_disable();
 }
 
 /// Reduces IRQ-disable nesting level on the current CPU and restores the
 /// original IRQ state when the level reaches 0.
 ///
-/// # Safety
-///
 /// Caller needs to make sure to match every `irqs_disable()` call with an
 /// `irqs_enable()` call.
 #[inline(always)]
-pub unsafe fn irqs_enable() {
-    unsafe {
-        this_cpu().irqs_enable();
-    }
+pub fn irqs_enable() {
+    this_cpu().irqs_enable();
 }
 
 /// Get IRQ-disable nesting count on the current CPU

--- a/kernel/src/cpu/vc.rs
+++ b/kernel/src/cpu/vc.rs
@@ -579,7 +579,7 @@ mod tests {
         let old_dr7 = verify_ghcb_gets_altered(get_dr7);
         assert_eq!(old_dr7, DR7_DEFAULT);
 
-        verify_ghcb_gets_altered(|| unsafe { set_dr7(DR7_TEST) });
+        verify_ghcb_gets_altered(|| set_dr7(DR7_TEST));
         let new_dr7 = verify_ghcb_gets_altered(get_dr7);
         assert_eq!(new_dr7, DR7_TEST);
     }

--- a/kernel/src/locking/rwlock.rs
+++ b/kernel/src/locking/rwlock.rs
@@ -333,30 +333,28 @@ mod tests {
         use crate::cpu::irqs_enabled;
         use crate::locking::*;
 
-        unsafe {
-            let was_enabled = irqs_enabled();
-            raw_irqs_enable();
-            let lock = RWLock::new(0);
+        let was_enabled = irqs_enabled();
+        raw_irqs_enable();
+        let lock = RWLock::new(0);
 
-            // Lock for write
-            let guard = lock.lock_write();
-            // IRQs must still be enabled;
-            assert!(irqs_enabled());
-            // Unlock
-            drop(guard);
+        // Lock for write
+        let guard = lock.lock_write();
+        // IRQs must still be enabled;
+        assert!(irqs_enabled());
+        // Unlock
+        drop(guard);
 
-            // Lock for read
-            let guard = lock.lock_read();
-            // IRQs must still be enabled;
-            assert!(irqs_enabled());
-            // Unlock
-            drop(guard);
+        // Lock for read
+        let guard = lock.lock_read();
+        // IRQs must still be enabled;
+        assert!(irqs_enabled());
+        // Unlock
+        drop(guard);
 
-            // IRQs must still be enabled
-            assert!(irqs_enabled());
-            if !was_enabled {
-                raw_irqs_disable();
-            }
+        // IRQs must still be enabled
+        assert!(irqs_enabled());
+        if !was_enabled {
+            raw_irqs_disable();
         }
     }
 
@@ -367,32 +365,30 @@ mod tests {
         use crate::cpu::{irqs_disabled, irqs_enabled};
         use crate::locking::*;
 
-        unsafe {
-            let was_enabled = irqs_enabled();
-            raw_irqs_enable();
-            let lock = RWLockIrqSafe::new(0);
+        let was_enabled = irqs_enabled();
+        raw_irqs_enable();
+        let lock = RWLockIrqSafe::new(0);
 
-            // Lock for write
-            let guard = lock.lock_write();
-            // IRQs must be disabled
-            assert!(irqs_disabled());
-            // Unlock
-            drop(guard);
+        // Lock for write
+        let guard = lock.lock_write();
+        // IRQs must be disabled
+        assert!(irqs_disabled());
+        // Unlock
+        drop(guard);
 
-            assert!(irqs_enabled());
+        assert!(irqs_enabled());
 
-            // Lock for read
-            let guard = lock.lock_read();
-            // IRQs must still be enabled;
-            assert!(irqs_disabled());
-            // Unlock
-            drop(guard);
+        // Lock for read
+        let guard = lock.lock_read();
+        // IRQs must still be enabled;
+        assert!(irqs_disabled());
+        // Unlock
+        drop(guard);
 
-            // IRQs must still be enabled
-            assert!(irqs_enabled());
-            if !was_enabled {
-                raw_irqs_disable();
-            }
+        // IRQs must still be enabled
+        assert!(irqs_enabled());
+        if !was_enabled {
+            raw_irqs_disable();
         }
     }
 }

--- a/kernel/src/locking/spinlock.rs
+++ b/kernel/src/locking/spinlock.rs
@@ -224,63 +224,57 @@ mod tests {
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn spin_lock_irq_unsafe() {
-        unsafe {
-            let was_enabled = irqs_enabled();
-            raw_irqs_enable();
+        let was_enabled = irqs_enabled();
+        raw_irqs_enable();
 
-            let spin_lock = SpinLock::new(0);
-            let guard = spin_lock.lock();
-            assert!(irqs_enabled());
-            drop(guard);
-            assert!(irqs_enabled());
+        let spin_lock = SpinLock::new(0);
+        let guard = spin_lock.lock();
+        assert!(irqs_enabled());
+        drop(guard);
+        assert!(irqs_enabled());
 
-            if !was_enabled {
-                raw_irqs_disable();
-            }
+        if !was_enabled {
+            raw_irqs_disable();
         }
     }
 
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn spin_lock_irq_safe() {
-        unsafe {
-            let was_enabled = irqs_enabled();
-            raw_irqs_enable();
+        let was_enabled = irqs_enabled();
+        raw_irqs_enable();
 
-            let spin_lock = SpinLockIrqSafe::new(0);
-            let guard = spin_lock.lock();
-            assert!(irqs_disabled());
-            drop(guard);
-            assert!(irqs_enabled());
+        let spin_lock = SpinLockIrqSafe::new(0);
+        let guard = spin_lock.lock();
+        assert!(irqs_disabled());
+        drop(guard);
+        assert!(irqs_enabled());
 
-            if !was_enabled {
-                raw_irqs_disable();
-            }
+        if !was_enabled {
+            raw_irqs_disable();
         }
     }
 
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn spin_trylock_irq_safe() {
-        unsafe {
-            let was_enabled = irqs_enabled();
-            raw_irqs_enable();
+        let was_enabled = irqs_enabled();
+        raw_irqs_enable();
 
-            let spin_lock = SpinLockIrqSafe::new(0);
+        let spin_lock = SpinLockIrqSafe::new(0);
 
-            // IRQs are enabled - taking the lock must succeed and disable IRQs
-            let g1 = spin_lock.try_lock();
-            assert!(g1.is_some());
-            assert!(irqs_disabled());
+        // IRQs are enabled - taking the lock must succeed and disable IRQs
+        let g1 = spin_lock.try_lock();
+        assert!(g1.is_some());
+        assert!(irqs_disabled());
 
-            // Release lock and check if that enables IRQs
-            drop(g1);
-            assert!(irqs_enabled());
+        // Release lock and check if that enables IRQs
+        drop(g1);
+        assert!(irqs_enabled());
 
-            // Leave with IRQs configured as test was entered.
-            if !was_enabled {
-                raw_irqs_disable();
-            }
+        // Leave with IRQs configured as test was entered.
+        if !was_enabled {
+            raw_irqs_disable();
         }
     }
 }

--- a/kernel/src/sev/ghcb.rs
+++ b/kernel/src/sev/ghcb.rs
@@ -378,9 +378,7 @@ impl GHCB {
         // to prevent reentrant use of the GHCB MSR.
         let guard = IrqGuard::new();
         write_msr(SEV_GHCB, ghcb_pa);
-        unsafe {
-            raw_vmgexit();
-        }
+        raw_vmgexit();
         drop(guard);
 
         let sw_exit_info_1 = self.get_exit_info_1_valid()?;

--- a/kernel/src/sev/msr_protocol.rs
+++ b/kernel/src/sev/msr_protocol.rs
@@ -79,9 +79,7 @@ pub fn verify_ghcb_version() {
     assert!(!irqs_enabled());
     // Request SEV information.
     write_msr(SEV_GHCB, GHCBMsr::SEV_INFO_REQ);
-    unsafe {
-        raw_vmgexit();
-    }
+    raw_vmgexit();
     let sev_info = read_msr(SEV_GHCB);
 
     // Parse the results.
@@ -110,9 +108,7 @@ pub fn hypervisor_ghcb_features() -> GHCBHvFeatures {
 pub fn init_hypervisor_ghcb_features() -> Result<(), GhcbMsrError> {
     let guard = IrqGuard::new();
     write_msr(SEV_GHCB, GHCBMsr::SNP_HV_FEATURES_REQ);
-    unsafe {
-        raw_vmgexit();
-    }
+    raw_vmgexit();
     let result = read_msr(SEV_GHCB);
     drop(guard);
     if (result & 0xFFF) == GHCBMsr::SNP_HV_FEATURES_RESP {
@@ -148,9 +144,7 @@ pub fn register_ghcb_gpa_msr(addr: PhysAddr) -> Result<(), GhcbMsrError> {
     info |= GHCBMsr::SNP_REG_GHCB_GPA_REQ;
     let guard = IrqGuard::new();
     write_msr(SEV_GHCB, info);
-    unsafe {
-        raw_vmgexit();
-    }
+    raw_vmgexit();
     info = read_msr(SEV_GHCB);
     drop(guard);
 
@@ -177,9 +171,7 @@ fn set_page_valid_status_msr(addr: PhysAddr, valid: bool) -> Result<(), GhcbMsrE
     info |= GHCBMsr::SNP_STATE_CHANGE_REQ;
     let guard = IrqGuard::new();
     write_msr(SEV_GHCB, info);
-    unsafe {
-        raw_vmgexit();
-    }
+    raw_vmgexit();
     let response = read_msr(SEV_GHCB);
     drop(guard);
 
@@ -205,16 +197,12 @@ pub fn invalidate_page_msr(addr: PhysAddr) -> Result<(), GhcbMsrError> {
 pub fn request_termination_msr() -> ! {
     let info: u64 = GHCBMsr::TERM_REQ;
 
-    // Safety
-    //
     // Since this processor is destined for a fatal termination, there is
     // no reason to preserve interrupt state.  Interrupts can be disabled
     // outright prior to shutdown.
-    unsafe {
-        raw_irqs_disable();
-        write_msr(SEV_GHCB, info);
-        raw_vmgexit();
-    }
+    raw_irqs_disable();
+    write_msr(SEV_GHCB, info);
+    raw_vmgexit();
     loop {
         halt();
     }

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -455,9 +455,7 @@ pub extern "C" fn stage2_main(launch_info: &Stage2LaunchInfo) {
     // Shut down the GHCB
     unsafe {
         shutdown_percpu();
-    }
 
-    unsafe {
         asm!("jmp *%rax",
              in("rax") u64::from(kernel_entry),
              in("r8") &launch_info,


### PR DESCRIPTION
Rust defines safety specifically with respect to memory guarantees enforced by the language (ownership, typing, bound, etc.) and specifically excludes overall program correctness (including data races and deadlock).  Functions that are safe with respect to the language definition of "safe" should not be declared `unsafe`.