### PR TITLE
hyperv: add logic specific to the use of the Hyper-V hypervisor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ bin/coconut-qemu.igvm: $(IGVMBUILDER) $(IGVMMEASURE) bin/stage1-trampoline.bin b
 	$(IGVMMEASURE) --check-kvm $@ measure
 
 bin/coconut-hyperv.igvm: $(IGVMBUILDER) $(IGVMMEASURE) bin/stage1-trampoline.bin bin/svsm-kernel.elf bin/stage2.bin
-	$(IGVMBUILDER) --sort --output $@ --tdx-stage1 bin/stage1-trampoline.bin --stage2 bin/stage2.bin --kernel bin/svsm-kernel.elf --comport 3 hyper-v --native --snp --tdp --vsm
+	$(IGVMBUILDER) --sort --output $@ --tdx-stage1 bin/stage1-trampoline.bin --stage2 bin/stage2.bin --kernel bin/svsm-kernel.elf --comport 3 hyper-v --snp --tdp --vsm
 	$(IGVMMEASURE) $@ measure
 
 bin/coconut-test-qemu.igvm: $(IGVMBUILDER) $(IGVMMEASURE) bin/stage1-trampoline.bin bin/test-kernel.elf bin/stage2.bin

--- a/configs/all-targets.json
+++ b/configs/all-targets.json
@@ -13,7 +13,6 @@
         "hyper-v": {
             "output": "coconut-hyperv.igvm",
             "platforms": [
-                "native",
                 "snp",
                 "tdp",
                 "vsm"

--- a/configs/hyperv-target.json
+++ b/configs/hyperv-target.json
@@ -3,7 +3,6 @@
         "hyper-v": {
             "output": "coconut-hyperv.igvm",
             "platforms": [
-                "native",
                 "snp",
                 "tdp",
                 "vsm"

--- a/kernel/src/address.rs
+++ b/kernel/src/address.rs
@@ -4,10 +4,11 @@
 //
 // Author: Carlos López <carlos.lopez@suse.com>
 
+use crate::mm::virt_to_phys;
 use crate::types::{PAGE_SHIFT, PAGE_SIZE};
+
 use core::fmt;
 use core::ops;
-
 use core::slice;
 
 use builtin_macros::*;
@@ -470,5 +471,20 @@ impl Address for VirtAddr {
         self.bits()
             .checked_sub(off)
             .map(|addr| sign_extend(addr).into())
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct VirtPhysPair {
+    pub vaddr: VirtAddr,
+    pub paddr: PhysAddr,
+}
+
+impl VirtPhysPair {
+    pub fn new(vaddr: VirtAddr) -> Self {
+        Self {
+            vaddr,
+            paddr: virt_to_phys(vaddr),
+        }
     }
 }

--- a/kernel/src/address.rs
+++ b/kernel/src/address.rs
@@ -322,6 +322,10 @@ impl VirtAddr {
         VirtAddr::new(self.0 + offset)
     }
 
+    pub const fn const_sub(&self, offset: usize) -> Self {
+        VirtAddr::new(self.0 - offset)
+    }
+
     /// Converts the `VirtAddr` to a slice of a given type
     ///
     /// # Arguments:

--- a/kernel/src/cpu/gdt.rs
+++ b/kernel/src/cpu/gdt.rs
@@ -145,10 +145,10 @@ impl ReadLockGuard<'static, GDT> {
         }
     }
 
-    pub fn base_limit(&self) -> (u64, u32) {
+    pub fn base_limit(&self) -> (u64, u16) {
         let gdt_entries = GDT_SIZE as usize;
         let base: *const GDT = core::ptr::from_ref(self);
-        let limit = ((mem::size_of::<u64>() * gdt_entries) - 1) as u32;
+        let limit = ((mem::size_of::<u64>() * gdt_entries) - 1) as u16;
         (base as u64, limit)
     }
 }

--- a/kernel/src/cpu/idt/common.rs
+++ b/kernel/src/cpu/idt/common.rs
@@ -355,9 +355,9 @@ impl WriteLockGuard<'static, IDT> {
 }
 
 impl ReadLockGuard<'static, IDT> {
-    pub fn base_limit(&self) -> (u64, u32) {
+    pub fn base_limit(&self) -> (u64, u16) {
         let base: *const IDT = core::ptr::from_ref(self);
-        let limit = (IDT_ENTRIES * mem::size_of::<IdtEntry>()) as u32;
+        let limit = (IDT_ENTRIES * mem::size_of::<IdtEntry>()) as u16;
         (base as u64, limit)
     }
 }

--- a/kernel/src/cpu/smp.rs
+++ b/kernel/src/cpu/smp.rs
@@ -22,7 +22,9 @@ fn start_cpu(platform: &dyn SvsmPlatform, apic_id: u32) -> Result<(), SvsmError>
     let percpu = PerCpu::alloc(apic_id)?;
     let pgtable = this_cpu().get_pgtable().clone_shared()?;
     percpu.setup(platform, pgtable)?;
-    platform.start_cpu(percpu, start_rip)?;
+
+    let context = percpu.get_initial_context(start_rip);
+    platform.start_cpu(percpu, &context)?;
 
     let percpu_shared = percpu.shared();
     while !percpu_shared.is_online() {}

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -98,6 +98,8 @@ pub enum SvsmError {
     NotSupported,
     /// Generic errors related to APIC emulation.
     Apic(ApicError),
+    /// Errors related to Hyper-V.
+    HyperV(u16),
 }
 
 impl From<ElfError> for SvsmError {

--- a/kernel/src/hyperv/hv.rs
+++ b/kernel/src/hyperv/hv.rs
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Jon Lange (jlange@microsoft.com)
+
+use crate::address::VirtAddr;
+use crate::cpu::cpuid::CpuidResult;
+use crate::cpu::msr::write_msr;
+use crate::cpu::percpu::this_cpu;
+use crate::error::SvsmError;
+use crate::hyperv::HyperVMsr;
+use crate::mm::alloc::allocate_pages;
+use crate::mm::pagetable::PTEntryFlags;
+use crate::mm::{virt_to_phys, SVSM_HYPERCALL_CODE_PAGE};
+use crate::utils::immut_after_init::ImmutAfterInitCell;
+
+static HYPERV_HYPERCALL_CODE_PAGE: ImmutAfterInitCell<VirtAddr> = ImmutAfterInitCell::uninit();
+
+pub fn is_hyperv_hypervisor() -> bool {
+    // Check if any hypervisor is present.
+    if (CpuidResult::get(1, 0).ecx & 0x80000000) == 0 {
+        return false;
+    }
+
+    // Get the hypervisor interface signature.
+    CpuidResult::get(0x40000001, 0).eax == 0x31237648
+}
+
+pub fn hyperv_setup_hypercalls() -> Result<(), SvsmError> {
+    // Allocate a page to use as the hypercall code page.
+    let page = allocate_pages(1)?;
+
+    // Map the page as executable at a known address.
+    let hypercall_va = SVSM_HYPERCALL_CODE_PAGE;
+    this_cpu()
+        .get_pgtable()
+        .map_4k(hypercall_va, virt_to_phys(page), PTEntryFlags::exec())?;
+
+    HYPERV_HYPERCALL_CODE_PAGE
+        .init(&hypercall_va)
+        .expect("Hypercall code page already allocated");
+
+    // Set the guest OS ID.  The value is arbitrary.
+    write_msr(HyperVMsr::GuestOSID.into(), 0xC0C0C0C0);
+
+    // Set the hypercall code page address to the physical address of the
+    // allocated page, and mark it enabled.
+    let pa = virt_to_phys(page);
+    write_msr(HyperVMsr::Hypercall.into(), u64::from(pa) | 1);
+
+    Ok(())
+}

--- a/kernel/src/hyperv/mod.rs
+++ b/kernel/src/hyperv/mod.rs
@@ -31,6 +31,46 @@ impl HvInputVtl {
     }
 }
 
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct HvSegmentRegister {
+    pub base: u64,
+    pub limit: u32,
+    pub selector: u16,
+    pub attributes: u16,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct HvTableRegister {
+    pub _rsvd: [u16; 3],
+    pub limit: u16,
+    pub base: u64,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct HvInitialVpContext {
+    pub rip: u64,
+    pub rsp: u64,
+    pub rflags: u64,
+    pub cs: HvSegmentRegister,
+    pub ds: HvSegmentRegister,
+    pub es: HvSegmentRegister,
+    pub fs: HvSegmentRegister,
+    pub gs: HvSegmentRegister,
+    pub ss: HvSegmentRegister,
+    pub tr: HvSegmentRegister,
+    pub ldtr: HvSegmentRegister,
+    pub idtr: HvTableRegister,
+    pub gdtr: HvTableRegister,
+    pub efer: u64,
+    pub cr0: u64,
+    pub cr3: u64,
+    pub cr4: u64,
+    pub pat: u64,
+}
+
 #[repr(u32)]
 #[derive(Clone, Copy, Debug)]
 pub enum HvRegisterName {

--- a/kernel/src/hyperv/mod.rs
+++ b/kernel/src/hyperv/mod.rs
@@ -9,3 +9,41 @@ pub mod msr;
 
 pub use hv::*;
 pub use msr::*;
+
+use bitfield_struct::bitfield;
+
+#[bitfield(u8)]
+pub struct HvInputVtl {
+    #[bits(4)]
+    target_vtl: u8,
+    use_target_vtl: bool,
+    #[bits(3)]
+    _rsvd_5_7: u8,
+}
+
+impl HvInputVtl {
+    pub fn use_self() -> Self {
+        Self::new()
+    }
+
+    pub fn use_vtl(vtl: u8) -> Self {
+        Self::new().with_target_vtl(vtl).with_use_target_vtl(true)
+    }
+}
+
+#[repr(u32)]
+#[derive(Clone, Copy, Debug)]
+pub enum HvRegisterName {
+    VsmVpStatus = 0xD0003,
+}
+
+#[bitfield(u64)]
+pub struct HvRegisterVsmVpStatus {
+    #[bits(4)]
+    pub active_vtl: u8,
+    pub active_mbec_enabled: bool,
+    #[bits(11)]
+    _rsvd_5_15: u64,
+    pub enabled_vtl_set: u16,
+    _rsvd_32_63: u32,
+}

--- a/kernel/src/hyperv/mod.rs
+++ b/kernel/src/hyperv/mod.rs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Jon Lange (jlange@microsoft.com)
+
+pub mod hv;
+pub mod msr;
+
+pub use hv::*;
+pub use msr::*;

--- a/kernel/src/hyperv/msr.rs
+++ b/kernel/src/hyperv/msr.rs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Jon Lange (jlange@microsoft.com)
+
+#[repr(u32)]
+#[derive(Clone, Copy, Debug)]
+pub enum HyperVMsr {
+    GuestOSID = 0x40000000,
+    Hypercall = 0x40000001,
+}
+
+impl From<HyperVMsr> for u32 {
+    fn from(msr: HyperVMsr) -> Self {
+        msr as u32
+    }
+}

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -22,6 +22,7 @@ pub mod fs;
 pub mod fw_cfg;
 pub mod fw_meta;
 pub mod greq;
+pub mod hyperv;
 pub mod igvm_params;
 pub mod insn_decode;
 pub mod io;

--- a/kernel/src/mm/address_space.rs
+++ b/kernel/src/mm/address_space.rs
@@ -147,6 +147,9 @@ pub const SVSM_SHARED_BASE: VirtAddr = virt_from_idx(PGTABLE_LVL3_IDX_SHARED);
 pub const SVSM_SHARED_STACK_BASE: VirtAddr = SVSM_SHARED_BASE.const_add(256 * SIZE_1G);
 pub const SVSM_SHARED_STACK_END: VirtAddr = SVSM_SHARED_STACK_BASE.const_add(SIZE_1G);
 
+/// Mapping address for Hyper-V hypercall page.
+pub const SVSM_HYPERCALL_CODE_PAGE: VirtAddr = SVSM_SHARED_STACK_BASE.const_sub(PAGE_SIZE);
+
 /// PerCPU mappings level 3 index
 pub const PGTABLE_LVL3_IDX_PERCPU: usize = 510;
 

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -10,6 +10,7 @@ use crate::address::{PhysAddr, VirtAddr};
 use crate::cpu::cpuid::CpuidResult;
 use crate::cpu::percpu::PerCpu;
 use crate::error::SvsmError;
+use crate::hyperv;
 use crate::io::IOPort;
 use crate::platform::native::NativePlatform;
 use crate::platform::snp::SnpPlatform;
@@ -141,7 +142,11 @@ pub trait SvsmPlatform {
     fn is_external_interrupt(&self, vector: usize) -> bool;
 
     /// Start an additional processor.
-    fn start_cpu(&self, cpu: &PerCpu, start_rip: u64) -> Result<(), SvsmError>;
+    fn start_cpu(
+        &self,
+        cpu: &PerCpu,
+        context: &hyperv::HvInitialVpContext,
+    ) -> Result<(), SvsmError>;
 }
 
 //FIXME - remove Copy trait

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -11,7 +11,7 @@ use crate::cpu::msr::write_msr;
 use crate::cpu::percpu::PerCpu;
 use crate::error::SvsmError;
 use crate::hyperv;
-use crate::hyperv::{hyperv_setup_hypercalls, is_hyperv_hypervisor};
+use crate::hyperv::{hyperv_setup_hypercalls, hyperv_start_cpu, is_hyperv_hypervisor};
 use crate::io::{IOPort, DEFAULT_IO_DRIVER};
 use crate::platform::{PageEncryptionMasks, PageStateChangeOp, PageValidateOp, SvsmPlatform};
 use crate::types::PageSize;
@@ -164,9 +164,13 @@ impl SvsmPlatform for NativePlatform {
 
     fn start_cpu(
         &self,
-        _cpu: &PerCpu,
-        _context: &hyperv::HvInitialVpContext,
+        cpu: &PerCpu,
+        context: &hyperv::HvInitialVpContext,
     ) -> Result<(), SvsmError> {
+        if self.is_hyperv {
+            return hyperv_start_cpu(cpu, context);
+        }
+
         todo!();
     }
 }

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -10,6 +10,7 @@ use crate::cpu::cpuid::CpuidResult;
 use crate::cpu::msr::write_msr;
 use crate::cpu::percpu::PerCpu;
 use crate::error::SvsmError;
+use crate::hyperv;
 use crate::hyperv::{hyperv_setup_hypercalls, is_hyperv_hypervisor};
 use crate::io::{IOPort, DEFAULT_IO_DRIVER};
 use crate::platform::{PageEncryptionMasks, PageStateChangeOp, PageValidateOp, SvsmPlatform};
@@ -161,7 +162,11 @@ impl SvsmPlatform for NativePlatform {
         false
     }
 
-    fn start_cpu(&self, _cpu: &PerCpu, _start_rip: u64) -> Result<(), SvsmError> {
+    fn start_cpu(
+        &self,
+        _cpu: &PerCpu,
+        _context: &hyperv::HvInitialVpContext,
+    ) -> Result<(), SvsmError> {
         todo!();
     }
 }

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -59,7 +59,11 @@ impl SvsmPlatform for NativePlatform {
         Ok(())
     }
 
-    fn setup_percpu(&self, _cpu: &PerCpu) -> Result<(), SvsmError> {
+    fn setup_percpu(&self, cpu: &PerCpu) -> Result<(), SvsmError> {
+        if self.is_hyperv {
+            cpu.allocate_hypercall_pages()?;
+        }
+
         Ok(())
     }
 

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -11,6 +11,7 @@ use crate::cpu::percpu::{current_ghcb, this_cpu, PerCpu};
 use crate::error::ApicError::Registration;
 use crate::error::SvsmError;
 use crate::greq::driver::guest_request_driver_init;
+use crate::hyperv;
 use crate::io::IOPort;
 use crate::mm::{PerCPUPageMappingGuard, PAGE_SIZE, PAGE_SIZE_2M};
 use crate::platform::{PageEncryptionMasks, PageStateChangeOp, PageValidateOp, SvsmPlatform};
@@ -291,8 +292,12 @@ impl SvsmPlatform for SnpPlatform {
         false
     }
 
-    fn start_cpu(&self, cpu: &PerCpu, start_rip: u64) -> Result<(), SvsmError> {
-        let (vmsa_pa, sev_features) = cpu.alloc_svsm_vmsa(*VTOM as u64, start_rip)?;
+    fn start_cpu(
+        &self,
+        cpu: &PerCpu,
+        context: &hyperv::HvInitialVpContext,
+    ) -> Result<(), SvsmError> {
+        let (vmsa_pa, sev_features) = cpu.alloc_svsm_vmsa(*VTOM as u64, context)?;
 
         current_ghcb().ap_create(vmsa_pa, cpu.get_apic_id().into(), 0, sev_features)
     }

--- a/kernel/src/platform/tdp.rs
+++ b/kernel/src/platform/tdp.rs
@@ -9,6 +9,7 @@ use crate::console::init_svsm_console;
 use crate::cpu::cpuid::CpuidResult;
 use crate::cpu::percpu::PerCpu;
 use crate::error::SvsmError;
+use crate::hyperv;
 use crate::io::IOPort;
 use crate::platform::{PageEncryptionMasks, PageStateChangeOp, PageValidateOp, SvsmPlatform};
 use crate::tdx::tdcall::{
@@ -172,7 +173,11 @@ impl SvsmPlatform for TdpPlatform {
         todo!();
     }
 
-    fn start_cpu(&self, _cpu: &PerCpu, _start_rip: u64) -> Result<(), SvsmError> {
+    fn start_cpu(
+        &self,
+        _cpu: &PerCpu,
+        _context: &hyperv::HvInitialVpContext,
+    ) -> Result<(), SvsmError> {
         todo!();
     }
 }

--- a/kernel/src/types.rs
+++ b/kernel/src/types.rs
@@ -43,9 +43,9 @@ pub const SVSM_USER_CS: u16 = 3 * 8;
 pub const SVSM_USER_DS: u16 = 4 * 8;
 pub const SVSM_TSS: u16 = 6 * 8;
 
-pub const SVSM_CS_FLAGS: u16 = 0x29b;
-pub const SVSM_DS_FLAGS: u16 = 0xc93;
-pub const SVSM_TR_FLAGS: u16 = 0x89;
+pub const SVSM_CS_ATTRIBUTES: u16 = 0xa09b;
+pub const SVSM_DS_ATTRIBUTES: u16 = 0xc093;
+pub const SVSM_TR_ATTRIBUTES: u16 = 0x89;
 
 /// VMPL level the guest OS will be executed at.
 /// Keep VMPL 1 for the SVSM and execute the OS at VMPL-2. This leaves VMPL-3


### PR DESCRIPTION
Hyper-V exposes a set of virtual CPUID leaves, MSRs, and a set of hypercalls to assist with virtualization.  The `hyperv` module includes definitions that permit the use of interfaces specific to Hyper-V.