### PR TITLE
CI: check new undocumented unsafe blocks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -112,3 +112,75 @@ jobs:
         with:
           command: fmt
           args: --all -- --check --config "format_code_in_doc_comments=true"
+
+  # Check for new undocumented unsafe blocks. This is to prevent them from
+  # growing before we add comments for all of them and manage to enable
+  # `clippy::undocumented_unsafe_blocks` lint.
+  #
+  # Progress documented at https://github.com/coconut-svsm/svsm/issues/228.
+  # When we fix that issue, we may remove this pipeline.
+  unsafe-check:
+    name: Check unsafe blocks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install specified rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: '1.82.0'
+            target: x86_64-unknown-none
+            profile: minimal
+            override: true
+            components: rustfmt, rust-src, clippy
+
+      - name: Install TPM 2.0 Reference Implementation build dependencies
+        run: sudo apt install -y autoconf autoconf-archive pkg-config build-essential automake
+
+      - name: Build
+        run: make FEATURES="default,enable-gdb" bin/svsm-kernel.elf stage1/stage1.o stage1/reset.o
+
+      - name: Clippy with undocumented_unsafe_blocks for PR branch
+        run: |
+          cargo clippy --workspace --all-features --exclude packit --exclude svsm-fuzz --exclude igvmbuilder --exclude igvmmeasure -- -W clippy::undocumented_unsafe_blocks 2> clippy_warnings_pr.txt
+
+      # Required because after the next checkout everything is removed.
+      - name: Upload PR warnings artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: clippy-warnings-pr
+          path: clippy_warnings_pr.txt
+
+      - name: Checkout base branch
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Build base branch
+        run: make FEATURES="default,enable-gdb" bin/svsm-kernel.elf stage1/stage1.o stage1/reset.o
+
+      - name: Clippy with undocumented_unsafe_blocks for base branch
+        run: |
+          cargo clippy --workspace --all-features --exclude packit --exclude svsm-fuzz --exclude igvmbuilder --exclude igvmmeasure -- -W clippy::undocumented_unsafe_blocks 2> clippy_warnings_base.txt
+
+      - name: Download PR warnings artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: clippy-warnings-pr
+
+      - name: Check new undocumented unsafe blocks
+        run: |
+          PR_WARNINGS=$(grep 'missing a safety comment' clippy_warnings_pr.txt | wc -l)
+          BASE_WARNINGS=$(grep 'missing a safety comment' clippy_warnings_base.txt | wc -l)
+
+          echo "Undocumented unsafe code blocks [PR: $PR_WARNINGS base: $BASE_WARNINGS]"
+
+          if [ "$PR_WARNINGS" -gt "$BASE_WARNINGS" ]; then
+            echo "$(($PR_WARNINGS - $BASE_WARNINGS)) new undocumented unsafe code blocks detected in this PR."
+            exit 1
+          fi
+


### PR DESCRIPTION
This is to prevent undocumented unsafe blocks from growing before we
add comments for all of them and manage to enable
`clippy::undocumented_unsafe_blocks` lint.
    
Progress documented at https://github.com/coconut-svsm/svsm/issues/228.
When we fix that issue, we may remove this pipeline.

~NOTE: the second patch it's just to test the new pipeline, I'll remove it if we want to merge this PR.~
I removed that patch, you can check the behavior with a new undocumented unsafe block in https://github.com/stefano-garzarella/svsm/pull/4