### PR TITLE
cpu/idt: Handle interrupt nesting correctly

### DIFF
--- a/kernel/src/cpu/idt/entry.S
+++ b/kernel/src/cpu/idt/entry.S
@@ -37,7 +37,7 @@ HV_DOORBELL_ADDR:
 	pushq	%rax
 .endm
 
-.macro default_entry_no_ist name: req handler:req error_code:req vector:req
+.macro default_entry_with_ist name: req handler:req error_code:req vector:req
 	.globl asm_entry_\name
 asm_entry_\name:
 	asm_clac
@@ -53,6 +53,26 @@ asm_entry_\name:
 	jmp	default_return
 .endm
 
+.macro default_entry_no_ist name: req handler:req error_code:req vector:req
+	.globl asm_entry_\name
+asm_entry_\name:
+	asm_clac
+
+	.if \error_code == 0
+	pushq $0
+	.endif
+	push_regs
+	testl 	${IF}, 0xC0(%rsp)
+	jz	L\@
+	sti
+L\@:
+	movl	$\vector, %esi
+	movq	%rsp, %rdi
+	xorl	%edx, %edx
+	call	ex_handler_\handler
+	jmp	default_return
+.endm
+
 .macro irq_entry name:req vector:req
 	.globl asm_entry_irq_\name
 asm_entry_irq_\name:
@@ -61,7 +81,7 @@ asm_entry_irq_\name:
 	pushq	$0
 	push_regs
 	movl	$\vector, %edi
-	call	common_isr_handler
+	call	common_isr_handler_entry
 	jmp	default_return
 .endm
 
@@ -344,7 +364,7 @@ default_entry_no_ist	name=ud		handler=panic			error_code=0	vector=6
 default_entry_no_ist	name=nm		handler=panic			error_code=0	vector=7
 
 // #DF Double-Fault Exception (Vector 8)
-default_entry_no_ist	name=df		handler=double_fault		error_code=1	vector=8
+default_entry_with_ist	name=df		handler=double_fault		error_code=1	vector=8
 
 // Coprocessor-Segment-Overrun Exception (Vector 9)
 // No handler - reserved vector

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -394,6 +394,29 @@ impl PerCpu {
         self.irq_state.enable();
     }
 
+    /// Increments IRQ-disable nesting level on the current CPU without
+    /// disabling interrupts.  This is used by exception and interrupt dispatch
+    /// routines that have already disabled interrupts.
+    ///
+    /// Caller needs to make sure to match every `push_nesting()` call with a
+    /// `pop_nesting()` call.
+    #[inline(always)]
+    pub fn irqs_push_nesting(&self, was_enabled: bool) {
+        self.irq_state.push_nesting(was_enabled);
+    }
+
+    /// Reduces IRQ-disable nesting level on the current CPU without restoring
+    /// the original IRQ state original IRQ state.  This is used by exception
+    /// and interrupt dispatch routines that will restore interrupt state
+    /// naturally.
+    ///
+    /// Caller needs to make sure to match every `disable()` call with a
+    /// `pop_state()` call.
+    #[inline(always)]
+    pub fn irqs_pop_nesting(&self) {
+        let _ = self.irq_state.pop_nesting();
+    }
+
     /// Get IRQ-disable nesting count on the current CPU
     ///
     /// # Returns
@@ -418,6 +441,12 @@ impl PerCpu {
 
     pub fn hv_doorbell(&self) -> Option<&'static HVDoorbell> {
         self.hv_doorbell.get()
+    }
+
+    pub fn process_hv_events_if_required(&self) {
+        if let Some(doorbell) = self.hv_doorbell.get() {
+            doorbell.process_if_required(&self.irq_state);
+        }
     }
 
     /// Gets a pointer to the location of the HV doorbell pointer in the


### PR DESCRIPTION
Exception handlers (other than IST-based exceptions) should run with interrupts enabled if interrupts were enabled at the time the exception was raised.  This is necessary to ensure that the `IrqState` nesting management is not confused by nesting that might occur within an exception handler.  In addition, most exceptions can safely tolerate interrupts, and need not impact system stability by suppressing interrupt delivery (this is particularly true for #VC exceptions, which can take a long time to execute due to emulation in the host).

IST-based exceptions must keep interrupts disabled as long as they execute on the IST stack (this currently applies only to #DF, which is fatal anyway).

Interrupt handlers must run with interrupts disabled, but need to update the `IrqState` in case they call into common code which attempts to disable interrupts.

The #HV handler must also run with interrupts disabled, and similarly needs to manage the `IrqState`.