### PR TITLE
virtio-blk storage via mmio using virtio-drivers [v2]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -54,33 +54,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
 dependencies = [
  "anstyle",
  "windows-sys",
@@ -88,18 +88,18 @@ dependencies = [
 
 [[package]]
 name = "arbitrary"
-version = "1.4.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
 dependencies = [
  "derive_arbitrary",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "base16ct"
@@ -121,7 +121,7 @@ checksum = "adc0846593a56638b74e136a45610f9934c052e14761bebca6b092d5522599e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -132,7 +132,7 @@ checksum = "6c2ce686adbebce0ee484a502c440b4657739adbad65eadf06d64f5816ee9765"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -189,13 +189,13 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.1"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
 dependencies = [
  "jobserver",
  "libc",
- "shlex",
+ "once_cell",
 ]
 
 [[package]]
@@ -216,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.21"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -226,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.21"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
  "anstream",
  "anstyle",
@@ -238,27 +238,27 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "const-oid"
@@ -276,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.15"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
@@ -336,13 +336,13 @@ dependencies = [
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.4.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -526,7 +526,7 @@ dependencies = [
  "range_map_vec",
  "thiserror",
  "tracing",
- "zerocopy 0.7.35",
+ "zerocopy 0.7.34",
 ]
 
 [[package]]
@@ -538,7 +538,7 @@ dependencies = [
  "bitfield-struct 0.7.0",
  "open-enum",
  "static_assertions",
- "zerocopy 0.7.35",
+ "zerocopy 0.7.34",
 ]
 
 [[package]]
@@ -550,7 +550,7 @@ dependencies = [
  "igvm",
  "igvm_defs",
  "uuid",
- "zerocopy 0.7.35",
+ "zerocopy 0.7.34",
  "zerocopy 0.8.10",
 ]
 
@@ -563,7 +563,7 @@ dependencies = [
  "igvm_defs",
  "p384",
  "sha2",
- "zerocopy 0.7.35",
+ "zerocopy 0.7.34",
  "zerocopy 0.8.10",
 ]
 
@@ -588,42 +588,43 @@ dependencies = [
 
 [[package]]
 name = "intrusive-collections"
-version = "0.9.7"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
+checksum = "b694dc9f70c3bda874626d2aed13b780f137aab435f4e9814121955cf706122e"
 dependencies = [
  "memoffset",
 ]
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "jobserver"
-version = "0.1.32"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.164"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.8"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b9569d2f74e257076d8c6bfa73fb505b46b851e51ddaecc825944aa3bed17fa"
+checksum = "a96cfd5557eb82f2b83fed4955246c988d331975a002961b07c81584d107e7f7"
 dependencies = [
  "arbitrary",
  "cc",
+ "once_cell",
 ]
 
 [[package]]
@@ -671,9 +672,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"
@@ -698,7 +699,7 @@ checksum = "8d1296fab5231654a5aec8bf9e87ba4e3938c502fc4c3c0425a00084c78944be"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -719,7 +720,7 @@ version = "0.1.1"
 dependencies = [
  "clap",
  "memmap2",
- "zerocopy 0.7.35",
+ "zerocopy 0.7.34",
 ]
 
 [[package]]
@@ -739,9 +740,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pkcs8"
@@ -785,18 +786,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -877,12 +878,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,9 +929,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
-version = "2.6.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "svsm"
@@ -989,9 +984,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1033,22 +1028,22 @@ version = "0.1.0"
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1070,7 +1065,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1090,9 +1085,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-xid"
@@ -1126,15 +1121,15 @@ dependencies = [
 
 [[package]]
 name = "utf8parse"
-version = "0.2.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.11.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 
 [[package]]
 name = "verify_external"
@@ -1158,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "version_check"
-version = "0.9.5"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vstd"
@@ -1180,18 +1175,18 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.52.6"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -1205,60 +1200,60 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.6"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.6"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.6"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.6"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.6"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.6"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.6"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.6"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
 dependencies = [
  "byteorder",
- "zerocopy-derive 0.7.35",
+ "zerocopy-derive 0.7.34",
 ]
 
 [[package]]
@@ -1272,13 +1267,13 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1289,7 +1284,7 @@ checksum = "593e7c96176495043fcb9e87cf7659f4d18679b5bab6b92bdef359c76a7795dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.66",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "enumn"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "ff"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,6 +975,7 @@ dependencies = [
  "test",
  "verify_external",
  "verify_proof",
+ "virtio-drivers",
  "vstd",
  "zerocopy 0.8.10",
 ]
@@ -1156,6 +1174,18 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "virtio-drivers"
+version = "0.7.5"
+source = "git+https://github.com/osteffenrh/virtio-drivers?branch=virtio-pr-2#63c5450f08bd557f609e0ffad7a5bd6281d6562e"
+dependencies = [
+ "bitflags 2.6.0",
+ "embedded-io",
+ "enumn",
+ "log",
+ "zerocopy 0.8.10",
+]
 
 [[package]]
 name = "vstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ p384 = { version = "0.13.0" }
 sha2 = "0.10.8"
 uuid = "1.6.1"
 # Add the derive feature by default because all crates use it.
-zerocopy = { version = "0.8.2", features = ["derive"] }
+zerocopy = { version = "0.8.10", features = ["derive"] }
 
 # Verus repos
 builtin = { git = "https://github.com/verus-lang/verus", rev ="943ba63", default-features = false }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -36,6 +36,7 @@ packit.workspace = true
 libtcgtpm = { workspace = true, optional = true }
 zerocopy = { workspace = true, features = ["alloc", "derive"] }
 release.workspace = true
+virtio-drivers = { git = "https://github.com/osteffenrh/virtio-drivers", branch = "virtio-pr-2" }
 
 builtin = { workspace = true, optional = true }
 builtin_macros = { workspace = true }

--- a/kernel/src/block/api.rs
+++ b/kernel/src/block/api.rs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 Red Hat, Inc.
+//
+// Author: Stefano Garzarella <sgarzare@redhat.com>
+// Author: Oliver Steffen <osteffen@redhat.com>
+
+#[derive(Debug)]
+pub enum BlockDeviceError {
+    Failed, // ToDo: insert proper errors
+}
+
+pub trait BlockDriver {
+    fn read_blocks(&self, block_id: usize, buf: &mut [u8]) -> Result<(), BlockDeviceError>;
+    fn write_blocks(&self, block_id: usize, buf: &[u8]) -> Result<(), BlockDeviceError>;
+    fn block_size_log2(&self) -> u8;
+    fn size(&self) -> usize;
+}

--- a/kernel/src/block/mod.rs
+++ b/kernel/src/block/mod.rs
@@ -5,3 +5,4 @@
 // Author: Oliver Steffen <osteffen@redhat.com>
 
 pub mod api;
+pub mod virtio_blk;

--- a/kernel/src/block/mod.rs
+++ b/kernel/src/block/mod.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 Red Hat, Inc.
+//
+// Author: Oliver Steffen <osteffen@redhat.com>
+
+pub mod api;

--- a/kernel/src/block/virtio_blk.rs
+++ b/kernel/src/block/virtio_blk.rs
@@ -49,3 +49,57 @@ impl BlockDriver for VirtIOBlkDriver {
         self.0.device.lock().capacity() as usize * SECTOR_SIZE
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::address::PhysAddr;
+    extern crate alloc;
+    use alloc::vec::Vec;
+    use zerocopy::IntoBytes;
+
+    use super::*;
+
+    static MMIO_BASE: u64 = 0xfef03000; // Hard-coded in Qemu
+
+    #[test]
+    #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
+    pub fn test_virtio_blk_512() {
+        let drv = VirtIOBlkDriver::new(PhysAddr::from(MMIO_BASE));
+        readback_test(&drv, 512);
+    }
+
+    #[test]
+    #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
+    pub fn test_virtio_blk_4096() {
+        let drv = VirtIOBlkDriver::new(PhysAddr::from(MMIO_BASE));
+        readback_test(&drv, 4096);
+    }
+
+    // #[test]
+    // pub fn test_virtio_blk_8192() {
+    //     let drv = VirtIOBlkDriver::new(PhysAddr::from(MMIO_BASE));
+    //     readback_test(&drv, 8192);
+    // }
+
+    fn readback_test(blk: &VirtIOBlkDriver, block_size: usize) {
+        for l in [[0xaa, 0x55], [0x55, 0xaa]] {
+            let mut buf: Vec<u8> = core::iter::repeat(l).flatten().take(block_size).collect();
+            let blocks = blk.size() / block_size;
+
+            for i in 0..blocks {
+                buf[0..size_of::<usize>()].copy_from_slice(usize::as_bytes(&i));
+                blk.write_blocks(i * (block_size / SECTOR_SIZE), &buf)
+                    .unwrap();
+            }
+
+            let mut rbuf: Vec<u8> = alloc::vec![0; block_size];
+
+            for i in 0..blocks {
+                buf[0..size_of::<usize>()].copy_from_slice(usize::as_bytes(&i));
+                blk.read_blocks(i * (block_size / SECTOR_SIZE), &mut rbuf)
+                    .unwrap();
+                assert!(rbuf == buf, "Error in block {i}: {rbuf:x?} != {buf:x?}");
+            }
+        }
+    }
+}

--- a/kernel/src/block/virtio_blk.rs
+++ b/kernel/src/block/virtio_blk.rs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 Red Hat, Inc.
+//
+// Author: Stefano Garzarella <sgarzare@redhat.com>
+// Author: Oliver Steffen <osteffen@redhat.com>
+
+use super::api::{BlockDeviceError, BlockDriver};
+use crate::address::PhysAddr;
+use crate::virtio::devices::VirtIOBlkDevice;
+use virtio_drivers::device::blk::SECTOR_SIZE;
+
+pub struct VirtIOBlkDriver(VirtIOBlkDevice);
+
+impl core::fmt::Debug for VirtIOBlkDriver {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("VirtIOBlkDriver").finish()
+    }
+}
+
+impl VirtIOBlkDriver {
+    pub fn new(mmio_base: PhysAddr) -> Self {
+        VirtIOBlkDriver(VirtIOBlkDevice::new(mmio_base))
+    }
+}
+
+impl BlockDriver for VirtIOBlkDriver {
+    fn read_blocks(&self, block_id: usize, buf: &mut [u8]) -> Result<(), BlockDeviceError> {
+        self.0
+            .device
+            .lock()
+            .read_blocks(block_id, buf)
+            .map_err(|_| BlockDeviceError::Failed)
+    }
+
+    fn write_blocks(&self, block_id: usize, buf: &[u8]) -> Result<(), BlockDeviceError> {
+        self.0
+            .device
+            .lock()
+            .write_blocks(block_id, buf)
+            .map_err(|_| BlockDeviceError::Failed)
+    }
+
+    fn block_size_log2(&self) -> u8 {
+        SECTOR_SIZE.ilog2().try_into().unwrap()
+    }
+
+    fn size(&self) -> usize {
+        self.0.device.lock().capacity() as usize * SECTOR_SIZE
+    }
+}

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -12,6 +12,7 @@
 
 pub mod acpi;
 pub mod address;
+pub mod block;
 pub mod config;
 pub mod console;
 pub mod cpu;

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -39,6 +39,7 @@ pub mod task;
 pub mod tdx;
 pub mod types;
 pub mod utils;
+pub mod virtio;
 #[cfg(all(feature = "vtpm", not(test)))]
 pub mod vtpm;
 

--- a/kernel/src/sev/ghcb.rs
+++ b/kernel/src/sev/ghcb.rs
@@ -29,7 +29,7 @@ use core::sync::atomic::{AtomicU16, AtomicU32, AtomicU64, AtomicU8, Ordering};
 use super::msr_protocol::{invalidate_page_msr, register_ghcb_gpa_msr, validate_page_msr};
 use super::{pvalidate, PvalidateOp};
 
-use zerocopy::{FromZeros, Immutable, IntoBytes};
+use zerocopy::{FromBytes, FromZeros, Immutable, IntoBytes};
 
 #[repr(C, packed)]
 #[derive(Debug, Default, Clone, Copy, IntoBytes, Immutable)]
@@ -97,6 +97,8 @@ enum GHCBExitCode {
     IOIO = 0x7b,
     MSR = 0x7c,
     RDTSCP = 0x87,
+    MMIO_READ = 0x8000_0001,
+    MMIO_WRITE = 0x8000_0002,
     SNP_PSC = 0x8000_0010,
     GUEST_REQUEST = 0x8000_0011,
     GUEST_EXT_REQUEST = 0x8000_0012,
@@ -443,6 +445,59 @@ impl GHCB {
             dst.store(src, Ordering::Relaxed);
         }
         Ok(())
+    }
+
+    fn read_buffer<T>(&self, offset: usize) -> Result<T, GhcbError>
+    where
+        T: Immutable + FromBytes,
+    {
+        offset
+            .checked_add(mem::size_of::<T>())
+            .filter(|end| *end <= GHCB_BUFFER_SIZE)
+            .ok_or(GhcbError::InvalidOffset)?;
+
+        // SAFETY: we have verified that offset is within bounds and does not
+        // overflow
+        let src = unsafe { self.buffer.as_ptr().add(offset) };
+
+        if src.align_offset(mem::align_of::<T>()) != 0 {
+            return Err(GhcbError::InvalidOffset);
+        }
+
+        // SAFETY: we have verified the pointer is aligned, as well as within
+        // bounds.
+        unsafe { Ok(src.cast::<T>().read_volatile()) }
+    }
+
+    pub fn mmio_write<T: IntoBytes + Immutable>(
+        &self,
+        pa: PhysAddr,
+        value: &T,
+    ) -> Result<(), SvsmError> {
+        self.clear();
+        self.write_buffer(value, 0)?;
+        let buffer_va = VirtAddr::from(self.buffer.as_ptr());
+        let buffer_pa = u64::from(virt_to_phys(buffer_va));
+        self.set_sw_scratch_valid(buffer_pa);
+        self.vmgexit(
+            GHCBExitCode::MMIO_WRITE,
+            u64::from(pa),
+            mem::size_of::<T>() as u64,
+        )?;
+        Ok(())
+    }
+
+    pub fn mmio_read<T: FromBytes + Immutable>(&self, pa: PhysAddr) -> Result<T, SvsmError> {
+        self.clear();
+        let buffer_va = VirtAddr::from(self.buffer.as_ptr());
+        let buffer_pa = u64::from(virt_to_phys(buffer_va));
+        self.set_sw_scratch_valid(buffer_pa);
+        self.vmgexit(
+            GHCBExitCode::MMIO_READ,
+            u64::from(pa),
+            mem::size_of::<T>() as u64,
+        )?;
+        Ok(self.read_buffer(0)?)
     }
 
     pub fn psc_entry(

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -326,6 +326,12 @@ pub extern "C" fn svsm_main() {
         panic!("Failed to launch FW: {e:#?}");
     }
 
+    {
+        use svsm::block::virtio_blk;
+        static MMIO_BASE: u64 = 0xfef03000;
+        let _blk = virtio_blk::VirtIOBlkDriver::new(PhysAddr::from(MMIO_BASE));
+    }
+
     start_kernel_task(request_processing_main, String::from("request-processing"))
         .expect("Failed to launch request processing task");
 

--- a/kernel/src/virtio/devices.rs
+++ b/kernel/src/virtio/devices.rs
@@ -1,0 +1,41 @@
+use super::hal::*;
+use core::ptr::NonNull;
+use virtio_drivers::device::blk::VirtIOBlk;
+use virtio_drivers::transport::mmio::MmioTransport;
+use virtio_drivers::PAGE_SIZE;
+
+use crate::address::PhysAddr;
+use crate::locking::SpinLock;
+use crate::mm::global_memory::{map_global_range_4k_shared, GlobalRangeGuard};
+use crate::mm::pagetable::PTEntryFlags;
+
+pub struct VirtIOBlkDevice {
+    pub device: SpinLock<VirtIOBlk<SvsmHal, MmioTransport<SvsmHal>>>,
+    _mmio_space: GlobalRangeGuard,
+}
+
+impl core::fmt::Debug for VirtIOBlkDevice {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("VirtIOBlkDevice").finish()
+    }
+}
+
+impl VirtIOBlkDevice {
+    pub fn new(mmio_base: PhysAddr) -> Self {
+        virtio_init();
+
+        let mem = map_global_range_4k_shared(mmio_base, PAGE_SIZE, PTEntryFlags::data())
+            .expect("Error mapping MMIO range");
+        let header = NonNull::new(mem.addr().as_mut_ptr()).unwrap();
+
+        // SAFETY: `header` is the MMIO config area; we have to trust the content is valid.
+        let transport = unsafe { MmioTransport::<SvsmHal>::new(header).unwrap() };
+
+        let blk = VirtIOBlk::new(transport).expect("Failed to create blk driver");
+
+        VirtIOBlkDevice {
+            device: SpinLock::new(blk),
+            _mmio_space: mem,
+        }
+    }
+}

--- a/kernel/src/virtio/hal.rs
+++ b/kernel/src/virtio/hal.rs
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2024 Red Hat, Inc.
+//
+// Author: Oliver Steffen <osteffen@redhat.com>
+
+extern crate alloc;
+use crate::locking::SpinLock;
+use alloc::vec::Vec;
+use core::{
+    cell::OnceCell,
+    ptr::{addr_of, NonNull},
+};
+use zerocopy::{FromBytes, Immutable, IntoBytes};
+
+use crate::{
+    address::{PhysAddr, VirtAddr},
+    cpu::{self, percpu::this_cpu},
+    mm::{page_visibility::*, *},
+};
+
+struct PageStore {
+    pages: Vec<(PhysAddr, SharedBox<[u8; PAGE_SIZE]>)>,
+}
+
+impl PageStore {
+    pub fn new() -> Self {
+        PageStore { pages: Vec::new() }
+    }
+
+    pub fn push(&mut self, pa: PhysAddr, shared_page: SharedBox<[u8; PAGE_SIZE]>) {
+        self.pages.push((pa, shared_page));
+    }
+
+    pub fn pop(&mut self, pa: PhysAddr) -> Option<SharedBox<[u8; PAGE_SIZE]>> {
+        if let Some(p) = self.pages.iter().position(|e| e.0 == pa) {
+            Some(self.pages.remove(p).1)
+        } else {
+            None
+        }
+    }
+}
+
+static SHARED_MEM: SpinLock<OnceCell<PageStore>> = SpinLock::new(OnceCell::new());
+
+pub fn virtio_init() {
+    SHARED_MEM.lock().get_or_init(PageStore::new);
+}
+
+#[derive(Debug)]
+pub struct SvsmHal;
+
+/// Implementation of virtio-drivers MMIO hardware abstraction for AMD SEV-SNP
+/// in the Coconut-SVSM context. Due to missing #VC handler for MMIO, use ghcb exits
+/// instead.
+///
+/// SAFETY: Complies with the safety requirements of the virtio_drivers::Hal trait.
+unsafe impl virtio_drivers::Hal for SvsmHal {
+    /// Allocates and zeroes the given number of contiguous physical pages of DMA memory for VirtIO
+    /// use.
+    ///
+    /// Limitation: `pages == 1` required.
+    fn dma_alloc(
+        pages: usize,
+        _direction: virtio_drivers::BufferDirection,
+    ) -> (virtio_drivers::PhysAddr, NonNull<u8>) {
+        // TODO: allow more than one page.
+        //       This currently works, becasue in "modern" virtio mode the crate only allocates
+        //       one page at a time.
+        assert!(pages == 1);
+
+        let shared_page = SharedBox::<[u8; PAGE_SIZE]>::try_new_zeroed().unwrap();
+        let pa = virt_to_phys(shared_page.addr());
+        let p = NonNull::<u8>::new(shared_page.addr().as_mut_ptr()).unwrap();
+
+        SHARED_MEM.lock().get_mut().unwrap().push(pa, shared_page);
+
+        (pa.into(), p)
+    }
+
+    /// Deallocates the given contiguous physical DMA memory pages.
+    ///
+    /// # Safety
+    ///
+    /// The memory must have been allocated by `dma_alloc` on the same `Hal` implementation, and not
+    /// yet deallocated. `pages` must be the same number passed to `dma_alloc` originally, and both
+    /// `paddr` and `vaddr` must be the values returned by `dma_alloc`.
+    ///
+    /// Limitation: `pages == 1` required.
+    unsafe fn dma_dealloc(
+        paddr: virtio_drivers::PhysAddr,
+        _vaddr: NonNull<u8>,
+        pages: usize,
+    ) -> i32 {
+        //TODO: allow more than one page
+        assert!(pages == 1);
+
+        SHARED_MEM
+            .lock()
+            .get_mut()
+            .unwrap()
+            .pop(paddr.into())
+            .unwrap();
+
+        0
+    }
+
+    /// Converts a physical address used for MMIO to a virtual address which the driver can access.
+    /// NOT IMPLEMENTED - only required for PCI transport, which is not used in Coconut.
+    unsafe fn mmio_phys_to_virt(_paddr: virtio_drivers::PhysAddr, _size: usize) -> NonNull<u8> {
+        todo!()
+    }
+
+    /// Shares the given memory range with the device, and returns the physical address that the
+    /// device can use to access it.
+    ///
+    /// # Safety
+    ///
+    /// The buffer must be a valid pointer to a non-empty memory range which will not be accessed by
+    /// any other thread for the duration of this method call.
+    ///
+    /// Limitation: `buffer.len() <= PAGE_SIZE`
+    unsafe fn share(
+        buffer: NonNull<[u8]>,
+        direction: virtio_drivers::BufferDirection,
+    ) -> virtio_drivers::PhysAddr {
+        // TODO: allow more than one page
+        assert!(buffer.len() <= PAGE_SIZE);
+
+        let shared_page = SharedBox::<[u8; PAGE_SIZE]>::try_new_zeroed().unwrap();
+
+        if direction == virtio_drivers::BufferDirection::DriverToDevice {
+            let src = buffer.as_ptr().cast::<u8>();
+            let dst = shared_page.addr().as_mut_ptr::<u8>();
+
+            // SAFETY: Assume `buffer` is valid because it is supplied by the vritio-drivers crate.
+            //         We assterted that `dst` can hold at least `buffer.len()`.
+            unsafe {
+                core::ptr::copy_nonoverlapping(src, dst, buffer.len());
+            }
+        }
+
+        let pa = virt_to_phys(shared_page.addr());
+        SHARED_MEM.lock().get_mut().unwrap().push(pa, shared_page);
+
+        // return pa of shared page
+        pa.into()
+    }
+
+    /// Unshares the given memory range from the device and (if necessary) copies it back to the
+    /// original buffer.
+    ///
+    /// # Safety
+    ///
+    /// The buffer must be a valid pointer to a non-empty memory range which will not be accessed by
+    /// any other thread for the duration of this method call. The `paddr` must be the value
+    /// previously returned by the corresponding `share` call.
+    ///
+    /// Limitation: `buffer.len() <= PAGE_SIZE`
+    unsafe fn unshare(
+        paddr: virtio_drivers::PhysAddr,
+        buffer: NonNull<[u8]>,
+        direction: virtio_drivers::BufferDirection,
+    ) {
+        assert!(buffer.len() <= PAGE_SIZE);
+
+        if let Some(shared_page) = SHARED_MEM.lock().get_mut().unwrap().pop(paddr.into()) {
+            let vaddr = phys_to_virt(paddr.into());
+            let va_from_shared = shared_page.addr();
+            assert!(vaddr == va_from_shared);
+
+            if direction == virtio_drivers::BufferDirection::DeviceToDriver {
+                let dst = buffer.as_ptr().cast::<u8>();
+                let src = vaddr.as_mut_ptr::<u8>();
+
+                // SAFETY: Assume `buffer` is valid and can hold at leader `buffer.len()`
+                //         because both are supplied by the vritio-drivers crate.
+                //         We assterted that `src` holds at least `buffer.len()`.
+                unsafe {
+                    core::ptr::copy_nonoverlapping(src, dst, buffer.len());
+                }
+            }
+        } else {
+            panic!("unshare: No shared page found at given pa");
+        }
+        // implicit drop of share_page here.
+    }
+
+    /// Performs memory mapped read from location of `src`. `src` itself is not modified,
+    /// the value is returned instead.
+    ///
+    /// The default implementation performs a regular volatile_read. This method is intended
+    /// to be overwritten in case MMIO memory needs to be accessed in a special way (for example AMD SEV-SNP).
+    ///
+    /// # Safety
+    ///
+    /// `src` must be properly alinged and reside at a readable memory address.
+    unsafe fn mmio_read<T: FromBytes + Immutable>(src: &T) -> T {
+        let paddr = this_cpu()
+            .get_pgtable()
+            .phys_addr(VirtAddr::from(addr_of!(*src)))
+            .unwrap();
+
+        cpu::percpu::current_ghcb()
+            .mmio_read::<T>(paddr)
+            .expect("GHCB MMIO Read failed")
+    }
+
+    /// Performs memory mapped write of `value` to the location of `dst`.
+    ///
+    /// The default implementation performs a regular volatile_write. This method is intended
+    /// to be overwritten in case MMIO memory needs to be accessed in a special way (for example AMD SEV-SNP).
+    ///
+    /// # Safety
+    ///
+    /// `dst` must be properly alinged and reside at a writable memory address.
+    unsafe fn mmio_write<T: IntoBytes + Immutable>(dst: &mut T, v: T) {
+        let paddr = this_cpu()
+            .get_pgtable()
+            .phys_addr(VirtAddr::from(addr_of!(*dst)))
+            .unwrap();
+
+        cpu::percpu::current_ghcb()
+            .mmio_write::<T>(paddr, &v)
+            .expect("GHCB MMIO Write failed");
+    }
+}

--- a/kernel/src/virtio/mod.rs
+++ b/kernel/src/virtio/mod.rs
@@ -1,0 +1,2 @@
+pub mod devices;
+mod hal;

--- a/scripts/launch_guest.sh
+++ b/scripts/launch_guest.sh
@@ -18,6 +18,8 @@ COM3_SERIAL="-serial null"  # used by hyper-v
 COM4_SERIAL="-serial null"  # used by in-SVSM tests
 QEMU_EXIT_DEVICE=""
 QEMU_TEST_IO_DEVICE=""
+STATE_DEVICE=""
+STATE_ENABLE=""
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -33,6 +35,13 @@ while [[ $# -gt 0 ]]; do
       ;;
     --image)
       IMAGE="$2"
+      shift
+      shift
+      ;;
+    --state)
+      STATE_ENABLE="x-svsm-virtio-mmio=on"
+      STATE_DEVICE="-global virtio-mmio.force-legacy=false \
+-drive file=$2,format=raw,if=none,id=mmio -device virtio-blk-device,drive=mmio"
       shift
       shift
       ;;
@@ -119,7 +128,7 @@ $SUDO_CMD \
   $QEMU \
     -enable-kvm \
     -cpu EPYC-v4 \
-    -machine $MACHINE \
+    -machine $MACHINE,$STATE_ENABLE \
     -object $MEMORY \
     $IGVM_OBJ \
     -object $SNP_GUEST \
@@ -134,4 +143,6 @@ $SUDO_CMD \
     $COM3_SERIAL \
     $COM4_SERIAL \
     $QEMU_EXIT_DEVICE \
-    $QEMU_TEST_IO_DEVICE
+    $QEMU_TEST_IO_DEVICE \
+    $STATE_DEVICE
+

--- a/scripts/test-in-svsm.sh
+++ b/scripts/test-in-svsm.sh
@@ -34,15 +34,17 @@ test_io(){
     done
 }
 
-PIPES_DIR=$(mktemp -d -q)
-mkfifo $PIPES_DIR/pipe.in
-mkfifo $PIPES_DIR/pipe.out
+TEST_DIR=$(mktemp -d -q)
+mkfifo $TEST_DIR/pipe.in
+mkfifo $TEST_DIR/pipe.out
+truncate -s 16M $TEST_DIR/svsm_state.raw
 
-test_io $PIPES_DIR/pipe.in $PIPES_DIR/pipe.out &
+test_io $TEST_DIR/pipe.in $TEST_DIR/pipe.out &
 TEST_IO_PID=$!
 
 $SCRIPT_DIR/launch_guest.sh --igvm $SCRIPT_DIR/../bin/coconut-test-qemu.igvm \
-    --unit-tests $PIPES_DIR/pipe || true
+    --state $TEST_DIR/svsm_state.raw \
+    --unit-tests $TEST_DIR/pipe || true
 
 kill $TEST_IO_PID
-rm -rf $PIPES_DIR
+rm -rf $TEST_DIR


### PR DESCRIPTION
This is version 2 of https://github.com/coconut-svsm/svsm/pull/343.

Add support for virtio-blk storage devices using the virtio-mmio transport.
MMIO accesses are done via explicit vmgexits. Interrupts are not used (-> polling).

The [virtio-drivers](https://github.com/rcore-os/virtio-drivers/) crate from the rcore-os project is used. It required some modifications: https://github.com/osteffenrh/virtio-drivers/pull/2
Crate License: MIT.

This PR requires a patched version of Qemu (https://github.com/coconut-svsm/qemu/pull/13), adding virtio-mmio slots to the Q35 machine model.

This build on https://github.com/coconut-svsm/svsm/pull/531

How to test:
- Use Qemu from https://github.com/coconut-svsm/qemu/pull/13
- run the in-svsm tests `make test-in-svsm`

ToDo:
- Write block size / buffer size is limited to max 4k, needs improvement of bounce buffer handling
- Proper error codes for the block layer and driver impl.
- Supply the MMIO base address via IGVM file

Fixes since V1:
- SMP works, mmio range is mapped for all cpus
- rebased to latest versions of Coconut and virtio-drivers

Things for future PRs:
- encryption layer
- file system

CC: @stefano-garzarella ;-)