### PR TITLE
cpu: implement interior mutability in `X86Tss`

### DIFF
--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -325,7 +325,7 @@ pub struct PerCpu {
     irq_state: IrqState,
 
     pgtbl: RefCell<Option<&'static mut PageTable>>,
-    tss: Cell<X86Tss>,
+    tss: X86Tss,
     isst: Cell<Isst>,
     svsm_vmsa: OnceCell<VmsaPage>,
     reset_ip: Cell<u64>,
@@ -365,7 +365,7 @@ impl PerCpu {
         Self {
             pgtbl: RefCell::new(None),
             irq_state: IrqState::new(),
-            tss: Cell::new(X86Tss::new()),
+            tss: X86Tss::new(),
             isst: Cell::new(Isst::default()),
             svsm_vmsa: OnceCell::new(),
             reset_ip: Cell::new(0xffff_fff0),
@@ -466,7 +466,7 @@ impl PerCpu {
         // to ensure that only a single reference can ever be taken at a time.
         let page_ref: RefMut<'_, Option<(VirtPhysPair, VirtPhysPair)>> =
             self.hypercall_pages.borrow_mut();
-        // SAFETY - the virtual addresses were allocated when the hypercall
+        // SAFETY: the virtual addresses were allocated when the hypercall
         // pages were configured, and the physical addresses were captured at
         // that time.
         unsafe { HypercallPagesGuard::new(RefMut::map(page_ref, |o| o.as_mut().unwrap())) }
@@ -625,9 +625,10 @@ impl PerCpu {
 
     fn setup_tss(&self) {
         let double_fault_stack = self.get_top_of_df_stack();
-        let mut tss = self.tss.get();
-        tss.set_ist_stack(IST_DF, double_fault_stack);
-        self.tss.set(tss);
+        // SAFETY: the stck pointer is known to be correct.
+        unsafe {
+            self.tss.set_ist_stack(IST_DF, double_fault_stack);
+        }
     }
 
     fn setup_isst(&self) {
@@ -743,14 +744,7 @@ impl PerCpu {
     }
 
     pub fn load_tss(&self) {
-        // SAFETY: this can only produce UB if someone else calls self.tss.set
-        // () while this new reference is alive, which cannot happen as this
-        // data is local to this CPU. We need to get a reference to the value
-        // inside the Cell because the address of the TSS will be used. If we
-        // did self.tss.get(), then the address of a temporary copy would be
-        // used.
-        let tss = unsafe { &*self.tss.as_ptr() };
-        gdt_mut().load_tss(tss);
+        gdt_mut().load_tss(&self.tss);
     }
 
     pub fn load_isst(&self) {
@@ -1035,10 +1029,15 @@ impl PerCpu {
         self.runqueue.lock_read().current_task()
     }
 
-    pub fn set_tss_rsp0(&self, addr: VirtAddr) {
-        let mut tss = self.tss.get();
-        tss.stacks[0] = addr;
-        self.tss.set(tss);
+    /// # Safety
+    /// No checks are performed on the stack address.  The caller must
+    /// ensure that the address is valid for stack usage.
+    pub unsafe fn set_tss_rsp0(&self, addr: VirtAddr) {
+        // SAFETY: the caller has guaranteed the correctness of the stack
+        // pointer.
+        unsafe {
+            self.tss.set_rsp0(addr);
+        }
     }
 }
 

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -383,7 +383,10 @@ pub fn schedule() {
             this_cpu().populate_page_table(&mut pt);
         }
 
-        this_cpu().set_tss_rsp0(next.stack_bounds.end());
+        // SAFETY: ths stack pointer is known to be correct.
+        unsafe {
+            this_cpu().set_tss_rsp0(next.stack_bounds.end());
+        }
         if is_cet_ss_supported() {
             write_msr(PL0_SSP, next.exception_shadow_stack.bits() as u64);
         }


### PR DESCRIPTION
The only fields of the TSS that ever require modification are the IST fields and RSP0.  Since RSP0 has to be modified on every task switch, it is undesirable to store TSS in a `Cell` because that requires copying the entire TSS in and out of the cell in order to modify just the single field.  Instead, the TSS can be made immutable, and can implement interior mutability for its own fields.  However, `Cell` cannot be used directly in this case because the X86 architecture defines the TSS such that the stack pointers are unaligned, and therefore assembly has to be used to modify the fields.