### PR TITLE
CI: be more verbose with new undocumented unsafe blocks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -145,7 +145,7 @@ jobs:
 
       - name: Clippy with undocumented_unsafe_blocks for PR branch
         run: |
-          cargo clippy --workspace --all-features --exclude packit --exclude svsm-fuzz --exclude igvmbuilder --exclude igvmmeasure -- -W clippy::undocumented_unsafe_blocks 2> clippy_warnings_pr.txt
+          cargo clippy --workspace --all-features --exclude packit --exclude svsm-fuzz --exclude igvmbuilder --exclude igvmmeasure --quiet -- -W clippy::undocumented_unsafe_blocks 2> clippy_warnings_pr.txt
 
       # Required because after the next checkout everything is removed.
       - name: Upload PR warnings artifact
@@ -165,7 +165,7 @@ jobs:
 
       - name: Clippy with undocumented_unsafe_blocks for base branch
         run: |
-          cargo clippy --workspace --all-features --exclude packit --exclude svsm-fuzz --exclude igvmbuilder --exclude igvmmeasure -- -W clippy::undocumented_unsafe_blocks 2> clippy_warnings_base.txt
+          cargo clippy --workspace --all-features --exclude packit --exclude svsm-fuzz --exclude igvmbuilder --exclude igvmmeasure --quiet -- -W clippy::undocumented_unsafe_blocks 2> clippy_warnings_base.txt
 
       - name: Download PR warnings artifact
         uses: actions/download-artifact@v3
@@ -180,7 +180,12 @@ jobs:
           echo "Undocumented unsafe code blocks [PR: $PR_WARNINGS base: $BASE_WARNINGS]"
 
           if [ "$PR_WARNINGS" -gt "$BASE_WARNINGS" ]; then
-            echo "$(($PR_WARNINGS - $BASE_WARNINGS)) new undocumented unsafe code blocks detected in this PR."
+            echo "ERROR: $(($PR_WARNINGS - $BASE_WARNINGS)) new undocumented unsafe code blocks detected in this PR"
+            echo "enabling the clippy::undocumented_unsafe_blocks lint in this way:"
+            echo "$ cargo clippy --workspace --all-features --exclude packit --exclude svsm-fuzz \\"
+            echo "  --exclude igvmbuilder --exclude igvmmeasure -- -W clippy::undocumented_unsafe_blocks"
+            echo ""
+            diff --color -u clippy_warnings_base.txt clippy_warnings_pr.txt
             exit 1
           fi
 


### PR DESCRIPTION
Print more information on how to locally replicate the warnings. Also add a diff between the two `clippy` outputs (on the base branch and on the PR) to better identify the new undocumented unsafe blocks in the PR that cause the new warnings.

Run `clippy` with `--quiet` to have a cleaner diff between the two runs.

I opened a PR with an undocumented unsafe block on my fork: https://github.com/stefano-garzarella/svsm/pull/5
The output on the failing job is something like this:
```
Undocumented unsafe code blocks [PR: 224 base: 223]
ERROR: 1 new undocumented unsafe code blocks detected in this PR
enabling the clippy::undocumented_unsafe_blocks lint in this way:
$ cargo clippy --workspace --all-features --exclude packit --exclude svsm-fuzz \
  --exclude igvmbuilder --exclude igvmmeasure -- -W clippy::undocumented_unsafe_blocks

--- clippy_warnings_base.txt	2024-12-02 18:26:50.028103603 +0000
+++ clippy_warnings_pr.txt	2024-12-02 18:26:50.660111125 +0000
@@ -1990,6 +1990,16 @@
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#undocumented_unsafe_blocks
 
 warning: unsafe block missing a safety comment
+   --> kernel/src/svsm.rs:144:5
+    |
+144 |     unsafe {
+    |     ^^^^^^^^
+    |
+    = help: consider adding a safety comment on the preceding line
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#undocumented_unsafe_blocks
+    = note: requested on the command line with `-W clippy::undocumented-unsafe-blocks`
+
+warning: unsafe block missing a safety comment
    --> kernel/src/stage2.rs:236:17
     |
 236 |     let bytes = unsafe { slice::from_raw_parts(elf_start.bits() as *const u8, elf_len) };
Error: Process completed with exit code 1.
```

cc @msft-jlange
