### PR TITLE
Userspace support: Refactor init to launch a simple device model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1308,6 +1308,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "userdm"
+version = "0.1.0"
+dependencies = [
+ "userlib",
+]
+
+[[package]]
 name = "userinit"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ members = [
     "user/lib",
     # Init user-space module
     "user/init",
+    # device model module
+    "user/dm",
     # Release version identifier
     "release",
     # Virtio Drivers (MMIO)
@@ -48,6 +50,7 @@ syscall = { path = "syscall" }
 packit = { path = "packit" }
 userlib = { path = "user/lib" }
 userinit = { path = "user/init" }
+userdm = { path = "user/dm" }
 release = { path = "release" }
 virtio-drivers = { path = "virtio-drivers" }
 

--- a/configs/all-targets.json
+++ b/configs/all-targets.json
@@ -53,6 +53,9 @@
         "modules": {
             "userinit": {
                 "path": "/init"
+            },
+            "userdm": {
+                "path": "/dm"
             }
         }
     }

--- a/configs/hyperv-target.json
+++ b/configs/hyperv-target.json
@@ -35,6 +35,9 @@
         "modules": {
             "userinit": {
                 "path": "/init"
+            },
+            "userdm": {
+                "path": "/dm"
             }
         }
     }

--- a/configs/qemu-target.json
+++ b/configs/qemu-target.json
@@ -35,6 +35,9 @@
         "modules": {
             "userinit": {
                 "path": "/init"
+            },
+            "userdm": {
+                "path": "/dm"
             }
         }
     }

--- a/configs/vanadium-target.json
+++ b/configs/vanadium-target.json
@@ -35,6 +35,9 @@
         "modules": {
             "userinit": {
                 "path": "/init"
+            },
+            "userdm": {
+                "path": "/dm"
             }
         }
     }

--- a/user/dm/Cargo.toml
+++ b/user/dm/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "userdm"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "userdm"
+path = "src/main.rs"
+test = false
+doctest = false
+
+[dependencies]
+userlib.workspace = true
+
+[lints]
+workspace = true

--- a/user/dm/build.rs
+++ b/user/dm/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("cargo:rustc-link-arg=-Tuser/lib/module.lds");
+    println!("cargo:rustc-link-arg=-no-pie");
+}

--- a/user/dm/src/main.rs
+++ b/user/dm/src/main.rs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2024 Intel Corporation.
+//
+// Author: Vijay Dhanraj <vijay.dhanraj@intel.com>
+
+#![no_std]
+#![no_main]
+
+use userlib::*;
+
+declare_main!(main);
+
+fn main() -> u32 {
+    0
+}

--- a/user/init/src/main.rs
+++ b/user/init/src/main.rs
@@ -1,41 +1,49 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2024 SUSE LLC
+//
+// Author: Joerg Roedel <jroedel@suse.de>
+
 #![no_std]
 #![no_main]
 
+use core::ffi::CStr;
 use userlib::*;
 
-use core::ptr::{addr_of, addr_of_mut};
-
-static mut SOME_BSS_DATA: [u64; 128] = [0; 128];
-static mut SOME_DATA: [u64; 128] = [0x01; 128];
-static SOME_RO_DATA: [u64; 128] = [0xee; 128];
-
-fn check(arr: &[u64; 128], val: u64) {
-    for v in arr.iter() {
-        if *v != val {
-            panic!("Unexpected array value");
-        }
-    }
-}
-
-fn write(arr: &mut [u64; 128], val: u64) {
-    for v in arr.iter_mut() {
-        *v = val;
-    }
-}
-
 declare_main!(main);
-
 fn main() -> u32 {
     println!("COCONUT-SVSM init process starting");
 
-    // SAFETY: Single-threaded process, so no data races. Safe to access global
-    // mutable data.
-    unsafe {
-        write(&mut *addr_of_mut!(SOME_DATA), 0xcc);
-        write(&mut *addr_of_mut!(SOME_BSS_DATA), 0xaa);
-        check(&*addr_of!(SOME_DATA), 0xccu64);
-        check(&*addr_of!(SOME_RO_DATA), 0xeeu64);
-        check(&*addr_of!(SOME_BSS_DATA), 0xaa);
+    let obj = opendir(c"/").expect("Cannot open root directory");
+
+    // Discover the first file under root directory, excluding `/init`.
+    let mut dirents: [DirEnt; 8] = Default::default();
+    let binfile = loop {
+        let n = readdir(&obj, &mut dirents).unwrap();
+        if let Some(f) = dirents
+            .iter()
+            .take(n)
+            .filter(|d| d.file_type == FileType::File)
+            .map(|d| {
+                CStr::from_bytes_until_nul(&d.file_name).expect("Filename is not nul-terminated!")
+            })
+            .find(|&f| f != c"init")
+        {
+            break f;
+        }
+        if n < dirents.len() {
+            return 0;
+        }
+    };
+
+    let mut path = [b'\0'; F_NAME_SIZE + 1];
+    path[0] = b'/';
+    path[1..=binfile.count_bytes()].copy_from_slice(binfile.to_bytes());
+    let file = CStr::from_bytes_until_nul(&path).unwrap();
+
+    match exec(file, c"/", 0) {
+        Ok(_) => 0,
+        Err(SysCallError::ENOTFOUND) => 1,
+        _ => panic!("{} launch failed", file.to_str().unwrap()),
     }
-    0
 }


### PR DESCRIPTION
This PR adds an initial version of `init` to launch a dummy device model.  The initial `dm` version just calls `exit` syscall without doing anything else.

Note: This PR is built on top of https://github.com/coconut-svsm/svsm/pull/520 and https://github.com/coconut-svsm/svsm/pull/539 PRs.