### PR TITLE
File System SysCalls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1018,6 +1018,9 @@ dependencies = [
 [[package]]
 name = "syscall"
 version = "0.1.0"
+dependencies = [
+ "bitflags 2.6.0",
+]
 
 [[package]]
 name = "test"

--- a/fuzz/fuzz_targets/fs.rs
+++ b/fuzz/fuzz_targets/fs.rs
@@ -11,7 +11,7 @@ use core::hint::black_box;
 use libfuzzer_sys::fuzz_target;
 use std::sync::OnceLock;
 use svsm::fs::FileHandle;
-use svsm::fs::{create, create_all, list_dir, mkdir, open, unlink, TestFileSystemGuard};
+use svsm::fs::{create, create_all, list_dir, mkdir, open_rw, unlink, TestFileSystemGuard};
 use svsm::mm::alloc::TestRootMem;
 
 const ROOT_MEM_SIZE: usize = 0x10000;
@@ -102,7 +102,7 @@ fuzz_target!(|actions: Vec<FsAction<'_>>| {
                 }
             }
             FsAction::Open(name) => {
-                if let Ok(fh) = open(name) {
+                if let Ok(fh) = open_rw(name) {
                     files.push(Handle::new(fh, name));
                 }
             }
@@ -110,7 +110,7 @@ fuzz_target!(|actions: Vec<FsAction<'_>>| {
                 let Some(file) = get_item(&files, *idx) else {
                     continue;
                 };
-                if let Ok(fh) = open(file.name) {
+                if let Ok(fh) = open_rw(file.name) {
                     files.push(Handle::new(fh, file.name));
                 }
             }

--- a/fuzz/fuzz_targets/fs.rs
+++ b/fuzz/fuzz_targets/fs.rs
@@ -188,7 +188,7 @@ fuzz_target!(|actions: Vec<FsAction<'_>>| {
 
                 // Reset the buffer and the file position
                 buf.fill(POISON_BYTE);
-                file.fd.seek(start_pos);
+                file.fd.seek_abs(start_pos);
 
                 // Read back the bytes and sanity check them
                 assert!(num <= len);
@@ -203,7 +203,7 @@ fuzz_target!(|actions: Vec<FsAction<'_>>| {
             }
             FsAction::Seek(idx, pos) => {
                 if let Some(file) = get_item(&files, *idx) {
-                    file.fd.seek(*pos);
+                    file.fd.seek_abs(*pos);
                 }
             }
             FsAction::Truncate(idx, off) => {

--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -302,6 +302,7 @@ extern "C" fn ex_handler_system_call(
         SYS_OPEN => sys_open(ctxt.regs.rdi, ctxt.regs.rsi, ctxt.regs.r8),
         SYS_READ => sys_read(ctxt.regs.rdi as u32, ctxt.regs.rsi, ctxt.regs.r8),
         SYS_WRITE => sys_write(ctxt.regs.rdi as u32, ctxt.regs.rsi, ctxt.regs.r8),
+        SYS_SEEK => sys_seek(ctxt.regs.rdi as u32, ctxt.regs.rsi, ctxt.regs.r8),
         SYS_OPENDIR => sys_opendir(ctxt.regs.rdi),
         SYS_READDIR => sys_readdir(ctxt.regs.rdi as u32, ctxt.regs.rsi, ctxt.regs.r8),
         _ => Err(SysCallError::EINVAL),

--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -300,6 +300,7 @@ extern "C" fn ex_handler_system_call(
         SYS_CLOSE => sys_close(ctxt.regs.rdi as u32),
         // Class 1 SysCalls.
         SYS_OPEN => sys_open(ctxt.regs.rdi, ctxt.regs.rsi, ctxt.regs.r8),
+        SYS_READ => sys_read(ctxt.regs.rdi as u32, ctxt.regs.rsi, ctxt.regs.r8),
         SYS_OPENDIR => sys_opendir(ctxt.regs.rdi),
         SYS_READDIR => sys_readdir(ctxt.regs.rdi as u32, ctxt.regs.rsi, ctxt.regs.r8),
         _ => Err(SysCallError::EINVAL),

--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -308,6 +308,7 @@ extern "C" fn ex_handler_system_call(
         SYS_OPENDIR => sys_opendir(ctxt.regs.rdi),
         SYS_READDIR => sys_readdir(ctxt.regs.rdi as u32, ctxt.regs.rsi, ctxt.regs.r8),
         SYS_MKDIR => sys_mkdir(ctxt.regs.rdi),
+        SYS_RMDIR => sys_mkdir(ctxt.regs.rdi),
         _ => Err(SysCallError::EINVAL),
     }
     .map_or_else(|e| e as usize, |v| v as usize);

--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -299,6 +299,7 @@ extern "C" fn ex_handler_system_call(
         SYS_EXEC => sys_exec(ctxt.regs.rdi, ctxt.regs.rsi, ctxt.regs.r8),
         SYS_CLOSE => sys_close(ctxt.regs.rdi as u32),
         // Class 1 SysCalls.
+        SYS_OPEN => sys_open(ctxt.regs.rdi, ctxt.regs.rsi, ctxt.regs.r8),
         SYS_OPENDIR => sys_opendir(ctxt.regs.rdi),
         SYS_READDIR => sys_readdir(ctxt.regs.rdi as u32, ctxt.regs.rsi, ctxt.regs.r8),
         _ => Err(SysCallError::EINVAL),

--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -307,6 +307,7 @@ extern "C" fn ex_handler_system_call(
         SYS_TRUNCATE => sys_truncate(ctxt.regs.rdi as u32, ctxt.regs.rsi),
         SYS_OPENDIR => sys_opendir(ctxt.regs.rdi),
         SYS_READDIR => sys_readdir(ctxt.regs.rdi as u32, ctxt.regs.rsi, ctxt.regs.r8),
+        SYS_MKDIR => sys_mkdir(ctxt.regs.rdi),
         _ => Err(SysCallError::EINVAL),
     }
     .map_or_else(|e| e as usize, |v| v as usize);

--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -303,6 +303,7 @@ extern "C" fn ex_handler_system_call(
         SYS_READ => sys_read(ctxt.regs.rdi as u32, ctxt.regs.rsi, ctxt.regs.r8),
         SYS_WRITE => sys_write(ctxt.regs.rdi as u32, ctxt.regs.rsi, ctxt.regs.r8),
         SYS_SEEK => sys_seek(ctxt.regs.rdi as u32, ctxt.regs.rsi, ctxt.regs.r8),
+        SYS_UNLINK => sys_unlink(ctxt.regs.rdi),
         SYS_TRUNCATE => sys_truncate(ctxt.regs.rdi as u32, ctxt.regs.rsi),
         SYS_OPENDIR => sys_opendir(ctxt.regs.rdi),
         SYS_READDIR => sys_readdir(ctxt.regs.rdi as u32, ctxt.regs.rsi, ctxt.regs.r8),

--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -301,6 +301,7 @@ extern "C" fn ex_handler_system_call(
         // Class 1 SysCalls.
         SYS_OPEN => sys_open(ctxt.regs.rdi, ctxt.regs.rsi, ctxt.regs.r8),
         SYS_READ => sys_read(ctxt.regs.rdi as u32, ctxt.regs.rsi, ctxt.regs.r8),
+        SYS_WRITE => sys_write(ctxt.regs.rdi as u32, ctxt.regs.rsi, ctxt.regs.r8),
         SYS_OPENDIR => sys_opendir(ctxt.regs.rdi),
         SYS_READDIR => sys_readdir(ctxt.regs.rdi as u32, ctxt.regs.rsi, ctxt.regs.r8),
         _ => Err(SysCallError::EINVAL),

--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -294,9 +294,11 @@ extern "C" fn ex_handler_system_call(
     };
 
     ctxt.regs.rax = match input {
+        // Class 0 SysCalls.
         SYS_EXIT => sys_exit(ctxt.regs.rdi as u32),
         SYS_EXEC => sys_exec(ctxt.regs.rdi, ctxt.regs.rsi, ctxt.regs.r8),
         SYS_CLOSE => sys_close(ctxt.regs.rdi as u32),
+        // Class 1 SysCalls.
         SYS_OPENDIR => sys_opendir(ctxt.regs.rdi),
         SYS_READDIR => sys_readdir(ctxt.regs.rdi as u32, ctxt.regs.rsi, ctxt.regs.r8),
         _ => Err(SysCallError::EINVAL),

--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -303,6 +303,7 @@ extern "C" fn ex_handler_system_call(
         SYS_READ => sys_read(ctxt.regs.rdi as u32, ctxt.regs.rsi, ctxt.regs.r8),
         SYS_WRITE => sys_write(ctxt.regs.rdi as u32, ctxt.regs.rsi, ctxt.regs.r8),
         SYS_SEEK => sys_seek(ctxt.regs.rdi as u32, ctxt.regs.rsi, ctxt.regs.r8),
+        SYS_TRUNCATE => sys_truncate(ctxt.regs.rdi as u32, ctxt.regs.rsi),
         SYS_OPENDIR => sys_opendir(ctxt.regs.rdi),
         SYS_READDIR => sys_readdir(ctxt.regs.rdi as u32, ctxt.regs.rsi, ctxt.regs.r8),
         _ => Err(SysCallError::EINVAL),

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -127,6 +127,8 @@ impl From<SvsmError> for SysCallError {
         match err {
             SvsmError::Alloc(AllocError::OutOfMemory) => SysCallError::ENOMEM,
             SvsmError::FileSystem(FsError::FileExists) => SysCallError::EEXIST,
+            SvsmError::FileSystem(FsError::WriteOnly) => SysCallError::EWRONLY,
+            SvsmError::FileSystem(FsError::ReadOnly) => SysCallError::ERDONLY,
 
             SvsmError::FileSystem(FsError::FileNotFound) | SvsmError::Obj(ObjError::NotFound) => {
                 SysCallError::ENOTFOUND

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -78,6 +78,8 @@ pub enum SvsmError {
     InvalidBytes,
     /// Error reported when converting to UTF-8
     InvalidUtf8,
+    /// A fault occured
+    Fault,
     /// Errors related to firmware parsing
     Firmware,
     /// Errors related to console operation

--- a/kernel/src/fs/api.rs
+++ b/kernel/src/fs/api.rs
@@ -28,6 +28,7 @@ pub enum FsError {
     Inval,
     FileExists,
     FileNotFound,
+    NotSupported,
     PackIt(PackItError),
 }
 
@@ -62,6 +63,7 @@ impl FsError {
     impl_fs_err!(inval, Inval);
     impl_fs_err!(file_exists, FileExists);
     impl_fs_err!(file_not_found, FileNotFound);
+    impl_fs_err!(not_supported, NotSupported);
 }
 
 /// Represents file operations

--- a/kernel/src/fs/api.rs
+++ b/kernel/src/fs/api.rs
@@ -33,6 +33,8 @@ pub enum FsError {
     BadHandle,
     ReadOnly,
     WriteOnly,
+    Busy,
+    NotEmpty,
     PackIt(PackItError),
 }
 
@@ -71,6 +73,8 @@ impl FsError {
     impl_fs_err!(bad_handle, BadHandle);
     impl_fs_err!(read_only, ReadOnly);
     impl_fs_err!(write_only, WriteOnly);
+    impl_fs_err!(busy, Busy);
+    impl_fs_err!(not_empty, NotEmpty);
 }
 
 /// Represents file operations
@@ -179,6 +183,14 @@ pub trait Directory: Debug + Send + Sync {
     ///
     /// A [`Vec<FileName>`] containing all the entries in the directory.
     fn list(&self) -> Vec<FileName>;
+
+    /// Prepare the directory for removal.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(())` if the directory is ready for removal, an `SvsmError`
+    /// value otherwise.
+    fn prepare_remove(&self) -> Result<(), SvsmError>;
 
     /// Used to lookup for an entry in the directory.
     ///

--- a/kernel/src/fs/api.rs
+++ b/kernel/src/fs/api.rs
@@ -30,6 +30,9 @@ pub enum FsError {
     FileExists,
     FileNotFound,
     NotSupported,
+    BadHandle,
+    ReadOnly,
+    WriteOnly,
     PackIt(PackItError),
 }
 
@@ -65,6 +68,9 @@ impl FsError {
     impl_fs_err!(file_exists, FileExists);
     impl_fs_err!(file_not_found, FileNotFound);
     impl_fs_err!(not_supported, NotSupported);
+    impl_fs_err!(bad_handle, BadHandle);
+    impl_fs_err!(read_only, ReadOnly);
+    impl_fs_err!(write_only, WriteOnly);
 }
 
 /// Represents file operations

--- a/kernel/src/fs/api.rs
+++ b/kernel/src/fs/api.rs
@@ -35,6 +35,8 @@ pub enum FsError {
     WriteOnly,
     Busy,
     NotEmpty,
+    IsFile,
+    IsDir,
     PackIt(PackItError),
 }
 
@@ -75,6 +77,8 @@ impl FsError {
     impl_fs_err!(write_only, WriteOnly);
     impl_fs_err!(busy, Busy);
     impl_fs_err!(not_empty, NotEmpty);
+    impl_fs_err!(is_dir, IsDir);
+    impl_fs_err!(is_file, IsFile);
 }
 
 /// Represents file operations

--- a/kernel/src/fs/api.rs
+++ b/kernel/src/fs/api.rs
@@ -11,6 +11,7 @@ use alloc::vec::Vec;
 use core::fmt::Debug;
 
 use crate::error::SvsmError;
+use crate::fs::Buffer;
 use crate::mm::PageRef;
 use crate::string::FixedString;
 use packit::PackItError;
@@ -82,6 +83,22 @@ pub trait File: Debug + Send + Sync {
     /// during the read operation.
     fn read(&self, buf: &mut [u8], offset: usize) -> Result<usize, SvsmError>;
 
+    /// Read contents of a file into a [`Buffer`]
+    ///
+    /// # Arguments
+    ///
+    /// - `buf`: [`Buffer`] to store the file contents into.
+    /// - `offset`: file offset to read from.
+    ///
+    /// # Returns
+    ///
+    /// [`Result<usize, SvsmError>`]: A [`Result`] containing the number of
+    /// bytes read if successful, or an [`SvsmError`] if there was a problem
+    /// during the read operation.
+    fn read_buffer(&self, _buf: &mut dyn Buffer, _offset: usize) -> Result<usize, SvsmError> {
+        Err(SvsmError::FileSystem(FsError::not_supported()))
+    }
+
     /// Used to write contents to a file
     ///
     /// # Arguments
@@ -95,6 +112,22 @@ pub trait File: Debug + Send + Sync {
     /// bytes written if successful, or an [`SvsmError`] if there was a problem
     /// during the write operation.
     fn write(&self, buf: &[u8], offset: usize) -> Result<usize, SvsmError>;
+
+    /// Write to file from a [`Buffer`]
+    ///
+    /// # Arguments:
+    ///
+    /// - `buffer`: Instance of [`Buffer`] to write data from.
+    /// - `offset`: File offset to write to.
+    ///
+    /// # Returns
+    ///
+    /// [`Result<usize, SvsmError>`]: A [`Result`] containing the number of
+    /// bytes written if successful, or an [`SvsmError`] if there was a problem
+    /// during the write operation.
+    fn write_buffer(&self, _buffer: &dyn Buffer, _offset: usize) -> Result<usize, SvsmError> {
+        Err(SvsmError::FileSystem(FsError::not_supported()))
+    }
 
     /// Used to truncate the file to the specified size.
     ///

--- a/kernel/src/fs/buffer.rs
+++ b/kernel/src/fs/buffer.rs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2024 SUSE LLC
+//
+// Author: Joerg Roedel <jroedel@suse.de>
+
+use crate::error::SvsmError;
+use crate::fs::FsError;
+
+pub trait Buffer {
+    /// Copy data from the buffer into a slice
+    ///
+    /// # Arguments
+    ///
+    /// - `buf`: Destination slice for data.
+    /// - `offset`: Offset into the buffer to start copying from.
+    ///
+    /// # Returns
+    ///
+    /// A `usize` representing the number of bytes copied on success, or
+    /// [`SvsmError`] on failure. Not that the content of `buf` is undefined on
+    /// failure.
+    fn read_buffer(&self, buf: &mut [u8], offset: usize) -> Result<usize, SvsmError>;
+
+    /// Copy data from a slice into the Buffer
+    ///
+    /// # Arguments
+    ///
+    /// - `buf`: Source slice for data.
+    /// - `offset`: Offset into the buffer to start copying to.
+    ///
+    /// # Returns
+    ///
+    /// A `usize` representing the number of bytes copied on success, or
+    /// [`SvsmError`] on failure.
+    fn write_buffer(&mut self, _buf: &[u8], _offset: usize) -> Result<usize, SvsmError> {
+        Err(SvsmError::FileSystem(FsError::not_supported()))
+    }
+
+    /// Total number of bytes represented by this buffer.
+    ///
+    /// # Returns
+    ///
+    /// Total number of bytes that can be copied from/to the buffer.
+    fn size(&self) -> usize;
+}

--- a/kernel/src/fs/filesystem.rs
+++ b/kernel/src/fs/filesystem.rs
@@ -96,7 +96,7 @@ impl RawFileHandle {
         self.file.truncate(offset)
     }
 
-    fn seek(&mut self, pos: usize) {
+    fn seek_abs(&mut self, pos: usize) {
         self.current = min(pos, self.file.size());
     }
 
@@ -212,13 +212,13 @@ impl FileHandle {
         self.handle.lock().truncate(offset)
     }
 
-    /// Used to change the current file offset.
+    /// Change the current file offset to an absolute position.
     ///
     /// # Arguments
     ///
     /// - `pos`: intended new file offset value.
-    pub fn seek(&self, pos: usize) {
-        self.handle.lock().seek(pos);
+    pub fn seek_abs(&self, pos: usize) {
+        self.handle.lock().seek_abs(pos);
     }
 
     /// Used to get the size of the file.
@@ -687,14 +687,14 @@ pub fn write(fh: &FileHandle, buf: &[u8]) -> Result<usize, SvsmError> {
     fh.write(buf)
 }
 
-/// Used to set the file offset
+/// Set the file offset to an absolute position.
 ///
 /// # Arguements
 ///
 /// - `fh`: Filehandle for the seek operation.
 /// - `pos`: new file offset value to be set.
-pub fn seek(fh: &FileHandle, pos: usize) {
-    fh.seek(pos)
+pub fn seek_abs(fh: &FileHandle, pos: usize) {
+    fh.seek_abs(pos)
 }
 
 #[cfg(test)]
@@ -845,7 +845,7 @@ mod tests {
 
         assert_eq!(fh.size(), 512);
 
-        fh.seek(256);
+        fh.seek_abs(256);
         let buf2: [u8; 512] = [0xcc; 512];
         let result = write(&fh, &buf2).unwrap();
         assert_eq!(result, 512);
@@ -853,7 +853,7 @@ mod tests {
         assert_eq!(fh.size(), 768);
 
         let mut buf3: [u8; 1024] = [0; 1024];
-        fh.seek(0);
+        fh.seek_abs(0);
         let result = read(&fh, &mut buf3).unwrap();
         assert_eq!(result, 768);
 

--- a/kernel/src/fs/filesystem.rs
+++ b/kernel/src/fs/filesystem.rs
@@ -91,9 +91,14 @@ impl RawFileHandle {
         result
     }
 
-    fn truncate(&self, offset: usize) -> Result<usize, SvsmError> {
+    fn truncate(&mut self, offset: usize) -> Result<usize, SvsmError> {
         self.check_write()?;
-        self.file.truncate(offset)
+        let result = self.file.truncate(offset);
+        let new_size = self.file.size();
+        if result.is_ok() && self.current >= new_size {
+            self.current = new_size;
+        }
+        result
     }
 
     fn seek_abs(&mut self, pos: usize) {
@@ -713,6 +718,34 @@ pub fn read(fh: &FileHandle, buf: &mut [u8]) -> Result<usize, SvsmError> {
 /// of bytes written if successful,  [`SvsmError`] otherwise.
 pub fn write(fh: &FileHandle, buf: &[u8]) -> Result<usize, SvsmError> {
     fh.write(buf)
+}
+
+/// Truncate file at a given offset.
+///
+/// # Arguments:
+///
+/// - `fh`: FileHandle of file to truncate.
+/// - `offset`: File offset to truncate at.
+///
+/// # Returns:
+///
+/// [`Result<usize, SvsmError>`]: [`Result`] containing the file size if
+/// successful,  [`SvsmError`] otherwise.
+pub fn truncate(fh: &FileHandle, offset: usize) -> Result<usize, SvsmError> {
+    fh.truncate(offset)
+}
+
+/// Return position of file read/write pointer.
+///
+/// # Arguments:
+///
+/// - `fh`: FileHandle to get position from.
+///
+/// # Returns:
+///
+/// Current position of the file pointer.
+pub fn position(fh: &FileHandle) -> usize {
+    fh.position()
 }
 
 /// Set the file offset to an absolute position.

--- a/kernel/src/fs/filesystem.rs
+++ b/kernel/src/fs/filesystem.rs
@@ -100,6 +100,16 @@ impl RawFileHandle {
         self.current = min(pos, self.file.size());
     }
 
+    fn seek_rel(&mut self, offset: isize) {
+        let pos = self.current.checked_add_signed(offset).unwrap_or(0);
+        self.seek_abs(pos);
+    }
+
+    fn seek_end(&mut self, offset: usize) {
+        let pos = self.file.size().saturating_sub(offset);
+        self.seek_abs(pos);
+    }
+
     fn size(&self) -> usize {
         self.file.size()
     }
@@ -219,6 +229,24 @@ impl FileHandle {
     /// - `pos`: intended new file offset value.
     pub fn seek_abs(&self, pos: usize) {
         self.handle.lock().seek_abs(pos);
+    }
+
+    /// Change the current file offset relative to the current position.
+    ///
+    /// # Arguments
+    ///
+    /// - `offset`: Signed value to add to current file position.
+    pub fn seek_rel(&self, offset: isize) {
+        self.handle.lock().seek_rel(offset);
+    }
+
+    /// Set the current file offset relative to the end of file.
+    ///
+    /// # Arguments
+    ///
+    /// - `offset`: Value to subtract from end-of-file position.
+    pub fn seek_end(&self, offset: usize) {
+        self.handle.lock().seek_end(offset);
     }
 
     /// Used to get the size of the file.
@@ -695,6 +723,26 @@ pub fn write(fh: &FileHandle, buf: &[u8]) -> Result<usize, SvsmError> {
 /// - `pos`: new file offset value to be set.
 pub fn seek_abs(fh: &FileHandle, pos: usize) {
     fh.seek_abs(pos)
+}
+
+/// Set the file offset relative to the current offset
+///
+/// # Arguements
+///
+/// - `fh`: Filehandle for the seek operation.
+/// - `offset`: Signed value to add to current file offset.
+pub fn seek_rel(fh: &FileHandle, offset: isize) {
+    fh.seek_rel(offset)
+}
+
+/// Set the file offset relative to end-of-file
+///
+/// # Arguements
+///
+/// - `fh`: Filehandle for the seek operation.
+/// - `offset`: Value to subtract from end-of-file offset.
+pub fn seek_end(fh: &FileHandle, offset: usize) {
+    fh.seek_end(offset)
 }
 
 #[cfg(test)]

--- a/kernel/src/fs/filesystem.rs
+++ b/kernel/src/fs/filesystem.rs
@@ -41,10 +41,26 @@ impl RawFileHandle {
         result
     }
 
+    fn read_buffer(&mut self, buffer: &mut dyn Buffer) -> Result<usize, SvsmError> {
+        let result = self.file.read_buffer(buffer, self.current);
+        if let Ok(bytes) = result {
+            self.current += bytes;
+        }
+        result
+    }
+
     fn write(&mut self, buf: &[u8]) -> Result<usize, SvsmError> {
         let result = self.file.write(buf, self.current);
         if let Ok(num) = result {
             self.current += num;
+        }
+        result
+    }
+
+    fn write_buffer(&mut self, buffer: &dyn Buffer) -> Result<usize, SvsmError> {
+        let result = self.file.write_buffer(buffer, self.current);
+        if let Ok(bytes) = result {
+            self.current += bytes;
         }
         result
     }
@@ -98,6 +114,21 @@ impl FileHandle {
         self.handle.lock().read(buf)
     }
 
+    /// Read contents from the file to a [`Buffer`].
+    ///
+    /// # Arguments
+    ///
+    /// - `buffer`: [`Buffer`] Object to store data in.
+    ///
+    /// # Returns
+    ///
+    /// [`Result<usize, SvsmError>`]: A [`Result`] containing the number of
+    /// bytes read if successful, or an [`SvsmError`] if there was a problem
+    /// during the read operation.
+    pub fn read_buffer(&self, buffer: &mut dyn Buffer) -> Result<usize, SvsmError> {
+        self.handle.lock().read_buffer(buffer)
+    }
+
     /// Used to write contents to the file handle
     ///
     /// # Arguments
@@ -111,6 +142,21 @@ impl FileHandle {
     /// during the write operation.
     pub fn write(&self, buf: &[u8]) -> Result<usize, SvsmError> {
         self.handle.lock().write(buf)
+    }
+
+    /// Write data to the file via a [`Buffer`].
+    ///
+    /// # Arguments
+    ///
+    /// - `buffer`: [`Buffer`] Object to write data from.
+    ///
+    /// # Returns
+    ///
+    /// [`Result<usize, SvsmError>`]: A [`Result`] containing the number of
+    /// bytes written if successful, or an [`SvsmError`] if the operation
+    /// failed.
+    pub fn write_buffer(&self, buffer: &dyn Buffer) -> Result<usize, SvsmError> {
+        self.handle.lock().write_buffer(buffer)
     }
 
     /// Used to truncate the file to the specified size.

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -5,12 +5,14 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 
 mod api;
+mod buffer;
 mod filesystem;
 mod init;
 mod obj;
 mod ramfs;
 
 pub use api::*;
+pub use buffer::*;
 pub use filesystem::*;
 pub use init::populate_ram_fs;
 pub use obj::FsObj;

--- a/kernel/src/fs/obj.rs
+++ b/kernel/src/fs/obj.rs
@@ -49,6 +49,12 @@ impl FsObj {
         }
     }
 
+    pub fn new_file(file_handle: FileHandle) -> Self {
+        Self {
+            entry: FsObjEntry::File(file_handle),
+        }
+    }
+
     pub fn readdir(&self) -> Result<Option<(FileName, DirEntry)>, SvsmError> {
         let FsObjEntry::Directory(ref dh) = self.entry else {
             return Err(SvsmError::NotSupported);

--- a/kernel/src/fs/obj.rs
+++ b/kernel/src/fs/obj.rs
@@ -70,6 +70,49 @@ impl FsObj {
         fh.write_buffer(buffer)
     }
 
+    pub fn seek_abs(&self, offset: usize) -> Result<usize, SvsmError> {
+        let FsObjEntry::File(ref fh) = self.entry else {
+            return Err(SvsmError::NotSupported);
+        };
+
+        fh.seek_abs(offset);
+        Ok(fh.position())
+    }
+
+    pub fn seek_rel(&self, offset: isize) -> Result<usize, SvsmError> {
+        let FsObjEntry::File(ref fh) = self.entry else {
+            return Err(SvsmError::NotSupported);
+        };
+
+        fh.seek_rel(offset);
+        Ok(fh.position())
+    }
+
+    pub fn seek_end(&self, offset: usize) -> Result<usize, SvsmError> {
+        let FsObjEntry::File(ref fh) = self.entry else {
+            return Err(SvsmError::NotSupported);
+        };
+
+        fh.seek_end(offset);
+        Ok(fh.position())
+    }
+
+    pub fn position(&self) -> Result<usize, SvsmError> {
+        let FsObjEntry::File(ref fh) = self.entry else {
+            return Err(SvsmError::NotSupported);
+        };
+
+        Ok(fh.position())
+    }
+
+    pub fn file_size(&self) -> Result<usize, SvsmError> {
+        let FsObjEntry::File(ref fh) = self.entry else {
+            return Err(SvsmError::NotSupported);
+        };
+
+        Ok(fh.size())
+    }
+
     pub fn readdir(&self) -> Result<Option<(FileName, DirEntry)>, SvsmError> {
         let FsObjEntry::Directory(ref dh) = self.entry else {
             return Err(SvsmError::NotSupported);

--- a/kernel/src/fs/obj.rs
+++ b/kernel/src/fs/obj.rs
@@ -113,6 +113,14 @@ impl FsObj {
         Ok(fh.size())
     }
 
+    pub fn truncate(&self, length: usize) -> Result<usize, SvsmError> {
+        let FsObjEntry::File(ref fh) = self.entry else {
+            return Err(SvsmError::NotSupported);
+        };
+
+        fh.truncate(length)
+    }
+
     pub fn readdir(&self) -> Result<Option<(FileName, DirEntry)>, SvsmError> {
         let FsObjEntry::Directory(ref dh) = self.entry else {
             return Err(SvsmError::NotSupported);

--- a/kernel/src/fs/obj.rs
+++ b/kernel/src/fs/obj.rs
@@ -6,7 +6,7 @@
 
 extern crate alloc;
 
-use super::{DirEntry, Directory, FileHandle, FileName};
+use super::{Buffer, DirEntry, Directory, FileHandle, FileName};
 use crate::error::SvsmError;
 use crate::syscall::Obj;
 use alloc::sync::Arc;
@@ -30,7 +30,6 @@ impl DirectoryHandle {
     }
 }
 
-#[allow(dead_code)]
 #[derive(Debug)]
 enum FsObjEntry {
     File(FileHandle),
@@ -53,6 +52,14 @@ impl FsObj {
         Self {
             entry: FsObjEntry::File(file_handle),
         }
+    }
+
+    pub fn read_buffer(&self, buffer: &mut dyn Buffer) -> Result<usize, SvsmError> {
+        let FsObjEntry::File(ref fh) = self.entry else {
+            return Err(SvsmError::NotSupported);
+        };
+
+        fh.read_buffer(buffer)
     }
 
     pub fn readdir(&self) -> Result<Option<(FileName, DirEntry)>, SvsmError> {

--- a/kernel/src/fs/obj.rs
+++ b/kernel/src/fs/obj.rs
@@ -62,6 +62,14 @@ impl FsObj {
         fh.read_buffer(buffer)
     }
 
+    pub fn write_buffer(&self, buffer: &dyn Buffer) -> Result<usize, SvsmError> {
+        let FsObjEntry::File(ref fh) = self.entry else {
+            return Err(SvsmError::NotSupported);
+        };
+
+        fh.write_buffer(buffer)
+    }
+
     pub fn readdir(&self) -> Result<Option<(FileName, DirEntry)>, SvsmError> {
         let FsObjEntry::Directory(ref dh) = self.entry else {
             return Err(SvsmError::NotSupported);

--- a/kernel/src/mm/guestmem.rs
+++ b/kernel/src/mm/guestmem.rs
@@ -43,7 +43,7 @@ pub fn read_u8(v: VirtAddr) -> Result<u8, SvsmError> {
     if rcx == 0 {
         Ok(ret)
     } else {
-        Err(SvsmError::InvalidAddress)
+        Err(SvsmError::Fault)
     }
 }
 
@@ -80,7 +80,7 @@ pub unsafe fn write_u8(v: VirtAddr, val: u8) -> Result<(), SvsmError> {
     if rcx == 0 {
         Ok(())
     } else {
-        Err(SvsmError::InvalidAddress)
+        Err(SvsmError::Fault)
     }
 }
 
@@ -109,7 +109,7 @@ unsafe fn read_u16(v: VirtAddr) -> Result<u16, SvsmError> {
     if rcx == 0 {
         Ok(ret)
     } else {
-        Err(SvsmError::InvalidAddress)
+        Err(SvsmError::Fault)
     }
 }
 
@@ -138,7 +138,7 @@ unsafe fn read_u32(v: VirtAddr) -> Result<u32, SvsmError> {
     if rcx == 0 {
         Ok(ret)
     } else {
-        Err(SvsmError::InvalidAddress)
+        Err(SvsmError::Fault)
     }
 }
 
@@ -165,7 +165,7 @@ unsafe fn read_u64(v: VirtAddr) -> Result<u64, SvsmError> {
     if rcx == 0 {
         Ok(val)
     } else {
-        Err(SvsmError::InvalidAddress)
+        Err(SvsmError::Fault)
     }
 }
 
@@ -192,7 +192,7 @@ unsafe fn do_movsb<T>(src: *const T, dst: *mut T) -> Result<(), SvsmError> {
     if rcx == 0 {
         Ok(())
     } else {
-        Err(SvsmError::InvalidAddress)
+        Err(SvsmError::Fault)
     }
 }
 

--- a/kernel/src/mm/mod.rs
+++ b/kernel/src/mm/mod.rs
@@ -19,7 +19,7 @@ pub mod virtualrange;
 pub mod vm;
 
 pub use address_space::*;
-pub use guestmem::GuestPtr;
+pub use guestmem::{copy_from_user, copy_to_user, GuestPtr};
 pub use memory::{valid_phys_address, writable_phys_addr};
 pub use pagebox::*;
 pub use ptguards::*;

--- a/kernel/src/mm/vm/mapping/file_mapping.rs
+++ b/kernel/src/mm/vm/mapping/file_mapping.rs
@@ -163,7 +163,7 @@ impl VirtualMapping for VMFileMapping {
 mod tests {
     use super::*;
     use crate::{
-        fs::{create, open, unlink, TestFileSystemGuard},
+        fs::{create, open_rw, unlink, TestFileSystemGuard},
         mm::alloc::{TestRootMem, DEFAULT_TEST_MEMORY_SIZE},
         types::PAGE_SIZE,
     };
@@ -215,7 +215,7 @@ mod tests {
         let offset = PAGE_SIZE + 0x60;
 
         let (fh, name) = create_16k_test_file();
-        let fh2 = open(name).unwrap();
+        let fh2 = open_rw(name).unwrap();
         let vm = VMFileMapping::new(&fh, offset, fh2.size() - offset, VMFileMappingFlags::Read);
         assert!(vm.is_err());
         unlink(name).unwrap();
@@ -227,7 +227,7 @@ mod tests {
         let _test_fs = TestFileSystemGuard::setup();
 
         let (fh, name) = create_16k_test_file();
-        let fh2 = open(name).unwrap();
+        let fh2 = open_rw(name).unwrap();
         let vm = VMFileMapping::new(&fh, 0, fh2.size() + 1, VMFileMappingFlags::Read);
         assert!(vm.is_err());
         unlink(name).unwrap();
@@ -239,7 +239,7 @@ mod tests {
         let _test_fs = TestFileSystemGuard::setup();
 
         let (fh, name) = create_16k_test_file();
-        let fh2 = open(name).unwrap();
+        let fh2 = open_rw(name).unwrap();
         let vm = VMFileMapping::new(&fh, PAGE_SIZE, fh2.size(), VMFileMappingFlags::Read);
         assert!(vm.is_err());
         unlink(name).unwrap();
@@ -257,7 +257,7 @@ mod tests {
             .map(0)
             .expect("Mapping of first VMFileMapping page failed");
 
-        let fh2 = open(name).unwrap();
+        let fh2 = open_rw(name).unwrap();
         assert_eq!(
             fh2.mapping(0)
                 .expect("Failed to get file page mapping")
@@ -272,7 +272,7 @@ mod tests {
         let _test_fs = TestFileSystemGuard::setup();
 
         let (fh, name) = create_16k_test_file();
-        let fh2 = open(name).unwrap();
+        let fh2 = open_rw(name).unwrap();
         let vm = VMFileMapping::new(&fh, 0, fh2.size(), flags)
             .expect("Failed to create new VMFileMapping");
 
@@ -296,7 +296,7 @@ mod tests {
         let _test_fs = TestFileSystemGuard::setup();
 
         let (fh, name) = create_5000b_test_file();
-        let fh2 = open(name).unwrap();
+        let fh2 = open_rw(name).unwrap();
         let vm = VMFileMapping::new(&fh, 0, fh2.size(), flags)
             .expect("Failed to create new VMFileMapping");
 
@@ -323,7 +323,7 @@ mod tests {
         let _test_fs = TestFileSystemGuard::setup();
 
         let (fh, name) = create_16k_test_file();
-        let fh2 = open(name).unwrap();
+        let fh2 = open_rw(name).unwrap();
         let vm = VMFileMapping::new(&fh, 2 * PAGE_SIZE, PAGE_SIZE, flags)
             .expect("Failed to create new VMFileMapping");
 

--- a/kernel/src/syscall/class1.rs
+++ b/kernel/src/syscall/class1.rs
@@ -10,8 +10,8 @@ use super::obj::{obj_add, obj_get};
 use crate::address::VirtAddr;
 use crate::error::SvsmError;
 use crate::fs::{
-    create_root, find_dir, open_root, truncate, unlink_root, DirEntry, FileNameArray, FsError,
-    FsObj, UserBuffer,
+    create_root, find_dir, mkdir_root, open_root, truncate, unlink_root, DirEntry, FileNameArray,
+    FsError, FsObj, UserBuffer,
 };
 use crate::mm::guestmem::UserPtr;
 use crate::task::current_task;
@@ -144,4 +144,13 @@ pub fn sys_readdir(obj_id: u32, dirents: usize, size: usize) -> Result<u64, SysC
         user_dirents_ptr.write(new_entry)?
     }
     Ok(size as u64)
+}
+
+pub fn sys_mkdir(path: usize) -> Result<u64, SysCallError> {
+    let user_path_ptr = UserPtr::<c_char>::new(VirtAddr::from(path));
+    let user_path = user_path_ptr.read_c_string()?;
+
+    mkdir_root(current_task().rootdir(), &user_path).map_err(SysCallError::from)?;
+
+    Ok(0)
 }

--- a/kernel/src/syscall/class1.rs
+++ b/kernel/src/syscall/class1.rs
@@ -10,7 +10,8 @@ use super::obj::{obj_add, obj_get};
 use crate::address::VirtAddr;
 use crate::error::SvsmError;
 use crate::fs::{
-    create_root, find_dir, open_root, truncate, DirEntry, FileNameArray, FsError, FsObj, UserBuffer,
+    create_root, find_dir, open_root, truncate, unlink_root, DirEntry, FileNameArray, FsError,
+    FsObj, UserBuffer,
 };
 use crate::mm::guestmem::UserPtr;
 use crate::task::current_task;
@@ -97,6 +98,15 @@ pub fn sys_truncate(obj_id: u32, length: usize) -> Result<u64, SysCallError> {
         .truncate(length)
         .map(|l| l as u64)
         .map_err(SysCallError::from)
+}
+
+pub fn sys_unlink(path: usize) -> Result<u64, SysCallError> {
+    let user_path_ptr = UserPtr::<c_char>::new(VirtAddr::from(path));
+    let user_path = user_path_ptr.read_c_string()?;
+
+    unlink_root(current_task().rootdir(), &user_path).map_err(SysCallError::from)?;
+
+    Ok(0)
 }
 
 pub fn sys_opendir(path: usize) -> Result<u64, SysCallError> {

--- a/kernel/src/syscall/class1.rs
+++ b/kernel/src/syscall/class1.rs
@@ -89,6 +89,16 @@ pub fn sys_seek(obj_id: u32, offset: usize, raw_mode: usize) -> Result<u64, SysC
     result.map(|p| p as u64).map_err(SysCallError::from)
 }
 
+pub fn sys_truncate(obj_id: u32, length: usize) -> Result<u64, SysCallError> {
+    let fs_obj = obj_get(obj_id.into())?;
+    let fs_obj = fs_obj.as_fs().ok_or(ENOTSUPP)?;
+
+    fs_obj
+        .truncate(length)
+        .map(|l| l as u64)
+        .map_err(SysCallError::from)
+}
+
 pub fn sys_opendir(path: usize) -> Result<u64, SysCallError> {
     let user_path_ptr = UserPtr::<c_char>::new(VirtAddr::from(path));
     let user_path = user_path_ptr.read_c_string()?;

--- a/kernel/src/syscall/class1.rs
+++ b/kernel/src/syscall/class1.rs
@@ -10,8 +10,8 @@ use super::obj::{obj_add, obj_get};
 use crate::address::VirtAddr;
 use crate::error::SvsmError;
 use crate::fs::{
-    create_root, find_dir, mkdir_root, open_root, truncate, unlink_root, DirEntry, FileNameArray,
-    FsError, FsObj, UserBuffer,
+    create_root, find_dir, mkdir_root, open_root, rmdir_root, truncate, unlink_root, DirEntry,
+    FileNameArray, FsError, FsObj, UserBuffer,
 };
 use crate::mm::guestmem::UserPtr;
 use crate::task::current_task;
@@ -151,6 +151,15 @@ pub fn sys_mkdir(path: usize) -> Result<u64, SysCallError> {
     let user_path = user_path_ptr.read_c_string()?;
 
     mkdir_root(current_task().rootdir(), &user_path).map_err(SysCallError::from)?;
+
+    Ok(0)
+}
+
+pub fn sys_rmdir(path: usize) -> Result<u64, SysCallError> {
+    let user_path_ptr = UserPtr::<c_char>::new(VirtAddr::from(path));
+    let user_path = user_path_ptr.read_c_string()?;
+
+    rmdir_root(current_task().rootdir(), &user_path).map_err(SysCallError::from)?;
 
     Ok(0)
 }

--- a/kernel/src/syscall/class1.rs
+++ b/kernel/src/syscall/class1.rs
@@ -62,6 +62,18 @@ pub fn sys_read(obj_id: u32, user_addr: usize, bytes: usize) -> Result<u64, SysC
         .map_err(SysCallError::from)
 }
 
+pub fn sys_write(obj_id: u32, user_addr: usize, bytes: usize) -> Result<u64, SysCallError> {
+    let fs_obj = obj_get(obj_id.into())?;
+    let fs_obj = fs_obj.as_fs().ok_or(ENOTSUPP)?;
+
+    let buffer = UserBuffer::new(VirtAddr::from(user_addr), bytes);
+
+    fs_obj
+        .write_buffer(&buffer)
+        .map(|b| b as u64)
+        .map_err(SysCallError::from)
+}
+
 pub fn sys_opendir(path: usize) -> Result<u64, SysCallError> {
     let user_path_ptr = UserPtr::<c_char>::new(VirtAddr::from(path));
     let user_path = user_path_ptr.read_c_string()?;

--- a/kernel/src/task/exec.rs
+++ b/kernel/src/task/exec.rs
@@ -8,7 +8,7 @@ extern crate alloc;
 
 use crate::address::{Address, VirtAddr};
 use crate::error::SvsmError;
-use crate::fs::{open, Directory};
+use crate::fs::{open_read, Directory};
 use crate::mm::vm::VMFileMappingFlags;
 use crate::mm::USER_MEM_END;
 use crate::task::{create_user_task, current_task, finish_user_task, schedule};
@@ -41,7 +41,7 @@ fn convert_elf_phdr_flags(flags: Elf64PhdrFlags) -> VMFileMappingFlags {
 ///
 /// `()` on success, [`SvsmError`] on failure.
 pub fn exec_user(binary: &str, root: Arc<dyn Directory>) -> Result<u32, SvsmError> {
-    let fh = open(binary)?;
+    let fh = open_read(binary)?;
     let file_size = fh.size();
 
     let current_task = current_task();

--- a/syscall/Cargo.toml
+++ b/syscall/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bitflags.workspace = true
 
 [lints]
 workspace = true

--- a/syscall/src/call.rs
+++ b/syscall/src/call.rs
@@ -74,6 +74,8 @@ pub enum SysCallError {
     ENOTFOUND = -7,
     ENOTSUPP = -8,
     EEXIST = -9,
+    ERDONLY = -10,
+    EWRONLY = -11,
     UNKNOWN = -128,
 }
 
@@ -89,6 +91,8 @@ impl From<i32> for SysCallError {
             -7 => SysCallError::ENOTFOUND,
             -8 => SysCallError::ENOTSUPP,
             -9 => SysCallError::EEXIST,
+            -10 => SysCallError::ERDONLY,
+            -11 => SysCallError::EWRONLY,
             _ => SysCallError::UNKNOWN,
         }
     }

--- a/syscall/src/class1.rs
+++ b/syscall/src/class1.rs
@@ -7,7 +7,7 @@
 use super::call::{syscall1, syscall2, syscall3, SysCallError};
 use super::def::{
     FileFlags, FileModes, SeekMode, SYS_OPEN, SYS_OPENDIR, SYS_READ, SYS_READDIR, SYS_SEEK,
-    SYS_TRUNCATE, SYS_WRITE,
+    SYS_TRUNCATE, SYS_UNLINK, SYS_WRITE,
 };
 use super::{DirEnt, Obj, ObjHandle};
 use core::ffi::CStr;
@@ -92,4 +92,10 @@ pub fn truncate(fd: &FsObjHandle, length: u64) -> Result<u64, SysCallError> {
     // SAFETY: Invokes a system call and does not directly change any memory of
     // the process.
     unsafe { syscall2(SYS_TRUNCATE, fd.id().into(), length) }
+}
+
+pub fn unlink(path: &CStr) -> Result<(), SysCallError> {
+    // SAFETY: Invokes a system call and does not directly change any memory of
+    // the process.
+    unsafe { syscall1(SYS_UNLINK, path.as_ptr() as u64).map(|_| ()) }
 }

--- a/syscall/src/class1.rs
+++ b/syscall/src/class1.rs
@@ -5,7 +5,10 @@
 // Author: Peter Fang <peter.fang@intel.com>
 
 use super::call::{syscall1, syscall3, SysCallError};
-use super::def::{FileFlags, FileModes, SYS_OPEN, SYS_OPENDIR, SYS_READ, SYS_READDIR, SYS_WRITE};
+use super::def::{
+    FileFlags, FileModes, SeekMode, SYS_OPEN, SYS_OPENDIR, SYS_READ, SYS_READDIR, SYS_SEEK,
+    SYS_WRITE,
+};
 use super::{DirEnt, Obj, ObjHandle};
 use core::ffi::CStr;
 
@@ -77,4 +80,10 @@ pub fn write(fd: &FsObjHandle, buffer: &[u8]) -> Result<usize, SysCallError> {
         )
         .map(|ret| ret.try_into().unwrap())
     }
+}
+
+pub fn seek(fd: &FsObjHandle, offset: i64, mode: SeekMode) -> Result<u64, SysCallError> {
+    // SAFETY: Invokes a system call and does not directly change any memory of
+    // the process.
+    unsafe { syscall3(SYS_SEEK, fd.id().into(), offset as u64, mode as u64) }
 }

--- a/syscall/src/class1.rs
+++ b/syscall/src/class1.rs
@@ -7,7 +7,7 @@
 use super::call::{syscall1, syscall2, syscall3, SysCallError};
 use super::def::{
     FileFlags, FileModes, SeekMode, SYS_MKDIR, SYS_OPEN, SYS_OPENDIR, SYS_READ, SYS_READDIR,
-    SYS_SEEK, SYS_TRUNCATE, SYS_UNLINK, SYS_WRITE,
+    SYS_RMDIR, SYS_SEEK, SYS_TRUNCATE, SYS_UNLINK, SYS_WRITE,
 };
 use super::{DirEnt, Obj, ObjHandle};
 use core::ffi::CStr;
@@ -104,4 +104,10 @@ pub fn mkdir(path: &CStr) -> Result<(), SysCallError> {
     // SAFETY: Invokes a system call and does not directly change any memory of
     // the process.
     unsafe { syscall1(SYS_MKDIR, path.as_ptr() as u64).map(|_| ()) }
+}
+
+pub fn rmdir(path: &CStr) -> Result<(), SysCallError> {
+    // SAFETY: Invokes a system call and does not directly change any memory of
+    // the process.
+    unsafe { syscall1(SYS_RMDIR, path.as_ptr() as u64).map(|_| ()) }
 }

--- a/syscall/src/class1.rs
+++ b/syscall/src/class1.rs
@@ -6,8 +6,8 @@
 
 use super::call::{syscall1, syscall2, syscall3, SysCallError};
 use super::def::{
-    FileFlags, FileModes, SeekMode, SYS_OPEN, SYS_OPENDIR, SYS_READ, SYS_READDIR, SYS_SEEK,
-    SYS_TRUNCATE, SYS_UNLINK, SYS_WRITE,
+    FileFlags, FileModes, SeekMode, SYS_MKDIR, SYS_OPEN, SYS_OPENDIR, SYS_READ, SYS_READDIR,
+    SYS_SEEK, SYS_TRUNCATE, SYS_UNLINK, SYS_WRITE,
 };
 use super::{DirEnt, Obj, ObjHandle};
 use core::ffi::CStr;
@@ -98,4 +98,10 @@ pub fn unlink(path: &CStr) -> Result<(), SysCallError> {
     // SAFETY: Invokes a system call and does not directly change any memory of
     // the process.
     unsafe { syscall1(SYS_UNLINK, path.as_ptr() as u64).map(|_| ()) }
+}
+
+pub fn mkdir(path: &CStr) -> Result<(), SysCallError> {
+    // SAFETY: Invokes a system call and does not directly change any memory of
+    // the process.
+    unsafe { syscall1(SYS_MKDIR, path.as_ptr() as u64).map(|_| ()) }
 }

--- a/syscall/src/class1.rs
+++ b/syscall/src/class1.rs
@@ -4,10 +4,10 @@
 //
 // Author: Peter Fang <peter.fang@intel.com>
 
-use super::call::{syscall1, syscall3, SysCallError};
+use super::call::{syscall1, syscall2, syscall3, SysCallError};
 use super::def::{
     FileFlags, FileModes, SeekMode, SYS_OPEN, SYS_OPENDIR, SYS_READ, SYS_READDIR, SYS_SEEK,
-    SYS_WRITE,
+    SYS_TRUNCATE, SYS_WRITE,
 };
 use super::{DirEnt, Obj, ObjHandle};
 use core::ffi::CStr;
@@ -86,4 +86,10 @@ pub fn seek(fd: &FsObjHandle, offset: i64, mode: SeekMode) -> Result<u64, SysCal
     // SAFETY: Invokes a system call and does not directly change any memory of
     // the process.
     unsafe { syscall3(SYS_SEEK, fd.id().into(), offset as u64, mode as u64) }
+}
+
+pub fn truncate(fd: &FsObjHandle, length: u64) -> Result<u64, SysCallError> {
+    // SAFETY: Invokes a system call and does not directly change any memory of
+    // the process.
+    unsafe { syscall2(SYS_TRUNCATE, fd.id().into(), length) }
 }

--- a/syscall/src/def.rs
+++ b/syscall/src/def.rs
@@ -25,6 +25,7 @@ pub const SYS_UNLINK: u64 = CLASS1 + 5;
 pub const SYS_OPENDIR: u64 = CLASS1 + 6;
 pub const SYS_READDIR: u64 = CLASS1 + 7;
 pub const SYS_MKDIR: u64 = CLASS1 + 8;
+pub const SYS_RMDIR: u64 = CLASS1 + 9;
 
 ///Maximum length of path name including null character in bytes
 pub const PATH_MAX: usize = 4096;

--- a/syscall/src/def.rs
+++ b/syscall/src/def.rs
@@ -24,6 +24,7 @@ pub const SYS_TRUNCATE: u64 = CLASS1 + 4;
 pub const SYS_UNLINK: u64 = CLASS1 + 5;
 pub const SYS_OPENDIR: u64 = CLASS1 + 6;
 pub const SYS_READDIR: u64 = CLASS1 + 7;
+pub const SYS_MKDIR: u64 = CLASS1 + 8;
 
 ///Maximum length of path name including null character in bytes
 pub const PATH_MAX: usize = 4096;

--- a/syscall/src/def.rs
+++ b/syscall/src/def.rs
@@ -20,8 +20,9 @@ pub const SYS_OPEN: u64 = CLASS1;
 pub const SYS_READ: u64 = CLASS1 + 1;
 pub const SYS_WRITE: u64 = CLASS1 + 2;
 pub const SYS_SEEK: u64 = CLASS1 + 3;
-pub const SYS_OPENDIR: u64 = CLASS1 + 4;
-pub const SYS_READDIR: u64 = CLASS1 + 5;
+pub const SYS_TRUNCATE: u64 = CLASS1 + 4;
+pub const SYS_OPENDIR: u64 = CLASS1 + 5;
+pub const SYS_READDIR: u64 = CLASS1 + 6;
 
 ///Maximum length of path name including null character in bytes
 pub const PATH_MAX: usize = 4096;

--- a/syscall/src/def.rs
+++ b/syscall/src/def.rs
@@ -19,6 +19,7 @@ pub const SYS_CLOSE: u64 = CLASS0 + 10;
 pub const SYS_OPEN: u64 = CLASS1;
 pub const SYS_READ: u64 = CLASS1 + 1;
 pub const SYS_WRITE: u64 = CLASS1 + 2;
+pub const SYS_SEEK: u64 = CLASS1 + 3;
 pub const SYS_OPENDIR: u64 = CLASS1 + 4;
 pub const SYS_READDIR: u64 = CLASS1 + 5;
 
@@ -60,6 +61,41 @@ bitflags! {
     pub struct FileFlags: usize {
         /// Create file if it does not exist
         const CREATE = 1 << 0;
+    }
+}
+
+//
+// Modes for Seek system call
+//
+#[derive(Debug)]
+pub enum SeekMode {
+    /// Absolute file position
+    Absolute = 0,
+    /// Relative file position
+    Relative = 1,
+    /// File position relative to EOF
+    End = 2,
+}
+
+impl From<SeekMode> for usize {
+    fn from(mode: SeekMode) -> Self {
+        mode as Self
+    }
+}
+
+impl TryFrom<usize> for SeekMode {
+    type Error = ();
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        if value == SeekMode::Absolute.into() {
+            Ok(SeekMode::Absolute)
+        } else if value == SeekMode::Relative.into() {
+            Ok(SeekMode::Relative)
+        } else if value == SeekMode::End.into() {
+            Ok(SeekMode::End)
+        } else {
+            Err(())
+        }
     }
 }
 

--- a/syscall/src/def.rs
+++ b/syscall/src/def.rs
@@ -18,6 +18,7 @@ pub const SYS_CLOSE: u64 = CLASS0 + 10;
 // Syscall number in class1
 pub const SYS_OPEN: u64 = CLASS1;
 pub const SYS_READ: u64 = CLASS1 + 1;
+pub const SYS_WRITE: u64 = CLASS1 + 2;
 pub const SYS_OPENDIR: u64 = CLASS1 + 4;
 pub const SYS_READDIR: u64 = CLASS1 + 5;
 

--- a/syscall/src/def.rs
+++ b/syscall/src/def.rs
@@ -17,6 +17,7 @@ pub const SYS_CLOSE: u64 = CLASS0 + 10;
 
 // Syscall number in class1
 pub const SYS_OPEN: u64 = CLASS1;
+pub const SYS_READ: u64 = CLASS1 + 1;
 pub const SYS_OPENDIR: u64 = CLASS1 + 4;
 pub const SYS_READDIR: u64 = CLASS1 + 5;
 

--- a/syscall/src/def.rs
+++ b/syscall/src/def.rs
@@ -21,8 +21,9 @@ pub const SYS_READ: u64 = CLASS1 + 1;
 pub const SYS_WRITE: u64 = CLASS1 + 2;
 pub const SYS_SEEK: u64 = CLASS1 + 3;
 pub const SYS_TRUNCATE: u64 = CLASS1 + 4;
-pub const SYS_OPENDIR: u64 = CLASS1 + 5;
-pub const SYS_READDIR: u64 = CLASS1 + 6;
+pub const SYS_UNLINK: u64 = CLASS1 + 5;
+pub const SYS_OPENDIR: u64 = CLASS1 + 6;
+pub const SYS_READDIR: u64 = CLASS1 + 7;
 
 ///Maximum length of path name including null character in bytes
 pub const PATH_MAX: usize = 4096;

--- a/syscall/src/def.rs
+++ b/syscall/src/def.rs
@@ -4,6 +4,8 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
+use bitflags::bitflags;
+
 // Syscall classes
 const CLASS0: u64 = 0;
 const CLASS1: u64 = 1 << 32;
@@ -14,6 +16,7 @@ pub const SYS_EXEC: u64 = CLASS0 + 4;
 pub const SYS_CLOSE: u64 = CLASS0 + 10;
 
 // Syscall number in class1
+pub const SYS_OPEN: u64 = CLASS1;
 pub const SYS_OPENDIR: u64 = CLASS1 + 4;
 pub const SYS_READDIR: u64 = CLASS1 + 5;
 
@@ -28,6 +31,34 @@ pub const F_NAME_SIZE: usize = 256;
 pub enum FileType {
     File,
     Directory,
+}
+
+//
+// Mode flags for Open system call
+//
+bitflags! {
+    #[derive(Debug, Copy, Clone, Default)]
+    pub struct FileModes: usize {
+        /// Open file for reading
+        const READ = 1 << 0;
+        /// Open file for writing
+        const WRITE = 1 << 1;
+        /// Place file pointer at EOF
+        const APPEND = 1 << 2;
+        /// Truncate file to zero
+        const TRUNC = 1 << 3;
+    }
+}
+
+//
+// File flags for Open system call
+//
+bitflags! {
+    #[derive(Debug, Copy, Clone, Default)]
+    pub struct FileFlags: usize {
+        /// Create file if it does not exist
+        const CREATE = 1 << 0;
+    }
 }
 
 #[repr(C)]


### PR DESCRIPTION
Here is an initial implementation of the remaining file-system system calls, namely:

* OPEN
* READ
* WRITE
* SEEK
* TRUNCATE

TRUNCATE was not initially specified, so READDIR and OPENDIR get new syscall numbers.

The code is completely untested and posted for reference and awareness only. I move the PR out of Draft state once I have tested all new system calls.