### PR TITLE
User-mode console support

### DIFF
--- a/kernel/src/console.rs
+++ b/kernel/src/console.rs
@@ -18,10 +18,16 @@ struct Console {
 
 impl fmt::Write for Console {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        for ch in s.bytes() {
-            self.writer.put_byte(ch);
-        }
+        self.write_bytes(s.as_bytes());
         Ok(())
+    }
+}
+
+impl Console {
+    pub fn write_bytes(&self, buffer: &[u8]) {
+        for b in buffer.iter() {
+            self.writer.put_byte(*b);
+        }
     }
 }
 
@@ -53,6 +59,18 @@ pub fn _print(args: fmt::Arguments<'_>) {
         return;
     }
     WRITER.lock().write_fmt(args).unwrap();
+}
+
+/// Writes all bytes from the slice to the console
+///
+/// # Arguments:
+///
+/// * `buffer`: u8 slice with bytes to write.
+pub fn console_write(buffer: &[u8]) {
+    if !*CONSOLE_INITIALIZED {
+        return;
+    }
+    WRITER.lock().write_bytes(buffer);
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/kernel/src/cpu/idt/entry.S
+++ b/kernel/src/cpu/idt/entry.S
@@ -336,7 +336,7 @@ return_user:
 
 .globl return_new_task
 return_new_task:
-	call setup_new_task
+	call setup_user_task
 	jmp default_return
 
 // #DE Divide-by-Zero-Error Exception (Vector 0)

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -48,6 +48,7 @@ use crate::types::{
     PAGE_SHIFT, PAGE_SHIFT_2M, PAGE_SIZE, PAGE_SIZE_2M, SVSM_TR_ATTRIBUTES, SVSM_TSS,
 };
 use crate::utils::MemoryRegion;
+use alloc::string::String;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::cell::{Cell, OnceCell, Ref, RefCell, RefMut, UnsafeCell};
@@ -763,7 +764,7 @@ impl PerCpu {
     }
 
     pub fn setup_idle_task(&self, entry: extern "C" fn()) -> Result<(), SvsmError> {
-        let idle_task = Task::create(self, entry)?;
+        let idle_task = Task::create(self, entry, String::from("idle"))?;
         self.runqueue.lock_read().set_idle_task(idle_task);
         Ok(())
     }

--- a/kernel/src/cpu/smp.rs
+++ b/kernel/src/cpu/smp.rs
@@ -4,6 +4,8 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
+extern crate alloc;
+
 use crate::acpi::tables::ACPICPUInfo;
 use crate::address::Address;
 use crate::cpu::percpu::{this_cpu, this_cpu_shared, PerCpu};
@@ -16,6 +18,8 @@ use crate::platform::SVSM_PLATFORM;
 use crate::requests::{request_loop, request_processing_main};
 use crate::task::{schedule_init, start_kernel_task};
 use crate::utils::immut_after_init::immut_after_init_set_multithreaded;
+
+use alloc::string::String;
 
 fn start_cpu(platform: &dyn SvsmPlatform, apic_id: u32) -> Result<(), SvsmError> {
     let start_rip: u64 = (start_ap as *const u8) as u64;
@@ -70,7 +74,8 @@ fn start_ap() {
 
 #[no_mangle]
 pub extern "C" fn ap_request_loop() {
-    start_kernel_task(request_processing_main).expect("Failed to launch request processing task");
+    start_kernel_task(request_processing_main, String::from("request-processing"))
+        .expect("Failed to launch request processing task");
     request_loop();
     panic!("Returned from request_loop!");
 }

--- a/kernel/src/fs/console.rs
+++ b/kernel/src/fs/console.rs
@@ -6,12 +6,15 @@
 
 extern crate alloc;
 
-use super::{Buffer, File, FsError};
+use super::{Buffer, File, FileHandle, FsError};
 use crate::console::console_write;
 use crate::cpu::percpu::current_task;
 use crate::error::SvsmError;
+use crate::fs::obj::FsObj;
 use crate::locking::SpinLock;
+use crate::syscall::Obj;
 use alloc::string::String;
+use alloc::sync::Arc;
 
 // With the value of 224 the ConsoleBuffer struct will be exactly 256 bytes
 // large, avoiding memory waste due to internal fragmentation.
@@ -121,4 +124,11 @@ impl File for ConsoleFile {
     fn size(&self) -> usize {
         0
     }
+}
+
+pub fn stdout_open() -> Arc<dyn Obj> {
+    let console_file: Arc<dyn File> = Arc::new(ConsoleFile::new());
+
+    // Stdout is write-only.
+    Arc::new(FsObj::new_file(FileHandle::new(&console_file, false, true)))
 }

--- a/kernel/src/fs/console.rs
+++ b/kernel/src/fs/console.rs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2024
+//
+// Author: Joerg Roedel <jroedel@suse.de>
+
+extern crate alloc;
+
+use super::{Buffer, File, FsError};
+use crate::console::console_write;
+use crate::cpu::percpu::current_task;
+use crate::error::SvsmError;
+use crate::locking::SpinLock;
+use alloc::string::String;
+
+// With the value of 224 the ConsoleBuffer struct will be exactly 256 bytes
+// large, avoiding memory waste due to internal fragmentation.
+const CONSOLE_LINE_BUFFER_SIZE: usize = 224;
+
+#[derive(Debug)]
+struct ConsoleBuffer {
+    prefix: String,
+    buffer: [u8; CONSOLE_LINE_BUFFER_SIZE],
+    fill: usize,
+}
+
+impl ConsoleBuffer {
+    fn new() -> Self {
+        let task = current_task();
+        let task_name = task.get_task_name();
+        let mut prefix = String::from("[");
+        prefix.push_str(task_name.as_str());
+        prefix.push_str("] ");
+        Self {
+            prefix,
+            buffer: [0u8; CONSOLE_LINE_BUFFER_SIZE],
+            fill: 0,
+        }
+    }
+
+    fn push(&mut self, b: u8) {
+        let newline: u8 = '\n'.try_into().unwrap();
+
+        if self.fill + 1 == CONSOLE_LINE_BUFFER_SIZE {
+            self.buffer[self.fill] = newline;
+            self.fill += 1;
+            self.flush();
+        }
+
+        let index = self.fill;
+        self.buffer[index] = b;
+        self.fill += 1;
+        if b == newline {
+            self.flush();
+        }
+    }
+
+    pub fn flush(&mut self) {
+        console_write(self.prefix.as_bytes());
+        console_write(&self.buffer[..self.fill]);
+        self.fill = 0;
+    }
+}
+
+#[derive(Debug)]
+pub struct ConsoleFile {
+    buffer: SpinLock<ConsoleBuffer>,
+}
+
+impl ConsoleFile {
+    pub fn new() -> Self {
+        Self {
+            buffer: SpinLock::new(ConsoleBuffer::new()),
+        }
+    }
+}
+
+impl Default for ConsoleFile {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl File for ConsoleFile {
+    fn read(&self, _buf: &mut [u8], _offset: usize) -> Result<usize, SvsmError> {
+        Ok(0)
+    }
+
+    fn read_buffer(&self, _buffer: &mut dyn Buffer, _offset: usize) -> Result<usize, SvsmError> {
+        Ok(0)
+    }
+
+    fn write(&self, buf: &[u8], _offset: usize) -> Result<usize, SvsmError> {
+        let mut console = self.buffer.lock();
+
+        for c in buf.iter() {
+            console.push(*c);
+        }
+
+        Ok(buf.len())
+    }
+
+    fn write_buffer(&self, buffer: &dyn Buffer, _offset: usize) -> Result<usize, SvsmError> {
+        let len = buffer.size();
+        let mut offset: usize = 0;
+
+        while offset < len {
+            let mut kernel_buffer: [u8; 16] = [0u8; 16];
+            let read = buffer.read_buffer(&mut kernel_buffer, offset)?;
+            self.write(&kernel_buffer[0..read], 0)?;
+            offset += read;
+        }
+
+        Ok(offset)
+    }
+
+    fn truncate(&self, _size: usize) -> Result<usize, SvsmError> {
+        Err(SvsmError::FileSystem(FsError::not_supported()))
+    }
+
+    fn size(&self) -> usize {
+        0
+    }
+}

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -14,7 +14,7 @@ mod ramfs;
 
 pub use api::*;
 pub use buffer::*;
-pub use console::ConsoleFile;
+pub use console::{stdout_open, ConsoleFile};
 pub use filesystem::*;
 pub use init::populate_ram_fs;
 pub use obj::FsObj;

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -6,6 +6,7 @@
 
 mod api;
 mod buffer;
+mod console;
 mod filesystem;
 mod init;
 mod obj;
@@ -13,6 +14,7 @@ mod ramfs;
 
 pub use api::*;
 pub use buffer::*;
+pub use console::ConsoleFile;
 pub use filesystem::*;
 pub use init::populate_ram_fs;
 pub use obj::FsObj;

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -7,6 +7,8 @@
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(not(test), no_main)]
 
+extern crate alloc;
+
 use bootlib::kernel_launch::KernelLaunchInfo;
 use core::arch::global_asm;
 use core::panic::PanicInfo;
@@ -50,6 +52,8 @@ use svsm::utils::{immut_after_init::ImmutAfterInitCell, zero_mem_region};
 use svsm::vtpm::vtpm_init;
 
 use svsm::mm::validate::{init_valid_bitmap_ptr, migrate_valid_bitmap};
+
+use alloc::string::String;
 
 extern "C" {
     pub static bsp_stack_end: u8;
@@ -319,7 +323,8 @@ pub extern "C" fn svsm_main() {
         panic!("Failed to launch FW: {e:#?}");
     }
 
-    start_kernel_task(request_processing_main).expect("Failed to launch request processing task");
+    start_kernel_task(request_processing_main, String::from("request-processing"))
+        .expect("Failed to launch request processing task");
 
     #[cfg(test)]
     crate::test_main();

--- a/kernel/src/syscall/obj.rs
+++ b/kernel/src/syscall/obj.rs
@@ -15,6 +15,7 @@ use alloc::sync::Arc;
 pub enum ObjError {
     InvalidHandle,
     NotFound,
+    Busy,
 }
 
 /// An object represents the type of resource like file, VM, vCPU in the

--- a/kernel/src/task/exec.rs
+++ b/kernel/src/task/exec.rs
@@ -17,6 +17,8 @@ use crate::utils::align_up;
 use alloc::sync::Arc;
 use elf::{Elf64File, Elf64PhdrFlags};
 
+use alloc::string::String;
+
 fn convert_elf_phdr_flags(flags: Elf64PhdrFlags) -> VMFileMappingFlags {
     let mut vm_flags = VMFileMappingFlags::Fixed;
 
@@ -59,7 +61,7 @@ pub fn exec_user(binary: &str, root: Arc<dyn Directory>) -> Result<u32, SvsmErro
     let virt_base = alloc_info.range.vaddr_begin;
     let entry = elf_bin.get_entry(virt_base);
 
-    let new_task = create_user_task(entry.try_into().unwrap(), root)?;
+    let new_task = create_user_task(entry.try_into().unwrap(), root, String::from("user"))?;
 
     for seg in elf_bin.image_load_segment_iter(virt_base) {
         let virt_start = VirtAddr::from(seg.vaddr_range.vaddr_begin);

--- a/kernel/src/task/exec.rs
+++ b/kernel/src/task/exec.rs
@@ -33,6 +33,16 @@ fn convert_elf_phdr_flags(flags: Elf64PhdrFlags) -> VMFileMappingFlags {
     vm_flags
 }
 
+/// Returns the name of the binary file without preceeding directories. This is
+/// used as the official task name.
+fn task_name(binary: &str) -> String {
+    let mut items = binary.split('/').filter(|x| !x.is_empty());
+    match items.nth_back(0) {
+        Some(p) => String::from(p),
+        None => String::from("unknown"),
+    }
+}
+
 /// Loads and executes an ELF binary in user-mode.
 ///
 /// # Arguments
@@ -61,7 +71,7 @@ pub fn exec_user(binary: &str, root: Arc<dyn Directory>) -> Result<u32, SvsmErro
     let virt_base = alloc_info.range.vaddr_begin;
     let entry = elf_bin.get_entry(virt_base);
 
-    let new_task = create_user_task(entry.try_into().unwrap(), root, String::from("user"))?;
+    let new_task = create_user_task(entry.try_into().unwrap(), root, task_name(binary))?;
 
     for seg in elf_bin.image_load_segment_iter(virt_base) {
         let virt_start = VirtAddr::from(seg.vaddr_range.vaddr_begin);

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -43,6 +43,7 @@ use crate::error::SvsmError;
 use crate::fs::Directory;
 use crate::locking::SpinLock;
 use crate::mm::{STACK_TOTAL_SIZE, SVSM_CONTEXT_SWITCH_SHADOW_STACK, SVSM_CONTEXT_SWITCH_STACK};
+use alloc::string::String;
 use alloc::sync::Arc;
 use core::arch::{asm, global_asm};
 use core::cell::OnceCell;
@@ -243,9 +244,9 @@ pub static TASKLIST: SpinLock<TaskList> = SpinLock::new(TaskList::new());
 /// # Returns
 ///
 /// A new instance of [`TaskPointer`] on success, [`SvsmError`] on failure.
-pub fn start_kernel_task(entry: extern "C" fn()) -> Result<TaskPointer, SvsmError> {
+pub fn start_kernel_task(entry: extern "C" fn(), name: String) -> Result<TaskPointer, SvsmError> {
     let cpu = this_cpu();
-    let task = Task::create(cpu, entry)?;
+    let task = Task::create(cpu, entry, name)?;
     TASKLIST.lock().list().push_back(task.clone());
 
     // Put task on the runqueue of this CPU
@@ -269,9 +270,10 @@ pub fn start_kernel_task(entry: extern "C" fn()) -> Result<TaskPointer, SvsmErro
 pub fn create_user_task(
     user_entry: usize,
     root: Arc<dyn Directory>,
+    name: String,
 ) -> Result<TaskPointer, SvsmError> {
     let cpu = this_cpu();
-    Task::create_user(cpu, user_entry, root)
+    Task::create_user(cpu, user_entry, root, name)
 }
 
 /// Finished user-space task creation by putting the task on the global

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -637,6 +637,34 @@ impl Task {
         Ok(id)
     }
 
+    /// Adds an object to the current task and maps it to a given object-id.
+    ///
+    /// # Arguments
+    ///
+    /// * `obj` - The object to be added.
+    /// * `handle` - Object handle to reference the object.
+    ///
+    /// # Returns
+    ///
+    /// * `Result<ObjHandle, SvsmError>` - Returns the object handle for the object
+    ///   to be added if successful, or an `SvsmError` on failure.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if allocating the object handle
+    /// fails or the object id is already in use.
+    pub fn add_obj_at(&self, obj: Arc<dyn Obj>, handle: ObjHandle) -> Result<ObjHandle, SvsmError> {
+        let mut objs = self.objs.lock_write();
+
+        if objs.get(&handle).is_some() {
+            return Err(SvsmError::from(ObjError::Busy));
+        }
+
+        objs.insert(handle, obj);
+
+        Ok(handle)
+    }
+
     /// Removes an object from the current task.
     ///
     /// # Arguments

--- a/syscall/src/class1.rs
+++ b/syscall/src/class1.rs
@@ -15,6 +15,12 @@ use core::ffi::CStr;
 #[derive(Debug)]
 pub struct FsObjHandle(ObjHandle);
 
+impl FsObjHandle {
+    pub(crate) const fn new(obj: ObjHandle) -> Self {
+        Self(obj)
+    }
+}
+
 impl Obj for FsObjHandle {
     fn id(&self) -> u32 {
         u32::from(&self.0)

--- a/syscall/src/console.rs
+++ b/syscall/src/console.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2024 SUSE LLC
+//
+// Author: Joerg Roedel <jroedel@suse.de>
+
+use crate::{write, FsObjHandle, ObjHandle, SysCallError};
+
+static CONSOLE_HANDLE: FsObjHandle = FsObjHandle::new(ObjHandle::new(0));
+
+pub fn write_console(buf: &[u8]) -> Result<usize, SysCallError> {
+    write(&CONSOLE_HANDLE, buf)
+}

--- a/syscall/src/lib.rs
+++ b/syscall/src/lib.rs
@@ -8,11 +8,13 @@
 mod call;
 mod class0;
 mod class1;
+mod console;
 mod def;
 mod obj;
 
 pub use call::SysCallError;
 pub use class0::*;
 pub use class1::*;
+pub use console::*;
 pub use def::*;
 pub use obj::*;

--- a/syscall/src/obj.rs
+++ b/syscall/src/obj.rs
@@ -18,7 +18,7 @@ use super::SYS_CLOSE;
 pub struct ObjHandle(u32);
 
 impl ObjHandle {
-    pub(crate) fn new(id: u32) -> Self {
+    pub(crate) const fn new(id: u32) -> Self {
         Self(id)
     }
 }

--- a/user/init/src/main.rs
+++ b/user/init/src/main.rs
@@ -26,6 +26,8 @@ fn write(arr: &mut [u64; 128], val: u64) {
 declare_main!(main);
 
 fn main() -> u32 {
+    println!("COCONUT-SVSM init process starting");
+
     // SAFETY: Single-threaded process, so no data races. Safe to access global
     // mutable data.
     unsafe {

--- a/user/lib/src/console.rs
+++ b/user/lib/src/console.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2024 SUSE LLC
+//
+// Author: Joerg Roedel <jroedel@suse.de>
+
+use crate::SpinLock;
+use core::fmt;
+use syscall::write_console;
+
+#[derive(Debug, Default)]
+struct ConsoleWriter {}
+
+impl ConsoleWriter {
+    const fn new() -> Self {
+        Self {}
+    }
+}
+
+impl fmt::Write for ConsoleWriter {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        // Ignore any errors from console writing.
+        let _ = write_console(s.as_bytes());
+        Ok(())
+    }
+}
+
+static CONSOLE_WRITER: SpinLock<ConsoleWriter> = SpinLock::new(ConsoleWriter::new());
+
+#[doc(hidden)]
+pub fn console_print(args: fmt::Arguments<'_>) {
+    use core::fmt::Write;
+    CONSOLE_WRITER.lock().write_fmt(args).unwrap()
+}
+
+#[macro_export]
+macro_rules! print {
+        ($($arg:tt)*) => (console_print(format_args!($($arg)*)))
+}
+
+#[macro_export]
+macro_rules! println {
+    () => (print!("\n"));
+    ($($arg:tt)*) => (print!("{}\n", format_args!($($arg)*)));
+}

--- a/user/lib/src/lib.rs
+++ b/user/lib/src/lib.rs
@@ -6,8 +6,10 @@
 
 #![no_std]
 
+pub mod console;
 pub mod locking;
 
+pub use console::*;
 use core::panic::PanicInfo;
 pub use locking::*;
 pub use syscall::*;
@@ -27,6 +29,7 @@ macro_rules! declare_main {
 }
 
 #[panic_handler]
-fn panic(_info: &PanicInfo<'_>) -> ! {
+fn panic(info: &PanicInfo<'_>) -> ! {
+    println!("Panic: {}", info);
     exit(!0);
 }

--- a/user/lib/src/lib.rs
+++ b/user/lib/src/lib.rs
@@ -6,7 +6,10 @@
 
 #![no_std]
 
+pub mod locking;
+
 use core::panic::PanicInfo;
+pub use locking::*;
 pub use syscall::*;
 
 #[macro_export]

--- a/user/lib/src/locking.rs
+++ b/user/lib/src/locking.rs
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2024 SUSE LLC
+//
+// Author: Joerg Roedel <jroedel@suse.de>
+
+use core::cell::UnsafeCell;
+use core::ops::{Deref, DerefMut};
+use core::sync::atomic::{AtomicU64, Ordering};
+
+/// A lock guard obtained from a [`SpinLock`]. This lock guard
+/// provides exclusive access to the data protected by a [`SpinLock`],
+/// ensuring that the lock is released when it goes out of scope.
+///
+/// # Examples
+///
+/// ```
+/// use userlib::SpinLock;
+///
+/// let data = 42;
+/// let spin_lock = SpinLock::new(data);
+///
+/// {
+///     let mut guard = spin_lock.lock();
+///     *guard += 1; // Modify the protected data.
+/// }; // Lock is automatically released when `guard` goes out of scope.
+/// ```
+
+#[derive(Debug)]
+pub struct LockGuard<'a, T> {
+    holder: &'a AtomicU64,
+    data: &'a mut T,
+}
+
+impl<T> Drop for LockGuard<'_, T> {
+    fn drop(&mut self) {
+        self.holder.fetch_add(1, Ordering::Release);
+    }
+}
+
+impl<T> Deref for LockGuard<'_, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        self.data
+    }
+}
+
+impl<T> DerefMut for LockGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        self.data
+    }
+}
+
+#[derive(Debug)]
+pub struct SpinLock<T> {
+    current: AtomicU64,
+    holder: AtomicU64,
+    data: UnsafeCell<T>,
+}
+
+// SAFETY: SpinLock guarantees mutually exclusive access to wrapped data.
+unsafe impl<T> Sync for SpinLock<T> {}
+
+impl<'a, T> SpinLock<T> {
+    /// Create a new `SpinLock`
+    ///
+    /// # Arguments:
+    ///
+    /// * `data`: Data to be protected by the `SpinLock`. The data is moved into
+    ///    and from this point on owned by the SpinLock.
+    ///
+    /// # Returns:
+    ///
+    /// New instance of `SpinLock` containing `data`.
+    pub const fn new(data: T) -> Self {
+        SpinLock {
+            current: AtomicU64::new(0),
+            holder: AtomicU64::new(0),
+            data: UnsafeCell::new(data),
+        }
+    }
+
+    /// Takes lock and returns [`LockGuard`] which gives exclusive access to
+    /// the protected data.
+    ///
+    /// # Returns:
+    ///
+    /// Instance of [`LockGuard`] to exclusivly access the data a release the
+    /// lock when it goes out of scope.
+    pub fn lock(&'a self) -> LockGuard<'a, T> {
+        let ticket = self.current.fetch_add(1, Ordering::Relaxed);
+        loop {
+            let h = self.holder.load(Ordering::Acquire);
+            if h == ticket {
+                break;
+            }
+        }
+
+        LockGuard {
+            holder: &self.holder,
+            // SAFETY: Safe because at this point the lock is held and this is
+            // guaranteed to be the only reference.
+            data: unsafe { &mut *self.data.get() },
+        }
+    }
+}


### PR DESCRIPTION
This PR implements console output support for user-mode processes. In user-mode code the `print!` and `println!` macros can now be used to print messages to the SVSM console.

It depends on PRs #539 and #548 and is here for testing and initial review. ~I will keep it in draft state until the dependencies have been merged.~