### PR TITLE
Revert "kernel/cpu: add safety comments"

### DIFF
--- a/kernel/src/cpu/control_regs.rs
+++ b/kernel/src/cpu/control_regs.rs
@@ -94,8 +94,6 @@ bitflags! {
 pub fn read_cr0() -> CR0Flags {
     let cr0: u64;
 
-    // SAFETY: The inline assembly just reads the processors CR0 register
-    // and does not change any state.
     unsafe {
         asm!("mov %cr0, %rax",
              out("rax") cr0,
@@ -117,9 +115,6 @@ pub fn write_cr0(cr0: CR0Flags) {
 
 pub fn read_cr2() -> usize {
     let ret: usize;
-
-    // SAFETY: The inline assembly just reads the processors CR2 register
-    // and does not change any state.
     unsafe {
         asm!("mov %cr2, %rax",
              out("rax") ret,
@@ -138,9 +133,6 @@ pub fn write_cr2(cr2: usize) {
 
 pub fn read_cr3() -> PhysAddr {
     let ret: usize;
-
-    // SAFETY: The inline assembly just reads the processors CR3 register
-    // and does not change any state.
     unsafe {
         asm!("mov %cr3, %rax",
              out("rax") ret,
@@ -187,8 +179,6 @@ bitflags! {
 pub fn read_cr4() -> CR4Flags {
     let cr4: u64;
 
-    // SAFETY: The inline assembly just reads the processors CR4 register
-    // and does not change any state.
     unsafe {
         asm!("mov %cr4, %rax",
              out("rax") cr4,

--- a/kernel/src/cpu/cpuid.rs
+++ b/kernel/src/cpu/cpuid.rs
@@ -55,9 +55,6 @@ impl CpuidResult {
         let mut result_ebx: u32;
         let mut result_ecx: u32;
         let mut result_edx: u32;
-        // SAFETY: Inline assembly to execute the CPUID instruction which does
-        // not change any state. Input registers (EAX, ECX) and output
-        // registers (EAX, EBX, ECX, EDX) are safely managed.
         unsafe {
             asm!("push %rbx",
                  "cpuid",

--- a/kernel/src/cpu/idt/common.rs
+++ b/kernel/src/cpu/idt/common.rs
@@ -348,8 +348,6 @@ impl WriteLockGuard<'static, IDT> {
             address: VirtAddr::from(self.entries.as_ptr()),
         };
 
-        // SAFETY: Inline assembly to load an IDT. `'static` lifetime ensures
-        // that address is always available for the CPU.
         unsafe {
             asm!("lidt (%rax)", in("rax") &desc, options(att_syntax));
         }
@@ -380,8 +378,6 @@ pub fn triple_fault() {
         address: VirtAddr::from(0u64),
     };
 
-    // SAFETY: This ends execution, this function will not return so memory
-    // safety is not an issue.
     unsafe {
         asm!("lidt (%rax)
               int3", in("rax") &desc, options(att_syntax));

--- a/kernel/src/cpu/irq_state.rs
+++ b/kernel/src/cpu/irq_state.rs
@@ -18,8 +18,6 @@ const EFLAGS_IF: u64 = 1 << 9;
 /// Callers need to take care of re-enabling IRQs.
 #[inline(always)]
 pub fn raw_irqs_disable() {
-    // SAFETY: Inline assembly to disable IRQs, which does not change any state
-    // related to memory safety.
     unsafe {
         asm!("cli", options(att_syntax, preserves_flags, nomem));
     }
@@ -32,8 +30,6 @@ pub fn raw_irqs_disable() {
 /// have been enabled.
 #[inline(always)]
 pub fn raw_irqs_enable() {
-    // SAFETY: Inline assembly to enable IRQs, which does not change any state
-    // related to memory safety.
     unsafe {
         asm!("sti", options(att_syntax, preserves_flags, nomem));
     }

--- a/kernel/src/cpu/mem.rs
+++ b/kernel/src/cpu/mem.rs
@@ -8,9 +8,6 @@ use core::arch::asm;
 /// that data races (both on `src` and `dst`) are explicitly permitted.
 #[inline(always)]
 pub unsafe fn copy_bytes(src: usize, dst: usize, size: usize) {
-    // SAFETY: Inline assembly to perform a memory copy.
-    // The safery requirements of the parameters are delegated to the caller of
-    // this function which is unsafe.
     unsafe {
         asm!(
             "rep movsb",
@@ -30,9 +27,6 @@ pub unsafe fn copy_bytes(src: usize, dst: usize, size: usize) {
 /// that data races are explicitly permitted.
 #[inline(always)]
 pub unsafe fn write_bytes(dst: usize, size: usize, value: u8) {
-    // SAFETY: Inline assembly to perform a memory write.
-    // The safery requirements of the parameters are delegated to the caller of
-    // this function which is unsafe.
     unsafe {
         asm!(
             "rep stosb",

--- a/kernel/src/cpu/msr.rs
+++ b/kernel/src/cpu/msr.rs
@@ -15,8 +15,6 @@ pub fn read_msr(msr: u32) -> u64 {
     let eax: u32;
     let edx: u32;
 
-    // SAFETY: Inline assembly to read the specified MSR. It does not change
-    // any state.
     unsafe {
         asm!("rdmsr",
              in("ecx") msr,
@@ -31,8 +29,6 @@ pub fn write_msr(msr: u32, val: u64) {
     let eax = (val & 0x0000_0000_ffff_ffff) as u32;
     let edx = (val >> 32) as u32;
 
-    // SAFETY: Inline assembly to write the specified MSR. It does not change
-    // any state related to memory safety.
     unsafe {
         asm!("wrmsr",
              in("ecx") msr,
@@ -46,7 +42,6 @@ pub fn rdtsc() -> u64 {
     let eax: u32;
     let edx: u32;
 
-    // SAFETY: Inline assembly to read the TSC. It does not change any state.
     unsafe {
         asm!("rdtsc",
              out("eax") eax,
@@ -67,8 +62,6 @@ pub fn rdtscp() -> RdtscpOut {
     let edx: u32;
     let ecx: u32;
 
-    // SAFETY: Inline assembly to read the TSC and PID. It does not change
-    // any state.
     unsafe {
         asm!("rdtscp",
              out("eax") eax,
@@ -84,8 +77,6 @@ pub fn rdtscp() -> RdtscpOut {
 
 pub fn read_flags() -> u64 {
     let rax: u64;
-    // SAFETY: Inline assembly to read the EFLAGS register. It does not change
-    // any state.
     unsafe {
         asm!(
             r#"

--- a/kernel/src/cpu/shadow_stack.rs
+++ b/kernel/src/cpu/shadow_stack.rs
@@ -25,8 +25,6 @@ pub fn determine_cet_support() {
     }
 
     let rcx: u64;
-    // SAFETY: Inline assembly to enable CET bit in CR4, which does not change
-    // any state related to memory safety.
     unsafe {
         asm!(// Try to enable CET in CR4.
              "   mov %cr4, %rax",

--- a/kernel/src/cpu/sse.rs
+++ b/kernel/src/cpu/sse.rs
@@ -85,9 +85,6 @@ pub fn sse_init() {
 /// no other part of the code is accessing this memory at the same time.
 pub unsafe fn sse_save_context(addr: u64) {
     let save_bits = SVSM_XCR0.load(Ordering::Relaxed);
-    // SAFETY: Inline assembly used to save the SSE/FPU context. This context
-    // store is specific to a task and no other part of the code is accessing
-    // this memory at the same time.
     unsafe {
         asm!(
             r#"
@@ -106,9 +103,6 @@ pub unsafe fn sse_save_context(addr: u64) {
 /// no other part of the code is accessing this memory at the same time.
 pub unsafe fn sse_restore_context(addr: u64) {
     let save_bits = SVSM_XCR0.load(Ordering::Relaxed);
-    // SAFETY: Inline assembly used to restore the SSE/FPU context. This context
-    // store is specific to a task and no other part of the code is accessing
-    // this memory at the same time.
     unsafe {
         asm!(
             r#"

--- a/kernel/src/cpu/tlb.rs
+++ b/kernel/src/cpu/tlb.rs
@@ -16,8 +16,6 @@ const INVLPGB_VALID_GLOBAL: u64 = 1u64 << 3;
 
 #[inline]
 fn do_invlpgb(rax: u64, rcx: u64, rdx: u64) {
-    // SAFETY: Inline assembly to invalidate TLB Entries, which does not change
-    // any state related to memory safety.
     unsafe {
         asm!("invlpgb",
              in("rax") rax,
@@ -29,8 +27,6 @@ fn do_invlpgb(rax: u64, rcx: u64, rdx: u64) {
 
 #[inline]
 fn do_tlbsync() {
-    // SAFETY: Inline assembly to synchronize TLB invalidations. It does not
-    // change any state.
     unsafe {
         asm!("tlbsync", options(att_syntax));
     }
@@ -64,8 +60,6 @@ pub fn flush_tlb_global_percpu() {
 
 pub fn flush_address_percpu(va: VirtAddr) {
     let va: u64 = va.page_align().bits() as u64;
-    // SAFETY: Inline assembly to invalidate TLB Entries, which does not change
-    // any state related to memory safety.
     unsafe {
         asm!("invlpg (%rax)",
              in("rax") va,


### PR DESCRIPTION
Reverts coconut-svsm/svsm#550

Sorry, wrongly merged this one.