### PR TITLE
kernel/pagetable: remove duplicate page table load

### DIFF
--- a/kernel/src/svsm_paging.rs
+++ b/kernel/src/svsm_paging.rs
@@ -92,8 +92,6 @@ pub fn init_page_table(
 
     init_global_ranges();
 
-    pgtable.load();
-
     Ok(pgtable)
 }
 


### PR DESCRIPTION
Init page table is loaded twice, in the end of `init_page_table()` and just after in `svsm_start()`. We can remove the first one.