### PR TITLE
cpu: use temporary GDT structures to load TSS

### DIFF
--- a/kernel/src/cpu/gdt.rs
+++ b/kernel/src/cpu/gdt.rs
@@ -35,11 +35,11 @@ impl GDTEntry {
     }
 
     pub const fn code_64_kernel() -> Self {
-        Self(0x00af9a000000ffffu64)
+        Self(0x00af9b000000ffffu64)
     }
 
     pub const fn data_64_kernel() -> Self {
-        Self(0x00cf92000000ffffu64)
+        Self(0x00cf93000000ffffu64)
     }
 
     pub const fn code_64_user() -> Self {
@@ -47,7 +47,7 @@ impl GDTEntry {
     }
 
     pub const fn data_64_user() -> Self {
-        Self(0x00cff2000000ffffu64)
+        Self(0x00cff3000000ffffu64)
     }
 }
 

--- a/kernel/src/cpu/gdt.rs
+++ b/kernel/src/cpu/gdt.rs
@@ -6,7 +6,6 @@
 
 use super::tss::X86Tss;
 use crate::address::VirtAddr;
-use crate::locking::{RWLock, ReadLockGuard, WriteLockGuard};
 use crate::types::{SVSM_CS, SVSM_DS, SVSM_TSS};
 use core::arch::asm;
 use core::mem;
@@ -53,7 +52,9 @@ impl GDTEntry {
 
 const GDT_SIZE: u16 = 8;
 
-#[derive(Copy, Clone, Debug, Default)]
+pub static GLOBAL_GDT: GDT = GDT::new();
+
+#[derive(Clone, Debug, Default)]
 pub struct GDT {
     entries: [GDTEntry; GDT_SIZE as usize],
 }
@@ -106,16 +107,30 @@ impl GDT {
     pub fn kernel_ds(&self) -> GDTEntry {
         self.entries[(SVSM_DS / 8) as usize]
     }
-}
 
-impl ReadLockGuard<'static, GDT> {
-    /// Load a GDT. Its lifetime must be static so that its entries are
-    /// always available to the CPU.
+    /// Makes this GDT the active GDT.
     pub fn load(&self) {
         let gdt_desc = self.descriptor();
+        // SAFETY: loading the GDT must be done in assembly.  Use of the GDT
+        // descriptor is safe because it describes a valid objct which
+        // implements Drop to clean up if the GDT object ever ceases to be
+        // valid.
+        unsafe {
+            asm!("lgdt ({0})",
+                 in(reg) &gdt_desc,
+                 options(att_syntax));
+        }
+    }
+
+    /// Loads all selectors from the current GDT.
+    pub fn load_selectors(&self) {
+        self.load();
+        // SAFETY: assembly is required to load segments from the GDT.  In the
+        // x86-64 architecture, the chosen selector values do not affect the
+        // validity of any memory addresses and thus cannot impact memory
+        // safety.
         unsafe {
             asm!(r#" /* Load GDT */
-                 lgdt   (%rax)
 
                  /* Reload data segments */
                  movw   %cx, %ds
@@ -131,7 +146,6 @@ impl ReadLockGuard<'static, GDT> {
                  lretq
             1:
                  "#,
-                in("rax") &gdt_desc,
                 in("rdx") SVSM_CS,
                 in("rcx") SVSM_DS,
                 options(att_syntax));
@@ -153,12 +167,24 @@ impl ReadLockGuard<'static, GDT> {
     }
 }
 
-static GDT: RWLock<GDT> = RWLock::new(GDT::new());
+impl Drop for GDT {
+    fn drop(&mut self) {
+        // Check to see whether the GDT being dropped is the one currently
+        // loaded on this CPU.  If so, reload the global GDT.
+        let gdt_desc: GDTDesc = Default::default();
+        // SAFETY: assembly is required to obtain the current GDT descriptor.
+        // The address of the returned descriptor is only used as a comparison
+        // to `self` and not for data access, so memory safety is not affected
+        // by the returned address.
+        unsafe {
+            asm!("sgdt ({0})",
+                 in(reg) &gdt_desc,
+                 options(att_syntax));
+        }
 
-pub fn gdt() -> ReadLockGuard<'static, GDT> {
-    GDT.lock_read()
-}
-
-pub fn gdt_mut() -> WriteLockGuard<'static, GDT> {
-    GDT.lock_write()
+        let gdt_addr = gdt_desc.addr;
+        if gdt_addr == VirtAddr::from(self as *const GDT) {
+            GLOBAL_GDT.load();
+        }
+    }
 }

--- a/kernel/src/cpu/idt/common.rs
+++ b/kernel/src/cpu/idt/common.rs
@@ -9,7 +9,7 @@ extern crate alloc;
 use crate::address::{Address, VirtAddr};
 use crate::cpu::control_regs::{read_cr0, read_cr4};
 use crate::cpu::efer::read_efer;
-use crate::cpu::gdt::gdt;
+use crate::cpu::gdt::GLOBAL_GDT;
 use crate::cpu::registers::{X86GeneralRegs, X86InterruptFrame};
 use crate::cpu::shadow_stack::is_cet_ss_supported;
 use crate::insn_decode::{InsnError, InsnMachineCtx, InsnMachineMem, Register, SegRegister};
@@ -95,8 +95,8 @@ impl InsnMachineCtx for X86ExceptionContext {
 
     fn read_seg(&self, seg: SegRegister) -> u64 {
         match seg {
-            SegRegister::CS => gdt().kernel_cs().to_raw(),
-            _ => gdt().kernel_ds().to_raw(),
+            SegRegister::CS => GLOBAL_GDT.kernel_cs().to_raw(),
+            _ => GLOBAL_GDT.kernel_ds().to_raw(),
         }
     }
 

--- a/kernel/src/cpu/mod.rs
+++ b/kernel/src/cpu/mod.rs
@@ -28,7 +28,6 @@ pub mod vmsa;
 pub mod x86;
 
 pub use apic::LocalApic;
-pub use gdt::{gdt, gdt_mut};
 pub use idt::common::X86ExceptionContext;
 pub use irq_state::{irqs_disabled, irqs_enabled, IrqGuard, IrqState};
 pub use percpu::{irq_nesting_count, irqs_disable, irqs_enable};

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -6,7 +6,7 @@
 
 extern crate alloc;
 
-use super::gdt_mut;
+use super::gdt::GDT;
 use super::isst::Isst;
 use super::msr::write_msr;
 use super::shadow_stack::{is_cet_ss_supported, ISST_ADDR};
@@ -773,7 +773,10 @@ impl PerCpu {
     }
 
     pub fn load_tss(&self) {
-        gdt_mut().load_tss(&self.tss);
+        // Create a temporary GDT to use to configure the TSS.
+        let mut gdt = GDT::new();
+        gdt.load();
+        gdt.load_tss(&self.tss);
     }
 
     pub fn load_isst(&self) {

--- a/kernel/src/cpu/vmsa.rs
+++ b/kernel/src/cpu/vmsa.rs
@@ -10,7 +10,7 @@ use crate::sev::status::{sev_flags, SEVStatusFlags};
 use crate::types::{GUEST_VMPL, SVSM_CS, SVSM_CS_ATTRIBUTES, SVSM_DS, SVSM_DS_ATTRIBUTES};
 use cpuarch::vmsa::{VMSASegment, VMSA};
 
-use super::gdt;
+use super::gdt::GLOBAL_GDT;
 use super::idt::common::idt;
 
 pub fn svsm_code_segment() -> hyperv::HvSegmentRegister {
@@ -32,7 +32,7 @@ pub fn svsm_data_segment() -> hyperv::HvSegmentRegister {
 }
 
 pub fn svsm_gdt_segment() -> hyperv::HvTableRegister {
-    let (base, limit) = gdt().base_limit();
+    let (base, limit) = GLOBAL_GDT.base_limit();
     hyperv::HvTableRegister {
         limit,
         base,

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -21,7 +21,7 @@ use svsm::address::{Address, PhysAddr, VirtAddr};
 use svsm::config::SvsmConfig;
 use svsm::console::install_console_logger;
 use svsm::cpu::cpuid::{dump_cpuid_table, register_cpuid_table};
-use svsm::cpu::gdt;
+use svsm::cpu::gdt::GLOBAL_GDT;
 use svsm::cpu::idt::stage2::{early_idt_init, early_idt_init_no_ghcb};
 use svsm::cpu::percpu::{this_cpu, PerCpu};
 use svsm::error::SvsmError;
@@ -84,7 +84,7 @@ fn setup_env(
     platform: &mut dyn SvsmPlatform,
     launch_info: &Stage2LaunchInfo,
 ) {
-    gdt().load();
+    GLOBAL_GDT.load();
     early_idt_init_no_ghcb();
 
     let debug_serial_port = config.debug_serial_port();

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -17,7 +17,7 @@ use svsm::config::SvsmConfig;
 use svsm::console::install_console_logger;
 use svsm::cpu::control_regs::{cr0_init, cr4_init};
 use svsm::cpu::cpuid::{dump_cpuid_table, register_cpuid_table};
-use svsm::cpu::gdt;
+use svsm::cpu::gdt::GLOBAL_GDT;
 use svsm::cpu::idt::svsm::{early_idt_init, idt_init};
 use svsm::cpu::percpu::{this_cpu, PerCpu};
 use svsm::cpu::shadow_stack::{
@@ -155,7 +155,8 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
     // SAFETY: we trust the previous stage to pass a valid pointer
     unsafe { init_valid_bitmap_ptr(new_kernel_region(&launch_info), vb_ptr) };
 
-    gdt().load();
+    GLOBAL_GDT.load();
+    GLOBAL_GDT.load_selectors();
     early_idt_init();
 
     // Capture the debug serial port before the launch info disappears from


### PR DESCRIPTION
Configuring TSS on the current CPU requires a valid GDT entry, but the GDT entry only needs to valid long enough to execute the LTR instruction.  Modifying the global GDT for this purpose is undesirable, even if safety is guaranteed by wrapping the global GDT with a lock.  It is more straightforward to keep the global GDT constant, and to create a temporary writable GDT on each processor to use long enough to execute LTR and configure the TSS.