### PR TITLE
cpu/idt: use the correct stack offset to find EFLAGS

### DIFF
--- a/kernel/src/cpu/idt/entry.S
+++ b/kernel/src/cpu/idt/entry.S
@@ -62,7 +62,7 @@ asm_entry_\name:
 	pushq $0
 	.endif
 	push_regs
-	testl 	${IF}, 0xC0(%rsp)
+	testl 	${IF}, 0xA0(%rsp)
 	jz	L\@
 	sti
 L\@:


### PR DESCRIPTION
The exception entry flow needs to determine whether interrupts were enabled at the time of exception delivery, but was using the wrong stack offset to do so.