### PR TITLE
cpu: ensure that `PerCpuShared` is `Sync`

### DIFF
--- a/kernel/src/utils/mod.rs
+++ b/kernel/src/utils/mod.rs
@@ -14,3 +14,10 @@ pub use memory_region::MemoryRegion;
 pub use util::{
     align_down, align_up, halt, is_aligned, overlap, page_align_up, page_offset, zero_mem_region,
 };
+
+/// Determines whether an object supports `Sync`.  The function is written to
+/// always return `true` because the compiler will prevent the function from
+/// being called on any type that is not `Sync`.
+pub fn is_sync<T: Sync>(_t: &T) -> bool {
+    true
+}


### PR DESCRIPTION
The `PerCpuShared` object is used by multiple threads and therefore must be `Sync`.  This change introduces a compile-time check to prevent changes to `PerCpuShared` that would prevent it from being `Sync`.