### PR TITLE
Revert "cpu/idt: Handle interrupt nesting correctly"

### DIFF
--- a/kernel/src/cpu/idt/entry.S
+++ b/kernel/src/cpu/idt/entry.S
@@ -37,22 +37,6 @@ HV_DOORBELL_ADDR:
 	pushq	%rax
 .endm
 
-.macro default_entry_with_ist name: req handler:req error_code:req vector:req
-	.globl asm_entry_\name
-asm_entry_\name:
-	asm_clac
-
-	.if \error_code == 0
-	pushq $0
-	.endif
-	push_regs
-	movl	$\vector, %esi
-	movq	%rsp, %rdi
-	xorl	%edx, %edx
-	call	ex_handler_\handler
-	jmp	default_return
-.endm
-
 .macro default_entry_no_ist name: req handler:req error_code:req vector:req
 	.globl asm_entry_\name
 asm_entry_\name:
@@ -62,10 +46,6 @@ asm_entry_\name:
 	pushq $0
 	.endif
 	push_regs
-	testl 	${IF}, 0xA0(%rsp)
-	jz	L\@
-	sti
-L\@:
 	movl	$\vector, %esi
 	movq	%rsp, %rdi
 	xorl	%edx, %edx
@@ -81,7 +61,7 @@ asm_entry_irq_\name:
 	pushq	$0
 	push_regs
 	movl	$\vector, %edi
-	call	common_isr_handler_entry
+	call	common_isr_handler
 	jmp	default_return
 .endm
 
@@ -364,7 +344,7 @@ default_entry_no_ist	name=ud		handler=panic			error_code=0	vector=6
 default_entry_no_ist	name=nm		handler=panic			error_code=0	vector=7
 
 // #DF Double-Fault Exception (Vector 8)
-default_entry_with_ist	name=df		handler=double_fault		error_code=1	vector=8
+default_entry_no_ist	name=df		handler=double_fault		error_code=1	vector=8
 
 // Coprocessor-Segment-Overrun Exception (Vector 9)
 // No handler - reserved vector

--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -317,24 +317,7 @@ pub extern "C" fn ex_handler_panic(ctx: &mut X86ExceptionContext, vector: usize)
 }
 
 #[no_mangle]
-pub extern "C" fn common_isr_handler_entry(vector: usize) {
-    // Since interrupt handlers execute with interrupts disabled, it is
-    // necessary to increment the per-CPU interrupt disable nesting state
-    // while the handler is running in case common code attempts to disable
-    // interrupts temporarily.  The fact that this interrupt was received
-    // means that the previous state must have had interrupts enabled.
-    let cpu = this_cpu();
-    cpu.irqs_push_nesting(true);
-
-    common_isr_handler(vector);
-
-    // Decrement the interrupt disable nesting count, but do not permit
-    // interrupts to be reenabled.  They will be reenabled during the IRET
-    // flow.
-    cpu.irqs_pop_nesting();
-}
-
-pub fn common_isr_handler(_vector: usize) {
+pub extern "C" fn common_isr_handler(_vector: usize) {
     // Interrupt injection requests currently require no processing; they occur
     // simply to ensure an exit from the guest.
 

--- a/kernel/src/cpu/irq_state.rs
+++ b/kernel/src/cpu/irq_state.rs
@@ -36,7 +36,9 @@ pub fn raw_irqs_enable() {
 
     // Now that interrupts are enabled, process any #HV events that may be
     // pending.
-    this_cpu().process_hv_events_if_required();
+    if let Some(doorbell) = this_cpu().hv_doorbell() {
+        doorbell.process_if_required();
+    }
 }
 
 /// Query IRQ state on current CPU
@@ -99,32 +101,6 @@ impl IrqState {
         }
     }
 
-    /// Increase IRQ-disable nesting level by 1. The method will not disable
-    /// interrupts because it is assumed to be called when interrupts are
-    /// already disabled.
-    ///
-    /// The caller needs to make sure to match the number of `push_nesting`
-    /// calls with the number of `pop_nesting` calls.
-    ///
-    /// * `was_enabled` - indicates whether interrupts were enabled at the
-    ///   time of nesting.  This may not be the current state of interrupts
-    ///   because interrupts may have been disabled for architectural reasons
-    ///   prior to his function being called.
-    ///
-    /// # Returns
-    ///
-    /// The previous nesting level.
-    pub fn push_nesting(&self, was_enabled: bool) {
-        debug_assert!(irqs_disabled());
-        let val = self.count.fetch_add(1, Ordering::Relaxed);
-
-        assert!(val >= 0);
-
-        if val == 0 {
-            self.state.store(was_enabled, Ordering::Relaxed)
-        }
-    }
-
     /// Increase IRQ-disable nesting level by 1. The method will disable IRQs.
     ///
     /// The caller needs to make sure to match the number of `disable` calls
@@ -134,27 +110,13 @@ impl IrqState {
         let state = irqs_enabled();
 
         raw_irqs_disable();
+        let val = self.count.fetch_add(1, Ordering::Relaxed);
 
-        self.push_nesting(state);
-    }
+        assert!(val >= 0);
 
-    /// Decrease IRQ-disable nesting level by 1. The method will not restore
-    /// the original IRQ state when the nesting level reaches 0.
-    ///
-    /// The caller needs to make sure to match the number of `pop_nesting`
-    /// calls with the number of `push_nesting` calls.
-    ///
-    /// # Returns
-    ///
-    /// The new IRQ nesting level.
-    pub fn pop_nesting(&self) -> isize {
-        debug_assert!(irqs_disabled());
-
-        let val = self.count.fetch_sub(1, Ordering::Relaxed);
-
-        assert!(val > 0);
-
-        val - 1
+        if val == 0 {
+            self.state.store(state, Ordering::Relaxed)
+        }
     }
 
     /// Decrease IRQ-disable nesting level by 1. The method will restore the
@@ -164,7 +126,13 @@ impl IrqState {
     /// with the number of `enable` calls.
     #[inline(always)]
     pub fn enable(&self) {
-        if self.pop_nesting() == 0 {
+        debug_assert!(irqs_disabled());
+
+        let val = self.count.fetch_sub(1, Ordering::Relaxed);
+
+        assert!(val > 0);
+
+        if val == 1 {
             let state = self.state.load(Ordering::Relaxed);
             if state {
                 raw_irqs_enable();

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -428,29 +428,6 @@ impl PerCpu {
         self.irq_state.enable();
     }
 
-    /// Increments IRQ-disable nesting level on the current CPU without
-    /// disabling interrupts.  This is used by exception and interrupt dispatch
-    /// routines that have already disabled interrupts.
-    ///
-    /// Caller needs to make sure to match every `push_nesting()` call with a
-    /// `pop_nesting()` call.
-    #[inline(always)]
-    pub fn irqs_push_nesting(&self, was_enabled: bool) {
-        self.irq_state.push_nesting(was_enabled);
-    }
-
-    /// Reduces IRQ-disable nesting level on the current CPU without restoring
-    /// the original IRQ state original IRQ state.  This is used by exception
-    /// and interrupt dispatch routines that will restore interrupt state
-    /// naturally.
-    ///
-    /// Caller needs to make sure to match every `disable()` call with a
-    /// `pop_state()` call.
-    #[inline(always)]
-    pub fn irqs_pop_nesting(&self) {
-        let _ = self.irq_state.pop_nesting();
-    }
-
     /// Get IRQ-disable nesting count on the current CPU
     ///
     /// # Returns
@@ -497,12 +474,6 @@ impl PerCpu {
 
     pub fn hv_doorbell(&self) -> Option<&'static HVDoorbell> {
         self.hv_doorbell.get()
-    }
-
-    pub fn process_hv_events_if_required(&self) {
-        if let Some(doorbell) = self.hv_doorbell.get() {
-            doorbell.process_if_required(&self.irq_state);
-        }
     }
 
     /// Gets a pointer to the location of the HV doorbell pointer in the

--- a/kernel/src/sev/hv_doorbell.rs
+++ b/kernel/src/sev/hv_doorbell.rs
@@ -3,14 +3,12 @@
 
 use crate::cpu::idt::svsm::common_isr_handler;
 use crate::cpu::percpu::this_cpu;
-use crate::cpu::IrqState;
 use crate::error::SvsmError;
 use crate::mm::page_visibility::SharedBox;
 use crate::mm::virt_to_phys;
 use crate::sev::ghcb::GHCB;
 
 use bitfield_struct::bitfield;
-use core::arch::asm;
 use core::cell::UnsafeCell;
 use core::sync::atomic::{AtomicU32, AtomicU8, Ordering};
 
@@ -114,24 +112,10 @@ impl HVDoorbell {
         // is performed.
     }
 
-    /// This function must always be called with interrupts enabled.
-    pub fn process_if_required(&self, irq_state: &IrqState) {
+    pub fn process_if_required(&self) {
         let flags = HVDoorbellFlags::from(self.flags.load(Ordering::Relaxed));
-        while flags.no_further_signal() {
-            // #HV event processing must always be performed with interrupts
-            // disabled.
-            irq_state.disable();
+        if flags.no_further_signal() {
             self.process_pending_events();
-
-            // Do not call the standard enable routine, because that could
-            // recursively call to process new events, resulting in unbounded
-            // nesting.  Intead, decrement the nesting count and directly
-            // enable interrupts here before continuing the loop to see
-            // whether additional events have arrived.
-            assert_eq!(irq_state.pop_nesting(), 0);
-            unsafe {
-                asm!("sti");
-            }
         }
     }
 
@@ -179,15 +163,7 @@ pub fn current_hv_doorbell() -> &'static HVDoorbell {
 /// Rust code.
 #[no_mangle]
 pub unsafe extern "C" fn process_hv_events(hv_doorbell: *const HVDoorbell) {
-    // Update the IRQ nesting state of the current CPU so calls to common
-    // code recognize that interrupts have been disabled.  Proceed as if
-    // interrupts were previously enabled, so that any code that deals with
-    // maskable interrupts knows that interrupts were enabled prior to reaching
-    // this point.
-    let cpu = this_cpu();
-    cpu.irqs_push_nesting(true);
     unsafe {
         (*hv_doorbell).process_pending_events();
     }
-    cpu.irqs_pop_nesting();
 }


### PR DESCRIPTION
This reverts commits 23ff1bf383974ff457ae9f3d6adf2c25a9fabb84 and 20fecdccfd86b75a950d7eb2a7298556f3a583ce.

The original commit broke user-space support in some weird ways. Revert it until things have been sorted out.