### PR TITLE
cpu: Handle interrupt nesting correctly

### DIFF
--- a/kernel/src/cpu/idt/entry.S
+++ b/kernel/src/cpu/idt/entry.S
@@ -37,7 +37,7 @@ HV_DOORBELL_ADDR:
 	pushq	%rax
 .endm
 
-.macro default_entry_no_ist name: req handler:req error_code:req vector:req
+.macro default_entry_with_ist name: req handler:req error_code:req vector:req
 	.globl asm_entry_\name
 asm_entry_\name:
 	asm_clac
@@ -53,6 +53,26 @@ asm_entry_\name:
 	jmp	default_return
 .endm
 
+.macro default_entry_no_ist name: req handler:req error_code:req vector:req
+	.globl asm_entry_\name
+asm_entry_\name:
+	asm_clac
+
+	.if \error_code == 0
+	pushq $0
+	.endif
+	push_regs
+	testl 	${IF}, 0xA0(%rsp)
+	jz	L\@
+	sti
+L\@:
+	movl	$\vector, %esi
+	movq	%rsp, %rdi
+	xorl	%edx, %edx
+	call	ex_handler_\handler
+	jmp	default_return
+.endm
+
 .macro irq_entry name:req vector:req
 	.globl asm_entry_irq_\name
 asm_entry_irq_\name:
@@ -61,7 +81,7 @@ asm_entry_irq_\name:
 	pushq	$0
 	push_regs
 	movl	$\vector, %edi
-	call	common_isr_handler
+	call	common_isr_handler_entry
 	jmp	default_return
 .endm
 
@@ -344,7 +364,7 @@ default_entry_no_ist	name=ud		handler=panic			error_code=0	vector=6
 default_entry_no_ist	name=nm		handler=panic			error_code=0	vector=7
 
 // #DF Double-Fault Exception (Vector 8)
-default_entry_no_ist	name=df		handler=double_fault		error_code=1	vector=8
+default_entry_with_ist	name=df		handler=double_fault		error_code=1	vector=8
 
 // Coprocessor-Segment-Overrun Exception (Vector 9)
 // No handler - reserved vector

--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -317,7 +317,24 @@ pub extern "C" fn ex_handler_panic(ctx: &mut X86ExceptionContext, vector: usize)
 }
 
 #[no_mangle]
-pub extern "C" fn common_isr_handler(_vector: usize) {
+pub extern "C" fn common_isr_handler_entry(vector: usize) {
+    // Since interrupt handlers execute with interrupts disabled, it is
+    // necessary to increment the per-CPU interrupt disable nesting state
+    // while the handler is running in case common code attempts to disable
+    // interrupts temporarily.  The fact that this interrupt was received
+    // means that the previous state must have had interrupts enabled.
+    let cpu = this_cpu();
+    cpu.irqs_push_nesting(true);
+
+    common_isr_handler(vector);
+
+    // Decrement the interrupt disable nesting count, but do not permit
+    // interrupts to be reenabled.  They will be reenabled during the IRET
+    // flow.
+    cpu.irqs_pop_nesting();
+}
+
+pub fn common_isr_handler(_vector: usize) {
     // Interrupt injection requests currently require no processing; they occur
     // simply to ensure an exit from the guest.
 

--- a/kernel/src/cpu/irq_state.rs
+++ b/kernel/src/cpu/irq_state.rs
@@ -11,7 +11,7 @@ use core::marker::PhantomData;
 use core::sync::atomic::{AtomicBool, AtomicIsize, Ordering};
 
 /// Interrupt flag in RFLAGS register
-const EFLAGS_IF: u64 = 1 << 9;
+pub const EFLAGS_IF: u64 = 1 << 9;
 
 /// Unconditionally disable IRQs
 ///

--- a/kernel/src/sev/hv_doorbell.rs
+++ b/kernel/src/sev/hv_doorbell.rs
@@ -3,12 +3,14 @@
 
 use crate::cpu::idt::svsm::common_isr_handler;
 use crate::cpu::percpu::this_cpu;
+use crate::cpu::IrqState;
 use crate::error::SvsmError;
 use crate::mm::page_visibility::SharedBox;
 use crate::mm::virt_to_phys;
 use crate::sev::ghcb::GHCB;
 
 use bitfield_struct::bitfield;
+use core::arch::asm;
 use core::cell::UnsafeCell;
 use core::sync::atomic::{AtomicU32, AtomicU8, Ordering};
 
@@ -112,10 +114,25 @@ impl HVDoorbell {
         // is performed.
     }
 
-    pub fn process_if_required(&self) {
+    /// This function must always be called with interrupts enabled.
+    pub fn process_if_required(&self, irq_state: &IrqState) {
         let flags = HVDoorbellFlags::from(self.flags.load(Ordering::Relaxed));
-        if flags.no_further_signal() {
+        while flags.no_further_signal() {
+            // #HV event processing must always be performed with interrupts
+            // disabled.
+            irq_state.disable();
             self.process_pending_events();
+
+            // Do not call the standard enable routine, because that could
+            // recursively call to process new events, resulting in unbounded
+            // nesting.  Intead, decrement the nesting count and directly
+            // enable interrupts here before continuing the loop to see
+            // whether additional events have arrived.
+            assert_eq!(irq_state.pop_nesting(), 0);
+            // SAFETY: interrupts can now be enabled directly.
+            unsafe {
+                asm!("sti");
+            }
         }
     }
 
@@ -163,7 +180,17 @@ pub fn current_hv_doorbell() -> &'static HVDoorbell {
 /// Rust code.
 #[no_mangle]
 pub unsafe extern "C" fn process_hv_events(hv_doorbell: *const HVDoorbell) {
+    // Update the IRQ nesting state of the current CPU so calls to common
+    // code recognize that interrupts have been disabled.  Proceed as if
+    // interrupts were previously enabled, so that any code that deals with
+    // maskable interrupts knows that interrupts were enabled prior to reaching
+    // this point.
+    let cpu = this_cpu();
+    cpu.irqs_push_nesting(true);
+    // SAFETY: the correctness of #HV doorbell page has been guaranteed by the
+    // caller.
     unsafe {
         (*hv_doorbell).process_pending_events();
     }
+    cpu.irqs_pop_nesting();
 }


### PR DESCRIPTION
This restores the logic to enable interrupts while handling exceptions, and also ensures that user mode runs with interrupts disabled when required.