### PR TITLE
task: use a symbolic constant to represent EFLAGS.IF

### DIFF
--- a/kernel/src/cpu/irq_state.rs
+++ b/kernel/src/cpu/irq_state.rs
@@ -11,7 +11,7 @@ use core::marker::PhantomData;
 use core::sync::atomic::{AtomicBool, AtomicIsize, Ordering};
 
 /// Interrupt flag in RFLAGS register
-const EFLAGS_IF: u64 = 1 << 9;
+pub const EFLAGS_IF: usize = 1 << 9;
 
 /// Unconditionally disable IRQs
 ///
@@ -49,7 +49,7 @@ pub fn raw_irqs_enable() {
 pub fn irqs_enabled() -> bool {
     // SAFETY: The inline assembly just reads the processors RFLAGS register
     // and does not change any state.
-    let state: u64;
+    let state: usize;
     unsafe {
         asm!("pushfq",
              "popq {}",

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -15,6 +15,7 @@ use core::sync::atomic::{AtomicU32, Ordering};
 
 use crate::address::{Address, VirtAddr};
 use crate::cpu::idt::svsm::return_new_task;
+use crate::cpu::irq_state::EFLAGS_IF;
 use crate::cpu::percpu::PerCpu;
 use crate::cpu::shadow_stack::is_cet_ss_supported;
 use crate::cpu::sse::{get_xsave_area_size, sse_restore_context};
@@ -469,9 +470,9 @@ impl Task {
         // Do not run user-mode with IRQs enabled on platforms which are not
         // ready for it.
         let iret_rflags: usize = if SVSM_PLATFORM.use_interrupts() {
-            0x202
+            2 | EFLAGS_IF
         } else {
-            0x2
+            2
         };
 
         let percpu_mapping = cpu.new_mapping(mapping.clone())?;


### PR DESCRIPTION
Prefer use of symbolic constants instead of numeric values for clarity.