### PR TITLE
build: include FW file in hyper-v configuration

### DIFF
--- a/configs/hyperv-target.json
+++ b/configs/hyperv-target.json
@@ -28,6 +28,9 @@
             "objcopy": "binary"
         }
     },
+    "firmware": {
+        "env": "HV_FW_FILE"
+    },
     "fs": {
         "modules": {
             "userinit": {


### PR DESCRIPTION
Include the Hyper-V firmware file when a pathname is specified to the build script.