### PR TITLE
kernel: use TPR for interrupt reentrancy protection

### DIFF
--- a/kernel/src/cpu/irq_state.rs
+++ b/kernel/src/cpu/irq_state.rs
@@ -5,10 +5,10 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 
 use crate::cpu::percpu::this_cpu;
-use crate::cpu::{irqs_disable, irqs_enable};
+use crate::cpu::{irqs_disable, irqs_enable, lower_tpr, raise_tpr};
 use core::arch::asm;
 use core::marker::PhantomData;
-use core::sync::atomic::{AtomicBool, AtomicIsize, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 
 /// Interrupt flag in RFLAGS register
 pub const EFLAGS_IF: usize = 1 << 9;
@@ -51,9 +51,9 @@ pub fn raw_irqs_enable() {
 #[inline(always)]
 #[must_use = "Unused irqs_enabled() result - meant to be irq_enable()?"]
 pub fn irqs_enabled() -> bool {
+    let state: usize;
     // SAFETY: The inline assembly just reads the processors RFLAGS register
     // and does not change any state.
-    let state: usize;
     unsafe {
         asm!("pushfq",
              "popq {}",
@@ -75,6 +75,50 @@ pub fn irqs_disabled() -> bool {
     !irqs_enabled()
 }
 
+/// Converts an interrupt vector to a TPR value.
+#[inline(always)]
+pub fn tpr_from_vector(vector: usize) -> usize {
+    // TPR is the high four bits of the vector number.
+    vector >> 4
+}
+
+/// Unconditionally set TPR.
+///
+/// Callers need to ensure that the selected TPR is appropriate for the
+/// current context.
+///
+/// * `tpr_value` - the new TPR value.
+#[inline(always)]
+pub fn raw_set_tpr(tpr_value: usize) {
+    // SAFETY: Inline assembly to change TPR, which does not change any state
+    // related to memory safety.
+    unsafe {
+        asm!("mov {tpr}, %cr8",
+             tpr = in(reg) tpr_value,
+             options(att_syntax));
+    }
+}
+
+/// Query IRQ state on current CPU
+///
+/// # Returns
+///
+/// The current TPR.
+#[inline(always)]
+pub fn raw_get_tpr() -> usize {
+    // SAFETY: The inline assembly just reads the TPR register and does not
+    // change any state.
+    unsafe {
+        let mut ret: usize;
+        asm!("movq %cr8, {tpr}",
+             tpr = out(reg) ret,
+             options(att_syntax));
+        ret
+    }
+}
+
+const TPR_LIMIT: usize = 16;
+
 /// This structure keeps track of PerCpu IRQ states. It tracks the original IRQ
 /// state and how deep IRQ-disable calls have been nested. The use of atomics
 /// is necessary for interior mutability and to make state modifications safe
@@ -87,8 +131,10 @@ pub fn irqs_disabled() -> bool {
 pub struct IrqState {
     /// IRQ state when count was `0`
     state: AtomicBool,
-    /// Depth of IRQ-disabled nesting
-    count: AtomicIsize,
+    /// Depth of IRQ-disabled nesting.  Index 0 specifies the count of
+    /// IRQ disables and the remaining indices specify the nesting count
+    /// for eached raised TPR level.
+    counts: [AtomicI32; TPR_LIMIT],
     /// Make the type !Send + !Sync
     phantom: PhantomData<*const ()>,
 }
@@ -98,7 +144,7 @@ impl IrqState {
     pub fn new() -> Self {
         Self {
             state: AtomicBool::new(false),
-            count: AtomicIsize::new(0),
+            counts: Default::default(),
             phantom: PhantomData,
         }
     }
@@ -120,7 +166,7 @@ impl IrqState {
     /// The previous nesting level.
     pub fn push_nesting(&self, was_enabled: bool) {
         debug_assert!(irqs_disabled());
-        let val = self.count.fetch_add(1, Ordering::Relaxed);
+        let val = self.counts[0].fetch_add(1, Ordering::Relaxed);
 
         assert!(val >= 0);
 
@@ -151,10 +197,10 @@ impl IrqState {
     /// # Returns
     ///
     /// The new IRQ nesting level.
-    pub fn pop_nesting(&self) -> isize {
+    pub fn pop_nesting(&self) -> i32 {
         debug_assert!(irqs_disabled());
 
-        let val = self.count.fetch_sub(1, Ordering::Relaxed);
+        let val = self.counts[0].fetch_sub(1, Ordering::Relaxed);
 
         assert!(val > 0);
 
@@ -181,8 +227,8 @@ impl IrqState {
     /// # Returns
     ///
     /// Levels of IRQ-disable nesting currently active
-    pub fn count(&self) -> isize {
-        self.count.load(Ordering::Relaxed)
+    pub fn count(&self) -> i32 {
+        self.counts[0].load(Ordering::Relaxed)
     }
 
     /// Changes whether interrupts will be enabled when the nesting count
@@ -192,8 +238,56 @@ impl IrqState {
     /// and must ensure that the specified value is appropriate for the
     /// current environment.
     pub fn set_restore_state(&self, enabled: bool) {
-        assert!(self.count.load(Ordering::Relaxed) != 0);
+        assert!(self.counts[0].load(Ordering::Relaxed) != 0);
         self.state.store(enabled, Ordering::Relaxed);
+    }
+
+    /// Increments TPR.
+    ///
+    /// The caller must ensure that a `raise_tpr()` call is followed by a
+    /// matching call to `lower_tpr()`.
+    ///
+    /// * `tpr_value` - The new TPR value.  Must be greater than or equal to
+    ///   the current TPR value.
+    #[inline(always)]
+    pub fn raise_tpr(&self, tpr_value: usize) {
+        assert!(tpr_value > 0 && tpr_value >= raw_get_tpr());
+        raw_set_tpr(tpr_value);
+
+        // Increment the count of requests to raise to this TPR to indicate
+        // the number of execution contexts that require this TPR.
+        self.counts[tpr_value].fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Decrements TPR.
+    ///
+    /// The caller must ensure that a `lower` call balances a preceding
+    /// `raise` call to the indicated level.
+    ///
+    /// * `tpr_value` - The TPR from which the caller would like to lower.
+    ///   Must be less than or equal to the current TPR.
+    #[inline(always)]
+    pub fn lower_tpr(&self, tpr_value: usize) {
+        let current_tpr = raw_get_tpr();
+        debug_assert!(tpr_value <= current_tpr);
+
+        // Decrement the count of execution contexts requiring this raised
+        // TPR.
+        let count = self.counts[tpr_value].fetch_sub(1, Ordering::Relaxed);
+        debug_assert!(count > 0);
+
+        if count == 1 && tpr_value >= current_tpr {
+            // Find the highest TPR that is still required.
+            for new_tpr in (0..tpr_value).rev() {
+                if self.counts[new_tpr].load(Ordering::Relaxed) != 0 {
+                    raw_set_tpr(new_tpr);
+                    return;
+                }
+            }
+
+            // No TPR is still in use, so lower to zero.
+            raw_set_tpr(0);
+        }
     }
 }
 
@@ -201,8 +295,9 @@ impl Drop for IrqState {
     /// This struct should never be dropped. Add a debug check in case it is
     /// dropped anyway.
     fn drop(&mut self) {
-        let count = self.count.load(Ordering::Relaxed);
-        assert_eq!(count, 0);
+        for count in &self.counts {
+            assert_eq!(count.load(Ordering::Relaxed), 0);
+        }
     }
 }
 
@@ -212,7 +307,7 @@ impl Drop for IrqState {
 ///
 /// The struct implements the `Default` and `Drop` traits for easy use.
 #[derive(Debug)]
-#[must_use = "if unused previous IRQ state will be immediatly restored"]
+#[must_use = "if unused previous IRQ state will be immediately restored"]
 pub struct IrqGuard {
     /// Make the type !Send + !Sync
     phantom: PhantomData<*const ()>,
@@ -244,9 +339,43 @@ impl Drop for IrqGuard {
     }
 }
 
+/// A TPR guard which raises TPR upon creation.  When the guard goes out of
+/// scope, TPR is lowered to the highest active TPR.
+///
+/// The struct implements the `Drop` trait for easy use.
+#[derive(Debug, Default)]
+#[must_use = "if unused previous TPR will be immediately restored"]
+pub struct TprGuard {
+    tpr_value: usize,
+
+    /// Make the type !Send + !Sync
+    phantom: PhantomData<*const ()>,
+}
+
+impl TprGuard {
+    pub fn raise(tpr_value: usize) -> Self {
+        // SAFETY: Safe because the struct implements `Drop, which restores
+        // TPR state.
+        raise_tpr(tpr_value);
+
+        Self {
+            tpr_value,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl Drop for TprGuard {
+    fn drop(&mut self) {
+        // Lower TPR from the value to which it was raised.
+        lower_tpr(self.tpr_value);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::platform::SVSM_PLATFORM;
 
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
@@ -291,6 +420,48 @@ mod tests {
         assert!(irqs_enabled());
         if !was_enabled {
             raw_irqs_disable();
+        }
+    }
+
+    #[test]
+    #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
+    fn tpr_test() {
+        if SVSM_PLATFORM.use_interrupts() {
+            assert_eq!(raw_get_tpr(), 0);
+            raise_tpr(7);
+            assert_eq!(raw_get_tpr(), 7);
+            raise_tpr(8);
+            assert_eq!(raw_get_tpr(), 8);
+            lower_tpr(8);
+            assert_eq!(raw_get_tpr(), 7);
+            lower_tpr(7);
+            assert_eq!(raw_get_tpr(), 0);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
+    fn tpr_guard_test() {
+        if SVSM_PLATFORM.use_interrupts() {
+            assert_eq!(raw_get_tpr(), 0);
+            // Test in-order raise/lower.
+            let g1 = TprGuard::raise(8);
+            assert_eq!(raw_get_tpr(), 8);
+            let g2 = TprGuard::raise(9);
+            assert_eq!(raw_get_tpr(), 9);
+            drop(g2);
+            assert_eq!(raw_get_tpr(), 8);
+            drop(g1);
+            assert_eq!(raw_get_tpr(), 0);
+            // Test out-of-order raise/lower.
+            let g1 = TprGuard::raise(8);
+            assert_eq!(raw_get_tpr(), 8);
+            let g2 = TprGuard::raise(9);
+            assert_eq!(raw_get_tpr(), 9);
+            drop(g1);
+            assert_eq!(raw_get_tpr(), 9);
+            drop(g2);
+            assert_eq!(raw_get_tpr(), 0);
         }
     }
 }

--- a/kernel/src/cpu/mod.rs
+++ b/kernel/src/cpu/mod.rs
@@ -29,7 +29,7 @@ pub mod x86;
 
 pub use apic::LocalApic;
 pub use idt::common::X86ExceptionContext;
-pub use irq_state::{irqs_disabled, irqs_enabled, IrqGuard, IrqState};
-pub use percpu::{irq_nesting_count, irqs_disable, irqs_enable};
+pub use irq_state::{irqs_disabled, irqs_enabled, IrqGuard, IrqState, TprGuard};
+pub use percpu::{irq_nesting_count, irqs_disable, irqs_enable, lower_tpr, raise_tpr};
 pub use registers::{X86GeneralRegs, X86InterruptFrame, X86SegmentRegs};
 pub use tlb::*;

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -457,8 +457,30 @@ impl PerCpu {
     /// # Returns
     ///
     /// Current nesting depth of irq_disable() calls.
-    pub fn irq_nesting_count(&self) -> isize {
+    pub fn irq_nesting_count(&self) -> i32 {
         self.irq_state.count()
+    }
+
+    /// Raises TPR on the current CPU.  Keeps track of the nesting level.
+    ///
+    /// The caller must ensure that every `raise_tpr()` call is followed by a
+    /// matching call to `lower_tpr()`.
+    #[inline(always)]
+    pub fn raise_tpr(&self, tpr_value: usize) {
+        self.irq_state.raise_tpr(tpr_value);
+    }
+
+    /// Lowers TPR from the current level to the new level required by the
+    /// current nesting state.
+    ///
+    /// The caller must ensure that a `lower_tpr()` call balances a preceding
+    /// `raise_tpr()` call to the indicated level.
+    ///
+    /// * `tpr_value` - The TPR from which the caller would like to lower.
+    ///   Must be less than or equal to the current TPR.
+    #[inline(always)]
+    pub fn lower_tpr(&self, tpr_value: usize) {
+        self.irq_state.lower_tpr(tpr_value);
     }
 
     /// Sets up the CPU-local GHCB page.
@@ -1105,8 +1127,30 @@ pub fn irqs_enable() {
 /// # Returns
 ///
 /// Current nesting depth of irq_disable() calls.
-pub fn irq_nesting_count() -> isize {
+pub fn irq_nesting_count() -> i32 {
     this_cpu().irq_nesting_count()
+}
+
+/// Raises TPR on the current CPU.  Keeps track of the nesting level.
+///
+/// The caller must ensure that every `raise_tpr()` call is followed by a
+/// matching call to `lower_tpr()`.
+#[inline(always)]
+pub fn raise_tpr(tpr_value: usize) {
+    this_cpu().raise_tpr(tpr_value);
+}
+
+/// Lowers TPR from the current level to the new level required by the
+/// current nesting state.
+///
+/// The caller must ensure that a `lower_tpr()` call balances a preceding
+/// `raise_tpr()` call to the indicated level.
+///
+/// * `tpr_value` - The TPR from which the caller would like to lower.
+///   Must be less than or equal to the current TPR.
+#[inline(always)]
+pub fn lower_tpr(tpr_value: usize) {
+    this_cpu().lower_tpr(tpr_value);
 }
 
 /// Gets the GHCB for this CPU.

--- a/kernel/src/locking/common.rs
+++ b/kernel/src/locking/common.rs
@@ -3,41 +3,46 @@
 // Copyright (c) 2024 SUSE LLC
 //
 // Author: Joerg Roedel <jroedel@suse.de>
-use crate::cpu::IrqGuard;
+use crate::cpu::{IrqGuard, TprGuard};
 use core::marker::PhantomData;
 
-/// Abstracts IRQ state handling when taking and releasing locks. There are two
-/// implemenations:
+/// Abstracts TPR and interrupt state handling when taking and releasing
+/// locks. There are three implemenations:
 ///
 ///   * [IrqUnsafeLocking] implements the methods as no-ops and does not change
-///     any IRQ state.
-///   * [IrqSafeLocking] actually disables and enables IRQs in the methods,
-///     making a lock IRQ-safe by using this structure.
+///     any IRQ or TPR state.
+///   * [IrqGuardLocking] actually disables and enables IRQs in the methods,
+///     ensuring that no interrupt can be taken while the lock is held.
+///   * [TprGuardLocking] raises and lowers TPR while the lock is held,
+///     ensuring that no higher priority interrupt can be taken while the lock
+///     is held.  This will panic when attempting to acquire a lower priority
+///     lock from a higher priority interrupt context.
 pub trait IrqLocking {
-    /// Associated helper function to disable IRQs and create an instance of
-    /// the implementing struct. This is used by lock implementations.
+    /// Associated helper function to modify TPR/interrupt state when a lock
+    /// is acquired.  This is used by lock implementations and will return an
+    /// instance of the object.
     ///
     /// # Returns
     ///
     /// New instance of implementing struct.
-    fn irqs_disable() -> Self;
+    fn acquire_lock() -> Self;
 }
 
-/// Implements the IRQ state handling methods as no-ops. For use it IRQ-unsafe
-/// locks.
+/// Implements the IRQ state handling methods as no-ops. Locks defined with
+/// this state handler are not safe with respect to reentrancy due to
+/// interrupt delivery.
 #[derive(Debug, Default)]
 pub struct IrqUnsafeLocking;
 
 impl IrqLocking for IrqUnsafeLocking {
-    fn irqs_disable() -> Self {
+    fn acquire_lock() -> Self {
         Self {}
     }
 }
 
-/// Properly implements the IRQ state handling methods. For use it IRQ-safe
-/// locks.
+/// Implements the state handling methods for locks that disable interrupts.
 #[derive(Debug, Default)]
-pub struct IrqSafeLocking {
+pub struct IrqGuardLocking {
     /// IrqGuard to keep track of IRQ state. IrqGuard implements Drop, which
     /// will re-enable IRQs when the struct goes out of scope.
     _guard: IrqGuard,
@@ -45,10 +50,29 @@ pub struct IrqSafeLocking {
     phantom: PhantomData<*const ()>,
 }
 
-impl IrqLocking for IrqSafeLocking {
-    fn irqs_disable() -> Self {
+impl IrqLocking for IrqGuardLocking {
+    fn acquire_lock() -> Self {
         Self {
             _guard: IrqGuard::new(),
+            phantom: PhantomData,
+        }
+    }
+}
+
+/// Implements the state handling methods for locks that raise and lower TPR.
+#[derive(Debug, Default)]
+pub struct TprGuardLocking<const TPR: usize> {
+    /// TprGuard to keep track of IRQ state. TprGuard implements Drop, which
+    /// will lower TPR as required when the struct goes out of scope.
+    _guard: TprGuard,
+    /// Make type explicitly !Send + !Sync
+    phantom: PhantomData<*const ()>,
+}
+
+impl<const TPR: usize> IrqLocking for TprGuardLocking<TPR> {
+    fn acquire_lock() -> Self {
+        Self {
+            _guard: TprGuard::raise(TPR),
             phantom: PhantomData,
         }
     }

--- a/kernel/src/locking/mod.rs
+++ b/kernel/src/locking/mod.rs
@@ -8,9 +8,12 @@ pub mod common;
 pub mod rwlock;
 pub mod spinlock;
 
-pub use common::{IrqLocking, IrqSafeLocking, IrqUnsafeLocking};
+pub use common::{IrqGuardLocking, IrqLocking, TprGuardLocking};
 pub use rwlock::{
-    RWLock, RWLockIrqSafe, ReadLockGuard, ReadLockGuardIrqSafe, WriteLockGuard,
-    WriteLockGuardIrqSafe,
+    RWLock, RWLockAnyTpr, RWLockIrqSafe, RWLockTpr, ReadLockGuard, ReadLockGuardAnyTpr,
+    ReadLockGuardIrqSafe, WriteLockGuard, WriteLockGuardAnyTpr, WriteLockGuardIrqSafe,
 };
-pub use spinlock::{LockGuard, LockGuardIrqSafe, RawLockGuard, SpinLock, SpinLockIrqSafe};
+pub use spinlock::{
+    LockGuard, LockGuardAnyTpr, LockGuardIrqSafe, RawLockGuard, SpinLock, SpinLockAnyTpr,
+    SpinLockIrqSafe, SpinLockTpr,
+};

--- a/kernel/src/locking/rwlock.rs
+++ b/kernel/src/locking/rwlock.rs
@@ -5,6 +5,7 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 
 use super::common::*;
+use crate::types::TPR_LOCK;
 use core::cell::UnsafeCell;
 use core::marker::PhantomData;
 use core::ops::{Deref, DerefMut};
@@ -41,7 +42,9 @@ impl<T, I> Deref for RawReadLockGuard<'_, T, I> {
 }
 
 pub type ReadLockGuard<'a, T> = RawReadLockGuard<'a, T, IrqUnsafeLocking>;
-pub type ReadLockGuardIrqSafe<'a, T> = RawReadLockGuard<'a, T, IrqSafeLocking>;
+pub type ReadLockGuardIrqSafe<'a, T> = RawReadLockGuard<'a, T, IrqGuardLocking>;
+pub type ReadLockGuardAnyTpr<'a, T, const TPR: usize> =
+    RawReadLockGuard<'a, T, TprGuardLocking<TPR>>;
 
 /// A guard that provides exclusive write access to the data protected by [`RWLock`]
 #[derive(Debug)]
@@ -81,7 +84,9 @@ impl<T, I> DerefMut for RawWriteLockGuard<'_, T, I> {
 }
 
 pub type WriteLockGuard<'a, T> = RawWriteLockGuard<'a, T, IrqUnsafeLocking>;
-pub type WriteLockGuardIrqSafe<'a, T> = RawWriteLockGuard<'a, T, IrqSafeLocking>;
+pub type WriteLockGuardIrqSafe<'a, T> = RawWriteLockGuard<'a, T, IrqGuardLocking>;
+pub type WriteLockGuardAnyTpr<'a, T, const TPR: usize> =
+    RawWriteLockGuard<'a, T, TprGuardLocking<TPR>>;
 
 /// A simple Read-Write Lock (RWLock) that allows multiple readers or
 /// one exclusive writer.
@@ -216,7 +221,7 @@ impl<T, I: IrqLocking> RawRWLock<T, I> {
     ///
     /// A [`ReadLockGuard`] that provides read access to the protected data.
     pub fn lock_read(&self) -> RawReadLockGuard<'_, T, I> {
-        let irq_state = I::irqs_disable();
+        let irq_state = I::acquire_lock();
         loop {
             let val = self.wait_for_writers();
             let (readers, _) = split_val(val);
@@ -246,7 +251,7 @@ impl<T, I: IrqLocking> RawRWLock<T, I> {
     ///
     /// A [`WriteLockGuard`] that provides write access to the protected data.
     pub fn lock_write(&self) -> RawWriteLockGuard<'_, T, I> {
-        let irq_state = I::irqs_disable();
+        let irq_state = I::acquire_lock();
 
         // Waiting for current writer to finish
         loop {
@@ -277,7 +282,9 @@ impl<T, I: IrqLocking> RawRWLock<T, I> {
 }
 
 pub type RWLock<T> = RawRWLock<T, IrqUnsafeLocking>;
-pub type RWLockIrqSafe<T> = RawRWLock<T, IrqSafeLocking>;
+pub type RWLockIrqSafe<T> = RawRWLock<T, IrqGuardLocking>;
+pub type RWLockAnyTpr<T, const TPR: usize> = RawRWLock<T, TprGuardLocking<TPR>>;
+pub type RWLockTpr<T> = RWLockAnyTpr<T, { TPR_LOCK }>;
 
 mod tests {
     #[test]
@@ -380,7 +387,7 @@ mod tests {
 
         // Lock for read
         let guard = lock.lock_read();
-        // IRQs must still be enabled;
+        // IRQs must be disabled
         assert!(irqs_disabled());
         // Unlock
         drop(guard);
@@ -390,5 +397,34 @@ mod tests {
         if !was_enabled {
             raw_irqs_disable();
         }
+    }
+
+    #[test]
+    #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
+    fn rw_lock_tpr() {
+        use crate::cpu::irq_state::raw_get_tpr;
+        use crate::locking::*;
+        use crate::types::TPR_LOCK;
+
+        assert_eq!(raw_get_tpr(), 0);
+        let lock = RWLockTpr::new(0);
+
+        // Lock for write
+        let guard = lock.lock_write();
+        // TPR must be raised
+        assert_eq!(raw_get_tpr(), TPR_LOCK);
+        // Unlock
+        drop(guard);
+        // TPR must be restored
+        assert_eq!(raw_get_tpr(), 0);
+
+        // Lock for read
+        let guard = lock.lock_read();
+        // TPR must be raised
+        assert_eq!(raw_get_tpr(), TPR_LOCK);
+        // Unlock
+        drop(guard);
+        // TPR must be restored
+        assert_eq!(raw_get_tpr(), 0);
     }
 }

--- a/kernel/src/types.rs
+++ b/kernel/src/types.rs
@@ -93,3 +93,6 @@ impl TryFrom<usize> for Bytes {
         }
     }
 }
+
+pub const TPR_NORMAL: usize = 0;
+pub const TPR_LOCK: usize = 2;


### PR DESCRIPTION
Using TPR for interrupt reentrancy protection allows high-priority interrupts to be serviced while low-priority interrupts are masked.  This PR introduces TPR management logic and integrates TPR management into locking mechanisms.