### PR TITLE
platform: Add abstractions for request processing

### DIFF
--- a/kernel/src/cpu/apic.rs
+++ b/kernel/src/cpu/apic.rs
@@ -12,7 +12,7 @@ use crate::error::SvsmError;
 use crate::mm::GuestPtr;
 use crate::platform::guest_cpu::GuestCpuState;
 use crate::platform::SVSM_PLATFORM;
-use crate::requests::SvsmCaa;
+use crate::sev::caa::SvsmCaa;
 use crate::sev::hv_doorbell::HVExtIntStatus;
 use crate::types::GUEST_VMPL;
 

--- a/kernel/src/cpu/smp.rs
+++ b/kernel/src/cpu/smp.rs
@@ -13,7 +13,7 @@ use crate::cpu::shadow_stack::{is_cet_ss_supported, SCetFlags, MODE_64BIT, S_CET
 use crate::cpu::sse::sse_init;
 use crate::enable_shadow_stacks;
 use crate::error::SvsmError;
-use crate::platform::{request_loop, request_processing_main, SvsmPlatform, SVSM_PLATFORM};
+use crate::platform::{request_task_main, SvsmPlatform, SVSM_PLATFORM};
 use crate::task::{schedule_init, start_kernel_task};
 use crate::utils::immut_after_init::immut_after_init_set_multithreaded;
 
@@ -72,8 +72,8 @@ fn start_ap() {
 
 #[no_mangle]
 pub extern "C" fn ap_request_loop() {
-    start_kernel_task(request_processing_main, String::from("request-processing"))
+    start_kernel_task(request_task_main, String::from("request-processing"))
         .expect("Failed to launch request processing task");
-    request_loop();
+    SVSM_PLATFORM.request_loop();
     panic!("Returned from request_loop!");
 }

--- a/kernel/src/cpu/smp.rs
+++ b/kernel/src/cpu/smp.rs
@@ -13,9 +13,7 @@ use crate::cpu::shadow_stack::{is_cet_ss_supported, SCetFlags, MODE_64BIT, S_CET
 use crate::cpu::sse::sse_init;
 use crate::enable_shadow_stacks;
 use crate::error::SvsmError;
-use crate::platform::SvsmPlatform;
-use crate::platform::SVSM_PLATFORM;
-use crate::requests::{request_loop, request_processing_main};
+use crate::platform::{request_loop, request_processing_main, SvsmPlatform, SVSM_PLATFORM};
 use crate::task::{schedule_init, start_kernel_task};
 use crate::utils::immut_after_init::immut_after_init_set_multithreaded;
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -30,7 +30,6 @@ pub mod locking;
 pub mod mm;
 pub mod platform;
 pub mod protocols;
-pub mod requests;
 pub mod serial;
 pub mod sev;
 pub mod string;

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -12,7 +12,6 @@ pub mod tdp;
 mod snp_fw;
 mod snp_requests;
 pub use snp_fw::{parse_fw_meta_data, SevFWMetaData};
-pub use snp_requests::{request_loop, request_processing_main};
 
 use native::NativePlatform;
 use snp::SnpPlatform;
@@ -168,6 +167,12 @@ pub trait SvsmPlatform {
         cpu: &PerCpu,
         context: &hyperv::HvInitialVpContext,
     ) -> Result<(), SvsmError>;
+
+    /// Entry point for the kernel request task.
+    fn request_task(&self) {}
+
+    /// Enter the main vCPU loop.
+    fn request_loop(&self);
 }
 
 //FIXME - remove Copy trait
@@ -224,4 +229,8 @@ pub fn halt() {
         SvsmPlatformType::Snp => SnpPlatform::halt(),
         SvsmPlatformType::Tdp => TdpPlatform::halt(),
     }
+}
+
+pub extern "C" fn request_task_main() {
+    SVSM_PLATFORM.request_task();
 }

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -10,7 +10,9 @@ pub mod snp;
 pub mod tdp;
 
 mod snp_fw;
+mod snp_requests;
 pub use snp_fw::{parse_fw_meta_data, SevFWMetaData};
+pub use snp_requests::{request_loop, request_processing_main};
 
 use native::NativePlatform;
 use snp::SnpPlatform;

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -173,4 +173,6 @@ impl SvsmPlatform for NativePlatform {
 
         todo!();
     }
+
+    fn request_loop(&self) {}
 }

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -7,6 +7,7 @@
 use super::snp_fw::{
     copy_tables_to_fw, launch_fw, prepare_fw_launch, print_fw_meta, validate_fw, validate_fw_memory,
 };
+use super::{snp_requests, PageEncryptionMasks, PageStateChangeOp, PageValidateOp, SvsmPlatform};
 use crate::address::{Address, PhysAddr, VirtAddr};
 use crate::config::SvsmConfig;
 use crate::console::init_svsm_console;
@@ -19,7 +20,6 @@ use crate::hyperv;
 use crate::io::IOPort;
 use crate::mm::memory::write_guest_memory_map;
 use crate::mm::{PerCPUPageMappingGuard, PAGE_SIZE, PAGE_SIZE_2M};
-use crate::platform::{PageEncryptionMasks, PageStateChangeOp, PageValidateOp, SvsmPlatform};
 use crate::sev::ghcb::GHCBIOSize;
 use crate::sev::hv_doorbell::current_hv_doorbell;
 use crate::sev::msr_protocol::{
@@ -329,6 +329,14 @@ impl SvsmPlatform for SnpPlatform {
         let (vmsa_pa, sev_features) = cpu.alloc_svsm_vmsa(*VTOM as u64, context)?;
 
         current_ghcb().ap_create(vmsa_pa, cpu.get_apic_id().into(), 0, sev_features)
+    }
+
+    fn request_task(&self) {
+        snp_requests::request_processing_main();
+    }
+
+    fn request_loop(&self) {
+        snp_requests::request_loop();
     }
 }
 

--- a/kernel/src/platform/snp_fw.rs
+++ b/kernel/src/platform/snp_fw.rs
@@ -6,6 +6,7 @@
 
 extern crate alloc;
 
+use super::snp_requests::update_mappings;
 use crate::address::PhysAddr;
 use crate::config::SvsmConfig;
 use crate::cpu::cpuid::copy_cpuid_table_to;
@@ -13,7 +14,6 @@ use crate::cpu::percpu::{current_ghcb, this_cpu, this_cpu_shared};
 use crate::error::SvsmError;
 use crate::mm::PerCPUPageMappingGuard;
 use crate::platform::PageStateChangeOp;
-use crate::requests::update_mappings;
 use crate::sev::{pvalidate, rmp_adjust, secrets_page, PvalidateOp, RMPFlags};
 use crate::types::{PageSize, GUEST_VMPL, PAGE_SIZE};
 use crate::utils::fw_meta::{find_table, RawMetaBuffer, Uuid};

--- a/kernel/src/platform/snp_requests.rs
+++ b/kernel/src/platform/snp_requests.rs
@@ -184,8 +184,7 @@ pub fn request_loop() {
     }
 }
 
-#[no_mangle]
-pub extern "C" fn request_processing_main() {
+pub fn request_processing_main() {
     let apic_id = this_cpu().get_apic_id();
 
     log::info!("Launching request-processing task on CPU {}", apic_id);

--- a/kernel/src/platform/tdp.rs
+++ b/kernel/src/platform/tdp.rs
@@ -183,6 +183,10 @@ impl SvsmPlatform for TdpPlatform {
     ) -> Result<(), SvsmError> {
         todo!();
     }
+
+    fn request_loop(&self) {
+        todo!();
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default)]

--- a/kernel/src/platform/tdp.rs
+++ b/kernel/src/platform/tdp.rs
@@ -60,11 +60,11 @@ impl SvsmPlatform for TdpPlatform {
     }
 
     fn setup_percpu(&self, _cpu: &PerCpu) -> Result<(), SvsmError> {
-        Err(TdxError::Unimplemented.into())
+        Ok(())
     }
 
     fn setup_percpu_current(&self, _cpu: &PerCpu) -> Result<(), SvsmError> {
-        Err(TdxError::Unimplemented.into())
+        Ok(())
     }
 
     fn get_page_encryption_masks(&self) -> PageEncryptionMasks {

--- a/kernel/src/protocols/core.rs
+++ b/kernel/src/protocols/core.rs
@@ -16,7 +16,7 @@ use crate::mm::{valid_phys_address, writable_phys_addr, GuestPtr};
 use crate::protocols::apic::{APIC_PROTOCOL, APIC_PROTOCOL_VERSION_MAX, APIC_PROTOCOL_VERSION_MIN};
 use crate::protocols::errors::SvsmReqError;
 use crate::protocols::RequestParams;
-use crate::requests::SvsmCaa;
+use crate::sev::caa::SvsmCaa;
 use crate::sev::utils::{
     pvalidate, rmp_clear_guest_vmsa, rmp_grant_guest_access, rmp_revoke_guest_access,
     rmp_set_guest_vmsa, PvalidateOp, RMPFlags, SevSnpError,

--- a/kernel/src/sev/caa.rs
+++ b/kernel/src/sev/caa.rs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2022-2023 SUSE LLC
+//
+// Author: Joerg Roedel <jroedel@suse.de>
+
+const _: () = assert!(core::mem::size_of::<SvsmCaa>() == 8);
+
+/// The SVSM Calling Area (CAA)
+#[repr(C, packed)]
+#[derive(Debug, Clone, Copy)]
+pub struct SvsmCaa {
+    pub call_pending: u8,
+    mem_available: u8,
+    pub no_eoi_required: u8,
+    _rsvd: [u8; 5],
+}
+
+impl SvsmCaa {
+    /// Returns a copy of the this CAA with the `call_pending` field cleared.
+    #[inline]
+    pub const fn serviced(self) -> Self {
+        Self {
+            call_pending: 0,
+            ..self
+        }
+    }
+
+    /// Returns a copy of the this CAA with the `no_eoi_required` flag updated
+    #[inline]
+    pub const fn update_no_eoi_required(self, no_eoi_required: u8) -> Self {
+        Self {
+            no_eoi_required,
+            ..self
+        }
+    }
+
+    /// A CAA with all of its fields set to zero.
+    #[inline]
+    pub const fn zeroed() -> Self {
+        Self {
+            call_pending: 0,
+            mem_available: 0,
+            no_eoi_required: 0,
+            _rsvd: [0; 5],
+        }
+    }
+}

--- a/kernel/src/sev/mod.rs
+++ b/kernel/src/sev/mod.rs
@@ -4,6 +4,7 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
+pub mod caa;
 pub mod ghcb;
 pub mod hv_doorbell;
 pub mod msr_protocol;

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -40,8 +40,9 @@ use svsm::mm::pagetable::paging_init;
 use svsm::mm::virtualrange::virt_log_usage;
 use svsm::mm::{init_kernel_mapping_info, FixedAddressMappingRange};
 use svsm::platform;
-use svsm::platform::{init_platform_type, SvsmPlatformCell, SVSM_PLATFORM};
-use svsm::requests::{request_loop, request_processing_main};
+use svsm::platform::{
+    init_platform_type, request_loop, request_processing_main, SvsmPlatformCell, SVSM_PLATFORM,
+};
 use svsm::sev::secrets_page_mut;
 use svsm::svsm_paging::{init_page_table, invalidate_early_boot_memory};
 use svsm::task::exec_user;

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -97,7 +97,7 @@ global_asm!(
 static CPUID_PAGE: ImmutAfterInitCell<SnpCpuidTable> = ImmutAfterInitCell::uninit();
 static LAUNCH_INFO: ImmutAfterInitCell<KernelLaunchInfo> = ImmutAfterInitCell::uninit();
 
-pub fn memory_init(launch_info: &KernelLaunchInfo) {
+fn memory_init(launch_info: &KernelLaunchInfo) {
     root_mem_init(
         PhysAddr::from(launch_info.heap_area_phys_start),
         VirtAddr::from(launch_info.heap_area_virt_start),
@@ -105,7 +105,7 @@ pub fn memory_init(launch_info: &KernelLaunchInfo) {
     );
 }
 
-pub fn boot_stack_info() {
+fn boot_stack_info() {
     // SAFETY: this is only unsafe because `bsp_stack_end` is an extern
     // static, but we're simply printing its address. We are not creating a
     // reference so this is safe.

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -40,9 +40,7 @@ use svsm::mm::pagetable::paging_init;
 use svsm::mm::virtualrange::virt_log_usage;
 use svsm::mm::{init_kernel_mapping_info, FixedAddressMappingRange};
 use svsm::platform;
-use svsm::platform::{
-    init_platform_type, request_loop, request_processing_main, SvsmPlatformCell, SVSM_PLATFORM,
-};
+use svsm::platform::{init_platform_type, request_task_main, SvsmPlatformCell, SVSM_PLATFORM};
 use svsm::sev::secrets_page_mut;
 use svsm::svsm_paging::{init_page_table, invalidate_early_boot_memory};
 use svsm::task::exec_user;
@@ -324,7 +322,7 @@ pub extern "C" fn svsm_main() {
         panic!("Failed to launch FW: {e:#?}");
     }
 
-    start_kernel_task(request_processing_main, String::from("request-processing"))
+    start_kernel_task(request_task_main, String::from("request-processing"))
         .expect("Failed to launch request processing task");
 
     #[cfg(test)]
@@ -335,7 +333,7 @@ pub extern "C" fn svsm_main() {
         Err(e) => log::info!("Failed to launch /init: {e:#?}"),
     }
 
-    request_loop();
+    SVSM_PLATFORM.request_loop();
 
     panic!("Road ends here!");
 }


### PR DESCRIPTION
Add new abstractions to SvsmPlatform:

- request_task() is the kernel task for request processing
- request_loop() is the main vCPU request loop

Also, return Ok() for setup_percpu* on TDP platforms so they don't error out.