### PR TITLE
testing: support configurations other than SNP/QEMU

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,8 @@ test-igvm: bin/coconut-test-qemu.igvm bin/coconut-test-hyperv.igvm bin/coconut-t
 test-in-svsm: utils/cbit bin/coconut-test-qemu.igvm $(IGVMMEASUREBIN)
 	./scripts/test-in-svsm.sh
 
+test-in-hyperv: bin/coconut-test-hyperv.igvm
+
 doc:
 	cargo doc -p svsm --open --all-features --document-private-items
 

--- a/bootlib/src/igvm_params.rs
+++ b/bootlib/src/igvm_params.rs
@@ -112,8 +112,12 @@ pub struct IgvmParamBlock {
     /// Indicates whether the guest can support alternate injection.
     pub use_alternate_injection: u8,
 
+    /// Indicates whether the guest can assume firmware services specific to
+    /// QEMU.
+    pub is_qemu: u8,
+
     #[doc(hidden)]
-    pub _reserved: [u8; 5],
+    pub _reserved: [u8; 4],
 
     /// Metadata containing information about the firmware image embedded in the
     /// IGVM file.

--- a/igvmbuilder/src/igvm_builder.rs
+++ b/igvmbuilder/src/igvm_builder.rs
@@ -216,6 +216,11 @@ impl IgvmBuilder {
             (fw_info, vtom)
         };
 
+        let is_qemu: u8 = match self.options.hypervisor {
+            Hypervisor::Qemu => 1,
+            _ => 0,
+        };
+
         // Most of the parameter block can be initialised with constants.
         Ok(IgvmParamBlock {
             param_area_size,
@@ -231,6 +236,7 @@ impl IgvmBuilder {
             kernel_base: self.gpa_map.kernel.get_start(),
             vtom,
             use_alternate_injection: u8::from(self.options.alt_injection),
+            is_qemu,
             ..Default::default()
         })
     }

--- a/kernel/src/config.rs
+++ b/kernel/src/config.rs
@@ -179,4 +179,11 @@ impl SvsmConfig<'_> {
             SvsmConfig::IgvmConfig(igvm_params) => igvm_params.use_alternate_injection(),
         }
     }
+
+    pub fn is_qemu(&self) -> bool {
+        match self {
+            SvsmConfig::FirmwareConfig(_) => true,
+            SvsmConfig::IgvmConfig(igvm_params) => igvm_params.is_qemu(),
+        }
+    }
 }

--- a/kernel/src/cpu/vc.rs
+++ b/kernel/src/cpu/vc.rs
@@ -20,6 +20,9 @@ use crate::mm::GuestPtr;
 use crate::sev::ghcb::GHCB;
 use core::fmt;
 
+#[cfg(test)]
+use crate::testutils::is_qemu_test_env;
+
 pub const SVM_EXIT_EXCP_BASE: usize = 0x40;
 pub const SVM_EXIT_LAST_EXCP: usize = 0x5f;
 pub const SVM_EXIT_RDTSC: usize = 0x6e;
@@ -442,74 +445,88 @@ mod tests {
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn test_port_io_8() {
-        const TEST_VAL: u8 = 0x12;
-        verify_ghcb_gets_altered(|| outb(TESTDEV_ECHO_LAST_PORT, TEST_VAL));
-        assert_eq!(
-            TEST_VAL,
-            verify_ghcb_gets_altered(|| inb(TESTDEV_ECHO_LAST_PORT))
-        );
+        if is_qemu_test_env() {
+            const TEST_VAL: u8 = 0x12;
+            verify_ghcb_gets_altered(|| outb(TESTDEV_ECHO_LAST_PORT, TEST_VAL));
+            assert_eq!(
+                TEST_VAL,
+                verify_ghcb_gets_altered(|| inb(TESTDEV_ECHO_LAST_PORT))
+            );
+        }
     }
 
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn test_port_io_16() {
-        const TEST_VAL: u16 = 0x4321;
-        verify_ghcb_gets_altered(|| outw(TESTDEV_ECHO_LAST_PORT, TEST_VAL));
-        assert_eq!(
-            TEST_VAL,
-            verify_ghcb_gets_altered(|| inw(TESTDEV_ECHO_LAST_PORT))
-        );
+        if is_qemu_test_env() {
+            const TEST_VAL: u16 = 0x4321;
+            verify_ghcb_gets_altered(|| outw(TESTDEV_ECHO_LAST_PORT, TEST_VAL));
+            assert_eq!(
+                TEST_VAL,
+                verify_ghcb_gets_altered(|| inw(TESTDEV_ECHO_LAST_PORT))
+            );
+        }
     }
 
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn test_port_io_32() {
-        const TEST_VAL: u32 = 0xabcd1234;
-        verify_ghcb_gets_altered(|| outl(TESTDEV_ECHO_LAST_PORT, TEST_VAL));
-        assert_eq!(
-            TEST_VAL,
-            verify_ghcb_gets_altered(|| inl(TESTDEV_ECHO_LAST_PORT))
-        );
+        if is_qemu_test_env() {
+            const TEST_VAL: u32 = 0xabcd1234;
+            verify_ghcb_gets_altered(|| outl(TESTDEV_ECHO_LAST_PORT, TEST_VAL));
+            assert_eq!(
+                TEST_VAL,
+                verify_ghcb_gets_altered(|| inl(TESTDEV_ECHO_LAST_PORT))
+            );
+        }
     }
 
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn test_port_io_8_hardcoded() {
-        const TEST_VAL: u8 = 0x12;
-        verify_ghcb_gets_altered(|| outb_to_testdev_echo(TEST_VAL));
-        assert_eq!(TEST_VAL, verify_ghcb_gets_altered(inb_from_testdev_echo));
+        if is_qemu_test_env() {
+            const TEST_VAL: u8 = 0x12;
+            verify_ghcb_gets_altered(|| outb_to_testdev_echo(TEST_VAL));
+            assert_eq!(TEST_VAL, verify_ghcb_gets_altered(inb_from_testdev_echo));
+        }
     }
 
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn test_port_io_16_hardcoded() {
-        const TEST_VAL: u16 = 0x4321;
-        verify_ghcb_gets_altered(|| outw_to_testdev_echo(TEST_VAL));
-        assert_eq!(TEST_VAL, verify_ghcb_gets_altered(inw_from_testdev_echo));
+        if is_qemu_test_env() {
+            const TEST_VAL: u16 = 0x4321;
+            verify_ghcb_gets_altered(|| outw_to_testdev_echo(TEST_VAL));
+            assert_eq!(TEST_VAL, verify_ghcb_gets_altered(inw_from_testdev_echo));
+        }
     }
 
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn test_port_io_32_hardcoded() {
-        const TEST_VAL: u32 = 0xabcd1234;
-        verify_ghcb_gets_altered(|| outl_to_testdev_echo(TEST_VAL));
-        assert_eq!(TEST_VAL, verify_ghcb_gets_altered(inl_from_testdev_echo));
+        if is_qemu_test_env() {
+            const TEST_VAL: u32 = 0xabcd1234;
+            verify_ghcb_gets_altered(|| outl_to_testdev_echo(TEST_VAL));
+            assert_eq!(TEST_VAL, verify_ghcb_gets_altered(inl_from_testdev_echo));
+        }
     }
 
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn test_port_io_string_16_get_last() {
-        const TEST_DATA: &[u16] = &[0x1234, 0x5678, 0x9abc, 0xdef0];
-        verify_ghcb_gets_altered(|| rep_outsw(TESTDEV_ECHO_LAST_PORT, TEST_DATA));
-        assert_eq!(
-            TEST_DATA.last().unwrap(),
-            &verify_ghcb_gets_altered(|| inw(TESTDEV_ECHO_LAST_PORT))
-        );
+        if is_qemu_test_env() {
+            const TEST_DATA: &[u16] = &[0x1234, 0x5678, 0x9abc, 0xdef0];
+            verify_ghcb_gets_altered(|| rep_outsw(TESTDEV_ECHO_LAST_PORT, TEST_DATA));
+            assert_eq!(
+                TEST_DATA.last().unwrap(),
+                &verify_ghcb_gets_altered(|| inw(TESTDEV_ECHO_LAST_PORT))
+            );
 
-        let mut test_data: [u16; 4] = [0; 4];
-        verify_ghcb_gets_altered(|| rep_insw(TESTDEV_ECHO_LAST_PORT, &mut test_data));
-        for d in test_data.iter() {
-            assert_eq!(d, TEST_DATA.last().unwrap());
+            let mut test_data: [u16; 4] = [0; 4];
+            verify_ghcb_gets_altered(|| rep_insw(TESTDEV_ECHO_LAST_PORT, &mut test_data));
+            for d in test_data.iter() {
+                assert_eq!(d, TEST_DATA.last().unwrap());
+            }
         }
     }
 
@@ -531,16 +548,20 @@ mod tests {
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn test_rdmsr_apic() {
-        let apic_base = verify_ghcb_gets_altered(|| read_msr(MSR_APIC_BASE));
-        assert_eq!(apic_base & APIC_BASE_PHYS_ADDR_MASK, APIC_DEFAULT_PHYS_BASE);
+        if is_qemu_test_env() {
+            let apic_base = verify_ghcb_gets_altered(|| read_msr(MSR_APIC_BASE));
+            assert_eq!(apic_base & APIC_BASE_PHYS_ADDR_MASK, APIC_DEFAULT_PHYS_BASE);
+        }
     }
 
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn test_rdmsr_debug_ctl() {
-        const MSR_DEBUG_CTL: u32 = 0x1d9;
-        let apic_base = verify_ghcb_gets_altered(|| read_msr(MSR_DEBUG_CTL));
-        assert_eq!(apic_base, 0);
+        if is_qemu_test_env() {
+            const MSR_DEBUG_CTL: u32 = 0x1d9;
+            let apic_base = verify_ghcb_gets_altered(|| read_msr(MSR_DEBUG_CTL));
+            assert_eq!(apic_base, 0);
+        }
     }
 
     const MSR_TSC_AUX: u32 = 0xc0000103;
@@ -548,10 +569,12 @@ mod tests {
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn test_wrmsr_tsc_aux() {
-        let test_val = 0x1234;
-        verify_ghcb_gets_altered(|| write_msr(MSR_TSC_AUX, test_val));
-        let readback = verify_ghcb_gets_altered(|| read_msr(MSR_TSC_AUX));
-        assert_eq!(test_val, readback);
+        if is_qemu_test_env() {
+            let test_val = 0x1234;
+            verify_ghcb_gets_altered(|| write_msr(MSR_TSC_AUX, test_val));
+            let readback = verify_ghcb_gets_altered(|| read_msr(MSR_TSC_AUX));
+            assert_eq!(test_val, readback);
+        }
     }
 
     #[test]
@@ -566,26 +589,31 @@ mod tests {
     // #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     #[ignore = "Currently unhandled by #VC handler"]
     fn test_vmmcall_vapic_poll_irq() {
-        const VMMCALL_HC_VAPIC_POLL_IRQ: u32 = 1;
+        if is_qemu_test_env() {
+            const VMMCALL_HC_VAPIC_POLL_IRQ: u32 = 1;
 
-        let res =
-            verify_ghcb_gets_altered(|| unsafe { raw_vmmcall(VMMCALL_HC_VAPIC_POLL_IRQ, 0, 0, 0) });
-        assert_eq!(res, 0);
+            let res = verify_ghcb_gets_altered(|| unsafe {
+                raw_vmmcall(VMMCALL_HC_VAPIC_POLL_IRQ, 0, 0, 0)
+            });
+            assert_eq!(res, 0);
+        }
     }
 
     #[test]
     // #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     #[ignore = "Currently unhandled by #VC handler"]
     fn test_read_write_dr7() {
-        const DR7_DEFAULT: u64 = 0x400;
-        const DR7_TEST: u64 = 0x401;
+        if is_qemu_test_env() {
+            const DR7_DEFAULT: u64 = 0x400;
+            const DR7_TEST: u64 = 0x401;
 
-        let old_dr7 = verify_ghcb_gets_altered(get_dr7);
-        assert_eq!(old_dr7, DR7_DEFAULT);
+            let old_dr7 = verify_ghcb_gets_altered(get_dr7);
+            assert_eq!(old_dr7, DR7_DEFAULT);
 
-        verify_ghcb_gets_altered(|| set_dr7(DR7_TEST));
-        let new_dr7 = verify_ghcb_gets_altered(get_dr7);
-        assert_eq!(new_dr7, DR7_TEST);
+            verify_ghcb_gets_altered(|| set_dr7(DR7_TEST));
+            let new_dr7 = verify_ghcb_gets_altered(get_dr7);
+            assert_eq!(new_dr7, DR7_TEST);
+        }
     }
 
     #[test]

--- a/kernel/src/greq/services.rs
+++ b/kernel/src/greq/services.rs
@@ -121,11 +121,12 @@ mod tests {
 
         use crate::serial::Terminal;
         use crate::testing::{assert_eq_warn, svsm_test_io, IORequest};
-        use crate::testutils::is_qemu_test_env;
+        use crate::testutils::{is_qemu_test_env, is_test_platform_type};
 
         use alloc::vec;
+        use bootlib::platform::SvsmPlatformType;
 
-        if is_qemu_test_env() {
+        if is_qemu_test_env() && is_test_platform_type(SvsmPlatformType::Snp) {
             let sp = svsm_test_io().unwrap();
 
             sp.put_byte(IORequest::GetLaunchMeasurement as u8);

--- a/kernel/src/igvm_params.rs
+++ b/kernel/src/igvm_params.rs
@@ -388,4 +388,8 @@ impl IgvmParams<'_> {
     pub fn use_alternate_injection(&self) -> bool {
         self.igvm_param_block.use_alternate_injection != 0
     }
+
+    pub fn is_qemu(&self) -> bool {
+        self.igvm_param_block.is_qemu != 0
+    }
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -56,3 +56,6 @@ extern crate self as svsm;
 // Include a module containing the test runner.
 #[cfg(all(test, test_in_svsm))]
 pub mod testing;
+// Utilities for test configurations.
+#[cfg(test)]
+pub mod testutils;

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -60,6 +60,9 @@ pub enum PageValidateOp {
 /// This defines a platform abstraction to permit the SVSM to run on different
 /// underlying architectures.
 pub trait SvsmPlatform {
+    #[cfg(test)]
+    fn platform_type(&self) -> SvsmPlatformType;
+
     /// Halts the system as required by the platform.
     fn halt()
     where

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -20,6 +20,9 @@ use crate::utils::MemoryRegion;
 #[cfg(debug_assertions)]
 use crate::mm::virt_to_phys;
 
+#[cfg(test)]
+use bootlib::platform::SvsmPlatformType;
+
 const APIC_MSR_EOI: u32 = 0x80B;
 const APIC_MSR_ICR: u32 = 0x830;
 
@@ -43,6 +46,11 @@ impl Default for NativePlatform {
 }
 
 impl SvsmPlatform for NativePlatform {
+    #[cfg(test)]
+    fn platform_type(&self) -> SvsmPlatformType {
+        SvsmPlatformType::Native
+    }
+
     fn env_setup(&mut self, debug_serial_port: u16, _vtom: usize) -> Result<(), SvsmError> {
         // In the native platform, console output does not require the use of
         // any platform services, so it can be initialized immediately.

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -35,6 +35,9 @@ use crate::utils::MemoryRegion;
 
 use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
+#[cfg(test)]
+use bootlib::platform::SvsmPlatformType;
+
 static SVSM_ENV_INITIALIZED: AtomicBool = AtomicBool::new(false);
 
 static GHCB_IO_DRIVER: GHCBIOPort = GHCBIOPort::new();
@@ -93,6 +96,11 @@ impl Default for SnpPlatform {
 }
 
 impl SvsmPlatform for SnpPlatform {
+    #[cfg(test)]
+    fn platform_type(&self) -> SvsmPlatformType {
+        SvsmPlatformType::Snp
+    }
+
     fn env_setup(&mut self, _debug_serial_port: u16, vtom: usize) -> Result<(), SvsmError> {
         sev_status_init();
         VTOM.init(&vtom).map_err(|_| SvsmError::PlatformInit)?;

--- a/kernel/src/platform/tdp.rs
+++ b/kernel/src/platform/tdp.rs
@@ -21,6 +21,9 @@ use crate::types::{PageSize, PAGE_SIZE};
 use crate::utils::immut_after_init::ImmutAfterInitCell;
 use crate::utils::{is_aligned, MemoryRegion};
 
+#[cfg(test)]
+use bootlib::platform::SvsmPlatformType;
+
 static GHCI_IO_DRIVER: GHCIIOPort = GHCIIOPort::new();
 static VTOM: ImmutAfterInitCell<usize> = ImmutAfterInitCell::uninit();
 
@@ -40,6 +43,11 @@ impl Default for TdpPlatform {
 }
 
 impl SvsmPlatform for TdpPlatform {
+    #[cfg(test)]
+    fn platform_type(&self) -> SvsmPlatformType {
+        SvsmPlatformType::Tdp
+    }
+
     fn halt() {
         tdvmcall_halt();
     }

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -330,7 +330,12 @@ pub extern "C" fn svsm_main() {
         .expect("Failed to launch request processing task");
 
     #[cfg(test)]
-    crate::test_main();
+    {
+        if config.is_qemu() {
+            crate::testutils::set_qemu_test_env();
+        }
+        crate::test_main();
+    }
 
     match exec_user("/init", opendir("/").expect("Failed to find FS root")) {
         Ok(_) => (),

--- a/kernel/src/testutils.rs
+++ b/kernel/src/testutils.rs
@@ -1,0 +1,11 @@
+use core::sync::atomic::{AtomicBool, Ordering};
+
+static QEMU_TEST_ENV: AtomicBool = AtomicBool::new(false);
+
+pub fn is_qemu_test_env() -> bool {
+    QEMU_TEST_ENV.load(Ordering::Acquire)
+}
+
+pub fn set_qemu_test_env() {
+    QEMU_TEST_ENV.store(true, Ordering::Release)
+}

--- a/kernel/src/testutils.rs
+++ b/kernel/src/testutils.rs
@@ -1,9 +1,15 @@
+use crate::platform::SVSM_PLATFORM;
+use bootlib::platform::SvsmPlatformType;
 use core::sync::atomic::{AtomicBool, Ordering};
 
 static QEMU_TEST_ENV: AtomicBool = AtomicBool::new(false);
 
 pub fn is_qemu_test_env() -> bool {
     QEMU_TEST_ENV.load(Ordering::Acquire)
+}
+
+pub fn is_test_platform_type(platform_type: SvsmPlatformType) -> bool {
+    SVSM_PLATFORM.platform_type() == platform_type
 }
 
 pub fn set_qemu_test_env() {


### PR DESCRIPTION
The `test-in-svsm` build configuration should support environments other than SNP running on QEMU.