### PR TITLE
libtcgtpm: update _plat__NVEnable and _plat__NVDisable signatures

### DIFF
--- a/kernel/src/vtpm/tcgtpm/mod.rs
+++ b/kernel/src/vtpm/tcgtpm/mod.rs
@@ -162,11 +162,11 @@ impl VtpmInterface for TcgTpm {
         // 5. Power it on indicating it requires startup. By default, OVMF will start
         //    and selftest it.
 
-        unsafe { _plat__NVEnable(VirtAddr::null().as_mut_ptr::<c_void>()) };
+        unsafe { _plat__NVEnable(VirtAddr::null().as_mut_ptr::<c_void>(), 0) };
 
         let mut rc = self.manufacture(1)?;
         if rc != 0 {
-            unsafe { _plat__NVDisable(1) };
+            unsafe { _plat__NVDisable(1 as *mut c_void, 0) };
             return Err(SvsmReqError::incomplete());
         }
 

--- a/libtcgtpm/deps/libtcgtpm.h
+++ b/libtcgtpm/deps/libtcgtpm.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stddef.h>
+
 typedef unsigned int uint32_t;
 void _plat__RunCommand(
     uint32_t         requestSize,   // IN: command buffer size
@@ -12,8 +14,8 @@ void _plat__LocalitySet(unsigned char locality);
 void _plat__SetNvAvail(void);
 int  _plat__Signal_PowerOn(void);
 int  _plat__Signal_Reset(void);
-void _plat__NVDisable(int delete);
-int  _plat__NVEnable(void *platParameter);
+void _plat__NVDisable(void *platParameter, size_t paramSize);
+int  _plat__NVEnable(void *platParameter, size_t paramSize);
 
 int  TPM_Manufacture(int firstTime);
 int  TPM_TearDown(void);


### PR DESCRIPTION
`_plat__NVEnable()` and `_plat__NVDisable()` APIs were updated in the new TCG TPM reference implementation to include an additional `paramSize` parameter (size_t) in their signatures.

This patch synchronizes the header file and Rust FFI calls with the new function prototypes.

Previously, the outdated header and calls passed fewer arguments than required by the new TCG TPM library. However, this mismatch did not cause issues because the new parameter (paramSize) is not used by the new implementation.

Additionally, the first parameter of `_plat__NVDisable()` has changed from `int delete` to `void* platParameter` in the new signature. However, the actual value passed (1) remains the same.

In the future we should find a better way to keep the headers synchronized and avoid this problem.

Fixes: 9894bf4d ("libtcgtpm: swtich from MS TPM to TCG TPM")