### PR TITLE
kernel/cpu: Fix access permissions for SVSM VMSAs

### DIFF
--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -838,7 +838,7 @@ impl PerCpu {
             return Err(SvsmError::Mem);
         }
 
-        let mut vmsa = VmsaPage::new(RMPFlags::GUEST_VMPL)?;
+        let mut vmsa = VmsaPage::new(RMPFlags::VMPL1)?;
         let paddr = vmsa.paddr();
 
         // Initialize VMSA


### PR DESCRIPTION
Make sure the guest OS can not access the VMSA pages of the SVSM by only giving permissions up to VMPL1.