### PR TITLE
kernel/cpu: add safety comments

### DIFF
--- a/kernel/src/cpu/efer.rs
+++ b/kernel/src/cpu/efer.rs
@@ -28,9 +28,16 @@ pub fn read_efer() -> EFERFlags {
     EFERFlags::from_bits_truncate(read_msr(EFER))
 }
 
-pub fn write_efer(efer: EFERFlags) {
+/// # Safety
+///
+/// The caller should ensure that the new value written to EFER MSR doesn't
+/// break memory safety.
+pub unsafe fn write_efer(efer: EFERFlags) {
     let val = efer.bits();
-    write_msr(EFER, val);
+    // SAFETY: requirements should be verified by the caller.
+    unsafe {
+        write_msr(EFER, val);
+    }
 }
 
 impl From<usize> for EFERFlags {

--- a/kernel/src/cpu/gdt.rs
+++ b/kernel/src/cpu/gdt.rs
@@ -80,7 +80,18 @@ impl GDT {
 
         let tss_entries = &self.entries[idx..idx + 1].as_mut_ptr();
 
+        // SAFETY:
+        // For add():
+        //   - idx and idx + size_of::<GDTEntry>() don't overflow isize.
+        //   - the borrow checker guarantees that self is still allocated
+        //   - self.entries[6:8] fits in self's allocation.
+        // For write_volatile():
+        //   - the borrow checker guarantees that self.entries is allocated
+        //   - alignment is checked inside
         unsafe {
+            assert_eq!(align_of_val(&tss_entries.add(0)), align_of::<GDTEntry>());
+            assert_eq!(align_of_val(&tss_entries.add(1)), align_of::<GDTEntry>());
+
             tss_entries.add(0).write_volatile(desc0);
             tss_entries.add(1).write_volatile(desc1);
         }
@@ -90,14 +101,14 @@ impl GDT {
         self.set_tss_entry(GDTEntry::null(), GDTEntry::null());
     }
 
-    pub fn load_tss(&mut self, tss: &X86Tss) {
+    pub fn load_tss(&mut self, tss: &'static X86Tss) {
         let (desc0, desc1) = tss.to_gdt_entry();
 
-        unsafe {
-            self.set_tss_entry(desc0, desc1);
-            asm!("ltr %ax", in("ax") SVSM_TSS, options(att_syntax));
-            self.clear_tss_entry()
-        }
+        self.set_tss_entry(desc0, desc1);
+        // SAFETY: loading task register must me done in assembly.
+        // tss is ensured to have a static lifetime so this is safe.
+        unsafe { asm!("ltr %ax", in("ax") SVSM_TSS, options(att_syntax)) };
+        self.clear_tss_entry()
     }
 
     pub fn kernel_cs(&self) -> GDTEntry {

--- a/kernel/src/cpu/msr.rs
+++ b/kernel/src/cpu/msr.rs
@@ -27,10 +27,15 @@ pub fn read_msr(msr: u32) -> u64 {
     (eax as u64) | (edx as u64) << 32
 }
 
-pub fn write_msr(msr: u32, val: u64) {
+/// # Safety
+///
+/// The caller should ensure that the new value in the target MSR doesn't break
+/// memory safety.
+pub unsafe fn write_msr(msr: u32, val: u64) {
     let eax = (val & 0x0000_0000_ffff_ffff) as u32;
     let edx = (val >> 32) as u32;
 
+    // SAFETY: requirements have to be checked by the caller.
     unsafe {
         asm!("wrmsr",
              in("ecx") msr,

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -876,7 +876,7 @@ impl PerCpu {
         Ok(())
     }
 
-    pub fn load_gdt_tss(&self, init_gdt: bool) {
+    pub fn load_gdt_tss(&'static self, init_gdt: bool) {
         // Create a temporary GDT to use to configure the TSS.
         let mut gdt = GDT::new();
         gdt.load();
@@ -893,7 +893,7 @@ impl PerCpu {
         unsafe { write_msr(ISST_ADDR, isst as u64) };
     }
 
-    pub fn load(&self) {
+    pub fn load(&'static self) {
         // SAFETY: along with the page table we are also uploading the right
         // TSS and ISST to ensure a memory safe execution state
         unsafe { self.get_pgtable().load() };

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -889,7 +889,8 @@ impl PerCpu {
 
     pub fn load_isst(&self) {
         let isst = self.isst.as_ptr();
-        write_msr(ISST_ADDR, isst as u64);
+        // SAFETY: ISST is already setup when this is called.
+        unsafe { write_msr(ISST_ADDR, isst as u64) };
     }
 
     pub fn load(&self) {

--- a/kernel/src/cpu/vc.rs
+++ b/kernel/src/cpu/vc.rs
@@ -577,7 +577,9 @@ mod tests {
     fn test_wrmsr_tsc_aux() {
         if is_qemu_test_env() && is_test_platform_type(SvsmPlatformType::Snp) {
             let test_val = 0x1234;
-            verify_ghcb_gets_altered(|| write_msr(MSR_TSC_AUX, test_val));
+            verify_ghcb_gets_altered(||
+                // SAFETY: writing to TSC_AUX MSR doesn't break memory safety.
+                unsafe { write_msr(MSR_TSC_AUX, test_val) });
             let readback = verify_ghcb_gets_altered(|| read_msr(MSR_TSC_AUX));
             assert_eq!(test_val, readback);
         }

--- a/kernel/src/cpu/x86/smap.rs
+++ b/kernel/src/cpu/x86/smap.rs
@@ -12,6 +12,7 @@ use core::arch::asm;
 #[inline(always)]
 pub fn clac() {
     if !cfg!(feature = "nosmap") {
+        // SAFETY: `clac` instruction doesn't break memory safety.
         unsafe { asm!("clac", options(att_syntax, nomem, nostack, preserves_flags)) }
     }
 }
@@ -22,6 +23,7 @@ pub fn clac() {
 #[inline(always)]
 pub fn stac() {
     if !cfg!(feature = "nosmap") {
+        // SAFETY: `stac` instruction doesn't break memory safety.
         unsafe { asm!("stac", options(att_syntax, nomem, nostack, preserves_flags)) }
     }
 }

--- a/kernel/src/sev/ghcb.rs
+++ b/kernel/src/sev/ghcb.rs
@@ -141,7 +141,11 @@ impl GhcbPage {
         pvalidate(vaddr, PageSize::Regular, PvalidateOp::Invalid)?;
 
         // Let the Hypervisor take the page back
-        invalidate_page_msr(paddr)?;
+        // SAFETY: we trust virt_to_phys() to return GHCB's physical address
+        // since it panics if vaddr is invalid.
+        unsafe {
+            invalidate_page_msr(paddr)?;
+        }
 
         // Needs guarding for Stage2 GHCB
         if valid_bitmap_valid_addr(paddr) {
@@ -169,10 +173,17 @@ impl Drop for GhcbPage {
             .expect("Could not re-encrypt page");
 
         // Unregister GHCB PA
-        register_ghcb_gpa_msr(PhysAddr::null()).expect("Could not unregister GHCB");
+        // SAFETY: mapping the GHCB at physical address 0 is safe.
+        unsafe {
+            register_ghcb_gpa_msr(PhysAddr::null()).expect("Could not unregister GHCB");
+        }
 
         // Ask the hypervisor to change the page back to the private page state.
-        validate_page_msr(paddr).expect("Could not change page state");
+        // SAFETY: we trust virt_to_phys() to return GHCB's physical address
+        // since it panics if vaddr is invalid.
+        unsafe {
+            validate_page_msr(paddr).expect("Could not change page state");
+        }
 
         // Make page guest-valid
         pvalidate(vaddr, PageSize::Regular, PvalidateOp::Valid).expect("Could not pvalidate page");
@@ -328,7 +339,9 @@ impl GHCB {
         let paddr = virt_to_phys(vaddr);
 
         // Register GHCB GPA
-        Ok(register_ghcb_gpa_msr(paddr)?)
+        // SAFETY: we trust virt_to_phys() to return self's physical address
+        // since it panics if vaddr is invalid.
+        unsafe { Ok(register_ghcb_gpa_msr(paddr)?) }
     }
 
     pub fn clear(&self) {
@@ -377,7 +390,10 @@ impl GHCB {
         // Disable interrupts between writing the MSR and making the GHCB call
         // to prevent reentrant use of the GHCB MSR.
         let guard = IrqGuard::new();
-        write_msr(SEV_GHCB, ghcb_pa);
+        // SAFETY: GHCB is already allocated and setup so this is safe.
+        unsafe {
+            write_msr(SEV_GHCB, ghcb_pa);
+        }
         raw_vmgexit();
         drop(guard);
 

--- a/kernel/src/sev/msr_protocol.rs
+++ b/kernel/src/sev/msr_protocol.rs
@@ -78,7 +78,8 @@ pub fn verify_ghcb_version() {
     // used.
     assert!(!irqs_enabled());
     // Request SEV information.
-    write_msr(SEV_GHCB, GHCBMsr::SEV_INFO_REQ);
+    // SAFETY: Requesting info through the GHCB MSR protocol is safe.
+    unsafe { write_msr(SEV_GHCB, GHCBMsr::SEV_INFO_REQ) };
     raw_vmgexit();
     let sev_info = read_msr(SEV_GHCB);
 
@@ -107,7 +108,8 @@ pub fn hypervisor_ghcb_features() -> GHCBHvFeatures {
 
 pub fn init_hypervisor_ghcb_features() -> Result<(), GhcbMsrError> {
     let guard = IrqGuard::new();
-    write_msr(SEV_GHCB, GHCBMsr::SNP_HV_FEATURES_REQ);
+    // SAFETY: Requesting HV features through the GHCB MSR protocol is safe.
+    unsafe { write_msr(SEV_GHCB, GHCBMsr::SNP_HV_FEATURES_REQ) };
     raw_vmgexit();
     let result = read_msr(SEV_GHCB);
     drop(guard);
@@ -138,12 +140,17 @@ pub fn init_hypervisor_ghcb_features() -> Result<(), GhcbMsrError> {
     }
 }
 
-pub fn register_ghcb_gpa_msr(addr: PhysAddr) -> Result<(), GhcbMsrError> {
+/// # Safety
+///
+/// Since this causes the GHCB to be remapped to a different physical address
+/// (allowing leaking and modifying its content), `addr` should be validated.
+pub unsafe fn register_ghcb_gpa_msr(addr: PhysAddr) -> Result<(), GhcbMsrError> {
     let mut info = addr.bits() as u64;
 
     info |= GHCBMsr::SNP_REG_GHCB_GPA_REQ;
     let guard = IrqGuard::new();
-    write_msr(SEV_GHCB, info);
+    // SAFETY: safety requirements should be checked by the caller
+    unsafe { write_msr(SEV_GHCB, info) };
     raw_vmgexit();
     info = read_msr(SEV_GHCB);
     drop(guard);
@@ -159,7 +166,10 @@ pub fn register_ghcb_gpa_msr(addr: PhysAddr) -> Result<(), GhcbMsrError> {
     Ok(())
 }
 
-fn set_page_valid_status_msr(addr: PhysAddr, valid: bool) -> Result<(), GhcbMsrError> {
+/// # Safety
+///
+/// See [`validate_page_msr`] or [`invalidate_page_msr`] safety requirements.
+unsafe fn set_page_valid_status_msr(addr: PhysAddr, valid: bool) -> Result<(), GhcbMsrError> {
     let mut info: u64 = (addr.bits() as u64) & 0x000f_ffff_ffff_f000;
 
     if valid {
@@ -170,7 +180,8 @@ fn set_page_valid_status_msr(addr: PhysAddr, valid: bool) -> Result<(), GhcbMsrE
 
     info |= GHCBMsr::SNP_STATE_CHANGE_REQ;
     let guard = IrqGuard::new();
-    write_msr(SEV_GHCB, info);
+    // SAFETY: safety requirements are delegated to the caller.
+    unsafe { write_msr(SEV_GHCB, info) };
     raw_vmgexit();
     let response = read_msr(SEV_GHCB);
     drop(guard);
@@ -186,12 +197,22 @@ fn set_page_valid_status_msr(addr: PhysAddr, valid: bool) -> Result<(), GhcbMsrE
     Ok(())
 }
 
-pub fn validate_page_msr(addr: PhysAddr) -> Result<(), GhcbMsrError> {
-    set_page_valid_status_msr(addr, true)
+/// # Safety
+///
+/// Since this causes a page to be remmaped with a different encryption
+/// attribute, `addr` should be validated.
+pub unsafe fn validate_page_msr(addr: PhysAddr) -> Result<(), GhcbMsrError> {
+    // SAFETY: safety requirements are delegated to the caller.
+    unsafe { set_page_valid_status_msr(addr, true) }
 }
 
-pub fn invalidate_page_msr(addr: PhysAddr) -> Result<(), GhcbMsrError> {
-    set_page_valid_status_msr(addr, false)
+/// # Safety
+///
+/// Since this causes a page to be remmaped with a different encryption
+/// attribute, `addr` should be validated.
+pub unsafe fn invalidate_page_msr(addr: PhysAddr) -> Result<(), GhcbMsrError> {
+    // SAFETY: safety requirements are delegated to the caller.
+    unsafe { set_page_valid_status_msr(addr, false) }
 }
 
 pub fn request_termination_msr() -> ! {
@@ -201,7 +222,8 @@ pub fn request_termination_msr() -> ! {
     // no reason to preserve interrupt state.  Interrupts can be disabled
     // outright prior to shutdown.
     raw_irqs_disable();
-    write_msr(SEV_GHCB, info);
+    // SAFETY: Requesting termination doesn't break memory safety.
+    unsafe { write_msr(SEV_GHCB, info) };
     raw_vmgexit();
     loop {
         halt();

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -451,7 +451,11 @@ pub fn schedule() {
             this_cpu().set_tss_rsp0(next.stack_bounds.end());
         }
         if is_cet_ss_supported() {
-            write_msr(PL0_SSP, next.exception_shadow_stack.bits() as u64);
+            // SAFETY: Task::exception_shadow_stack is always initialized when
+            // creating a new Task.
+            unsafe {
+                write_msr(PL0_SSP, next.exception_shadow_stack.bits() as u64);
+            }
         }
 
         // Get task-pointers, consuming the Arcs and release their reference


### PR DESCRIPTION
Safety comments for:
- `stac` and `clac` instructions
- some TSS-related pieces of GDT code
- as described in #553 `write_msr()` should be unsafe since it can break memory safety. This part is still missing two comments [here](https://github.com/p4zuu/svsm/blob/f11a86f1ecbc33550ccaf443fe74dea15dceb5ac/kernel/src/sev/msr_protocol.rs#L148) and [here](https://github.com/p4zuu/svsm/blob/f11a86f1ecbc33550ccaf443fe74dea15dceb5ac/kernel/src/sev/msr_protocol.rs#L175) in the GHCB MSR protocol where I have doubt if the MSR request is subject to breaking memory safety or not, specifically `SNP_REG_GHCB_GPA_REQ` and `SNP_STATE_CHANGE_REQ` GHCB requests. My guess is a garbage request parameter can break the platform, but does it still count as memory safety?
