### PR TITLE
requests: handle interrupts when halted in the request loop

### DIFF
--- a/kernel/src/requests.rs
+++ b/kernel/src/requests.rs
@@ -71,7 +71,12 @@ pub fn update_mappings() -> Result<(), SvsmError> {
     let mut ret = Ok(());
 
     if !locked.needs_update() {
-        return Ok(());
+        // If there is no VMSA, then the update request must be considered a
+        // failure even though no work was required.
+        return match locked.vmsa_phys() {
+            Some(_) => Ok(()),
+            None => Err(SvsmError::MissingVMSA),
+        };
     }
 
     cpu.unmap_guest_vmsa();


### PR DESCRIPTION
If the request loop determines that there is no active VMSA, the processor enters a halt state.  This halt state can terminate if an interrupt is received.  If that happens, the request loop will observe that no change to the VMSA mapping has been requested.  In this case, the request loop must return to the halt state rather than attempting to process any requests.