### PR TITLE
igvmbuilder: enable long mode paging in the initial VSM context

### DIFF
--- a/igvmbuilder/src/gpa_map.rs
+++ b/igvmbuilder/src/gpa_map.rs
@@ -66,6 +66,7 @@ pub struct GpaMap {
     pub guest_context: GpaRange,
     pub kernel: GpaRange,
     pub vmsa: GpaRange,
+    pub init_page_tables: GpaRange,
 }
 
 impl GpaMap {
@@ -73,6 +74,7 @@ impl GpaMap {
         options: &CmdOptions,
         firmware: &Option<Box<dyn Firmware>>,
     ) -> Result<Self, Box<dyn Error>> {
+        //   0x010000-0x010FFF: initial page tables for VSM platforms
         //   0x800000-0x804FFF: zero-filled (must be pre-validated)
         //   0x805000-0x805FFF: initial stage 2 stack page
         //   0x806000-0x806FFF: Secrets page
@@ -167,6 +169,7 @@ impl GpaMap {
             guest_context,
             kernel,
             vmsa,
+            init_page_tables: GpaRange::new(0x10000, 2 * PAGE_SIZE_4K)?,
         };
         if options.verbose {
             println!("GPA Map: {gpa_map:#X?}");

--- a/igvmbuilder/src/main.rs
+++ b/igvmbuilder/src/main.rs
@@ -16,6 +16,7 @@ mod gpa_map;
 mod igvm_builder;
 mod igvm_firmware;
 mod ovmf_firmware;
+mod paging;
 mod platform;
 mod stage2_stack;
 mod vmsa;

--- a/igvmbuilder/src/paging.rs
+++ b/igvmbuilder/src/paging.rs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 Microsoft Corporation
+//
+// Author: Jon Lange <jlange@microsoft.com>
+
+use igvm::IgvmDirectiveHeader;
+use igvm_defs::{IgvmPageDataFlags, IgvmPageDataType, PAGE_SIZE_4K};
+
+use zerocopy::{Immutable, IntoBytes};
+
+#[derive(Clone, Copy, Immutable, IntoBytes)]
+struct PageTablePage {
+    ptes: [u64; 512],
+}
+
+#[derive(Clone, Copy, Default)]
+struct InitPageTables {
+    pages: [PageTablePage; 2],
+}
+
+impl Default for PageTablePage {
+    fn default() -> Self {
+        Self { ptes: [0; 512] }
+    }
+}
+
+pub fn construct_init_page_tables(
+    init_page_table_gpa: u64,
+    compatibility_mask: u32,
+    directives: &mut Vec<IgvmDirectiveHeader>,
+) {
+    let mut page_tables: InitPageTables = InitPageTables::default();
+
+    // The initial page tables comparise a single PML4E that points to a page
+    // that includes entries which map the low 4 GB of the address space
+    // with an identity map of 1 GB pages.
+    // This PML4E is present, writable, accesed, and dirty.
+    page_tables.pages[0].ptes[0] = 0x63 | (init_page_table_gpa + PAGE_SIZE_4K);
+
+    for i in 0..4 {
+        // This PTE is present, writable, accesed, dirty, and large page.
+        page_tables.pages[1].ptes[i] = 0xE3 | ((i as u64) << 30);
+    }
+
+    for (i, data) in page_tables.pages.iter().enumerate() {
+        // Allocate a byte vector to contain a copy of the initial page table
+        // data.
+        let mut page_table_data = Vec::<u8>::new();
+        page_table_data.extend_from_slice(data.as_bytes());
+
+        directives.push(IgvmDirectiveHeader::PageData {
+            gpa: init_page_table_gpa + (i as u64) * PAGE_SIZE_4K,
+            compatibility_mask,
+            flags: IgvmPageDataFlags::new(),
+            data_type: IgvmPageDataType::NORMAL,
+            data: page_table_data,
+        });
+    }
+}


### PR DESCRIPTION
The VSM environment requires CR0.PG to be set when entering VTL 2 for the first time.  In this environment, the IGVM file must be built with initial page tables that map the low 4 GB, which permits stage 2 to start with paging enabled.  This also requires that stage 2 must start in long mode, because the paging mode cannot be changed once the VM starts executing (if CR0.PG must always be set, then it is not possible to change from 3-level PAE tables to 4-level tables).  Stage 2 will still start executing in 32-bit mode as usual, and will rebuild the page tables in its own memory area, as it always has, but that code can now execute with paging enabled as required by VSM.