### PR TITLE
platform/native: require the use of X2APIC

### DIFF
--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -7,7 +7,7 @@
 use crate::address::{PhysAddr, VirtAddr};
 use crate::console::init_svsm_console;
 use crate::cpu::cpuid::CpuidResult;
-use crate::cpu::msr::write_msr;
+use crate::cpu::msr::{read_msr, write_msr};
 use crate::cpu::percpu::PerCpu;
 use crate::error::SvsmError;
 use crate::hyperv;
@@ -22,6 +22,9 @@ use crate::mm::virt_to_phys;
 
 #[cfg(test)]
 use bootlib::platform::SvsmPlatformType;
+
+const MSR_APIC_BASE: u32 = 0x1B;
+const APIC_X2_ENABLE_MASK: u64 = 0xC00;
 
 const APIC_MSR_EOI: u32 = 0x80B;
 const APIC_MSR_ICR: u32 = 0x830;
@@ -41,6 +44,11 @@ impl NativePlatform {
 
 impl Default for NativePlatform {
     fn default() -> Self {
+        // Execution is not possible unless X2APIC is supported.
+        let features = CpuidResult::get(1, 0);
+        if (features.ecx & 0x200000) == 0 {
+            panic!("X2APIC is not supported");
+        }
         Self::new()
     }
 }
@@ -78,6 +86,15 @@ impl SvsmPlatform for NativePlatform {
     }
 
     fn setup_percpu_current(&self, _cpu: &PerCpu) -> Result<(), SvsmError> {
+        // Enable X2APIC mode.
+        // SAFETY: accesses to the APIC_BASE MSR are safe if the address is not
+        // being changed.
+        let apic_base = read_msr(MSR_APIC_BASE);
+        let apic_base_x2_enabled = apic_base | APIC_X2_ENABLE_MASK;
+        if apic_base != apic_base_x2_enabled {
+            write_msr(MSR_APIC_BASE, apic_base_x2_enabled);
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
For simplicity and consistency, require the native platform to use X2APIC so that APIC management can be identical across all native environments.