### PR TITLE
task: assign each task a unique portion of the kernel address space

### DIFF
--- a/fuzz/fuzz_targets/bitmap_allocator.rs
+++ b/fuzz/fuzz_targets/bitmap_allocator.rs
@@ -149,8 +149,8 @@ impl TestBitmapAllocator for BitmapAllocator1024 {
 }
 
 fuzz_target!(|actions: Vec<BmaAction>| {
-    let mut bma64 = BitmapAllocator64::new();
-    let mut bma1024 = BitmapAllocator1024::new();
+    let mut bma64 = BitmapAllocator64::new_full();
+    let mut bma1024 = BitmapAllocator1024::new_full();
     for action in actions.iter() {
         let bma64_before = bma64;
         let bma1024_before = bma1024.clone();

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -560,7 +560,11 @@ impl PerCpu {
     }
 
     pub fn init_page_table(&self, pgtable: PageBox<PageTable>) -> Result<(), SvsmError> {
-        self.vm_range.initialize()?;
+        // SAFETY: The per-CPU address range is fully aligned to top-level
+        // paging boundaries.
+        unsafe {
+            self.vm_range.initialize()?;
+        }
         self.set_pgtable(PageBox::leak(pgtable));
 
         Ok(())

--- a/kernel/src/mm/address_space.rs
+++ b/kernel/src/mm/address_space.rs
@@ -133,7 +133,7 @@ pub const STACK_SIZE: usize = PAGE_SIZE * STACK_PAGES;
 pub const STACK_GUARD_SIZE: usize = STACK_SIZE;
 pub const STACK_TOTAL_SIZE: usize = STACK_SIZE + STACK_GUARD_SIZE;
 
-const fn virt_from_idx(idx: usize) -> VirtAddr {
+pub const fn virt_from_idx(idx: usize) -> VirtAddr {
     VirtAddr::new(idx << ((3 * 9) + 12))
 }
 

--- a/kernel/src/mm/address_space.rs
+++ b/kernel/src/mm/address_space.rs
@@ -219,19 +219,19 @@ pub const SVSM_PERTASK_BASE: VirtAddr = virt_from_idx(PGTABLE_LVL3_IDX_PERTASK);
 pub const SVSM_PERTASK_END: VirtAddr = SVSM_PERTASK_BASE.const_add(SIZE_LEVEL3);
 
 /// Kernel stack for a task
-pub const SVSM_PERTASK_STACK_BASE: VirtAddr = SVSM_PERTASK_BASE;
+pub const SVSM_PERTASK_STACK_BASE_OFFSET: usize = 0;
 
 /// Kernel shadow stack for normal execution of a task
-pub const SVSM_PERTASK_SHADOW_STACK_BASE: VirtAddr =
-    SVSM_PERTASK_STACK_BASE.const_add(STACK_TOTAL_SIZE);
+pub const SVSM_PERTASK_SHADOW_STACK_BASE_OFFSET: usize =
+    SVSM_PERTASK_STACK_BASE_OFFSET + STACK_TOTAL_SIZE;
 
 /// Kernel shadow stack for exception handling
-pub const SVSM_PERTASK_EXCEPTION_SHADOW_STACK_BASE: VirtAddr =
-    SVSM_PERTASK_SHADOW_STACK_BASE.const_add(PAGE_SIZE);
+pub const SVSM_PERTASK_EXCEPTION_SHADOW_STACK_BASE_OFFSET: usize =
+    SVSM_PERTASK_SHADOW_STACK_BASE_OFFSET + PAGE_SIZE;
 
 /// SSE context save area for a task
-pub const SVSM_PERTASK_XSAVE_AREA_BASE: VirtAddr =
-    SVSM_PERTASK_EXCEPTION_SHADOW_STACK_BASE.const_add(PAGE_SIZE);
+pub const SVSM_PERTASK_XSAVE_AREA_BASE: usize =
+    SVSM_PERTASK_EXCEPTION_SHADOW_STACK_BASE_OFFSET + PAGE_SIZE;
 
 /// Page table self-map level 3 index
 pub const PGTABLE_LVL3_IDX_PTE_SELFMAP: usize = 493;

--- a/kernel/src/mm/virtualrange.rs
+++ b/kernel/src/mm/virtualrange.rs
@@ -36,7 +36,7 @@ impl VirtualRange {
             start_virt: VirtAddr::null(),
             page_count: 0,
             page_shift: PAGE_SHIFT,
-            bits: BitmapAllocator1024::new(),
+            bits: BitmapAllocator1024::new_full(),
         }
     }
 

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -789,7 +789,7 @@ extern "C" fn task_exit() {
     schedule();
 }
 
-#[cfg(test)]
+#[cfg(all(test, test_in_svsm))]
 mod tests {
     extern crate alloc;
     use crate::task::start_kernel_task;

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -215,7 +215,11 @@ impl Task {
         cpu.populate_page_table(&mut pgtable);
 
         let vm_kernel_range = VMR::new(SVSM_PERTASK_BASE, SVSM_PERTASK_END, PTEntryFlags::empty());
-        vm_kernel_range.initialize()?;
+        // SAFETY: The kernel mode task address range is fully aligned to
+        // top-level paging boundaries.
+        unsafe {
+            vm_kernel_range.initialize()?;
+        }
 
         let xsa = Self::allocate_xsave_area();
         let xsa_addr = u64::from(xsa.vaddr()) as usize;
@@ -319,7 +323,11 @@ impl Task {
         name: String,
     ) -> Result<TaskPointer, SvsmError> {
         let vm_user_range = VMR::new(USER_MEM_START, USER_MEM_END, PTEntryFlags::USER);
-        vm_user_range.initialize_lazy()?;
+        // SAFETY: the user address range is fully aligned to top-level paging
+        // boundaries.
+        unsafe {
+            vm_user_range.initialize_lazy()?;
+        }
         let create_args = CreateTaskArguments {
             entry: user_entry,
             name,


### PR DESCRIPTION
Each task uses a portion of the kernel address space to store task-specific memory, which is only visible in the context of the task that owns it.  However, references to task-specific memory can be passed between tasks, and Rust memory safety relies on the principle that any reference (which is captured by its virtual address) must refer to the same underlying data in every context in which that reference is used.  This safety principle is defeated if any address is valid in more than one task at a time.  Assigning each task a unique portion of the address space ensures that any per-task address that crosses a task boundary will cause a fault instead of referring to the wrong data.