### PR TITLE
stage2: Use IGVM memory map to resize SVSM kernel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "igvm"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7984b10433b50e06a06bd50c69bca4888a5d7de8975f64ea4c2a7687eb99b09d"
+checksum = "7b4ae8479aa3163c8a0fa716aa6ef08a6553e1097f8a89544f46fee695b5a162"
 dependencies = [
  "bitfield-struct 0.7.0",
  "crc32fast",
@@ -531,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "igvm_defs"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b64ec5588c475372ae830475d3ee9a7bd255407dcb9f03faf6d493556eb6105a"
+checksum = "e4f70c18b574e5c7fa6222c1f0ebd8bfe2e14b762573b799faf8697c044b0e2a"
 dependencies = [
  "bitfield-struct 0.7.0",
  "open-enum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,8 @@ bitflags = "2.4"
 clap = { version = "4.4.14", default-features = false }
 gdbstub = { version = "0.6.6", default-features = false }
 gdbstub_arch = { version = "0.2.4" }
-igvm = { version = "0.3.2", default-features = false }
-igvm_defs = { version = "0.3.2", default-features = false }
+igvm = { version = "0.3.4", default-features = false }
+igvm_defs = { version = "0.3.4", default-features = false }
 intrusive-collections = "0.9.6"
 libfuzzer-sys = "0.4"
 log = "0.4.17"

--- a/bootlib/src/igvm_params.rs
+++ b/bootlib/src/igvm_params.rs
@@ -136,11 +136,18 @@ pub struct IgvmParamBlock {
     /// memory region (e.g. for VMSA contents).
     pub kernel_reserved_size: u32,
 
-    /// The number of bytes in the kernel memory region.
-    pub kernel_size: u32,
-
     /// The guest physical address of the base of the kernel memory region.
     pub kernel_base: u64,
+
+    /// The minimum size to allocate for the kernel in bytes. If the hypervisor supplies a memory
+    /// region in the memory map that starts at kernel_base and is larger, that size will be used
+    /// instead.
+    pub kernel_min_size: u32,
+
+    /// The maximum size to allocate for the kernel in bytes. If the hypervisor supplies a memory
+    /// region in the memory map that starts at kernel_base and is larger, this maximum size will
+    /// be used instead.
+    pub kernel_max_size: u32,
 
     /// The value of vTOM used by the guest, or zero if not used.
     pub vtom: u64,

--- a/igvmbuilder/src/igvm_builder.rs
+++ b/igvmbuilder/src/igvm_builder.rs
@@ -192,6 +192,7 @@ impl IgvmBuilder {
     fn create_param_block(&self) -> Result<IgvmParamBlock, Box<dyn Error>> {
         let param_page_offset = PAGE_SIZE_4K as u32;
         let memory_map_offset = param_page_offset + PAGE_SIZE_4K as u32;
+        let kernel_min_size = 0x1000000; // 16 MiB
         let (guest_context_offset, param_area_size) = if self.gpa_map.guest_context.get_size() == 0
         {
             (0, memory_map_offset + PAGE_SIZE_4K as u32)
@@ -237,8 +238,9 @@ impl IgvmBuilder {
             stage1_size: self.gpa_map.stage1_image.get_size() as u32,
             stage1_base: self.gpa_map.stage1_image.get_start(),
             kernel_reserved_size: PAGE_SIZE_4K as u32, // Reserved for VMSA
-            kernel_size: self.gpa_map.kernel.get_size() as u32,
             kernel_base: self.gpa_map.kernel.get_start(),
+            kernel_min_size,
+            kernel_max_size: self.gpa_map.kernel.get_size() as u32,
             vtom,
             use_alternate_injection: u8::from(self.options.alt_injection),
             is_qemu,
@@ -328,7 +330,7 @@ impl IgvmBuilder {
             self.directives.push(IgvmDirectiveHeader::RequiredMemory {
                 gpa: param_block.kernel_base,
                 compatibility_mask: COMPATIBILITY_MASK.get() & !VSM_COMPATIBILITY_MASK,
-                number_of_bytes: param_block.kernel_size,
+                number_of_bytes: param_block.kernel_min_size,
                 vtl2_protectable: false,
             });
         }
@@ -337,7 +339,7 @@ impl IgvmBuilder {
             self.directives.push(IgvmDirectiveHeader::RequiredMemory {
                 gpa: param_block.kernel_base,
                 compatibility_mask: VSM_COMPATIBILITY_MASK,
-                number_of_bytes: param_block.kernel_size,
+                number_of_bytes: param_block.kernel_min_size,
                 vtl2_protectable: true,
             });
         }

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -363,6 +363,8 @@ pub extern "C" fn stage2_main(launch_info: &Stage2LaunchInfo) {
         .find_kernel_region()
         .expect("Failed to find memory region for SVSM kernel");
 
+    log::info!("SVSM memory region: {kernel_region:?}");
+
     init_valid_bitmap_alloc(kernel_region).expect("Failed to allocate valid-bitmap");
 
     // The physical memory region we've loaded so far


### PR DESCRIPTION
If the IGVM memory map contains a PARAVISOR_RESERVED entry, then place the SVSM kernel at that region instead of the region specified in the IgvmParamBlock. If no such entry exists in the memory map, then continue using the IgvmParamBlock.

This allows the hypervisor to dynamically resize the SVSM based on the machine shape without changing the IgvmParamBlock and thus the launch measurement. This is necessary because the SVSM uses more memory when there are more vCPUs (and, in the future, guest memory).

Note this relies on an unpublished IGVM spec change to add the PARAVISOR_RESERVED MemoryMapEntryType.