### PR TITLE
Make sure stack frames are 16-byte-aligned

### DIFF
--- a/kernel/src/address.rs
+++ b/kernel/src/address.rs
@@ -6,6 +6,7 @@
 
 use crate::mm::virt_to_phys;
 use crate::types::{PAGE_SHIFT, PAGE_SIZE};
+use crate::utils::{align_down, align_up, is_aligned};
 
 use core::fmt;
 use core::ops;
@@ -59,7 +60,15 @@ pub trait Address:
     #[requires(align_up_requires(from_spec(*self), align))]
     #[ensures(|ret: Self| ret === addr_align_up(*self, align))]
     fn align_up(&self, align: InnerAddr) -> Self {
-        Self::from((self.bits() + (align - 1)) & !(align - 1))
+        Self::from(align_up(self.bits(), align))
+    }
+
+    #[inline]
+    #[verus_verify]
+    #[requires(align_requires(align))]
+    #[ensures(|ret: Self| ret === addr_align_down(*self, align))]
+    fn align_down(&self, align: InnerAddr) -> Self {
+        Self::from(align_down(self.bits(), align))
     }
 
     #[inline]
@@ -75,7 +84,7 @@ pub trait Address:
     #[requires(align_requires(PAGE_SIZE))]
     #[ensures(|ret: Self| ret === addr_page_align_down(*self))]
     fn page_align(&self) -> Self {
-        Self::from(self.bits() & !(PAGE_SIZE - 1))
+        self.align_down(PAGE_SIZE)
     }
 
     #[inline]
@@ -83,7 +92,7 @@ pub trait Address:
     #[requires(align_requires(align))]
     #[ensures(|ret: bool| ret == addr_is_aligned_spec(*self, align))]
     fn is_aligned(&self, align: InnerAddr) -> bool {
-        (self.bits() & (align - 1)) == 0
+        is_aligned(self.bits(), align)
     }
 
     #[inline]

--- a/kernel/src/boot_stage2.rs
+++ b/kernel/src/boot_stage2.rs
@@ -254,8 +254,16 @@ global_asm!(
         shrq $3, %rcx
         rep stosq
 
+        /*
+         * Follow the C calling convention for x86-64:
+         *
+         * - Pass &Stage2LaunchInfo as the first argument (%rdi)
+         * - Make sure (%rsp + 8) is 16b-aligned when control is transferred
+         *   to stage2_main
+         */
         movl %ebp, %edi
-        jmp stage2_main
+        andq $~0xf, %rsp
+        call stage2_main
 
         .data
 

--- a/kernel/src/mm/vm/mapping/kernel_stack.rs
+++ b/kernel/src/mm/vm/mapping/kernel_stack.rs
@@ -5,7 +5,7 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 
 use super::VirtualMapping;
-use crate::address::{PhysAddr, VirtAddr};
+use crate::address::{Address, PhysAddr, VirtAddr};
 use crate::error::SvsmError;
 use crate::mm::address_space::STACK_SIZE;
 use crate::mm::pagetable::PTEntryFlags;
@@ -38,7 +38,9 @@ impl VMKernelStack {
     /// Virtual address to program into the hardware stack register
     pub fn top_of_stack(&self, base: VirtAddr) -> VirtAddr {
         let guard_size = self.guard_pages * PAGE_SIZE;
-        base + guard_size + self.alloc.mapping_size()
+        let tos = (base + guard_size + self.alloc.mapping_size()).align_down(16);
+        debug_assert!(tos > base + guard_size);
+        tos
     }
 
     /// Returns the stack bounds of this kernel stack

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -472,8 +472,8 @@ pub extern "C" fn stage2_main(launch_info: &Stage2LaunchInfo) -> ! {
 
         asm!("jmp *%rax",
              in("rax") u64::from(kernel_entry),
-             in("r8") &launch_info,
-             in("r9") valid_bitmap.bits(),
+             in("rdi") &launch_info,
+             in("rsi") valid_bitmap.bits(),
              options(att_syntax))
     };
 

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -348,7 +348,7 @@ fn prepare_heap(
 }
 
 #[no_mangle]
-pub extern "C" fn stage2_main(launch_info: &Stage2LaunchInfo) {
+pub extern "C" fn stage2_main(launch_info: &Stage2LaunchInfo) -> ! {
     let platform_type = SvsmPlatformType::from(launch_info.platform_type);
 
     init_platform_type(platform_type);
@@ -477,7 +477,7 @@ pub extern "C" fn stage2_main(launch_info: &Stage2LaunchInfo) {
              options(att_syntax))
     };
 
-    panic!("Road ends here!");
+    unreachable!("Road ends here!");
 }
 
 #[panic_handler]

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -80,7 +80,11 @@ global_asm!(
         /* Setup stack */
         leaq bsp_stack_end(%rip), %rsp
 
-        jmp svsm_start
+        /*
+         * Make sure (%rsp + 8) is 16b-aligned when control is transferred
+         * to svsm_start as required by the C calling convention for x86-64.
+         */
+        call svsm_start
 
         .bss
 
@@ -146,7 +150,7 @@ fn init_cpuid_table(addr: VirtAddr) {
 }
 
 #[no_mangle]
-pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
+extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) -> ! {
     let launch_info: KernelLaunchInfo = *li;
     init_platform_type(launch_info.platform_type);
 
@@ -259,7 +263,7 @@ pub extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) {
     sse_init();
     schedule_init();
 
-    panic!("SVSM entry point terminated unexpectedly");
+    unreachable!("SVSM entry point terminated unexpectedly");
 }
 
 #[no_mangle]

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -66,8 +66,8 @@ extern "C" {
  * The stage2 loader will map and load the svsm binary image and jump to
  * startup_64.
  *
- * %r8  Pointer to the KernelLaunchInfo structure
- * %r9  Pointer to the valid-bitmap from stage2
+ * %rdi  Pointer to the KernelLaunchInfo structure
+ * %rsi  Pointer to the valid-bitmap from stage2
  */
 global_asm!(
     r#"
@@ -80,9 +80,6 @@ global_asm!(
         /* Setup stack */
         leaq bsp_stack_end(%rip), %rsp
 
-        /* Jump to rust code */
-        movq    %r8, %rdi
-        movq    %r9, %rsi
         jmp svsm_start
 
         .bss

--- a/kernel/src/utils/util.rs
+++ b/kernel/src/utils/util.rs
@@ -26,9 +26,9 @@ where
 
 pub fn is_aligned<T>(addr: T, align: T) -> bool
 where
-    T: Sub<Output = T> + BitAnd<Output = T> + PartialEq + From<u32>,
+    T: Sub<Output = T> + BitAnd<Output = T> + PartialEq + From<u8>,
 {
-    (addr & (align - T::from(1))) == T::from(0)
+    (addr & (align - T::from(1u8))) == T::from(0u8)
 }
 
 pub fn halt() {


### PR DESCRIPTION
The x86-64 ABI requires 16b-aligned stack frames. Stack misalignment can sometimes lead to hard-to-debug segfaults because x86-64 code that follows the calling convention can assume that stack frames are 16b-aligned. This patch series makes sure this requirement is respected at various transition points in SVSM.