### PR TITLE
Add support for TD SMP

### DIFF
--- a/bootlib/src/kernel_launch.rs
+++ b/bootlib/src/kernel_launch.rs
@@ -8,6 +8,15 @@ use crate::platform::SvsmPlatformType;
 use core::mem::size_of;
 use zerocopy::{Immutable, IntoBytes};
 
+// The SIPI stub is placed immediately below the stage 2 heap.
+pub const SIPI_STUB_GPA: u32 = 0xF000;
+
+// The first 640 KB of RAM (low memory)
+pub const LOWMEM_END: u32 = 0xA0000;
+
+pub const STAGE2_HEAP_START: u32 = 0x10000; // 64 KB
+pub const STAGE2_HEAP_END: u32 = LOWMEM_END; // 640 KB
+pub const STAGE2_BASE: u32 = 0x800000; // Start of stage2 area excluding heap
 pub const STAGE2_STACK_END: u32 = 0x805000;
 pub const STAGE2_INFO_SZ: u32 = size_of::<Stage2LaunchInfo>() as u32;
 pub const STAGE2_STACK: u32 = STAGE2_STACK_END + 0x1000 - STAGE2_INFO_SZ;
@@ -95,6 +104,3 @@ pub struct ApStartContext {
     pub transition_cr3: u32,
     pub context_size: u32,
 }
-
-// The SIPI stub is placed immediately below the stage 2 heap are.
-pub const SIPI_STUB_GPA: u32 = 0xF000;

--- a/igvmbuilder/src/gpa_map.rs
+++ b/igvmbuilder/src/gpa_map.rs
@@ -7,7 +7,9 @@
 use std::error::Error;
 use std::fs::metadata;
 
-use bootlib::kernel_launch::{CPUID_PAGE, SECRETS_PAGE, STAGE2_STACK_END, STAGE2_START};
+use bootlib::kernel_launch::{
+    CPUID_PAGE, SECRETS_PAGE, STAGE2_BASE, STAGE2_STACK_END, STAGE2_START,
+};
 use igvm_defs::PAGE_SIZE_4K;
 
 use crate::cmd_options::{CmdOptions, Hypervisor};
@@ -158,7 +160,7 @@ impl GpaMap {
         };
 
         let gpa_map = Self {
-            base_addr: 0x800000,
+            base_addr: STAGE2_BASE.into(),
             stage1_image,
             stage2_stack: GpaRange::new_page(STAGE2_STACK_END.into())?,
             stage2_image,

--- a/kernel/src/fw_cfg.rs
+++ b/kernel/src/fw_cfg.rs
@@ -10,6 +10,7 @@ use crate::address::{Address, PhysAddr};
 use crate::error::SvsmError;
 use crate::mm::pagetable::max_phys_addr;
 use crate::utils::MemoryRegion;
+use bootlib::kernel_launch::{STAGE2_MAXLEN, STAGE2_START};
 
 use super::io::IOPort;
 use alloc::string::String;
@@ -214,7 +215,7 @@ impl<'a> FwCfg<'a> {
             .or_else(|_| self.find_kernel_region_e820())?;
 
         // Make sure that the kernel region doesn't overlap with the loader.
-        if kernel_region.start() < PhysAddr::from(640 * 1024u64) {
+        if kernel_region.start() < PhysAddr::from(u64::from(STAGE2_START + STAGE2_MAXLEN)) {
             return Err(SvsmError::FwCfg(FwCfgError::KernelRegion));
         }
 

--- a/kernel/src/igvm_params.rs
+++ b/kernel/src/igvm_params.rs
@@ -18,12 +18,11 @@ use alloc::vec::Vec;
 use cpuarch::vmsa::VMSA;
 
 use bootlib::igvm_params::{IgvmGuestContext, IgvmParamBlock, IgvmParamPage};
+use bootlib::kernel_launch::LOWMEM_END;
 use core::mem::size_of;
 use igvm_defs::{IgvmEnvironmentInfo, MemoryMapEntryType, IGVM_VHS_MEMORY_MAP_ENTRY};
 
 const IGVM_MEMORY_ENTRIES_PER_PAGE: usize = PAGE_SIZE / size_of::<IGVM_VHS_MEMORY_MAP_ENTRY>();
-
-const STAGE2_END_ADDR: usize = 0xA0000;
 
 #[derive(Clone, Debug)]
 #[repr(C, align(64))]
@@ -323,9 +322,12 @@ impl IgvmParams<'_> {
         let mut regions = Vec::new();
 
         if self.igvm_param_block.firmware.in_low_memory != 0 {
-            // Add the stage 2 region to the firmware region list so
+            // Add the lowmem region to the firmware region list so
             // permissions can be granted to the guest VMPL for that range.
-            regions.push(MemoryRegion::new(PhysAddr::new(0), STAGE2_END_ADDR));
+            regions.push(MemoryRegion::from_addresses(
+                PhysAddr::from(0u64),
+                PhysAddr::from(u64::from(LOWMEM_END)),
+            ));
         }
 
         regions.push(MemoryRegion::new(

--- a/kernel/src/mm/memory.rs
+++ b/kernel/src/mm/memory.rs
@@ -13,7 +13,7 @@ use crate::error::SvsmError;
 use crate::locking::RWLock;
 use crate::utils::MemoryRegion;
 use alloc::vec::Vec;
-use bootlib::kernel_launch::KernelLaunchInfo;
+use bootlib::kernel_launch::{KernelLaunchInfo, LOWMEM_END};
 
 use super::pagetable::LAUNCH_VMSA_ADDR;
 
@@ -115,7 +115,7 @@ pub fn valid_phys_address(paddr: PhysAddr) -> bool {
 }
 
 /// The starting address of the ISA range.
-const ISA_RANGE_START: PhysAddr = PhysAddr::new(0xa0000);
+const ISA_RANGE_START: PhysAddr = PhysAddr::new(LOWMEM_END as usize);
 
 /// The ending address of the ISA range.
 const ISA_RANGE_END: PhysAddr = PhysAddr::new(0x100000);

--- a/kernel/src/platform/tdp.rs
+++ b/kernel/src/platform/tdp.rs
@@ -29,6 +29,12 @@ use bootlib::platform::SvsmPlatformType;
 static GHCI_IO_DRIVER: GHCIIOPort = GHCIIOPort::new();
 static VTOM: ImmutAfterInitCell<usize> = ImmutAfterInitCell::uninit();
 
+#[derive(Debug)]
+#[repr(C, packed)]
+pub struct TdMailbox {
+    pub vcpu_index: u32,
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct TdpPlatform {}
 

--- a/kernel/src/svsm_paging.rs
+++ b/kernel/src/svsm_paging.rs
@@ -14,7 +14,7 @@ use crate::mm::PageBox;
 use crate::platform::{PageStateChangeOp, PageValidateOp, SvsmPlatform};
 use crate::types::PageSize;
 use crate::utils::{page_align_up, MemoryRegion};
-use bootlib::kernel_launch::KernelLaunchInfo;
+use bootlib::kernel_launch::{KernelLaunchInfo, LOWMEM_END};
 
 struct IgvmParamInfo<'a> {
     virt_addr: VirtAddr,
@@ -133,7 +133,10 @@ pub fn invalidate_early_boot_memory(
     // invalidate stage 2 memory, unless firmware is loaded into low memory.
     // Also invalidate the boot data if required.
     if !config.fw_in_low_memory() {
-        let lowmem_region = MemoryRegion::new(PhysAddr::null(), 640 * 1024);
+        let lowmem_region = MemoryRegion::from_addresses(
+            PhysAddr::from(0u64),
+            PhysAddr::from(u64::from(LOWMEM_END)),
+        );
         invalidate_boot_memory_region(platform, config, lowmem_region)?;
     }
 


### PR DESCRIPTION
This patch series reuses the logic introduced in https://github.com/coconut-svsm/svsm/pull/581. A software-based mailbox is used for AP signaling. TD APs will enter `ap_request_loop()` after this series is applied.