### PR TITLE
kernel/utils/memory_region: Implement formatting traits

### DIFF
--- a/kernel/src/mm/memory.rs
+++ b/kernel/src/mm/memory.rs
@@ -82,7 +82,7 @@ pub fn init_memory_map(
 
     log::info!("Guest Memory Regions:");
     for r in regions.iter() {
-        log::info!("  {:018x}-{:018x}", r.start(), r.end());
+        log::info!("  {r:#018x}");
     }
 
     let mut map = MEMORY_MAP.lock_write();

--- a/kernel/src/platform/snp_fw.rs
+++ b/kernel/src/platform/snp_fw.rs
@@ -296,11 +296,7 @@ pub fn print_fw_meta(fw_meta: &SevFWMetaData) {
     };
 
     for region in &fw_meta.valid_mem {
-        log::info!(
-            "  Pre-Validated Region {:#018x}-{:#018x}",
-            region.start(),
-            region.end()
-        );
+        log::info!("  Pre-Validated Region {region:#018x}");
     }
 }
 

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -364,11 +364,7 @@ pub extern "C" fn stage2_main(launch_info: &Stage2LaunchInfo) -> ! {
         .find_kernel_region()
         .expect("Failed to find memory region for SVSM kernel");
 
-    log::info!(
-        "SVSM memory region: start={:#018x}, end={:#018x}",
-        u64::from(kernel_region.start()),
-        u64::from(kernel_region.end())
-    );
+    log::info!("SVSM memory region: {kernel_region:#018x}");
 
     init_valid_bitmap_alloc(kernel_region).expect("Failed to allocate valid-bitmap");
 
@@ -459,7 +455,7 @@ pub extern "C" fn stage2_main(launch_info: &Stage2LaunchInfo) -> ! {
     );
     log::info!("  kernel_region_phys_end   = {:#018x}", kernel_region.end());
     log::info!(
-        "  kernel_virtual_base   = {:#018x}",
+        "  kernel_virtual_base      = {:#018x}",
         loaded_kernel_vregion.start()
     );
 

--- a/kernel/src/svsm_paging.rs
+++ b/kernel/src/svsm_paging.rs
@@ -102,11 +102,7 @@ fn invalidate_boot_memory_region(
 ) -> Result<(), SvsmError> {
     // Caller must ensure the memory region's starting address is page-aligned
     let aligned_region = MemoryRegion::new(region.start(), page_align_up(region.len()));
-    log::info!(
-        "Invalidating boot region {:018x}-{:018x}",
-        aligned_region.start(),
-        aligned_region.end()
-    );
+    log::info!("Invalidating boot region {aligned_region:#018x}");
 
     if !aligned_region.is_empty() {
         platform.validate_physical_page_range(aligned_region, PageValidateOp::Invalidate)?;

--- a/kernel/src/utils/memory_region.rs
+++ b/kernel/src/utils/memory_region.rs
@@ -6,6 +6,7 @@
 
 use crate::address::Address;
 use crate::types::PageSize;
+use core::fmt;
 
 /// An abstraction over a memory region, expressed in terms of physical
 /// ([`PhysAddr`](crate::address::PhysAddr)) or virtual
@@ -14,6 +15,28 @@ use crate::types::PageSize;
 pub struct MemoryRegion<A> {
     start: A,
     end: A,
+}
+
+impl<A> fmt::Display for MemoryRegion<A>
+where
+    A: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[{}-{}]", self.start, self.end)
+    }
+}
+
+impl<A> fmt::LowerHex for MemoryRegion<A>
+where
+    A: fmt::LowerHex,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[")?;
+        self.start.fmt(f)?;
+        f.write_str("-")?;
+        self.end.fmt(f)?;
+        f.write_str("]")
+    }
 }
 
 impl<A> MemoryRegion<A>


### PR DESCRIPTION
MemoryRegion is often used for logging. Provide generic implementations for fmt::Display and fmt::LowerHex.