### PR TITLE
github/workflows: install bindgen-cli in publish-docs.yml

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -27,6 +27,13 @@ jobs:
             profile: minimal
             override: true
 
+      # bindgen-cli is required to generate bindings for TPM 2.0 Reference Implementation
+      - name: Install bindgen-cli
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: bindgen-cli
+
       - name: Install TPM 2.0 Reference Implementation build dependencies
         run: sudo apt install -y autoconf autoconf-archive pkg-config build-essential automake
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,6 +28,7 @@ jobs:
             override: true
             components: rustfmt, rust-src, clippy
 
+      # bindgen-cli is required to generate bindings for TPM 2.0 Reference Implementation
       - name: Install bindgen-cli
         uses: actions-rs/cargo@v1
         with:
@@ -154,6 +155,7 @@ jobs:
             override: true
             components: rustfmt, rust-src, clippy
 
+      # bindgen-cli is required to generate bindings for TPM 2.0 Reference Implementation
       - name: Install bindgen-cli
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
`bindgen` is used in our build process to build libtcgtpm. This workflow uses `make docsite` which will build also libtcgtpm, but it is currently failing with:

    make[1]: bindgen: No such file or directory

Let's add also a comment in other .yml to remember to install it in future pipelines.

In the future, we may integrate `bindgen` in the build.rs instead of invoking it from the Makefile.