### PR TITLE
Two enums

### DIFF
--- a/bootlib/src/igvm_params.rs
+++ b/bootlib/src/igvm_params.rs
@@ -116,6 +116,9 @@ pub struct IgvmParamBlock {
     /// QEMU.
     pub is_qemu: u8,
 
+    /// Indicates the hypervisor SVSM expects to run on.
+    pub hypervisor: Hypervisor,
+
     #[doc(hidden)]
     pub _reserved: [u8; 4],
 
@@ -151,6 +154,23 @@ pub struct IgvmParamBlock {
 
     /// The value of vTOM used by the guest, or zero if not used.
     pub vtom: u64,
+}
+
+/// This Hypervisor enum is same as in igvm_builder, but we create this new definition since the
+/// enum in igvm_builder needs to derive parsing functions with clap, which is not compatible with
+/// the no_std environment in bootlib.
+#[derive(IntoBytes, Immutable, PartialEq, Clone, Copy, Debug, Default)]
+#[repr(C)]
+pub enum Hypervisor {
+    /// Build an IGVM file compatible with QEMU
+    #[default]
+    Qemu,
+
+    /// Build an IGVM file compatible with Hyper-V
+    HyperV,
+
+    /// Build an IGVM file compatible with Google's Vanadium
+    Vanadium,
 }
 
 /// The IGVM context page is a measured page that is used to specify the start

--- a/bootlib/src/igvm_params.rs
+++ b/bootlib/src/igvm_params.rs
@@ -114,7 +114,7 @@ pub struct IgvmParamBlock {
 
     /// Indicates whether the guest can assume firmware services specific to
     /// QEMU.
-    pub is_qemu: u8,
+    pub has_qemu_fw_services: u8,
 
     /// Indicates the hypervisor SVSM expects to run on.
     pub hypervisor: Hypervisor,

--- a/igvmbuilder/src/igvm_builder.rs
+++ b/igvmbuilder/src/igvm_builder.rs
@@ -223,7 +223,7 @@ impl IgvmBuilder {
             (fw_info, vtom)
         };
 
-        let is_qemu: u8 = match self.options.hypervisor {
+        let has_qemu_fw_services: u8 = match self.options.hypervisor {
             Hypervisor::Qemu => 1,
             // Vanadium also supports qemu firmware services
             Hypervisor::Vanadium => 1,
@@ -252,7 +252,7 @@ impl IgvmBuilder {
             kernel_max_size: self.gpa_map.kernel.get_size() as u32,
             vtom,
             use_alternate_injection: u8::from(self.options.alt_injection),
-            is_qemu,
+            has_qemu_fw_services,
             hypervisor,
             ..Default::default()
         })

--- a/igvmbuilder/src/igvm_builder.rs
+++ b/igvmbuilder/src/igvm_builder.rs
@@ -225,7 +225,15 @@ impl IgvmBuilder {
 
         let is_qemu: u8 = match self.options.hypervisor {
             Hypervisor::Qemu => 1,
+            // Vanadium also supports qemu firmware services
+            Hypervisor::Vanadium => 1,
             _ => 0,
+        };
+
+        let hypervisor: bootlib::igvm_params::Hypervisor = match self.options.hypervisor {
+            Hypervisor::Qemu => bootlib::igvm_params::Hypervisor::Qemu,
+            Hypervisor::HyperV => bootlib::igvm_params::Hypervisor::HyperV,
+            Hypervisor::Vanadium => bootlib::igvm_params::Hypervisor::Vanadium,
         };
 
         // Most of the parameter block can be initialised with constants.
@@ -245,6 +253,7 @@ impl IgvmBuilder {
             vtom,
             use_alternate_injection: u8::from(self.options.alt_injection),
             is_qemu,
+            hypervisor,
             ..Default::default()
         })
     }

--- a/kernel/src/config.rs
+++ b/kernel/src/config.rs
@@ -186,4 +186,11 @@ impl SvsmConfig<'_> {
             SvsmConfig::IgvmConfig(igvm_params) => igvm_params.is_qemu(),
         }
     }
+
+    pub fn hypervisor(&self) -> bootlib::igvm_params::Hypervisor {
+        match self {
+            SvsmConfig::FirmwareConfig(_) => bootlib::igvm_params::Hypervisor::Qemu,
+            SvsmConfig::IgvmConfig(igvm_params) => igvm_params.hypervisor(),
+        }
+    }
 }

--- a/kernel/src/config.rs
+++ b/kernel/src/config.rs
@@ -180,10 +180,10 @@ impl SvsmConfig<'_> {
         }
     }
 
-    pub fn is_qemu(&self) -> bool {
+    pub fn has_qemu_fw_services(&self) -> bool {
         match self {
             SvsmConfig::FirmwareConfig(_) => true,
-            SvsmConfig::IgvmConfig(igvm_params) => igvm_params.is_qemu(),
+            SvsmConfig::IgvmConfig(igvm_params) => igvm_params.has_qemu_fw_services(),
         }
     }
 

--- a/kernel/src/igvm_params.rs
+++ b/kernel/src/igvm_params.rs
@@ -417,8 +417,8 @@ impl IgvmParams<'_> {
         self.igvm_param_block.use_alternate_injection != 0
     }
 
-    pub fn is_qemu(&self) -> bool {
-        self.igvm_param_block.is_qemu != 0
+    pub fn has_qemu_fw_services(&self) -> bool {
+        self.igvm_param_block.has_qemu_fw_services != 0
     }
 
     pub fn hypervisor(&self) -> bootlib::igvm_params::Hypervisor {

--- a/kernel/src/igvm_params.rs
+++ b/kernel/src/igvm_params.rs
@@ -420,4 +420,8 @@ impl IgvmParams<'_> {
     pub fn is_qemu(&self) -> bool {
         self.igvm_param_block.is_qemu != 0
     }
+
+    pub fn hypervisor(&self) -> bootlib::igvm_params::Hypervisor {
+        self.igvm_param_block.hypervisor
+    }
 }

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -9,6 +9,7 @@
 
 pub mod boot_stage2;
 
+use bootlib::igvm_params::Hypervisor;
 use bootlib::kernel_launch::{
     KernelLaunchInfo, Stage2LaunchInfo, LOWMEM_END, STAGE2_HEAP_END, STAGE2_HEAP_START,
     STAGE2_START,
@@ -428,10 +429,12 @@ pub extern "C" fn stage2_main(launch_info: &Stage2LaunchInfo) -> ! {
     )
     .expect("Failed to map and validate heap");
 
-    // Determine whether use of interrupts n the SVSM should be suppressed.
+    // Determine whether use of interrupts in the SVSM should be suppressed.
     // This is required when running SNP under KVM/QEMU.
     let suppress_svsm_interrupts = match platform_type {
-        SvsmPlatformType::Snp => config.is_qemu(),
+        SvsmPlatformType::Snp => {
+            config.hypervisor() == Hypervisor::Vanadium || config.hypervisor() == Hypervisor::Qemu
+        }
         _ => false,
     };
 

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -331,7 +331,7 @@ pub extern "C" fn svsm_main() {
 
     #[cfg(test)]
     {
-        if config.is_qemu() {
+        if config.has_qemu_fw_services() {
             crate::testutils::set_qemu_test_env();
         }
         crate::test_main();


### PR DESCRIPTION
This PR intends to suppress interrupts on Vanadium, and also enable the use of TestDev on Vanadium. To do this, it also disambiguates the IgvmParamBlock.is_qemu field as described in https://github.com/coconut-svsm/svsm/issues/608