### PR TITLE
Remove init stack

### DIFF
--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -636,6 +636,10 @@ impl PerCpu {
         self.current_stack.get()
     }
 
+    pub fn set_current_stack(&self, stack: MemoryRegion<VirtAddr>) {
+        self.current_stack.set(stack);
+    }
+
     pub fn get_apic_id(&self) -> u32 {
         self.shared().apic_id()
     }
@@ -1149,14 +1153,14 @@ impl PerCpu {
             self.irq_state.set_restore_state(true);
         }
         let task = self.runqueue.lock_write().schedule_init();
-        self.current_stack.set(task.stack_bounds());
+        self.set_current_stack(task.stack_bounds());
         task
     }
 
     pub fn schedule_prepare(&self) -> Option<(TaskPointer, TaskPointer)> {
         let ret = self.runqueue.lock_write().schedule_prepare();
         if let Some((_, ref next)) = ret {
-            self.current_stack.set(next.stack_bounds());
+            self.set_current_stack(next.stack_bounds());
         };
         ret
     }

--- a/kernel/src/debug/stacktrace.rs
+++ b/kernel/src/debug/stacktrace.rs
@@ -46,14 +46,14 @@ impl StackUnwinder {
         };
 
         let cpu = this_cpu();
-        let top_of_init_stack = cpu.get_top_of_stack();
-        let top_of_df_stack = cpu.get_top_of_df_stack();
         let current_stack = cpu.get_current_stack();
+        let top_of_cs_stack = cpu.get_top_of_context_switch_stack();
+        let top_of_df_stack = cpu.get_top_of_df_stack();
 
         let stacks: StacksBounds = [
-            MemoryRegion::from_addresses(top_of_init_stack - STACK_SIZE, top_of_init_stack),
-            MemoryRegion::from_addresses(top_of_df_stack - STACK_SIZE, top_of_df_stack),
             current_stack,
+            MemoryRegion::from_addresses(top_of_cs_stack - STACK_SIZE, top_of_cs_stack),
+            MemoryRegion::from_addresses(top_of_df_stack - STACK_SIZE, top_of_df_stack),
         ];
 
         Self::new(VirtAddr::from(rbp), stacks)
@@ -146,7 +146,7 @@ impl StackUnwinder {
         // A new task is launched with RBP = 0, which is pushed onto the stack
         // immediatly and can serve as a marker when the end of the stack has
         // been reached.
-        rbp == VirtAddr::new(0)
+        rbp == VirtAddr::null()
     }
 }
 

--- a/kernel/src/debug/stacktrace.rs
+++ b/kernel/src/debug/stacktrace.rs
@@ -5,7 +5,7 @@
 // Author: Nicolai Stange <nstange@suse.de>
 
 use crate::{
-    address::VirtAddr,
+    address::{Address, VirtAddr},
     cpu::idt::common::{is_exception_handler_return_site, X86ExceptionContext},
     cpu::percpu::this_cpu,
     mm::address_space::STACK_SIZE,
@@ -18,6 +18,7 @@ struct StackFrame {
     rbp: VirtAddr,
     rsp: VirtAddr,
     rip: VirtAddr,
+    is_aligned: bool,
     is_last: bool,
     is_exception_frame: bool,
     _stack_depth: usize, // Not needed for frame unwinding, only as diagnostic information.
@@ -83,6 +84,8 @@ impl StackUnwinder {
             return UnwoundStackFrame::Invalid;
         };
 
+        // The x86-64 ABI requires stack frames to be 16b-aligned
+        let is_aligned = rbp.is_aligned(16);
         let is_last = Self::frame_is_last(rbp);
         let is_exception_frame = is_exception_handler_return_site(rip);
 
@@ -99,6 +102,7 @@ impl StackUnwinder {
             rbp,
             rip,
             rsp,
+            is_aligned,
             is_last,
             is_exception_frame,
             _stack_depth,
@@ -186,7 +190,11 @@ pub fn print_stack(skip: usize) {
     log::info!("---BACKTRACE---:");
     for frame in unwinder.skip(skip) {
         match frame {
-            UnwoundStackFrame::Valid(item) => log::info!("  [{:#018x}]", item.rip),
+            UnwoundStackFrame::Valid(item) => log::info!(
+                "  [{:#018x}]{}",
+                item.rip,
+                if !item.is_aligned { " #" } else { "" }
+            ),
             UnwoundStackFrame::Invalid => log::info!("  Invalid frame"),
         }
     }

--- a/kernel/src/mm/address_space.rs
+++ b/kernel/src/mm/address_space.rs
@@ -170,12 +170,8 @@ pub const SVSM_PERCPU_VMSA_BASE: VirtAddr = SVSM_PERCPU_BASE.const_add(4 * SIZE_
 /// Region for PerCPU Stacks
 pub const SVSM_PERCPU_STACKS_BASE: VirtAddr = SVSM_PERCPU_BASE.const_add(SIZE_LEVEL1);
 
-/// Stack address of the per-cpu init task
-pub const SVSM_STACKS_INIT_TASK: VirtAddr = SVSM_PERCPU_STACKS_BASE;
-
 /// Shadow stack address of the per-cpu init task
-pub const SVSM_SHADOW_STACKS_INIT_TASK: VirtAddr =
-    SVSM_STACKS_INIT_TASK.const_add(STACK_TOTAL_SIZE);
+pub const SVSM_SHADOW_STACKS_INIT_TASK: VirtAddr = SVSM_PERCPU_STACKS_BASE;
 
 /// Stack address to use during context switches
 pub const SVSM_CONTEXT_SWITCH_STACK: VirtAddr = SVSM_SHADOW_STACKS_INIT_TASK.const_add(PAGE_SIZE);

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -78,7 +78,15 @@ global_asm!(
 
         .globl  startup_64
     startup_64:
-        /* Setup stack */
+        /*
+         * Setup stack.
+         *
+         * bsp_stack is always mapped across all page tables because it
+         * uses the shared PML4E, making it accessible after switching to
+         * the first task's page table.
+         *
+         * See switch_to() for details.
+         */
         leaq bsp_stack_end(%rip), %rsp
 
         /*

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -47,7 +47,7 @@ use svsm::svsm_paging::{init_page_table, invalidate_early_boot_memory};
 use svsm::task::exec_user;
 use svsm::task::{schedule_init, start_kernel_task};
 use svsm::types::PAGE_SIZE;
-use svsm::utils::{immut_after_init::ImmutAfterInitCell, zero_mem_region};
+use svsm::utils::{immut_after_init::ImmutAfterInitCell, zero_mem_region, MemoryRegion};
 #[cfg(all(feature = "vtpm", not(test)))]
 use svsm::vtpm::vtpm_init;
 
@@ -58,6 +58,7 @@ use release::COCONUT_VERSION;
 use alloc::string::String;
 
 extern "C" {
+    pub static bsp_stack: u8;
     pub static bsp_stack_end: u8;
 }
 
@@ -76,7 +77,7 @@ global_asm!(
         .section ".startup.text","ax"
         .code64
 
-        .globl  startup_64
+        .globl startup_64
     startup_64:
         /*
          * Setup stack.
@@ -89,11 +90,15 @@ global_asm!(
          */
         leaq bsp_stack_end(%rip), %rsp
 
+        /* Mark the next stack frame as the bottom frame */
+        xor %rbp, %rbp
+
         /*
          * Make sure (%rsp + 8) is 16b-aligned when control is transferred
          * to svsm_start as required by the C calling convention for x86-64.
          */
         call svsm_start
+        int3
 
         .bss
 
@@ -117,12 +122,9 @@ pub fn memory_init(launch_info: &KernelLaunchInfo) {
     );
 }
 
-pub fn boot_stack_info() {
-    // SAFETY: this is only unsafe because `bsp_stack_end` is an extern
-    // static, but we're simply printing its address. We are not creating a
-    // reference so this is safe.
-    let vaddr = VirtAddr::from(&raw const bsp_stack_end);
-    log::info!("Boot stack starts        @ {:#018x}", vaddr);
+fn boot_stack_info() {
+    let bs = this_cpu().get_current_stack();
+    log::info!("Boot stack @ {bs:#018x}");
 }
 
 fn mapping_info_init(launch_info: &KernelLaunchInfo) {
@@ -237,6 +239,11 @@ extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) -> ! {
         .setup_on_cpu(&*platform)
         .expect("Failed to run percpu.setup_on_cpu()");
     bsp_percpu.load();
+    // Now the stack unwinder can be used
+    bsp_percpu.set_current_stack(MemoryRegion::from_addresses(
+        VirtAddr::from(&raw const bsp_stack),
+        VirtAddr::from(&raw const bsp_stack_end),
+    ));
 
     if is_cet_ss_supported() {
         enable_shadow_stacks!(bsp_percpu);

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -438,11 +438,6 @@ pub fn schedule_task(task: TaskPointer) {
     schedule();
 }
 
-#[no_mangle]
-extern "C" fn free_init_stack() {
-    this_cpu().free_init_stack().unwrap();
-}
-
 global_asm!(
     // Make the value of the `shadow-stacks` feature usable in assembly.
     ".set const_false, 0",
@@ -476,7 +471,7 @@ global_asm!(
 
         // If `prev` is not null...
         testq   %r12, %r12
-        jz      3f
+        jz      1f
 
         // Save the current stack pointer
         movq    %rsp, {TASK_RSP_OFFSET}(%r12)
@@ -540,12 +535,6 @@ global_asm!(
         popfq
 
         ret
-
-    3:
-        // Switch to a stack pointer that's valid after init stack is freed.
-        mov     %r14, %rsp
-        call    free_init_stack
-        jmp     1b
     "#,
     TASK_RSP_OFFSET = const offset_of!(Task, rsp),
     TASK_SSP_OFFSET = const offset_of!(Task, ssp),


### PR DESCRIPTION
Commit 676e7412129119fc837cdf206c2138f17a41d804 introduced the side effect of breaking the stack unwinder because `init_stack` no longer exists after the first context switch in `schedule_init()`. This commit fixes that by completely removing `init_stack`:
- BSP is not impacted because it never uses `init_stack` and uses `bsp_stack` instead
- AP now uses `context_switch_stack` as its initial stack because this stack was originally designed to be used only when switching between tasks

Also, improve the stack unwinder by allowing it to dump the stack while running in the initial stack and detecting stack misalignment.
