### PR TITLE
requests: refactor SVSM request loop

### DIFF
--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -1365,14 +1365,17 @@ pub fn current_task() -> TaskPointer {
 
 #[no_mangle]
 pub extern "C" fn cpu_idle_loop() {
-    // Start request processing on this CPU.
-    let apic_id = this_cpu().get_apic_id();
-    let processing_name = format!("request-processing on CPU {}", apic_id);
-    start_kernel_task(request_processing_main, processing_name)
-        .expect("Failed to launch request processing task");
-    let loop_name = format!("request-loop on CPU {}", apic_id);
-    start_kernel_task(request_loop_main, loop_name)
-        .expect("Failed to launch request loop task");
+    // Start request processing on this CPU if required.
+    if SVSM_PLATFORM.start_svsm_request_loop() {
+        // Start request processing on this CPU.
+        let apic_id = this_cpu().get_apic_id();
+        let processing_name = format!("request-processing on CPU {}", apic_id);
+        start_kernel_task(request_processing_main, processing_name)
+            .expect("Failed to launch request processing task");
+        let loop_name = format!("request-loop on CPU {}", apic_id);
+        start_kernel_task(request_loop_main, loop_name)
+            .expect("Failed to launch request loop task");
+    }
 
     loop {
         // Go idle

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -16,6 +16,7 @@ use native::NativePlatform;
 use snp::SnpPlatform;
 use tdp::TdpPlatform;
 
+use core::arch::asm;
 use core::ops::{Deref, DerefMut};
 
 use crate::address::{PhysAddr, VirtAddr};
@@ -27,7 +28,6 @@ use crate::error::SvsmError;
 use crate::hyperv;
 use crate::io::IOPort;
 use crate::types::PageSize;
-use crate::utils;
 use crate::utils::immut_after_init::ImmutAfterInitCell;
 use crate::utils::MemoryRegion;
 
@@ -69,7 +69,10 @@ pub trait SvsmPlatform {
     where
         Self: Sized,
     {
-        utils::halt();
+        // SAFETY: executing HLT in assembly is always safe.
+        unsafe {
+            asm!("hlt");
+        }
     }
 
     /// Performs basic early initialization of the runtime environment.

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -178,6 +178,11 @@ pub trait SvsmPlatform {
         cpu: &PerCpu,
         context: &hyperv::HvInitialVpContext,
     ) -> Result<(), SvsmError>;
+
+    /// Indicates whether this platform should invoke the SVSM request loop.
+    fn start_svsm_request_loop(&self) -> bool {
+        false
+    }
 }
 
 //FIXME - remove Copy trait

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -330,6 +330,10 @@ impl SvsmPlatform for SnpPlatform {
 
         current_ghcb().ap_create(vmsa_pa, cpu.get_apic_id().into(), 0, sev_features)
     }
+
+    fn start_svsm_request_loop(&self) -> bool {
+        true
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default)]

--- a/kernel/src/requests.rs
+++ b/kernel/src/requests.rs
@@ -13,12 +13,12 @@ use crate::protocols::core::core_protocol_request;
 use crate::protocols::errors::{SvsmReqError, SvsmResultCode};
 use crate::sev::ghcb::switch_to_vmpl;
 
+use crate::platform::halt;
 #[cfg(all(feature = "vtpm", not(test)))]
 use crate::protocols::{vtpm::vtpm_protocol_request, SVSM_VTPM_PROTOCOL};
 use crate::protocols::{RequestParams, SVSM_APIC_PROTOCOL, SVSM_CORE_PROTOCOL};
 use crate::sev::vmsa::VMSAControl;
 use crate::types::GUEST_VMPL;
-use crate::utils::halt;
 use cpuarch::vmsa::GuestVMExit;
 
 /// The SVSM Calling Area (CAA)

--- a/kernel/src/sev/msr_protocol.rs
+++ b/kernel/src/sev/msr_protocol.rs
@@ -9,7 +9,7 @@ use crate::cpu::irq_state::raw_irqs_disable;
 use crate::cpu::msr::{read_msr, write_msr, SEV_GHCB};
 use crate::cpu::{irqs_enabled, IrqGuard};
 use crate::error::SvsmError;
-use crate::utils::halt;
+use crate::platform::halt;
 use crate::utils::immut_after_init::ImmutAfterInitCell;
 
 use super::utils::raw_vmgexit;

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -10,8 +10,9 @@ mod tasks;
 mod waiting;
 
 pub use schedule::{
-    create_user_task, current_task, current_task_terminated, finish_user_task, is_current_task,
-    schedule, schedule_init, schedule_task, start_kernel_task, terminate, RunQueue, TASKLIST,
+    create_user_task, current_task, current_task_terminated, finish_user_task, go_idle,
+    is_current_task, schedule, schedule_init, schedule_task, start_kernel_task, terminate,
+    RunQueue, TASKLIST,
 };
 
 pub use tasks::{

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -67,6 +67,9 @@ pub struct RunQueue {
 
     /// Temporary storage for tasks which are about to be terminated
     terminated_task: Option<TaskPointer>,
+
+    /// Pointer to a task that should be woken when returning from idle
+    wake_from_idle: Option<TaskPointer>,
 }
 
 impl RunQueue {
@@ -79,6 +82,7 @@ impl RunQueue {
             current_task: None,
             idle_task: OnceCell::new(),
             terminated_task: None,
+            wake_from_idle: None,
         }
     }
 
@@ -190,6 +194,16 @@ impl RunQueue {
     /// Panics if there is no current task.
     pub fn current_task(&self) -> TaskPointer {
         self.current_task.as_ref().unwrap().clone()
+    }
+
+    /// Wakes a task from idle if required.
+    ///
+    /// # Returns
+    ///
+    /// An `Option<TaskPointer>` indicating which task should be woken, if
+    /// any.
+    pub fn wake_from_idle(&mut self) -> Option<TaskPointer> {
+        self.wake_from_idle.take()
     }
 }
 
@@ -326,6 +340,27 @@ pub fn terminate() {
     schedule();
 }
 
+pub fn go_idle() {
+    // Mark this task as blocked and indicate that it is waiting for wake after
+    // idle.  Only one task on each CPU can be in the wake-from-idle state at
+    // one time.
+    let task = this_cpu().current_task();
+    task.set_task_blocked();
+    let mut runqueue = this_cpu().runqueue().lock_write();
+    assert!(runqueue.wake_from_idle.is_none());
+    runqueue.wake_from_idle = Some(task);
+    drop(runqueue);
+
+    // Find another task to run.  If no other task is runnable, then the idle
+    // thread will execute.
+    schedule();
+}
+
+// SAFETY: This function returns a raw pointer to a task. It is safe
+// because this function is only used in the task switch code, which also only
+// takes a single reference to the next and previous tasks. Also, this
+// function works on an Arc, which ensures that only a single mutable reference
+// can exist.
 fn task_pointer(taskptr: TaskPointer) -> *const Task {
     Arc::as_ptr(&taskptr)
 }

--- a/kernel/src/utils/mod.rs
+++ b/kernel/src/utils/mod.rs
@@ -14,5 +14,5 @@ pub mod util;
 pub use memory_region::MemoryRegion;
 pub use scoped::{ScopedMut, ScopedRef};
 pub use util::{
-    align_down, align_up, halt, is_aligned, overlap, page_align_up, page_offset, zero_mem_region,
+    align_down, align_up, is_aligned, overlap, page_align_up, page_offset, zero_mem_region,
 };

--- a/kernel/src/utils/util.rs
+++ b/kernel/src/utils/util.rs
@@ -6,7 +6,6 @@
 
 use crate::address::{Address, VirtAddr};
 use crate::types::PAGE_SIZE;
-use core::arch::asm;
 use core::ops::{Add, BitAnd, Not, Sub};
 
 pub fn align_up<T>(addr: T, align: T) -> T
@@ -29,14 +28,6 @@ where
     T: Sub<Output = T> + BitAnd<Output = T> + PartialEq + From<u8>,
 {
     (addr & (align - T::from(1u8))) == T::from(0u8)
-}
-
-pub fn halt() {
-    // SAFETY: Inline assembly to call HLT instruction, which does not change
-    // any state related to memory safety.
-    unsafe {
-        asm!("hlt", options(att_syntax));
-    }
 }
 
 pub fn page_align_up(x: usize) -> usize {


### PR DESCRIPTION
Move the SVSM request loop out of the idle task and into a separate task, and invoke it only on SNP platforms.  This is a step towards moving SVSM request processing out of the kernel, and enabling it to be excluded in configurations that only support paravisor processing.