### PR TITLE
github/workflows: remove `Install bindgen-cli` step

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -141,15 +141,6 @@ jobs:
             override: true
             components: rustfmt, rust-src, clippy
 
-      # TODO: remove this step after merging https://github.com/coconut-svsm/svsm/pull/606
-      # This is still required because here we checkout the `base` branch that
-      # still requires `bindgen-cli` to build libtcgtpm
-      - name: Install bindgen-cli
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: bindgen-cli
-
       - name: Install TPM 2.0 Reference Implementation build dependencies
         run: sudo apt install -y autoconf autoconf-archive pkg-config build-essential automake
 


### PR DESCRIPTION
After merging https://github.com/coconut-svsm/svsm/pull/606 we don't need to install `bindgen-cli` anymore to build our code.

Depends on #606 