### PR TITLE
task: fix some safety issues

### DIFF
--- a/kernel/src/cpu/smp.rs
+++ b/kernel/src/cpu/smp.rs
@@ -149,7 +149,12 @@ extern "C" fn start_ap() -> ! {
     this_cpu_shared().set_online();
 
     sse_init();
-    schedule_init();
+
+    // SAFETY: there is no current task running on this processor yet, so
+    // initializing the scheduler is safe.
+    unsafe {
+        schedule_init();
+    }
 
     unreachable!("Road ends here!");
 }

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -262,7 +262,12 @@ extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) -> ! {
         .expect("Failed to initialize SVSM platform object");
 
     sse_init();
-    schedule_init();
+
+    // SAFETY: there is no current task running on this processor yet, so
+    // initializing the scheduler is safe.
+    unsafe {
+        schedule_init();
+    }
 
     unreachable!("SVSM entry point terminated unexpectedly");
 }


### PR DESCRIPTION
Starting the scheduler is an unsafe operation because it relies on there not being a current task, which is a guarantee the compiler cannot make on its own.

Also, a function that returns a pointer is not necessarily unsafe.  The operation of using the pointer is where the code becomes unsafe.