### PR TITLE
kernel/io: add safety comments

### DIFF
--- a/kernel/src/io.rs
+++ b/kernel/src/io.rs
@@ -9,10 +9,14 @@ use core::fmt::Debug;
 
 pub trait IOPort: Sync + Debug {
     fn outb(&self, port: u16, value: u8) {
+        // SAFETY: Inline assembly to write an ioport, which does not change
+        // any state related to memory safety.
         unsafe { asm!("outb %al, %dx", in("al") value, in("dx") port, options(att_syntax)) }
     }
 
     fn inb(&self, port: u16) -> u8 {
+        // SAFETY: Inline assembly to read an ioport, which does not change
+        // any state related to memory safety.
         unsafe {
             let ret: u8;
             asm!("inb %dx, %al", in("dx") port, out("al") ret, options(att_syntax));
@@ -21,10 +25,14 @@ pub trait IOPort: Sync + Debug {
     }
 
     fn outw(&self, port: u16, value: u16) {
+        // SAFETY: Inline assembly to write an ioport, which does not change
+        // any state related to memory safety.
         unsafe { asm!("outw %ax, %dx", in("ax") value, in("dx") port, options(att_syntax)) }
     }
 
     fn inw(&self, port: u16) -> u16 {
+        // SAFETY: Inline assembly to read an ioport, which does not change
+        // any state related to memory safety.
         unsafe {
             let ret: u16;
             asm!("inw %dx, %ax", in("dx") port, out("ax") ret, options(att_syntax));
@@ -33,10 +41,14 @@ pub trait IOPort: Sync + Debug {
     }
 
     fn outl(&self, port: u16, value: u32) {
+        // SAFETY: Inline assembly to write an ioport, which does not change
+        // any state related to memory safety.
         unsafe { asm!("outl %eax, %dx", in("eax") value, in("dx") port, options(att_syntax)) }
     }
 
     fn inl(&self, port: u16) -> u32 {
+        // SAFETY: Inline assembly to read an ioport, which does not change
+        // any state related to memory safety.
         unsafe {
             let ret: u32;
             asm!("inl %dx, %eax", in("dx") port, out("eax") ret, options(att_syntax));


### PR DESCRIPTION
Add safety comments for the inline assembly blocks.