### PR TITLE
kernel: add safety comments

### DIFF
--- a/kernel/src/sev/ghcb.rs
+++ b/kernel/src/sev/ghcb.rs
@@ -664,9 +664,9 @@ impl GHCB {
     #[inline]
     #[cfg(test)]
     pub fn fill(&self, val: u8) {
+        // SAFETY: All bytes in `Self` are part of an atomic integer type.
+        // This allows us to cast `Self` to a slice of `AtomicU8`s.
         let bytes = unsafe {
-            // SAFETY: All bytes in `Self` are part of an atomic integer type.
-            // This allows us to cast `Self` to a slice of `AtomicU8`s.
             core::slice::from_raw_parts(self as *const _ as *const AtomicU8, size_of::<Self>())
         };
         for byte in bytes {
@@ -688,6 +688,7 @@ pub fn switch_to_vmpl(vmpl: u32) {
         Some(doorbell) => ptr::from_ref(doorbell),
         None => ptr::null(),
     };
+    // SAFETY: FFI call. Parameters and return values are checked.
     unsafe {
         if !switch_to_vmpl_unsafe(ptr, vmpl) {
             panic!("Failed to switch to VMPL {}", vmpl);

--- a/kernel/src/sev/secrets_page.rs
+++ b/kernel/src/sev/secrets_page.rs
@@ -66,6 +66,7 @@ impl SecretsPage {
     pub unsafe fn copy_from(&mut self, source: VirtAddr) {
         let from = source.as_ptr::<SecretsPage>();
 
+        // SAFETY: demanded to the caller
         unsafe {
             *self = *from;
         }
@@ -83,6 +84,7 @@ impl SecretsPage {
     pub unsafe fn copy_to(&self, target: VirtAddr) {
         let to = target.as_mut_ptr::<SecretsPage>();
 
+        // SAFETY: demanded to the caller
         unsafe {
             *to = *self;
         }

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -62,11 +62,9 @@ fn setup_stage2_allocator(heap_start: u64, heap_end: u64) {
 
 fn init_percpu(platform: &mut dyn SvsmPlatform) -> Result<(), SvsmError> {
     let bsp_percpu = PerCpu::alloc(0)?;
-    let init_pgtable = unsafe {
-        // SAFETY: pgtable is a static mut and this is the only place where we
-        // get a reference to it.
-        &mut *addr_of_mut!(pgtable)
-    };
+    // SAFETY: pgtable is a static mut and this is the only place where we
+    // get a reference to it.
+    let init_pgtable = unsafe { &mut *addr_of_mut!(pgtable) };
     bsp_percpu.set_pgtable(init_pgtable);
     bsp_percpu.map_self_stage2()?;
     platform.setup_guest_host_comm(bsp_percpu, true);
@@ -81,6 +79,7 @@ fn init_percpu(platform: &mut dyn SvsmPlatform) -> Result<(), SvsmError> {
 /// The caller must ensure that the `PerCpu` is never used again.
 unsafe fn shutdown_percpu() {
     let ptr = SVSM_PERCPU_BASE.as_mut_ptr::<PerCpu>();
+    // SAFETY: demanded to the caller
     unsafe {
         core::ptr::drop_in_place(ptr);
     }

--- a/kernel/src/task/exec.rs
+++ b/kernel/src/task/exec.rs
@@ -64,6 +64,8 @@ pub fn exec_user(binary: &str, root: Arc<dyn Directory>) -> Result<u32, SvsmErro
         file_size,
         VMFileMappingFlags::Read,
     )?;
+    // SAFETY: `vstart` has just been mapped using `file_size` as the size,
+    // so it is safe to create a slice of the same size.
     let buf = unsafe { vstart.to_slice::<u8>(file_size) };
     let elf_bin = Elf64File::read(buf).map_err(|_| SvsmError::Mem)?;
 

--- a/kernel/src/utils/util.rs
+++ b/kernel/src/utils/util.rs
@@ -32,6 +32,8 @@ where
 }
 
 pub fn halt() {
+    // SAFETY: Inline assembly to call HLT instruction, which does not change
+    // any state related to memory safety.
     unsafe {
         asm!("hlt", options(att_syntax));
     }


### PR DESCRIPTION
New simple safety comments around our code. More like fixes of comments not put before the unsafe block, blocks within unsafe functions that demand the caller, FFI, inline asm, etc.