### PR TITLE
syscall: Implement CAPABILITIES

### DIFF
--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -342,6 +342,8 @@ extern "C" fn ex_handler_system_call(
         SYS_READDIR => sys_readdir(ctxt.regs.rdi as u32, ctxt.regs.rsi, ctxt.regs.r8),
         SYS_MKDIR => sys_mkdir(ctxt.regs.rdi),
         SYS_RMDIR => sys_rmdir(ctxt.regs.rdi),
+        // Class 3 SysCalls.
+        SYS_CAPABILITIES => sys_capabilities(ctxt.regs.rdi as u32),
         _ => Err(SysCallError::EINVAL),
     }
     .map_or_else(|e| e as usize, |v| v as usize);

--- a/kernel/src/platform/capabilities.rs
+++ b/kernel/src/platform/capabilities.rs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (C) 2025 Intel Corporation
+//
+// Author: Chuanxiao Dong <chuanxiao.dong@intel.com>
+
+#[derive(Copy, Clone, Debug)]
+pub enum Cap {
+    AvailableVmBitmap = 0,
+    GlobalFeatureBitmap,
+    NrCaps,
+}
+
+impl TryFrom<u32> for Cap {
+    type Error = ();
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        if value == Cap::AvailableVmBitmap.into() {
+            Ok(Cap::AvailableVmBitmap)
+        } else if value == Cap::GlobalFeatureBitmap.into() {
+            Ok(Cap::GlobalFeatureBitmap)
+        } else if value == Cap::NrCaps.into() {
+            Ok(Cap::NrCaps)
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl From<Cap> for u32 {
+    fn from(cap: Cap) -> Self {
+        cap as Self
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct Caps([u64; Cap::NrCaps as usize]);
+
+impl Caps {
+    pub fn new(vm_bitmap: u64, global_feat_bitmap: u64) -> Self {
+        let mut caps = [0; Cap::NrCaps as usize];
+
+        caps[Cap::AvailableVmBitmap as usize] = vm_bitmap;
+        caps[Cap::GlobalFeatureBitmap as usize] = global_feat_bitmap;
+        Self(caps)
+    }
+
+    pub fn get(&self, idx: Cap) -> u64 {
+        match idx {
+            Cap::NrCaps => Cap::NrCaps as u64,
+            _ => *self.0.get(idx as usize).unwrap(),
+        }
+    }
+}

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -23,6 +23,7 @@ use crate::io::{IOPort, DEFAULT_IO_DRIVER};
 use crate::mm::PerCPUPageMappingGuard;
 use crate::types::{PageSize, PAGE_SIZE};
 use crate::utils::MemoryRegion;
+use syscall::GlobalFeatureFlags;
 
 use bootlib::kernel_launch::{ApStartContext, SIPI_STUB_GPA};
 use core::{mem, ptr};
@@ -102,7 +103,8 @@ impl SvsmPlatform for NativePlatform {
     }
 
     fn capabilities(&self) -> Caps {
-        Caps::new(0, 0)
+        let features = GlobalFeatureFlags::PLATFORM_TYPE_NATIVE;
+        Caps::new(0, features)
     }
 
     fn cpuid(&self, eax: u32) -> Option<CpuidResult> {

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -6,6 +6,8 @@
 // Author: Jon Lange <jlange@microsoft.com>
 // Author: Joerg Roedel <jroedel@suse.de>
 
+use super::capabilities::Caps;
+use super::{PageEncryptionMasks, PageStateChangeOp, PageValidateOp, SvsmPlatform};
 use crate::address::{PhysAddr, VirtAddr};
 use crate::console::init_svsm_console;
 use crate::cpu::apic::{ApicIcr, IcrMessageType};
@@ -19,7 +21,6 @@ use crate::hyperv;
 use crate::hyperv::{hyperv_setup_hypercalls, hyperv_start_cpu, is_hyperv_hypervisor};
 use crate::io::{IOPort, DEFAULT_IO_DRIVER};
 use crate::mm::PerCPUPageMappingGuard;
-use crate::platform::{PageEncryptionMasks, PageStateChangeOp, PageValidateOp, SvsmPlatform};
 use crate::types::{PageSize, PAGE_SIZE};
 use crate::utils::MemoryRegion;
 
@@ -98,6 +99,10 @@ impl SvsmPlatform for NativePlatform {
             addr_mask_width: 64,
             phys_addr_sizes: res.eax,
         }
+    }
+
+    fn capabilities(&self) -> Caps {
+        Caps::new(0, 0)
     }
 
     fn cpuid(&self, eax: u32) -> Option<CpuidResult> {

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -35,6 +35,7 @@ use crate::sev::{
 use crate::types::PageSize;
 use crate::utils::immut_after_init::ImmutAfterInitCell;
 use crate::utils::MemoryRegion;
+use syscall::GlobalFeatureFlags;
 
 use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
@@ -200,7 +201,8 @@ impl SvsmPlatform for SnpPlatform {
     fn capabilities(&self) -> Caps {
         // VMPL0 is SVSM. VMPL1 to VMPL3 are guest.
         let vm_bitmap: u64 = 0xE;
-        Caps::new(vm_bitmap, 0)
+        let features = GlobalFeatureFlags::PLATFORM_TYPE_SNP;
+        Caps::new(vm_bitmap, features)
     }
 
     fn cpuid(&self, eax: u32) -> Option<CpuidResult> {

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -4,9 +4,11 @@
 //
 // Author: Jon Lange <jlange@microsoft.com>
 
+use super::capabilities::Caps;
 use super::snp_fw::{
     copy_tables_to_fw, launch_fw, prepare_fw_launch, print_fw_meta, validate_fw, validate_fw_memory,
 };
+use super::{PageEncryptionMasks, PageStateChangeOp, PageValidateOp, SvsmPlatform};
 use crate::address::{Address, PhysAddr, VirtAddr};
 use crate::config::SvsmConfig;
 use crate::console::init_svsm_console;
@@ -20,7 +22,6 @@ use crate::hyperv;
 use crate::io::IOPort;
 use crate::mm::memory::write_guest_memory_map;
 use crate::mm::{PerCPUPageMappingGuard, PAGE_SIZE, PAGE_SIZE_2M};
-use crate::platform::{PageEncryptionMasks, PageStateChangeOp, PageValidateOp, SvsmPlatform};
 use crate::sev::ghcb::GHCBIOSize;
 use crate::sev::hv_doorbell::current_hv_doorbell;
 use crate::sev::msr_protocol::{
@@ -194,6 +195,12 @@ impl SvsmPlatform for SnpPlatform {
         } else {
             todo!()
         }
+    }
+
+    fn capabilities(&self) -> Caps {
+        // VMPL0 is SVSM. VMPL1 to VMPL3 are guest.
+        let vm_bitmap: u64 = 0xE;
+        Caps::new(vm_bitmap, 0)
     }
 
     fn cpuid(&self, eax: u32) -> Option<CpuidResult> {

--- a/kernel/src/platform/tdp.rs
+++ b/kernel/src/platform/tdp.rs
@@ -26,6 +26,7 @@ use crate::utils::immut_after_init::ImmutAfterInitCell;
 use crate::utils::{is_aligned, MemoryRegion};
 use bootlib::kernel_launch::{ApStartContext, SIPI_STUB_GPA};
 use core::{mem, ptr};
+use syscall::GlobalFeatureFlags;
 
 #[cfg(test)]
 use bootlib::platform::SvsmPlatformType;
@@ -109,7 +110,8 @@ impl SvsmPlatform for TdpPlatform {
         let num_vms = tdcall_vm_read(MD_TDCS_NUM_L2_VMS);
         // VM 0 is always L1 itself
         let vm_bitmap = ((1 << num_vms) - 1) << 1;
-        Caps::new(vm_bitmap, 0)
+        let features = GlobalFeatureFlags::PLATFORM_TYPE_TDP;
+        Caps::new(vm_bitmap, features)
     }
 
     fn cpuid(&self, eax: u32) -> Option<CpuidResult> {

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -37,7 +37,7 @@ use svsm::mm::pagetable::paging_init;
 use svsm::mm::virtualrange::virt_log_usage;
 use svsm::mm::{init_kernel_mapping_info, FixedAddressMappingRange};
 use svsm::platform;
-use svsm::platform::{init_platform_type, SvsmPlatformCell, SVSM_PLATFORM};
+use svsm::platform::{init_capabilities, init_platform_type, SvsmPlatformCell, SVSM_PLATFORM};
 use svsm::sev::secrets_page_mut;
 use svsm::svsm_paging::{init_page_table, invalidate_early_boot_memory};
 use svsm::task::exec_user;
@@ -312,6 +312,8 @@ pub extern "C" fn svsm_main() {
 
     populate_ram_fs(LAUNCH_INFO.kernel_fs_start, LAUNCH_INFO.kernel_fs_end)
         .expect("Failed to unpack FS archive");
+
+    init_capabilities();
 
     let cpus = config.load_cpu_info().expect("Failed to load ACPI tables");
     let mut nr_cpus = 0;

--- a/kernel/src/syscall/class3.rs
+++ b/kernel/src/syscall/class3.rs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2025 Intel Corporation.
+//
+// Author: Chuanxiao Dong <chuanxiao.dong@intel.com>
+
+use crate::platform::capabilities::Cap;
+use crate::platform::CAPS;
+use syscall::SysCallError;
+
+pub fn sys_capabilities(index: u32) -> Result<u64, SysCallError> {
+    let cap = match index {
+        0 => Cap::NrCaps,
+        i if i <= Cap::NrCaps as u32 => (i - 1).try_into().unwrap(),
+        _ => return Err(SysCallError::ENOTFOUND),
+    };
+    Ok(CAPS.get(cap))
+}

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -6,8 +6,10 @@
 
 mod class0;
 mod class1;
+mod class3;
 mod obj;
 
 pub use class0::*;
 pub use class1::*;
+pub use class3::*;
 pub use obj::{Obj, ObjError, ObjHandle};

--- a/kernel/src/tdx/error.rs
+++ b/kernel/src/tdx/error.rs
@@ -15,6 +15,7 @@ pub enum TdxSuccess {
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum TdxError {
+    OperandInvalid,
     NoVeInfo,
     PageSizeMismatch,
     Unimplemented,
@@ -44,6 +45,7 @@ pub fn tdx_result(err: u64) -> Result<TdxSuccess, TdxError> {
         }
     } else {
         match code {
+            0xC000_0100 => Err(TdxError::OperandInvalid),
             0xC000_0704 => Err(TdxError::NoVeInfo),
             0xC000_0B0B => Err(TdxError::PageSizeMismatch),
             _ => Err(TdxError::Unknown(err)),

--- a/syscall/src/class3.rs
+++ b/syscall/src/class3.rs
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2025 Intel Corporation.
+//
+// Author: Chuanxiao Dong <chuanxiao.dong@intel.com>
+
+use super::call::{syscall1, SysCallError};
+use super::SYS_CAPABILITIES;
+
+pub fn capabilities(index: u32) -> Result<u64, SysCallError> {
+    // SAFETY: Invokes a system call and does not directly change any memory of
+    // the process.
+    unsafe { syscall1(SYS_CAPABILITIES, index.into()) }
+}

--- a/syscall/src/def.rs
+++ b/syscall/src/def.rs
@@ -9,6 +9,7 @@ use bitflags::bitflags;
 // Syscall classes
 const CLASS0: u64 = 0;
 const CLASS1: u64 = 1 << 32;
+const CLASS3: u64 = 3 << 32;
 
 // Syscall number in class0
 pub const SYS_EXIT: u64 = CLASS0;
@@ -26,6 +27,9 @@ pub const SYS_OPENDIR: u64 = CLASS1 + 6;
 pub const SYS_READDIR: u64 = CLASS1 + 7;
 pub const SYS_MKDIR: u64 = CLASS1 + 8;
 pub const SYS_RMDIR: u64 = CLASS1 + 9;
+
+// Syscall number in class3
+pub const SYS_CAPABILITIES: u64 = CLASS3;
 
 ///Maximum length of path name including null character in bytes
 pub const PATH_MAX: usize = 4096;

--- a/syscall/src/def.rs
+++ b/syscall/src/def.rs
@@ -123,3 +123,37 @@ impl Default for DirEnt {
         }
     }
 }
+
+bitflags! {
+    #[derive(Clone, Copy, Debug)]
+    pub struct GlobalFeatureFlags: u64 {
+        const _ = 0x7; // Define bits used for platform type since
+                       // multi-bit flags should be avoided
+    }
+}
+
+impl GlobalFeatureFlags {
+    pub const PLATFORM_TYPE_NATIVE: u64 = 0;
+    pub const PLATFORM_TYPE_SNP: u64 = 1;
+    pub const PLATFORM_TYPE_TDP: u64 = 2;
+
+    pub fn is_snp(&self) -> bool {
+        (self.bits() & 0x7) == Self::PLATFORM_TYPE_SNP
+    }
+
+    pub fn is_tdp(&self) -> bool {
+        (self.bits() & 0x7) == Self::PLATFORM_TYPE_TDP
+    }
+}
+
+impl From<u64> for GlobalFeatureFlags {
+    fn from(flags: u64) -> Self {
+        GlobalFeatureFlags::from_bits_truncate(flags)
+    }
+}
+
+impl From<GlobalFeatureFlags> for u64 {
+    fn from(flags: GlobalFeatureFlags) -> Self {
+        flags.bits() & GlobalFeatureFlags::all().bits()
+    }
+}

--- a/syscall/src/lib.rs
+++ b/syscall/src/lib.rs
@@ -8,6 +8,7 @@
 mod call;
 mod class0;
 mod class1;
+mod class3;
 mod console;
 mod def;
 mod obj;
@@ -15,6 +16,7 @@ mod obj;
 pub use call::SysCallError;
 pub use class0::*;
 pub use class1::*;
+pub use class3::*;
 pub use console::*;
 pub use def::*;
 pub use obj::*;


### PR DESCRIPTION
The `CAPABILITIES` syscall takes an index as its input and returns the corresponding capability in a u64 as per the syscall ABI.
Bits [2:0] of GlobalFeatureFlags are defined as the platform type.