### PR TITLE
build: Exit with non-zero code on failure

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -7,6 +7,7 @@ import platform
 import shutil
 import json
 import os
+import sys
 
 SUPPORTED_IGVM_TARGETS=["qemu", "hyper-v", "vanadium"]
 
@@ -634,6 +635,10 @@ def build(args):
 
     Args:
       args: A structure initialized from command line options.
+
+    Returns:
+        True on successful build
+        False on failue
     """
 	# Create output directory if it does not exist yet.
     if not os.path.exists("bin"):
@@ -647,13 +652,19 @@ def build(args):
             build_one(recipe, helpers, args)
 
     except FileNotFoundError as f:
-        print(f"Error: {f}")
+        print(f"Error: {recipe}: {f}")
+        return False
     except json.JSONDecodeError as e:
         print(f"Error: {recipe}: {e}")
+        return False
     except subprocess.CalledProcessError as e:
-        print(f"Error: {e}")
+        print(f"Error: {recipe}: {e}")
+        return False
     except ValueError as verr:
-        print(f"Error: {verr}")
+        print(f"Error: {recipe}: {verr}")
+        return False
+
+    return True
 
 def parse_arguments():
     """Parses command-line arguments."""
@@ -686,5 +697,5 @@ def parse_arguments():
     return parser.parse_args()
 
 if __name__ == "__main__":
-    build(parse_arguments())
+    sys.exit(os.EX_OK if build(parse_arguments()) else os.EX_SOFTWARE)
 


### PR DESCRIPTION
Exit the build python script with a non-zero code in case the build fails.
This is useful when calling it from other scripts.
Additionally include the filename of the recipe in the
error messages printed.

Currently it does this:
```
$ ./build configs/qemu-target.json; echo $?
Building igvmbuilder...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.04s
Building igvmmeasure...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.05s
Building packit...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.03s
Building svsm...
   Compiling svsm v0.1.0 (/home/osteffen/work/svsm/coconut/svsm/kernel)
error: expected `;`, found `asdasda`
  --> kernel/src/kernel_region.rs:14:45
   |
14 |     MemoryRegion::from_addresses(start, end)
   |                                             ^ help: add `;` here
15 |         asdasda
   |         ------- unexpected token

error[E0425]: cannot find value `asdasda` in this scope
  --> kernel/src/kernel_region.rs:15:9
   |
15 |         asdasda
   |         ^^^^^^^ not found in this scope

For more information about this error, try `rustc --explain E0425`.
error: could not compile `svsm` (lib) due to 2 previous errors
Error: Command '['cargo', 'build', '--bin', 'svsm', '--features', 'vtpm', '--target', 'x86_64-unknown-none']' returned non-zero exit status 101.
0   <-- should be non-zero!
```

Will then be:
```
$ ./build configs/qemu-target.json; echo $?
Building igvmbuilder...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.05s
Building igvmmeasure...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.05s
Building packit...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.04s
Building svsm...
   Compiling svsm v0.1.0 (/home/osteffen/work/svsm/coconut/svsm/kernel)
error: expected `;`, found `asdasda`
  --> kernel/src/kernel_region.rs:14:45
   |
14 |     MemoryRegion::from_addresses(start, end)
   |                                             ^ help: add `;` here
15 |         asdasda
   |         ------- unexpected token

error[E0425]: cannot find value `asdasda` in this scope
  --> kernel/src/kernel_region.rs:15:9
   |
15 |         asdasda
   |         ^^^^^^^ not found in this scope

For more information about this error, try `rustc --explain E0425`.
error: could not compile `svsm` (lib) due to 2 previous errors
Error: configs/qemu-target.json: Command '['cargo', 'build', '--bin', 'svsm', '--features', 'vtpm', '--target', 'x86_64-unknown-none']' returned non-zero exit status 101.
70
```