### PR TITLE
Allow early stack unwinding

### DIFF
--- a/kernel/src/cpu/idt/entry.S
+++ b/kernel/src/cpu/idt/entry.S
@@ -375,6 +375,9 @@ default_entry_no_ist	name=ss		handler=panic			error_code=1	vector=12
 // #GP General-Protection Exception (Vector 13)
 default_entry_no_ist	name=gp		handler=general_protection	error_code=1	vector=13
 
+// #PF Early Page-Fault Exception (Vector 14)
+default_entry_no_ist	name=pf_early	handler=page_fault_early	error_code=1	vector=14
+
 // #PF Page-Fault Exception (Vector 14)
 default_entry_no_ist	name=pf		handler=page_fault		error_code=1	vector=14
 

--- a/kernel/src/debug/stacktrace.rs
+++ b/kernel/src/debug/stacktrace.rs
@@ -7,8 +7,8 @@
 use crate::{
     address::{Address, VirtAddr},
     cpu::idt::common::{is_exception_handler_return_site, X86ExceptionContext},
-    cpu::percpu::this_cpu,
-    mm::address_space::STACK_SIZE,
+    cpu::percpu::try_this_cpu,
+    mm::{STACK_SIZE, STACK_TOTAL_SIZE, SVSM_CONTEXT_SWITCH_STACK, SVSM_STACK_IST_DF_BASE},
     utils::MemoryRegion,
 };
 use core::{arch::asm, mem};
@@ -38,6 +38,11 @@ struct StackUnwinder {
     stacks: StacksBounds,
 }
 
+extern "C" {
+    static bsp_stack: u8;
+    static bsp_stack_end: u8;
+}
+
 impl StackUnwinder {
     pub fn unwind_this_cpu() -> Self {
         let mut rbp: usize;
@@ -46,16 +51,25 @@ impl StackUnwinder {
                  options(att_syntax));
         };
 
-        let cpu = this_cpu();
-        let current_stack = cpu.get_current_stack();
-        let top_of_cs_stack = cpu.get_top_of_context_switch_stack();
-        let top_of_df_stack = cpu.get_top_of_df_stack();
-
-        let stacks: StacksBounds = [
-            current_stack,
-            MemoryRegion::from_addresses(top_of_cs_stack - STACK_SIZE, top_of_cs_stack),
-            MemoryRegion::from_addresses(top_of_df_stack - STACK_SIZE, top_of_df_stack),
-        ];
+        let stacks: StacksBounds = if let Some(cpu) = try_this_cpu() {
+            let current_stack = cpu.get_current_stack();
+            let top_of_cs_stack = cpu.get_top_of_context_switch_stack();
+            let top_of_df_stack = cpu.get_top_of_df_stack();
+            [
+                current_stack,
+                MemoryRegion::from_addresses(top_of_cs_stack - STACK_SIZE, top_of_cs_stack),
+                MemoryRegion::from_addresses(top_of_df_stack - STACK_SIZE, top_of_df_stack),
+            ]
+        } else {
+            // Use default stack addresses
+            let bsp_init_stack = MemoryRegion::from_addresses(
+                VirtAddr::from(&raw const bsp_stack),
+                VirtAddr::from(&raw const bsp_stack_end),
+            );
+            let cs_stack = MemoryRegion::new(SVSM_CONTEXT_SWITCH_STACK, STACK_TOTAL_SIZE);
+            let df_stack = MemoryRegion::new(SVSM_STACK_IST_DF_BASE, STACK_TOTAL_SIZE);
+            [bsp_init_stack, cs_stack, df_stack]
+        };
 
         Self::new(VirtAddr::from(rbp), stacks)
     }

--- a/kernel/src/debug/stacktrace.rs
+++ b/kernel/src/debug/stacktrace.rs
@@ -205,7 +205,7 @@ pub fn print_stack(skip: usize) {
     for frame in unwinder.skip(skip) {
         match frame {
             UnwoundStackFrame::Valid(item) => log::info!(
-                "  [{:#018x}]{}",
+                "  [{:016x}]{}",
                 item.rip,
                 if !item.is_aligned { " #" } else { "" }
             ),

--- a/kernel/src/svsm.lds
+++ b/kernel/src/svsm.lds
@@ -12,6 +12,10 @@ SECTIONS
 		*(.entry.text)
 		entry_code_end = .;
 		. = ALIGN(16);
+		early_exception_table_start = .;
+		KEEP(*(__early_exception_table))
+		early_exception_table_end = .;
+		. = ALIGN(16);
 		exception_table_start = .;
 		KEEP(*(__exception_table))
 		exception_table_end = .;

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -166,7 +166,6 @@ extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) -> ! {
     // SAFETY: we trust the previous stage to pass a valid pointer
     unsafe { init_valid_bitmap_ptr(new_kernel_region(&launch_info), vb_ptr) };
 
-    GLOBAL_GDT.load();
     GLOBAL_GDT.load_selectors();
     early_idt_init();
 
@@ -239,6 +238,8 @@ extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) -> ! {
         VirtAddr::from(&raw const bsp_stack_end),
     ));
 
+    idt_init();
+
     if is_cet_ss_supported() {
         enable_shadow_stacks!(bsp_percpu);
     }
@@ -250,7 +251,6 @@ extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) -> ! {
         .setup_idle_task(svsm_main)
         .expect("Failed to allocate idle task for BSP");
 
-    idt_init();
     platform
         .env_setup_late(debug_serial_port)
         .expect("Late environment setup failed");

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -52,8 +52,8 @@ use svsm::mm::validate::{init_valid_bitmap_ptr, migrate_valid_bitmap};
 use release::COCONUT_VERSION;
 
 extern "C" {
-    pub static bsp_stack: u8;
-    pub static bsp_stack_end: u8;
+    static bsp_stack: u8;
+    static bsp_stack_end: u8;
 }
 
 /*
@@ -97,8 +97,10 @@ global_asm!(
         .bss
 
         .align {PAGE_SIZE}
+        .globl bsp_stack
     bsp_stack:
         .fill 8*{PAGE_SIZE}, 1, 0
+        .globl bsp_stack_end
     bsp_stack_end:
         "#,
     PAGE_SIZE = const PAGE_SIZE,


### PR DESCRIPTION
Allow the stack unwinder to work right after preparing the console in the SVSM kernel. Use an early #PF handler and the early exception table to determine if the PerCpu page is ready. If there is no PerCpu available, perform best-effort unwinding based on the default stack regions.