### PR TITLE
Documentation: Replace "Authors:" with "Author:" in headers

### DIFF
--- a/kernel/src/cpu/idt/entry.S
+++ b/kernel/src/cpu/idt/entry.S
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2024 SUSE LLC
 //
-// Authors: Joerg Roedel <jroedel@suse.de>
+// Author: Joerg Roedel <jroedel@suse.de>
 
 .code64
 

--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2022-2023 SUSE LLC
 //
-// Authors: Joerg Roedel <jroedel@suse.de>
+// Author: Joerg Roedel <jroedel@suse.de>
 
 use super::super::control_regs::read_cr2;
 use super::super::extable::handle_exception_table;

--- a/kernel/src/cpu/x86/mod.rs
+++ b/kernel/src/cpu/x86/mod.rs
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2024 SUSE LLC
 //
-// Authors: Thomas Leroy <tleroy@suse.de>
+// Author: Thomas Leroy <tleroy@suse.de>
 
 pub mod apic;
 pub mod smap;

--- a/kernel/src/cpu/x86/smap.S
+++ b/kernel/src/cpu/x86/smap.S
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2024 SUSE LLC
 //
-// Authors: Thomas Leroy <tleroy@suse.de>
+// Author: Thomas Leroy <tleroy@suse.de>
 
 .code64
 

--- a/kernel/src/cpu/x86/smap.rs
+++ b/kernel/src/cpu/x86/smap.rs
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2024 SUSE LLC
 //
-// Authors: Thomas Leroy <tleroy@suse.de>
+// Author: Thomas Leroy <tleroy@suse.de>
 
 use core::arch::asm;
 

--- a/kernel/src/crypto/mod.rs
+++ b/kernel/src/crypto/mod.rs
@@ -2,7 +2,7 @@
 //
 // Copyright (C) 2023 IBM
 //
-// Authors: Claudio Carvalho <cclaudio@linux.ibm.com>
+// Author: Claudio Carvalho <cclaudio@linux.ibm.com>
 
 //! SVSM kernel crypto API
 

--- a/kernel/src/crypto/rustcrypto.rs
+++ b/kernel/src/crypto/rustcrypto.rs
@@ -2,7 +2,7 @@
 //
 // Copyright (C) 2023 IBM
 //
-// Authors: Claudio Carvalho <cclaudio@linux.ibm.com>
+// Author: Claudio Carvalho <cclaudio@linux.ibm.com>
 
 //! RustCrypto implementation
 

--- a/kernel/src/greq/driver.rs
+++ b/kernel/src/greq/driver.rs
@@ -2,7 +2,7 @@
 //
 // Copyright (C) 2023 IBM
 //
-// Authors: Claudio Carvalho <cclaudio@linux.ibm.com>
+// Author: Claudio Carvalho <cclaudio@linux.ibm.com>
 
 //! Driver to send `SNP_GUEST_REQUEST` commands to the PSP. It can be any of the
 //! request or response command types defined in the SEV-SNP spec, regardless if it's

--- a/kernel/src/greq/mod.rs
+++ b/kernel/src/greq/mod.rs
@@ -2,7 +2,7 @@
 //
 // Copyright (C) 2023 IBM
 //
-// Authors: Claudio Carvalho <cclaudio@linux.ibm.com>
+// Author: Claudio Carvalho <cclaudio@linux.ibm.com>
 
 //! `SNP_GUEST_REQUEST` mechanism to communicate with the PSP
 

--- a/kernel/src/greq/msg.rs
+++ b/kernel/src/greq/msg.rs
@@ -2,7 +2,7 @@
 //
 // Copyright (C) 2023 IBM
 //
-// Authors: Claudio Carvalho <cclaudio@linux.ibm.com>
+// Author: Claudio Carvalho <cclaudio@linux.ibm.com>
 
 //! Message that carries an encrypted `SNP_GUEST_REQUEST` command in the payload
 

--- a/kernel/src/greq/pld_report.rs
+++ b/kernel/src/greq/pld_report.rs
@@ -2,7 +2,7 @@
 //
 // Copyright (C) 2023 IBM
 //
-// Authors: Claudio Carvalho <cclaudio@linux.ibm.com>
+// Author: Claudio Carvalho <cclaudio@linux.ibm.com>
 
 //! `SNP_GUEST_REQUEST` command to request an attestation report.
 

--- a/kernel/src/greq/services.rs
+++ b/kernel/src/greq/services.rs
@@ -2,7 +2,7 @@
 //
 // Copyright (C) 2023 IBM
 //
-// Authors: Claudio Carvalho <cclaudio@linux.ibm.com>
+// Author: Claudio Carvalho <cclaudio@linux.ibm.com>
 
 //! API to send `SNP_GUEST_REQUEST` commands to the PSP
 

--- a/kernel/src/vtpm/mod.rs
+++ b/kernel/src/vtpm/mod.rs
@@ -2,7 +2,7 @@
 //
 // Copyright (C) 2023 IBM
 //
-// Authors: Claudio Carvalho <cclaudio@linux.ibm.com>
+// Author: Claudio Carvalho <cclaudio@linux.ibm.com>
 
 //! This crate defines the Virtual TPM interfaces and shows what
 //! TPM backends are supported

--- a/kernel/src/vtpm/tcgtpm/mod.rs
+++ b/kernel/src/vtpm/tcgtpm/mod.rs
@@ -2,7 +2,7 @@
 //
 // Copyright (C) 2023 IBM
 //
-// Authors: Claudio Carvalho <cclaudio@linux.ibm.com>
+// Author: Claudio Carvalho <cclaudio@linux.ibm.com>
 
 //! This crate implements the virtual TPM interfaces for the TPM 2.0
 //! Reference Implementation (by Microsoft)

--- a/kernel/src/vtpm/tcgtpm/wrapper.rs
+++ b/kernel/src/vtpm/tcgtpm/wrapper.rs
@@ -2,7 +2,7 @@
 //
 // Copyright (C) 2023 IBM
 //
-// Authors: Claudio Carvalho <cclaudio@linux.ibm.com>
+// Author: Claudio Carvalho <cclaudio@linux.ibm.com>
 
 //! Implement functions required to build the TPM 2.0 Reference Implementation
 //! libraries.

--- a/libtcgtpm/build.rs
+++ b/libtcgtpm/build.rs
@@ -2,7 +2,7 @@
 //
 // Copyright (C) 2024 IBM
 //
-// Authors: Claudio Carvalho <cclaudio@linux.ibm.com>
+// Author: Claudio Carvalho <cclaudio@linux.ibm.com>
 
 use std::env::current_dir;
 use std::path::PathBuf;

--- a/libtcgtpm/deps/openssl_svsm.conf
+++ b/libtcgtpm/deps/openssl_svsm.conf
@@ -2,7 +2,7 @@
 #
 # Copyright (C) 2023 IBM Corporation
 #
-# Authors: Claudio Carvalho <cclaudio@linux.ibm.com>
+# Author: Claudio Carvalho <cclaudio@linux.ibm.com>
 
 my %targets = (
     "SVSM" => {


### PR DESCRIPTION
Only "// Author: " is the permissible format in the pre-commit hook. Fix them so that we stop running into pre-commit errors on these existing headers.

The is a follow-up of https://github.com/coconut-svsm/svsm/pull/620#discussion_r1955801517