### PR TITLE
igvm: use MADT for determining APIC IDs

### DIFF
--- a/bootlib/src/igvm_params.rs
+++ b/bootlib/src/igvm_params.rs
@@ -99,6 +99,13 @@ pub struct IgvmParamBlock {
     pub param_page_offset: u32,
 
     /// The offset, in bytes, from the base of the parameter block to the base
+    /// of the host-supplied MADT.
+    pub madt_offset: u32,
+
+    /// The size, in bytes, of the MADT area.
+    pub madt_size: u32,
+
+    /// The offset, in bytes, from the base of the parameter block to the base
     /// of the memory map (which is in IGVM format).
     pub memory_map_offset: u32,
 

--- a/fuzz/fuzz_targets/acpi.rs
+++ b/fuzz/fuzz_targets/acpi.rs
@@ -10,7 +10,7 @@ use core::num::NonZeroUsize;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use libfuzzer_sys::{fuzz_target, Corpus};
 use std::hint::black_box;
-use svsm::acpi::tables::load_acpi_cpu_info;
+use svsm::acpi::tables::load_fw_cpu_info;
 use svsm::fw_cfg::FwCfg;
 use svsm::io::IOPort;
 
@@ -57,7 +57,7 @@ fuzz_target!(|data: &[u8]| -> Corpus {
     };
     let fwcfg = FwCfg::new(&io);
 
-    if let Ok(info) = load_acpi_cpu_info(&fwcfg) {
+    if let Ok(info) = load_fw_cpu_info(&fwcfg) {
         let _ = black_box(info);
     }
 

--- a/kernel/src/config.rs
+++ b/kernel/src/config.rs
@@ -14,7 +14,7 @@ use crate::error::SvsmError;
 use crate::fw_cfg::FwCfg;
 use crate::igvm_params::IgvmParams;
 use crate::mm::{PerCPUPageMappingGuard, PAGE_SIZE, SIZE_1G};
-use crate::platform::{parse_fw_meta_data, SevFWMetaData};
+use crate::platform::{parse_fw_meta_data, SevFWMetaData, SvsmPlatform};
 use crate::serial::SERIAL_PORT;
 use crate::utils::MemoryRegion;
 use alloc::vec::Vec;
@@ -59,65 +59,92 @@ fn check_ovmf_regions(
 }
 
 #[derive(Debug)]
-pub enum SvsmConfig<'a> {
-    FirmwareConfig(FwCfg<'a>),
-    IgvmConfig(IgvmParams<'a>),
+pub struct SvsmConfig<'a> {
+    fw_cfg: Option<FwCfg<'a>>,
+    igvm_params: Option<IgvmParams<'a>>,
 }
 
-impl SvsmConfig<'_> {
+impl<'a> SvsmConfig<'a> {
+    pub fn new(platform: &dyn SvsmPlatform, igvm_params: Option<IgvmParams<'a>>) -> SvsmConfig<'a> {
+        // Create a firmware config object if there is no IGVM parameter block,
+        // or if the IGVM parameter block indicates that firmwrae config
+        // services are available on this system.
+        let is_qemu = if let Some(ref igvm) = igvm_params {
+            igvm.is_qemu()
+        } else {
+            true
+        };
+        let fw_cfg = if is_qemu {
+            let io_port = platform.get_io_port();
+            Some(FwCfg::new(io_port))
+        } else {
+            None
+        };
+        Self {
+            igvm_params,
+            fw_cfg,
+        }
+    }
+
+    pub fn get_igvm_params(&self) -> Option<&IgvmParams<'_>> {
+        self.igvm_params.as_ref()
+    }
+
     pub fn find_kernel_region(&self) -> Result<MemoryRegion<PhysAddr>, SvsmError> {
-        match self {
-            SvsmConfig::FirmwareConfig(fw_cfg) => fw_cfg.find_kernel_region(),
-            SvsmConfig::IgvmConfig(igvm_params) => igvm_params.find_kernel_region(),
+        match &self.igvm_params {
+            Some(igvm_params) => igvm_params.find_kernel_region(),
+            None => self.fw_cfg.as_ref().unwrap().find_kernel_region(),
         }
     }
     pub fn page_state_change_required(&self) -> bool {
-        match self {
-            SvsmConfig::FirmwareConfig(_) => true,
-            SvsmConfig::IgvmConfig(igvm_params) => igvm_params.page_state_change_required(),
+        match &self.igvm_params {
+            Some(igvm_params) => igvm_params.page_state_change_required(),
+            None => true,
         }
     }
     pub fn get_memory_regions(&self) -> Result<Vec<MemoryRegion<PhysAddr>>, SvsmError> {
-        match self {
-            SvsmConfig::FirmwareConfig(fw_cfg) => fw_cfg.get_memory_regions(),
-            SvsmConfig::IgvmConfig(igvm_params) => igvm_params.get_memory_regions(),
+        match &self.igvm_params {
+            Some(igvm_params) => igvm_params.get_memory_regions(),
+            None => self.fw_cfg.as_ref().unwrap().get_memory_regions(),
         }
     }
     pub fn write_guest_memory_map(&self, map: &[MemoryRegion<PhysAddr>]) -> Result<(), SvsmError> {
-        match self {
-            SvsmConfig::FirmwareConfig(_) => Ok(()),
-            SvsmConfig::IgvmConfig(igvm_params) => igvm_params.write_guest_memory_map(map),
+        match &self.igvm_params {
+            Some(igvm_params) => igvm_params.write_guest_memory_map(map),
+            None => Ok(()),
         }
     }
     pub fn reserved_kernel_area_size(&self) -> usize {
-        match self {
-            SvsmConfig::FirmwareConfig(_) => 0,
-            SvsmConfig::IgvmConfig(igvm_params) => igvm_params.reserved_kernel_area_size(),
+        match &self.igvm_params {
+            Some(igvm_params) => igvm_params.reserved_kernel_area_size(),
+            None => 0,
         }
     }
     pub fn load_cpu_info(&self) -> Result<Vec<ACPICPUInfo>, SvsmError> {
-        match self {
-            SvsmConfig::FirmwareConfig(fw_cfg) => load_acpi_cpu_info(fw_cfg),
-            SvsmConfig::IgvmConfig(igvm_params) => igvm_params.load_cpu_info(),
+        match &self.igvm_params {
+            Some(igvm_params) => igvm_params.load_cpu_info(),
+            None => load_acpi_cpu_info(self.fw_cfg.as_ref().unwrap()),
         }
     }
+
     pub fn should_launch_fw(&self) -> bool {
-        match self {
-            SvsmConfig::FirmwareConfig(_) => true,
-            SvsmConfig::IgvmConfig(igvm_params) => igvm_params.should_launch_fw(),
+        match &self.igvm_params {
+            Some(igvm_params) => igvm_params.should_launch_fw(),
+            None => true,
         }
     }
 
     pub fn debug_serial_port(&self) -> u16 {
-        match self {
-            SvsmConfig::FirmwareConfig(_) => SERIAL_PORT,
-            SvsmConfig::IgvmConfig(igvm_params) => igvm_params.debug_serial_port(),
+        match &self.igvm_params {
+            Some(igvm_params) => igvm_params.debug_serial_port(),
+            None => SERIAL_PORT,
         }
     }
 
     pub fn get_fw_metadata(&self) -> Option<SevFWMetaData> {
-        match self {
-            SvsmConfig::FirmwareConfig(_) => {
+        match &self.igvm_params {
+            Some(igvm_params) => igvm_params.get_fw_metadata(),
+            None => {
                 // Map the metadata location which is defined by the firmware config
                 let guard =
                     PerCPUPageMappingGuard::create_4k(PhysAddr::from(4 * SIZE_1G - PAGE_SIZE))
@@ -128,7 +155,6 @@ impl SvsmConfig<'_> {
                 let metadata = unsafe { slice::from_raw_parts(vstart, PAGE_SIZE) };
                 Some(parse_fw_meta_data(metadata).expect("Failed to parse FW SEV meta-data"))
             }
-            SvsmConfig::IgvmConfig(igvm_params) => igvm_params.get_fw_metadata(),
         }
     }
 
@@ -136,54 +162,58 @@ impl SvsmConfig<'_> {
         &self,
         kernel_region: &MemoryRegion<PhysAddr>,
     ) -> Vec<MemoryRegion<PhysAddr>> {
-        match self {
-            SvsmConfig::FirmwareConfig(fw_cfg) => {
-                let flash_regions = fw_cfg.iter_flash_regions().collect::<Vec<_>>();
-                check_ovmf_regions(&flash_regions, kernel_region);
-                flash_regions
-            }
-            SvsmConfig::IgvmConfig(igvm_params) => {
+        match &self.igvm_params {
+            Some(igvm_params) => {
                 let flash_regions = igvm_params.get_fw_regions();
                 if !igvm_params.fw_in_low_memory() {
                     check_ovmf_regions(&flash_regions, kernel_region);
                 }
                 flash_regions
             }
+            None => {
+                let flash_regions = self
+                    .fw_cfg
+                    .as_ref()
+                    .unwrap()
+                    .iter_flash_regions()
+                    .collect::<Vec<_>>();
+                check_ovmf_regions(&flash_regions, kernel_region);
+                flash_regions
+            }
         }
     }
 
     pub fn fw_in_low_memory(&self) -> bool {
-        match self {
-            SvsmConfig::FirmwareConfig(_) => false,
-            SvsmConfig::IgvmConfig(igvm_params) => igvm_params.fw_in_low_memory(),
+        match &self.igvm_params {
+            Some(igvm_params) => igvm_params.fw_in_low_memory(),
+            None => false,
         }
     }
 
     pub fn invalidate_boot_data(&self) -> bool {
-        match self {
-            SvsmConfig::FirmwareConfig(_) => false,
-            SvsmConfig::IgvmConfig(_) => true,
-        }
+        // Boot data should be invalidated if and only if IGVM parameters were
+        // present.
+        self.igvm_params.is_some()
     }
 
     pub fn initialize_guest_vmsa(&self, vmsa: &mut VMSA) -> Result<(), SvsmError> {
-        match self {
-            SvsmConfig::FirmwareConfig(_) => Ok(()),
-            SvsmConfig::IgvmConfig(igvm_params) => igvm_params.initialize_guest_vmsa(vmsa),
+        match &self.igvm_params {
+            Some(igvm_params) => igvm_params.initialize_guest_vmsa(vmsa),
+            None => Ok(()),
         }
     }
 
     pub fn use_alternate_injection(&self) -> bool {
-        match self {
-            SvsmConfig::FirmwareConfig(_) => false,
-            SvsmConfig::IgvmConfig(igvm_params) => igvm_params.use_alternate_injection(),
+        match &self.igvm_params {
+            Some(igvm_params) => igvm_params.use_alternate_injection(),
+            None => false,
         }
     }
 
     pub fn is_qemu(&self) -> bool {
-        match self {
-            SvsmConfig::FirmwareConfig(_) => true,
-            SvsmConfig::IgvmConfig(igvm_params) => igvm_params.is_qemu(),
+        match &self.igvm_params {
+            Some(igvm_params) => igvm_params.is_qemu(),
+            None => true,
         }
     }
 }

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -208,6 +208,14 @@ impl SvsmPlatformCell {
             }
         }
     }
+
+    pub fn platform(&self) -> &dyn SvsmPlatform {
+        match self {
+            SvsmPlatformCell::Native(platform) => platform,
+            SvsmPlatformCell::Snp(platform) => platform,
+            SvsmPlatformCell::Tdp(platform) => platform,
+        }
+    }
 }
 
 impl Deref for SvsmPlatformCell {


### PR DESCRIPTION
The IGVM format specifies a mechanism for the host to inject an MADT into the guest address space.  This MADT should be used to determine the set of APIC IDs associated with the set of CPUs that will be started by the guest.