### PR TITLE
kernel: permit the use of IPIs prior to guest entry

### DIFF
--- a/kernel/src/cpu/irq_state.rs
+++ b/kernel/src/cpu/irq_state.rs
@@ -375,6 +375,7 @@ impl Drop for TprGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cpu::ipi::ipi_available;
     use crate::platform::SVSM_PLATFORM;
 
     #[test]
@@ -426,7 +427,7 @@ mod tests {
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn tpr_test() {
-        if SVSM_PLATFORM.use_interrupts() {
+        if SVSM_PLATFORM.use_interrupts() || ipi_available() {
             assert_eq!(raw_get_tpr(), 0);
             raise_tpr(7);
             assert_eq!(raw_get_tpr(), 7);
@@ -442,7 +443,7 @@ mod tests {
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn tpr_guard_test() {
-        if SVSM_PLATFORM.use_interrupts() {
+        if SVSM_PLATFORM.use_interrupts() || ipi_available() {
             assert_eq!(raw_get_tpr(), 0);
             // Test in-order raise/lower.
             let g1 = TprGuard::raise(8);

--- a/kernel/src/cpu/smp.rs
+++ b/kernel/src/cpu/smp.rs
@@ -8,6 +8,7 @@ use crate::acpi::tables::ACPICPUInfo;
 use crate::address::{Address, VirtAddr};
 use crate::cpu::efer::EFERFlags;
 use crate::cpu::idt::idt;
+use crate::cpu::ipi::ipi_start_cpu;
 use crate::cpu::percpu::{cpu_idle_loop, this_cpu, this_cpu_shared, PerCpu};
 use crate::cpu::shadow_stack::{is_cet_ss_supported, SCetFlags, MODE_64BIT, S_CET};
 use crate::cpu::sse::sse_init;
@@ -160,6 +161,9 @@ extern "C" fn start_ap() -> ! {
 
     // Send a life-sign
     log::info!("AP with APIC-ID {} is online", this_cpu().get_apic_id());
+
+    // Mark this CPU as participating in IPI usage.
+    ipi_start_cpu();
 
     // Set CPU online so that BSP can proceed
     this_cpu_shared().set_online();

--- a/kernel/src/requests.rs
+++ b/kernel/src/requests.rs
@@ -4,6 +4,7 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
+use crate::cpu::ipi::wait_for_ipi_block;
 use crate::cpu::percpu::{process_requests, this_cpu, wait_for_requests};
 use crate::cpu::{flush_tlb_global_sync, IrqGuard};
 use crate::error::SvsmError;
@@ -146,6 +147,10 @@ fn check_requests() -> Result<bool, SvsmReqError> {
 
 #[no_mangle]
 pub extern "C" fn request_loop_main() {
+    // Suppress the use of IPIs before entering the guest, and ensure that all
+    // other CPUs have done the same.
+    wait_for_ipi_block();
+
     let apic_id = this_cpu().get_apic_id();
     log::info!("Launching request loop task on CPU {}", apic_id);
 

--- a/kernel/src/sev/snp_apic.rs
+++ b/kernel/src/sev/snp_apic.rs
@@ -7,14 +7,34 @@
 // Author: Jon Lange <jlange@microsoft.com>
 
 use crate::cpu::percpu::current_ghcb;
-use crate::cpu::x86::apic::APIC_OFFSET_EOI;
+use crate::cpu::x86::apic::{APIC_OFFSET_EOI, APIC_OFFSET_ICR};
 use crate::cpu::x86::x2apic::MSR_X2APIC_BASE;
 use crate::cpu::x86::{ApicAccess, MSR_APIC_BASE};
 use crate::error::SvsmError;
 use crate::sev::hv_doorbell::current_hv_doorbell;
 
+use core::sync::atomic::{AtomicBool, Ordering};
+
 #[derive(Debug)]
-pub struct GHCBApicAccessor {}
+pub struct GHCBApicAccessor {
+    use_restr_inj: AtomicBool,
+}
+
+impl GHCBApicAccessor {
+    const fn new() -> Self {
+        Self {
+            use_restr_inj: AtomicBool::new(false),
+        }
+    }
+
+    pub fn set_use_restr_inj(&self, use_restr_inj: bool) {
+        self.use_restr_inj.store(use_restr_inj, Ordering::Relaxed)
+    }
+
+    pub fn use_restr_inj(&self) -> bool {
+        self.use_restr_inj.load(Ordering::Relaxed)
+    }
+}
 
 impl ApicAccess for GHCBApicAccessor {
     fn update_apic_base(&self, and_mask: u64, or_mask: u64) {
@@ -45,19 +65,23 @@ impl ApicAccess for GHCBApicAccessor {
     }
 
     fn icr_write(&self, icr: u64) -> Result<(), SvsmError> {
-        current_ghcb().hv_ipi(icr)?;
+        // The #HV IPI can only be used if restricted injection is supported.
+        // Otherwise, the IPI must be sent via an X2APIC ICR write.
+        if self.use_restr_inj() {
+            current_ghcb().hv_ipi(icr)?;
+        } else {
+            self.apic_write(APIC_OFFSET_ICR, icr);
+        }
+
         Ok(())
     }
 
     fn eoi(&self) {
         // Issue an explicit EOI unless no explicit EOI is required.
-        if !current_hv_doorbell().no_eoi_required() {
-            // 0x80B is the X2APIC EOI MSR.
-            // Errors here cannot be handled but should not be grounds for
-            // panic.
+        if !self.use_restr_inj() || !current_hv_doorbell().no_eoi_required() {
             self.apic_write(APIC_OFFSET_EOI, 0);
         }
     }
 }
 
-pub static GHCB_APIC_ACCESSOR: GHCBApicAccessor = GHCBApicAccessor {};
+pub static GHCB_APIC_ACCESSOR: GHCBApicAccessor = GHCBApicAccessor::new();


### PR DESCRIPTION
Until KVM supports separate interrupts per privilege context (VMPL, TDP L2, etc.), interrupt state must be exclusively associated with the guest OS, not with the SVSM.  However, prior to the guest being started on any processor, there is no reason not to make use of interrupts in the SVSM because there is no ambiguity.  This change permits the use of IPIs up to the point in time that all processors are ready to begin the request loop on all CPUs, at which point IPI usage is suppressed and interrupt state becomes exclusive to the guest OS.