### PR TITLE
qemu/native: place svsm kernel below 512G

### DIFF
--- a/igvmbuilder/src/gpa_map.rs
+++ b/igvmbuilder/src/gpa_map.rs
@@ -125,8 +125,8 @@ impl GpaMap {
         // Choose the kernel base and maximum size.
         let kernel = match options.hypervisor {
             Hypervisor::Qemu => {
-                // Place the kernel area at 512 GB with a maximum size of 16 MB.
-                GpaRange::new(0x0000008000000000, 0x01000000)?
+                // Place the kernel area below 512 GB with a maximum size of 16 MB.
+                GpaRange::new(0x0000007fff000000, 0x01000000)?
             }
             Hypervisor::HyperV => {
                 // Place the kernel area at 64 MB with a maximum size of 16 MB.


### PR DESCRIPTION
Makes igvm work in native platform mode on somewhat older intel hardware with phys-bits = 39 (which can't address memory above 512G).