### PR TITLE
Cleanup X2APIC code and fix IRQ delivery on the Native Platform with QEMU

### DIFF
--- a/kernel/src/cpu/x86/apic.rs
+++ b/kernel/src/cpu/x86/apic.rs
@@ -52,3 +52,13 @@ pub fn x2apic_eoi() {
     // SAFETY: writing to EOI MSR doesn't break memory safety.
     unsafe { write_msr(MSR_X2APIC_EOI, 0) };
 }
+
+/// Write a command to the Interrupt Command Register.
+///
+/// # Arguments
+///
+/// - `icr` - The 64-bit value describing the interrupt command.
+pub fn x2apic_icr_write(icr: u64) {
+    // SAFETY: writing to ICR MSR doesn't break memory safety.
+    unsafe { write_msr(MSR_X2APIC_ICR, icr) };
+}

--- a/kernel/src/cpu/x86/apic.rs
+++ b/kernel/src/cpu/x86/apic.rs
@@ -46,3 +46,9 @@ pub fn x2apic_enable() {
         }
     }
 }
+
+/// Send an End-of-Interrupt notification to the X2APIC.
+pub fn x2apic_eoi() {
+    // SAFETY: writing to EOI MSR doesn't break memory safety.
+    unsafe { write_msr(MSR_X2APIC_EOI, 0) };
+}

--- a/kernel/src/cpu/x86/apic.rs
+++ b/kernel/src/cpu/x86/apic.rs
@@ -6,12 +6,18 @@
 // Author: Jon Lange <jlange@microsoft.com>
 // Author: Joerg Roedel <jroedel@suse.de>
 
+use crate::cpu::msr::{read_msr, write_msr};
+
 /// End-of-Interrupt register MSR offset
 pub const MSR_X2APIC_EOI: u32 = 0x80B;
 /// Interrupt-Service-Register base MSR offset
 pub const MSR_X2APIC_ISR: u32 = 0x810;
 /// Interrupt-Control-Register register MSR offset
 pub const MSR_X2APIC_ICR: u32 = 0x830;
+
+const MSR_APIC_BASE: u32 = 0x1B;
+const APIC_ENABLE_MASK: u64 = 0x800;
+const APIC_X2_ENABLE_MASK: u64 = 0x400;
 
 /// Get the MSR offset relative to a bitmap base MSR and the mask for the MSR
 /// value to check for a specific vector bit being set in IRR, ISR, or TMR.
@@ -23,4 +29,20 @@ pub const MSR_X2APIC_ICR: u32 = 0x830;
 pub fn apic_register_bit(vector: usize) -> (u32, u32) {
     let index: u8 = vector as u8;
     ((index >> 5) as u32, 1 << (index & 0x1F))
+}
+
+/// Enables the X2APIC by setting the AE and EXTD bits in the APIC base address
+/// register.
+pub fn x2apic_enable() {
+    // Enable X2APIC mode.
+    let apic_base = read_msr(MSR_APIC_BASE);
+    let apic_base_x2_enabled = apic_base | APIC_ENABLE_MASK | APIC_X2_ENABLE_MASK;
+    if apic_base != apic_base_x2_enabled {
+        // SAFETY: enabling X2APIC mode allows accessing APIC's control
+        // registers through MSR accesses, so enabling it doesn't break
+        // memory safety itself.
+        unsafe {
+            write_msr(MSR_APIC_BASE, apic_base_x2_enabled);
+        }
+    }
 }

--- a/kernel/src/cpu/x86/apic.rs
+++ b/kernel/src/cpu/x86/apic.rs
@@ -13,8 +13,13 @@ pub const MSR_X2APIC_ISR: u32 = 0x810;
 /// Interrupt-Control-Register register MSR offset
 pub const MSR_X2APIC_ICR: u32 = 0x830;
 
-// Returns the MSR offset and bitmask to identify a specific vector in an
-// APIC register (IRR, ISR, or TMR).
+/// Get the MSR offset relative to a bitmap base MSR and the mask for the MSR
+/// value to check for a specific vector bit being set in IRR, ISR, or TMR.
+///
+/// # Returns
+///
+/// A `(u32, u32)` tuple with the MSR offset as the first and the vector
+/// bitmask as the second value.
 pub fn apic_register_bit(vector: usize) -> (u32, u32) {
     let index: u8 = vector as u8;
     ((index >> 5) as u32, 1 << (index & 0x1F))

--- a/kernel/src/cpu/x86/apic.rs
+++ b/kernel/src/cpu/x86/apic.rs
@@ -1,12 +1,17 @@
 // SPDX-License-Identifier: MIT
 //
 // Copyright (c) Microsoft Corporation
+// Copyright (c) SUSE LLC
 //
 // Author: Jon Lange <jlange@microsoft.com>
+// Author: Joerg Roedel <jroedel@suse.de>
 
-pub const APIC_MSR_EOI: u32 = 0x80B;
-pub const APIC_MSR_ISR: u32 = 0x810;
-pub const APIC_MSR_ICR: u32 = 0x830;
+/// End-of-Interrupt register MSR offset
+pub const MSR_X2APIC_EOI: u32 = 0x80B;
+/// Interrupt-Service-Register base MSR offset
+pub const MSR_X2APIC_ISR: u32 = 0x810;
+/// Interrupt-Control-Register register MSR offset
+pub const MSR_X2APIC_ICR: u32 = 0x830;
 
 // Returns the MSR offset and bitmask to identify a specific vector in an
 // APIC register (IRR, ISR, or TMR).

--- a/kernel/src/cpu/x86/apic.rs
+++ b/kernel/src/cpu/x86/apic.rs
@@ -53,6 +53,23 @@ pub fn x2apic_eoi() {
     unsafe { write_msr(MSR_X2APIC_EOI, 0) };
 }
 
+/// Check whether a give IRQ vector is currently being serviced by returning
+/// the value of its ISR bit from X2APIC.
+///
+/// # Arguments
+///
+/// - `vector` - The IRQ vector for which to check the ISR bit.
+///
+/// # Returns
+///
+/// Returns `True` when the ISR bit for the vector is 1, `False` otherwise.
+pub fn x2apic_in_service(vector: usize) -> bool {
+    // Examine the APIC ISR to determine whether this interrupt vector is
+    // active.  If so, it is assumed to be an external interrupt.
+    let (msr, mask) = apic_register_bit(vector);
+    (read_msr(MSR_X2APIC_ISR + msr) & mask as u64) != 0
+}
+
 /// Write a command to the Interrupt Command Register.
 ///
 /// # Arguments

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -14,7 +14,7 @@ use crate::cpu::cpuid::CpuidResult;
 use crate::cpu::msr::write_msr;
 use crate::cpu::percpu::PerCpu;
 use crate::cpu::smp::create_ap_start_context;
-use crate::cpu::x86::apic::{x2apic_enable, MSR_X2APIC_EOI, MSR_X2APIC_ICR};
+use crate::cpu::x86::apic::{x2apic_enable, x2apic_eoi, MSR_X2APIC_ICR};
 use crate::error::SvsmError;
 use crate::hyperv;
 use crate::hyperv::{hyperv_setup_hypercalls, hyperv_start_cpu, is_hyperv_hypervisor};
@@ -171,8 +171,7 @@ impl SvsmPlatform for NativePlatform {
     }
 
     fn eoi(&self) {
-        // SAFETY: writing to EOI MSR doesn't break memory safety.
-        unsafe { write_msr(MSR_X2APIC_EOI, 0) };
+        x2apic_eoi();
     }
 
     fn is_external_interrupt(&self, _vector: usize) -> bool {

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //
 // Copyright (c) Microsoft Corporation
+// Copyright (c) SUSE LLC
 //
 // Author: Jon Lange <jlange@microsoft.com>
+// Author: Joerg Roedel <jroedel@suse.de>
 
 use crate::address::{PhysAddr, VirtAddr};
 use crate::console::init_svsm_console;
@@ -12,7 +14,7 @@ use crate::cpu::cpuid::CpuidResult;
 use crate::cpu::msr::{read_msr, write_msr};
 use crate::cpu::percpu::PerCpu;
 use crate::cpu::smp::create_ap_start_context;
-use crate::cpu::x86::apic::{APIC_MSR_EOI, APIC_MSR_ICR};
+use crate::cpu::x86::apic::{MSR_X2APIC_EOI, MSR_X2APIC_ICR};
 use crate::error::SvsmError;
 use crate::hyperv;
 use crate::hyperv::{hyperv_setup_hypercalls, hyperv_start_cpu, is_hyperv_hypervisor};
@@ -180,13 +182,13 @@ impl SvsmPlatform for NativePlatform {
 
     fn post_irq(&self, icr: u64) -> Result<(), SvsmError> {
         // SAFETY: writing to ICR MSR doesn't break memory safety.
-        unsafe { write_msr(APIC_MSR_ICR, icr) };
+        unsafe { write_msr(MSR_X2APIC_ICR, icr) };
         Ok(())
     }
 
     fn eoi(&self) {
         // SAFETY: writing to EOI MSR doesn't break memory safety.
-        unsafe { write_msr(APIC_MSR_EOI, 0) };
+        unsafe { write_msr(MSR_X2APIC_EOI, 0) };
     }
 
     fn is_external_interrupt(&self, _vector: usize) -> bool {

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -11,10 +11,9 @@ use crate::console::init_svsm_console;
 use crate::cpu::apic::{ApicIcr, IcrMessageType};
 use crate::cpu::control_regs::read_cr3;
 use crate::cpu::cpuid::CpuidResult;
-use crate::cpu::msr::write_msr;
 use crate::cpu::percpu::PerCpu;
 use crate::cpu::smp::create_ap_start_context;
-use crate::cpu::x86::apic::{x2apic_enable, x2apic_eoi, MSR_X2APIC_ICR};
+use crate::cpu::x86::apic::{x2apic_enable, x2apic_eoi, x2apic_icr_write};
 use crate::error::SvsmError;
 use crate::hyperv;
 use crate::hyperv::{hyperv_setup_hypercalls, hyperv_start_cpu, is_hyperv_hypervisor};
@@ -165,8 +164,7 @@ impl SvsmPlatform for NativePlatform {
     }
 
     fn post_irq(&self, icr: u64) -> Result<(), SvsmError> {
-        // SAFETY: writing to ICR MSR doesn't break memory safety.
-        unsafe { write_msr(MSR_X2APIC_ICR, icr) };
+        x2apic_icr_write(icr);
         Ok(())
     }
 

--- a/kernel/src/platform/tdp.rs
+++ b/kernel/src/platform/tdp.rs
@@ -10,7 +10,7 @@ use crate::cpu::cpuid::CpuidResult;
 use crate::cpu::msr::read_msr;
 use crate::cpu::percpu::PerCpu;
 use crate::cpu::smp::create_ap_start_context;
-use crate::cpu::x86::apic::{apic_register_bit, APIC_MSR_ISR};
+use crate::cpu::x86::apic::{apic_register_bit, MSR_X2APIC_ISR};
 use crate::error::SvsmError;
 use crate::hyperv;
 use crate::io::IOPort;
@@ -203,7 +203,7 @@ impl SvsmPlatform for TdpPlatform {
         // Examine the APIC ISR to determine whether this interrupt vector is
         // active.  If so, it is assumed to be an external interrupt.
         let (msr, mask) = apic_register_bit(vector);
-        (read_msr(APIC_MSR_ISR + msr) & mask as u64) != 0
+        (read_msr(MSR_X2APIC_ISR + msr) & mask as u64) != 0
     }
 
     fn start_cpu(

--- a/kernel/src/platform/tdp.rs
+++ b/kernel/src/platform/tdp.rs
@@ -10,7 +10,7 @@ use crate::cpu::cpuid::CpuidResult;
 use crate::cpu::msr::read_msr;
 use crate::cpu::percpu::PerCpu;
 use crate::cpu::smp::create_ap_start_context;
-use crate::cpu::x86::apic::{apic_register_bit, MSR_X2APIC_ISR};
+use crate::cpu::x86::apic::{apic_register_bit, x2apic_eoi, MSR_X2APIC_ISR};
 use crate::error::SvsmError;
 use crate::hyperv;
 use crate::io::IOPort;
@@ -197,7 +197,9 @@ impl SvsmPlatform for TdpPlatform {
         Err(TdxError::Unimplemented.into())
     }
 
-    fn eoi(&self) {}
+    fn eoi(&self) {
+        x2apic_eoi();
+    }
 
     fn is_external_interrupt(&self, vector: usize) -> bool {
         // Examine the APIC ISR to determine whether this interrupt vector is


### PR DESCRIPTION
Cleanup the X2APIC code by moving accesses for `kernel/src/cpu/x86/apic.rs` and calling the accessors from the native and TDP platform implementations.

Also fix IRQ delivery with QEMU/KVM by setting the ASE bit in APIC.SPIV on X2APIC initialization.