### PR TITLE
Enable UMIP

### DIFF
--- a/kernel/src/cpu/control_regs.rs
+++ b/kernel/src/cpu/control_regs.rs
@@ -6,7 +6,7 @@
 
 use super::features::cpu_has_pge;
 use crate::address::{Address, PhysAddr};
-use crate::cpu::features::{cpu_has_smap, cpu_has_smep};
+use crate::cpu::features::{cpu_has_smap, cpu_has_smep, cpu_has_umip};
 use crate::platform::SvsmPlatform;
 use bitflags::bitflags;
 use core::arch::asm;
@@ -46,6 +46,10 @@ pub fn cr4_init(platform: &dyn SvsmPlatform) {
     if !cfg!(feature = "nosmap") {
         assert!(cpu_has_smap(platform), "CPU does not support SMAP");
         cr4.insert(CR4Flags::SMAP);
+    }
+
+    if cpu_has_umip(platform) {
+        cr4.insert(CR4Flags::UMIP);
     }
 
     // SAFETY: we are not changing any execution-state relevant flags

--- a/kernel/src/cpu/features.rs
+++ b/kernel/src/cpu/features.rs
@@ -11,28 +11,19 @@ const X86_FEATURE_SMEP: u32 = 7;
 const X86_FEATURE_SMAP: u32 = 20;
 
 pub fn cpu_has_pge(platform: &dyn SvsmPlatform) -> bool {
-    let ret = platform.cpuid(0x00000001);
-
-    match ret {
-        None => false,
-        Some(c) => (c.edx >> X86_FEATURE_PGE) & 1 == 1,
-    }
+    platform
+        .cpuid(0x0000_0001)
+        .map_or_else(|| false, |c| (c.edx >> X86_FEATURE_PGE) & 1 == 1)
 }
 
 pub fn cpu_has_smep(platform: &dyn SvsmPlatform) -> bool {
-    let ret = platform.cpuid(0x0000_0007);
-
-    match ret {
-        None => false,
-        Some(c) => (c.ebx >> X86_FEATURE_SMEP & 1) == 1,
-    }
+    platform
+        .cpuid(0x0000_0007)
+        .map_or_else(|| false, |c| (c.ebx >> X86_FEATURE_SMEP & 1) == 1)
 }
 
 pub fn cpu_has_smap(platform: &dyn SvsmPlatform) -> bool {
-    let ret = platform.cpuid(0x0000_0007);
-
-    match ret {
-        None => false,
-        Some(c) => (c.ebx >> X86_FEATURE_SMAP & 1) == 1,
-    }
+    platform
+        .cpuid(0x0000_0007)
+        .map_or_else(|| false, |c| (c.ebx >> X86_FEATURE_SMAP & 1) == 1)
 }

--- a/kernel/src/cpu/features.rs
+++ b/kernel/src/cpu/features.rs
@@ -9,6 +9,7 @@ use crate::platform::SvsmPlatform;
 const X86_FEATURE_PGE: u32 = 13;
 const X86_FEATURE_SMEP: u32 = 7;
 const X86_FEATURE_SMAP: u32 = 20;
+const X86_FEATURE_UMIP: u32 = 2;
 
 pub fn cpu_has_pge(platform: &dyn SvsmPlatform) -> bool {
     platform
@@ -26,4 +27,10 @@ pub fn cpu_has_smap(platform: &dyn SvsmPlatform) -> bool {
     platform
         .cpuid(0x0000_0007)
         .map_or_else(|| false, |c| (c.ebx >> X86_FEATURE_SMAP & 1) == 1)
+}
+
+pub fn cpu_has_umip(platform: &dyn SvsmPlatform) -> bool {
+    platform
+        .cpuid(0x0000_0007)
+        .map_or_else(|| false, |c| (c.ecx >> X86_FEATURE_UMIP & 1) == 1)
 }

--- a/kernel/src/cpu/gdt.rs
+++ b/kernel/src/cpu/gdt.rs
@@ -17,6 +17,8 @@ struct GDTDesc {
     addr: VirtAddr,
 }
 
+// The base address of the GDT should be aligned on an 8-byte boundary
+// to yield the best processor performance.
 #[derive(Copy, Clone, Debug, Default)]
 pub struct GDTEntry(u64);
 

--- a/kernel/src/cpu/idt/common.rs
+++ b/kernel/src/cpu/idt/common.rs
@@ -214,8 +214,10 @@ pub fn user_mode(ctxt: &X86ExceptionContext) -> bool {
     (ctxt.frame.cs & 3) == 3
 }
 
+// The base addresses of the IDT should be aligned on an 8-byte boundary
+// to maximize performance of cache line fills.
 #[derive(Copy, Clone, Default, Debug)]
-#[repr(C, packed)]
+#[repr(C, packed(8))]
 pub struct IdtEntry {
     low: u64,
     high: u64,
@@ -305,7 +307,7 @@ impl IdtEntry {
 
 const IDT_ENTRIES: usize = 256;
 
-#[repr(C, packed)]
+#[repr(C, packed(2))]
 #[derive(Default, Clone, Copy, Debug)]
 struct IdtDesc {
     size: u16,


### PR DESCRIPTION
UMIP (User-Mode Instruction Prevention) prevents user-mode applications from executing SGDT/SIDT/SLDT/SMSW/STR. A `#GP(0)` is raised if any of these instrctions is executed in CPL > 0 and CR4.UMIP = 1. It is generally a good idea to enable such prevention before user space comes up because these instructions can leak critical information regarding memory layout and configuration.