### PR TITLE
cpu: use robust mechanisms to determine availability of CET

### DIFF
--- a/kernel/src/cpu/control_regs.rs
+++ b/kernel/src/cpu/control_regs.rs
@@ -7,6 +7,7 @@
 use super::features::cpu_has_pge;
 use crate::address::{Address, PhysAddr};
 use crate::cpu::features::{cpu_has_smap, cpu_has_smep, cpu_has_umip};
+use crate::cpu::shadow_stack::is_cet_ss_supported;
 use crate::platform::SvsmPlatform;
 use bitflags::bitflags;
 use core::arch::asm;
@@ -50,6 +51,10 @@ pub fn cr4_init(platform: &dyn SvsmPlatform) {
 
     if cpu_has_umip(platform) {
         cr4.insert(CR4Flags::UMIP);
+    }
+
+    if is_cet_ss_supported() {
+        cr4.insert(CR4Flags::CET);
     }
 
     // SAFETY: we are not changing any execution-state relevant flags

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -23,6 +23,7 @@ use crate::address::{PhysAddr, VirtAddr};
 use crate::config::SvsmConfig;
 use crate::cpu::cpuid::CpuidResult;
 use crate::cpu::percpu::PerCpu;
+use crate::cpu::shadow_stack::determine_cet_support_from_cpuid;
 use crate::cpu::tlb::{flush_tlb, TlbFlushScope};
 use crate::error::SvsmError;
 use crate::hyperv;
@@ -108,6 +109,11 @@ pub trait SvsmPlatform {
 
     /// Determines the paging encryption masks for the current architecture.
     fn get_page_encryption_masks(&self) -> PageEncryptionMasks;
+
+    /// Determine whether shadow stacks are supported.
+    fn determine_cet_support(&self) -> bool {
+        determine_cet_support_from_cpuid()
+    }
 
     /// Obtain CPUID using platform-specific tables.
     fn cpuid(&self, eax: u32) -> Option<CpuidResult>;

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -185,6 +185,12 @@ impl SvsmPlatform for SnpPlatform {
         }
     }
 
+    fn determine_cet_support(&self) -> bool {
+        // CET is supported on all SNP platforms, and CPUID should not be
+        // consulted to determine this.
+        true
+    }
+
     fn cpuid(&self, eax: u32) -> Option<CpuidResult> {
         cpuid_table(eax)
     }

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -186,9 +186,14 @@ impl SvsmPlatform for SnpPlatform {
     }
 
     fn determine_cet_support(&self) -> bool {
-        // CET is supported on all SNP platforms, and CPUID should not be
-        // consulted to determine this.
-        true
+        // Examine CPUID information to see whether CET is supported by the
+        // hypervisor.  If no CPUID information is present, then assume that
+        // CET is supported.
+        if let Some(cpuid) = cpuid_table(7) {
+            (cpuid.ecx & 0x80) != 0
+        } else {
+            todo!()
+        }
     }
 
     fn cpuid(&self, eax: u32) -> Option<CpuidResult> {

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -192,8 +192,8 @@ extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) -> ! {
     }
 
     cr0_init();
+    determine_cet_support(&*platform);
     cr4_init(&*platform);
-    determine_cet_support();
 
     install_console_logger("SVSM").expect("Console logger already initialized");
     platform


### PR DESCRIPTION
Attempting control state changes and catching related exceptions is not a terribly robust way of feature detection.  The architecturally approved mechanism for feature detection is CPUID, and in those cases where it is unavailable or unreliable due to constraints within the underlying platform, there other usually better enumeration mechanisms available.