### PR TITLE
kernel/vc: remove MMIO handling from IOIO VC

### DIFF
--- a/kernel/src/cpu/vc.rs
+++ b/kernel/src/cpu/vc.rs
@@ -87,6 +87,13 @@ impl fmt::Display for VcError {
     }
 }
 
+/// Handles a #VC exception in stage 2 before the GHCB is set up.
+///
+/// # Parameters
+/// - registers state before the exception was raise through a [`X86ExceptionContext`].
+///
+/// # Returns
+/// - a `SvsmError` if the handling went wrong.
 pub fn stage2_handle_vc_exception_no_ghcb(ctx: &mut X86ExceptionContext) -> Result<(), SvsmError> {
     let err = ctx.error_code;
     let insn_ctx = vc_decode_insn(ctx)?;
@@ -100,6 +107,14 @@ pub fn stage2_handle_vc_exception_no_ghcb(ctx: &mut X86ExceptionContext) -> Resu
     Ok(())
 }
 
+/// Handles a #VC exception in stage 2 using GHCB features, requiring the GHCB to
+/// be set up beforehand.
+///
+/// # Parameters
+/// - registers state before the exception was raise through a [`X86ExceptionContext`].
+///
+/// # Returns
+/// - a `SvsmError` if the handling went wrong.
 pub fn stage2_handle_vc_exception(ctx: &mut X86ExceptionContext) -> Result<(), SvsmError> {
     let err = ctx.error_code;
 
@@ -125,6 +140,14 @@ pub fn stage2_handle_vc_exception(ctx: &mut X86ExceptionContext) -> Result<(), S
     Ok(())
 }
 
+/// Handles a runtime #VC exception.
+///
+/// # Parameters
+/// - registers state before the exception was raise through a [`X86ExceptionContext`].
+/// - the exception vector code.
+///
+/// # Returns
+/// - a `SvsmError` if the handling went wrong.
 pub fn handle_vc_exception(ctx: &mut X86ExceptionContext, vector: usize) -> Result<(), SvsmError> {
     let error_code = ctx.error_code;
 

--- a/kernel/src/insn_decode/decode.rs
+++ b/kernel/src/insn_decode/decode.rs
@@ -720,6 +720,29 @@ impl DecodedInsnCtx {
             })
     }
 
+    /// Emulates IOIO instructions using the provided machine context.
+    ///
+    /// # Arguments
+    ///
+    /// * `mctx` - A mutable reference to an object implementing the
+    ///   `InsnMachineCtx` trait to provide the necessary machine context
+    ///   for emulation.
+    ///
+    /// # Returns
+    ///
+    /// An `Ok(())` if emulation is successful or an `InsnError` otherwise.
+    pub fn emulate_ioio<I: InsnMachineCtx>(&self, mctx: &mut I) -> Result<(), InsnError> {
+        self.insn
+            .ok_or(InsnError::UnSupportedInsn)
+            .and_then(|insn| match insn {
+                DecodedInsn::In(_, _)
+                | DecodedInsn::Out(_, _)
+                | DecodedInsn::Ins
+                | DecodedInsn::Outs => self.emulate(mctx),
+                _ => Err(InsnError::UnSupportedInsn),
+            })
+    }
+
     fn decode<I: InsnMachineCtx>(
         &mut self,
         bytes: &[u8; MAX_INSN_SIZE],


### PR DESCRIPTION
There is a path to emulate MMIO instructions in the IOIO #VC handler, I think that's not what we want.

**I don't have access to a SEV-SNP platform, I would need someone to test it, test-in-svsm included. Thanks!**