### PR TITLE
task: Remove alignment requirement for TaskVirtualRegionGuard indices

### DIFF
--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -60,7 +60,7 @@ impl TaskVirtualRegionGuard {
     fn alloc() -> Result<Self, SvsmError> {
         let index = KTASK_VADDR_BITMAP
             .lock()
-            .alloc(1, 1)
+            .alloc(1, 0)
             .ok_or(SvsmError::Alloc(AllocError::OutOfMemory))?;
         Ok(Self { index })
     }


### PR DESCRIPTION
Each TaskVirtualRegionGuard gets a unique index that indicates where its vaddr region is. Previously only even indices were allocated since the alloc function was given an alignment of 1, but this is unncessary as every index is valid.

This doubles the number of possible tasks from 512 to 1024. By default, 3 tasks are created per vCPU, so this doubles the number of vCPUs supported from 170 to 341 (in theory). Actually tested with 224 vCPUs.