### PR TITLE
Add safe memory constructs for large requests 

### DIFF
--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -1297,6 +1297,13 @@ impl PerCpuVmsas {
             .any(|vmsa| vmsa.paddr == paddr)
     }
 
+    pub fn overlaps(&self, region: &MemoryRegion<PhysAddr>) -> bool {
+        self.vmsas
+            .lock_read()
+            .iter()
+            .any(|vmsa| region.overlap(&MemoryRegion::new(vmsa.paddr, PAGE_SIZE)))
+    }
+
     pub fn register(
         &self,
         paddr: PhysAddr,

--- a/kernel/src/mm/ptguards.rs
+++ b/kernel/src/mm/ptguards.rs
@@ -141,7 +141,7 @@ impl Drop for PerCPUPageMappingGuard {
 /// unmap the specific memory range after being dropped.
 #[derive(Debug)]
 pub struct MemMappingGuard<T> {
-    // The guard of holding the temperary mapping for a specific memory range.
+    // The guard of holding the temporary mapping for a specific memory range.
     guard: PerCPUPageMappingGuard,
     // The starting offset of the memory range.
     start_off: usize,


### PR DESCRIPTION
With arbitrary length memory access in service requests, we need to be able to read/write memory across multiple pages safely.

This is groundwork for the attestation service to write manifests and read "selectors" of arbitrary length.