### PR TITLE
platform/tdp: Add IPI support

### DIFF
--- a/kernel/src/cpu/msr.rs
+++ b/kernel/src/cpu/msr.rs
@@ -32,7 +32,7 @@ pub fn read_msr(msr: u32) -> u64 {
 /// The caller should ensure that the new value in the target MSR doesn't break
 /// memory safety.
 pub unsafe fn write_msr(msr: u32, val: u64) {
-    let eax = (val & 0x0000_0000_ffff_ffff) as u32;
+    let eax = val as u32;
     let edx = (val >> 32) as u32;
 
     // SAFETY: requirements have to be checked by the caller.

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -891,7 +891,9 @@ impl PerCpu {
 
     // Setup code which needs to run on the target CPU
     pub fn setup_on_cpu(&self, platform: &dyn SvsmPlatform) -> Result<(), SvsmError> {
-        platform.setup_percpu_current(self)
+        platform.setup_percpu_current(self)?;
+        assert!(self.get_apic().id() == self.get_apic_id());
+        Ok(())
     }
 
     pub fn setup_idle_task(&self, entry: extern "C" fn()) -> Result<(), SvsmError> {

--- a/kernel/src/cpu/x86/apic.rs
+++ b/kernel/src/cpu/x86/apic.rs
@@ -69,6 +69,8 @@ pub const APIC_OFFSET_SPIV: usize = 0xF;
 pub const APIC_OFFSET_ISR: usize = 0x10;
 /// Interrupt-Control-Register register MSR offset
 pub const APIC_OFFSET_ICR: usize = 0x30;
+/// SELF-IPI register MSR offset (x2APIC only)
+pub const APIC_OFFSET_SELF_IPI: usize = 0x3F;
 
 // SPIV bits
 const APIC_SPIV_VECTOR_MASK: u64 = (1u64 << 8) - 1;

--- a/kernel/src/cpu/x86/apic.rs
+++ b/kernel/src/cpu/x86/apic.rs
@@ -61,6 +61,8 @@ pub trait ApicAccess: core::fmt::Debug {
 /// APIC Base MSR
 pub const MSR_APIC_BASE: u32 = 0x1B;
 
+/// Local APIC ID register MSR offset
+pub const APIC_OFFSET_ID: usize = 0x2;
 /// End-of-Interrupt register MSR offset
 pub const APIC_OFFSET_EOI: usize = 0xB;
 /// Spurious-Interrupt-Register MSR offset
@@ -134,6 +136,12 @@ impl X86Apic {
     /// Enable the APIC-Software-Enable bit.
     pub fn sw_enable(&self) {
         self.spiv_write(0xff, true);
+    }
+
+    /// Get APIC ID
+    #[inline(always)]
+    pub fn id(&self) -> u32 {
+        self.regs().apic_read(APIC_OFFSET_ID) as u32
     }
 
     /// Sends an EOI message

--- a/kernel/src/cpu/x86/x2apic.rs
+++ b/kernel/src/cpu/x86/x2apic.rs
@@ -19,6 +19,8 @@ pub const MSR_X2APIC_SPIV: u32 = 0x80F;
 pub const MSR_X2APIC_ISR: u32 = 0x810;
 /// Interrupt-Control-Register register MSR offset
 pub const MSR_X2APIC_ICR: u32 = 0x830;
+/// SELF-IPI register MSR offset
+pub const MSR_X2APIC_SELF_IPI: u32 = 0x83F;
 
 #[derive(Debug)]
 pub struct X2ApicAccessor {}

--- a/kernel/src/platform/tdp.rs
+++ b/kernel/src/platform/tdp.rs
@@ -150,12 +150,7 @@ impl SvsmPlatform for TdpPlatform {
         _size: PageSize,
         op: PageStateChangeOp,
     ) -> Result<(), SvsmError> {
-        // The cast to u32 below is awkward, but the is_aligned() function
-        // requires its type to be convertible to u32 - which usize is not -
-        // and for an alignment check, only the low 32 bits are needed anyway.
-        if !region.start().is_aligned(PAGE_SIZE)
-            || !is_aligned(region.len() as u32, PAGE_SIZE as u32)
-        {
+        if !region.start().is_aligned(PAGE_SIZE) || !is_aligned(region.len(), PAGE_SIZE) {
             return Err(SvsmError::InvalidAddress);
         }
         let gpa = match op {
@@ -174,9 +169,6 @@ impl SvsmPlatform for TdpPlatform {
         region: MemoryRegion<PhysAddr>,
         op: PageValidateOp,
     ) -> Result<(), SvsmError> {
-        // The cast to u32 below is awkward, but the is_aligned() function
-        // requires its type to be convertible to u32 - which usize is not -
-        // and for an alignment check, only the low 32 bits are needed anyway.
         if !region.start().is_aligned(PAGE_SIZE) || !is_aligned(region.len(), PAGE_SIZE) {
             return Err(SvsmError::InvalidAddress);
         }
@@ -198,12 +190,7 @@ impl SvsmPlatform for TdpPlatform {
         region: MemoryRegion<VirtAddr>,
         op: PageValidateOp,
     ) -> Result<(), SvsmError> {
-        // The cast to u32 below is awkward, but the is_aligned() function
-        // requires its type to be convertible to u32 - which usize is not -
-        // and for an alignment check, only the low 32 bits are needed anyway
-        if !region.start().is_aligned(PAGE_SIZE)
-            || !is_aligned(region.len() as u32, PAGE_SIZE as u32)
-        {
+        if !region.start().is_aligned(PAGE_SIZE) || !is_aligned(region.len(), PAGE_SIZE) {
             return Err(SvsmError::InvalidAddress);
         }
         match op {

--- a/kernel/src/tdx/apic.rs
+++ b/kernel/src/tdx/apic.rs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (C) 2025 Intel Corporation
+//
+// Author: Peter Fang <peter.fang@intel.com>
+
+use crate::cpu::apic::{ApicIcr, IcrDestFmt, IcrMessageType};
+use crate::cpu::msr::{read_msr, write_msr};
+use crate::cpu::percpu::this_cpu;
+use crate::cpu::x86::apic::{APIC_OFFSET_ICR, APIC_OFFSET_SELF_IPI, APIC_OFFSET_SPIV};
+use crate::cpu::x86::x2apic::{MSR_X2APIC_BASE, MSR_X2APIC_SELF_IPI};
+use crate::cpu::x86::{ApicAccess, MSR_APIC_BASE};
+use crate::tdx::tdcall;
+
+#[derive(Debug)]
+pub struct TdxApicAccessor {}
+
+impl TdxApicAccessor {
+    fn is_self_ipi(offset: usize, value: u64) -> Option<u64> {
+        match offset {
+            // Preserve hw behaviors (e.g. reserved-bit checking)
+            APIC_OFFSET_SELF_IPI => Some(value),
+            // Convert to a self-IPI if applicable
+            APIC_OFFSET_ICR => {
+                let icr = ApicIcr::from(value);
+                match icr.destination_shorthand() {
+                    // Logical destination mode can be supported if needed;
+                    // defer to GHCI for now.
+                    // The same goes for lowest priority delivery mode.
+                    IcrDestFmt::Dest => {
+                        if icr.message_type() == IcrMessageType::Fixed
+                            && !icr.destination_mode()
+                            && icr.destination() == this_cpu().get_apic_id()
+                        {
+                            Some(icr.vector() as u64)
+                        } else {
+                            None
+                        }
+                    }
+                    IcrDestFmt::OnlySelf => {
+                        debug_assert!(icr.message_type() == IcrMessageType::Fixed);
+                        Some(icr.vector() as u64)
+                    }
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+
+    // NOTE:
+    // Needs to be updated when new GHCI APIC registers are used.
+    fn is_ghci_msr(offset: usize) -> bool {
+        matches!(offset, APIC_OFFSET_SPIV | APIC_OFFSET_ICR)
+    }
+}
+
+impl ApicAccess for TdxApicAccessor {
+    fn update_apic_base(&self, and_mask: u64, or_mask: u64) {
+        let current_value = tdcall::tdvmcall_rdmsr(MSR_APIC_BASE);
+        let new_value = (current_value & and_mask) | or_mask;
+
+        if current_value != new_value {
+            tdcall::tdvmcall_wrmsr(MSR_APIC_BASE, new_value);
+        }
+    }
+
+    fn apic_write(&self, offset: usize, value: u64) {
+        let msr = MSR_X2APIC_BASE + u32::try_from(offset).unwrap();
+
+        if let Some(v) = Self::is_self_ipi(offset, value) {
+            // SAFETY: Writes to X2APIC MSRs never harm memory safety.
+            unsafe { write_msr(MSR_X2APIC_SELF_IPI, v) };
+        } else if Self::is_ghci_msr(offset) {
+            tdcall::tdvmcall_wrmsr(msr, value);
+        } else {
+            // SAFETY: Writes to X2APIC MSRs never harm memory safety.
+            unsafe { write_msr(msr, value) };
+        }
+    }
+
+    fn apic_read(&self, offset: usize) -> u64 {
+        let msr = MSR_X2APIC_BASE + u32::try_from(offset).unwrap();
+
+        if Self::is_ghci_msr(offset) {
+            tdcall::tdvmcall_rdmsr(msr)
+        } else {
+            read_msr(msr)
+        }
+    }
+}
+
+pub static TDX_APIC_ACCESSOR: TdxApicAccessor = TdxApicAccessor {};

--- a/kernel/src/tdx/apic.rs
+++ b/kernel/src/tdx/apic.rs
@@ -7,7 +7,9 @@
 use crate::cpu::apic::{ApicIcr, IcrDestFmt, IcrMessageType};
 use crate::cpu::msr::{read_msr, write_msr};
 use crate::cpu::percpu::this_cpu;
-use crate::cpu::x86::apic::{APIC_OFFSET_ICR, APIC_OFFSET_SELF_IPI, APIC_OFFSET_SPIV};
+use crate::cpu::x86::apic::{
+    APIC_OFFSET_ICR, APIC_OFFSET_ID, APIC_OFFSET_SELF_IPI, APIC_OFFSET_SPIV,
+};
 use crate::cpu::x86::x2apic::{MSR_X2APIC_BASE, MSR_X2APIC_SELF_IPI};
 use crate::cpu::x86::{ApicAccess, MSR_APIC_BASE};
 use crate::tdx::tdcall;
@@ -51,7 +53,7 @@ impl TdxApicAccessor {
     // NOTE:
     // Needs to be updated when new GHCI APIC registers are used.
     fn is_ghci_msr(offset: usize) -> bool {
-        matches!(offset, APIC_OFFSET_SPIV | APIC_OFFSET_ICR)
+        matches!(offset, APIC_OFFSET_ID | APIC_OFFSET_SPIV | APIC_OFFSET_ICR)
     }
 }
 

--- a/kernel/src/tdx/mod.rs
+++ b/kernel/src/tdx/mod.rs
@@ -4,6 +4,7 @@
 //
 // Author: Jon Lange <jlange@microsoft.com>
 
+pub mod apic;
 pub mod error;
 pub mod tdcall;
 pub mod ve;


### PR DESCRIPTION
TDX guests rely on virtual x2APIC mode + host VMM APIC emulation for APIC functionalities. Reuse the APIC driver implementation and catch x2APIC MSR access #VEs as they appear.