### PR TITLE
config, fw_cfg: Read cpu count from fw_cfg item on Qemu

### DIFF
--- a/kernel/src/config.rs
+++ b/kernel/src/config.rs
@@ -130,7 +130,17 @@ impl<'a> SvsmConfig<'a> {
             }
         }
 
-        load_fw_cpu_info(self.fw_cfg.as_ref().unwrap())
+        // Fall back to fw_cfg, if present, and read a hidden file to get CPU count
+        if let Some(c) = self.fw_cfg.as_ref() {
+            Ok((0..c.get_cpu_count())
+                .map(|i| ACPICPUInfo {
+                    apic_id: i,
+                    enabled: true,
+                })
+                .collect())
+        } else {
+            load_fw_cpu_info(self.fw_cfg.as_ref().unwrap())
+        }
     }
 
     pub fn should_launch_fw(&self) -> bool {

--- a/kernel/src/fw_cfg.rs
+++ b/kernel/src/fw_cfg.rs
@@ -236,4 +236,10 @@ impl<'a> FwCfg<'a> {
 
         (0..num).map(|_| self.read_memory_region())
     }
+
+    pub fn get_cpu_count(&self) -> u32 {
+        const CPU_COUNT_HIDDEN_FILE: u16 = 0x5;
+        self.select(CPU_COUNT_HIDDEN_FILE);
+        self.read_le::<u32>()
+    }
 }

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -315,7 +315,9 @@ pub extern "C" fn svsm_main() {
 
     init_capabilities();
 
-    let cpus = config.load_cpu_info().expect("Failed to load ACPI tables");
+    let cpus = config
+        .load_cpu_info()
+        .expect("Failed to determine number of CPUs");
     let mut nr_cpus = 0;
 
     for cpu in cpus.iter() {


### PR DESCRIPTION
Due to a problem with ACPI tables and Linux when running under Qemu [1],
determine the CPU count via a hidden fw_cfg item instead and don't read
any ACPI tables.

[1] https://github.com/coconut-svsm/svsm/issues/646

