### PR TITLE
svsm: correctly support TDP on Hyper-V

### DIFF
--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -26,7 +26,7 @@ use crate::cpu::vmsa::{svsm_code_segment, svsm_data_segment, svsm_gdt_segment, s
 use crate::cpu::{IrqState, LocalApic};
 use crate::error::{ApicError, SvsmError};
 use crate::hyperv;
-use crate::hyperv::HypercallPagesGuard;
+use crate::hyperv::{HypercallPagesGuard, IS_HYPERV};
 use crate::locking::{LockGuard, RWLock, RWLockIrqSafe, SpinLock};
 use crate::mm::alloc::{allocate_pages, free_page};
 use crate::mm::page_visibility::{make_page_private, make_page_shared};
@@ -667,6 +667,10 @@ impl PerCpu {
         self.current_stack.set(stack);
     }
 
+    pub fn get_cpu_index(&self) -> usize {
+        self.shared().cpu_index()
+    }
+
     pub fn get_apic_id(&self) -> u32 {
         self.shared().apic_id()
     }
@@ -884,6 +888,12 @@ impl PerCpu {
 
         // Complete platform-specific initialization.
         platform.setup_percpu(self)?;
+
+        // Allocate hypercall pages if running on Hyper-V, unless this is the
+        // BSP (where they will be allocated later).
+        if self.shared.cpu_index() != 0 && *IS_HYPERV {
+            self.allocate_hypercall_pages()?;
+        }
 
         Ok(())
     }

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -28,7 +28,8 @@ use crate::error::{ApicError, SvsmError};
 use crate::hyperv;
 use crate::hyperv::HypercallPagesGuard;
 use crate::locking::{LockGuard, RWLock, RWLockIrqSafe, SpinLock};
-use crate::mm::alloc::allocate_pages;
+use crate::mm::alloc::{allocate_pages, free_page};
+use crate::mm::page_visibility::{make_page_private, make_page_shared};
 use crate::mm::pagetable::{PTEntryFlags, PageTable};
 use crate::mm::virtualrange::VirtualRange;
 use crate::mm::vm::{
@@ -584,6 +585,28 @@ impl PerCpu {
     /// Allocates hypercall input/output pages for this CPU.
     pub fn allocate_hypercall_pages(&self) -> Result<(), SvsmError> {
         let vaddr = allocate_pages(2)?;
+
+        // Attempt to make each page shared.  This must be done carefully so
+        // that state is correctly restored in the event of failure.
+        // SAFETY: the virtual addresses are correct because the pages were
+        // just allocated.  If conversion is successful, these pages will never
+        // be freed, and if conversion if unsuccessful, state will correctly be
+        // restored here before the pages are freed.
+        unsafe {
+            let mut r = make_page_shared(vaddr);
+            if r.is_ok() {
+                let r2 = make_page_shared(vaddr + PAGE_SIZE);
+                if r2.is_err() {
+                    make_page_private(vaddr).expect("Failed to restore private page");
+                    r = r2;
+                }
+            }
+            if r.is_err() {
+                free_page(vaddr);
+                return r;
+            }
+        }
+
         let pages = (
             VirtPhysPair::new(vaddr),
             VirtPhysPair::new(vaddr + PAGE_SIZE),

--- a/kernel/src/hyperv/hv.rs
+++ b/kernel/src/hyperv/hv.rs
@@ -18,12 +18,119 @@ use crate::mm::pagetable::PTEntryFlags;
 use crate::mm::{virt_to_phys, SVSM_HYPERCALL_CODE_PAGE};
 use crate::types::PAGE_SIZE;
 use crate::utils::immut_after_init::ImmutAfterInitCell;
+use crate::utils::unsafe_copy_bytes;
 
 use core::arch::asm;
 use core::cell::RefMut;
-use core::slice;
+use core::marker::PhantomData;
+use core::mem;
+use core::mem::MaybeUninit;
+use core::ptr;
 
 use bitfield_struct::bitfield;
+
+#[derive(Debug)]
+struct HypercallInput<H, T: ?Sized> {
+    header: *mut H,
+    rep_count: usize,
+    _phantom: PhantomData<T>,
+}
+
+impl<H, T: ?Sized> HypercallInput<H, T> {
+    // SAFETY: the caller must guarantee the safety of the header pointer so
+    // that this function can assume the safety guarantees expected for
+    // subsequent access.
+    unsafe fn new(header: *mut H) -> Self {
+        Self {
+            header,
+            rep_count: 0,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// This function requires the use of `mut self` because it generates
+    /// mutable references to the addresses described by the hypercall pages,
+    /// but the compiler cannot understand that relationship.  Therefore,
+    /// suppress the warning for needless mut because it is actually required
+    /// in this case.
+    #[allow(clippy::needless_pass_by_ref_mut)]
+    fn write_header(&mut self, header: &H) {
+        // SAFETY: the source pointer is a safe reference, and the safety of
+        // the destination pointer was determined when the input object was
+        // created.
+        unsafe {
+            unsafe_copy_bytes(
+                ptr::from_ref(header) as usize,
+                self.header as usize,
+                mem::size_of::<H>(),
+            );
+        }
+    }
+}
+
+impl<H, T> HypercallInput<H, T> {
+    // SAFETY: the caller must guarantee the safety of the header pointer so
+    // that this function can assume the safety guarantees expected for
+    // subsequent access.
+    unsafe fn new_rep(header: *mut H, page_size: usize) -> Self {
+        let rep_count = (page_size - mem::size_of::<H>()) / mem::size_of::<T>();
+        Self {
+            header,
+            rep_count,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// This function requires the use of `mut self` because it generates
+    /// mutable references to the addresses described by the hypercall pages,
+    /// but the compiler cannot understand that relationship.  Therefore,
+    /// suppress the warning for needless mut because it is actually required
+    /// in this case.
+    #[allow(clippy::needless_pass_by_ref_mut)]
+    fn write_rep(&mut self, index: usize, item: T) {
+        assert!(index < self.rep_count);
+        let addr = self.header as usize + mem::size_of::<H>() + (index * core::mem::size_of::<T>());
+        // SAFETY: the source pointer is a safe reference, and the safety of
+        // the destination pointer is guaranteed by the address calculation
+        // at the time the input object was created, plus the bounds check
+        // above.
+        unsafe {
+            unsafe_copy_bytes(ptr::from_ref(&item) as usize, addr, mem::size_of::<T>());
+        }
+    }
+}
+
+#[derive(Debug)]
+struct HypercallOutput<T> {
+    array: *const T,
+    rep_count: usize,
+}
+
+impl<T> HypercallOutput<T> {
+    // SAFETY: the caller must guarantee the safety of the array pointer so
+    // that this function can assume the safety guarantees expected for
+    // subsequent access.
+    unsafe fn new(array: *const T, rep_count: usize) -> Self {
+        Self { array, rep_count }
+    }
+
+    fn read(&self, index: usize) -> T {
+        assert!(index < self.rep_count);
+        let addr = self.array as usize + (index * core::mem::size_of::<T>());
+
+        let mut item = MaybeUninit::<T>::uninit();
+
+        // SAFETY: the source pointer is a safe reference, and the safety of
+        // the destination pointer is guaranteed by the address calculation
+        // at the time the input object was created, plus the bounds check
+        // above.  The copy guarantees the initialization of the output object.
+        unsafe {
+            unsafe_copy_bytes(addr, item.as_mut_ptr() as usize, mem::size_of::<T>());
+
+            item.assume_init()
+        }
+    }
+}
 
 #[derive(Debug)]
 pub struct HypercallPagesGuard<'a> {
@@ -68,13 +175,13 @@ impl<'a> HypercallPagesGuard<'a> {
     /// suppress the warning for needless mut because it is actually required
     /// in this case.
     #[allow(clippy::needless_pass_by_ref_mut)]
-    fn hypercall_input<H>(&mut self) -> &mut H {
+    fn hypercall_input<H>(&mut self) -> HypercallInput<H, ()> {
         let header = self.input.vaddr.as_mut_ptr::<H>();
         assert!(size_of::<H>() <= PAGE_SIZE);
         // SAFETY: the virtual address represents an entire page which is
         // exclusively owned by the `HypercallPagesGuard` and can safely be
         // cast to a header of type `H`.
-        unsafe { &mut *header }
+        unsafe { HypercallInput::new(header) }
     }
 
     /// Divides a hypercall input page into a header of type `H` and a slice
@@ -87,27 +194,20 @@ impl<'a> HypercallPagesGuard<'a> {
     /// suppress the warning for needless mut because it is actually required
     /// in this case.
     #[allow(clippy::needless_pass_by_ref_mut)]
-    fn hypercall_rep_input<H, T>(&mut self) -> (&mut H, &mut [T]) {
-        let header_size = size_of::<H>();
-        assert!(header_size <= PAGE_SIZE);
-        let rep_count = (PAGE_SIZE - header_size) / size_of::<T>();
+    fn hypercall_rep_input<H, T>(&mut self) -> HypercallInput<H, T> {
         let header = self.input.vaddr.as_mut_ptr::<H>();
-        let rep_slice = self.input.vaddr.const_add(header_size).as_mut_ptr::<T>();
+        assert!(size_of::<H>() <= PAGE_SIZE);
+
         // SAFETY: the virtual address represents an entire page which is
         // exclusively owned by the `HypercallPagesGuard` and can safely be
         // cast to a header of type `H` followed by an array of `T` up to the
         // size of one page.
-        unsafe {
-            (
-                &mut *header,
-                slice::from_raw_parts_mut(rep_slice, rep_count),
-            )
-        }
+        unsafe { HypercallInput::new_rep(header, PAGE_SIZE) }
     }
 
     /// Casts a hypercall output page into a slice of repeated elements of
     /// type `T` and returns a reference to that slice.
-    fn hypercall_output<T>(&self, output: HvHypercallOutput) -> &[T] {
+    fn hypercall_output<T>(&self, output: HvHypercallOutput) -> HypercallOutput<T> {
         // A non-REP hypercall is assumed to have a single output element.
         let output_count = output.count();
         let count: usize = if output_count != 0 {
@@ -119,7 +219,7 @@ impl<'a> HypercallPagesGuard<'a> {
         // SAFETY: the virtual address represents an entire page which is
         // exclusively owned by the `HypercallPagesGuard` and can safely be
         // cast to an array of `T` up to the size of one page.
-        unsafe { slice::from_raw_parts(self.output.vaddr.as_ptr::<T>(), count) }
+        unsafe { HypercallOutput::new(self.output.vaddr.as_ptr::<T>(), count) }
     }
 }
 
@@ -260,9 +360,9 @@ pub fn get_vp_register(name: hyperv::HvRegisterName) -> Result<u64, SvsmError> {
     };
 
     let mut hypercall_pages = this_cpu().get_hypercall_pages();
-    let (header, slice) = hypercall_pages.hypercall_rep_input::<HvInputGetVpRegister, u32>();
-    *header = input_header;
-    slice[0] = name as u32;
+    let mut input_page = hypercall_pages.hypercall_rep_input::<HvInputGetVpRegister, u32>();
+    input_page.write_header(&input_header);
+    input_page.write_rep(0, name as u32);
 
     // SAFETY: the GetVpRegisters hypercall does not write to any memory other
     // than the hypercall page, and does not consume memory that is not
@@ -273,8 +373,8 @@ pub fn get_vp_register(name: hyperv::HvRegisterName) -> Result<u64, SvsmError> {
         return Err(HyperV(status));
     }
 
-    let output = hypercall_pages.hypercall_output::<u64>(call_output);
-    let reg = output[0];
+    let output_page = hypercall_pages.hypercall_output::<u64>(call_output);
+    let reg = output_page.read(0);
 
     drop(hypercall_pages);
 
@@ -307,8 +407,8 @@ fn enable_vp_vtl_hypercall(
     let input_control = HvHypercallInput::new().with_call_code(HvCallCode::EnableVpVtl as u16);
 
     let mut hypercall_pages = this_cpu().get_hypercall_pages();
-    let header = hypercall_pages.hypercall_input::<HvInputEnableVpVtl>();
-    *header = input_header;
+    let mut input_page = hypercall_pages.hypercall_input::<HvInputEnableVpVtl>();
+    input_page.write_header(&input_header);
 
     // SAFETY: the EnableVpVtl hypercall does not write to any memory and
     // does not consume memory that is not included in the hypercall input.
@@ -348,8 +448,8 @@ fn start_vp_hypercall(
         HvHypercallInput::new().with_call_code(HvCallCode::StartVirtualProcessor as u16);
 
     let mut hypercall_pages = this_cpu().get_hypercall_pages();
-    let header = hypercall_pages.hypercall_input::<HvInputStartVirtualProcessor>();
-    *header = input_header;
+    let mut input_page = hypercall_pages.hypercall_input::<HvInputStartVirtualProcessor>();
+    input_page.write_header(&input_header);
 
     // SAFETY: the StartVp hypercall does not write to any memory and does not
     // consume memory that is not included in the hypercall input.

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -205,7 +205,14 @@ impl SvsmPlatform for SnpPlatform {
     }
 
     fn cpuid(&self, eax: u32) -> Option<CpuidResult> {
-        cpuid_table(eax)
+        // If this is an architectural CPUID leaf, then extract the result
+        // from the CPUID table.  Otherwise, request the value from the
+        // hypervisor.
+        if (eax >> 28) == 4 {
+            current_ghcb().cpuid(eax).ok()
+        } else {
+            cpuid_table(eax)
+        }
     }
 
     fn setup_guest_host_comm(&mut self, cpu: &PerCpu, is_bsp: bool) {

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -29,6 +29,7 @@ use svsm::debug::gdbstub::svsm_gdbstub::{debug_break, gdbstub_start};
 use svsm::debug::stacktrace::print_stack;
 use svsm::enable_shadow_stacks;
 use svsm::fs::{initialize_fs, opendir, populate_ram_fs};
+use svsm::hyperv::hyperv_setup;
 use svsm::igvm_params::IgvmParams;
 use svsm::kernel_region::new_kernel_region;
 use svsm::mm::alloc::{memory_info, print_memory_info, root_mem_init};
@@ -293,6 +294,8 @@ pub extern "C" fn svsm_main() {
     SVSM_PLATFORM
         .env_setup_svsm()
         .expect("SVSM platform environment setup failed");
+
+    hyperv_setup().expect("failed to complete Hyper-V setup");
 
     let launch_info = &*LAUNCH_INFO;
     let igvm_params = if launch_info.igvm_params_virt_addr != 0 {

--- a/kernel/src/tdx/error.rs
+++ b/kernel/src/tdx/error.rs
@@ -26,6 +26,7 @@ pub enum TdxError {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum TdVmcallError {
     OperandInvalid,
+    Retry,
     Unknown(u64),
 }
 
@@ -62,6 +63,7 @@ pub fn tdx_recoverable_error(err: u64) -> bool {
 pub fn tdvmcall_result(err: u64) -> Result<(), TdxError> {
     match err {
         0 => Ok(()),
+        1 => Err(TdxError::Vmcall(TdVmcallError::Retry)),
         0x8000_0000_0000_0000 => Err(TdxError::Vmcall(TdVmcallError::OperandInvalid)),
         _ => Err(TdxError::Vmcall(TdVmcallError::Unknown(err))),
     }

--- a/kernel/src/utils/mod.rs
+++ b/kernel/src/utils/mod.rs
@@ -9,10 +9,12 @@ pub mod fw_meta;
 pub mod immut_after_init;
 pub mod memory_region;
 pub mod scoped;
+pub mod unsafe_copy;
 pub mod util;
 
 pub use memory_region::MemoryRegion;
 pub use scoped::{ScopedMut, ScopedRef};
+pub use unsafe_copy::*;
 pub use util::{
     align_down, align_up, is_aligned, overlap, page_align_up, page_offset, zero_mem_region,
 };

--- a/kernel/src/utils/unsafe_copy.rs
+++ b/kernel/src/utils/unsafe_copy.rs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Jon Lange (jlange@microsoft.com)
+
+use core::arch::asm;
+
+/// # Safety
+///
+/// The caller is required to ensure that the source/destination pointers and
+/// size will not result in overwriting memory unexpectedly.
+pub unsafe fn unsafe_copy_bytes(src: usize, dst: usize, size: usize) {
+    // SAFETY: the caller is responsible for ensuring that the addresses are
+    // correct and safe.
+    unsafe {
+        asm!("cld",
+             "rep movsb",
+             in("rsi") src,
+             in("rdi") dst,
+             in("rcx") size,
+             options(att_syntax));
+    }
+}


### PR DESCRIPTION
Correct behavior of TDP on Hyper-V requires the SVSM to make Hyper-V hypercalls.  This change includes the infrastructure required to detect a Hyper-V interface when running on TDP (or SNP), the infrastructure required to make hypercalls on TDP (or SNP), and the logic required for the SVSM to operate correctly when running TDP on top of Hyper-V.