### PR TITLE
platform: make `SVSM_PLATFORM` a dynamic reference

### DIFF
--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -372,11 +372,11 @@ pub extern "C" fn stage2_main(launch_info: &Stage2LaunchInfo) -> ! {
     let platform_type = SvsmPlatformType::from(launch_info.platform_type);
 
     init_platform_type(platform_type);
-    let mut platform = SvsmPlatformCell::new(platform_type, true);
+    let mut platform_cell = SvsmPlatformCell::new(true);
+    let platform = platform_cell.platform_mut();
 
-    let config =
-        get_svsm_config(launch_info, &*platform).expect("Failed to get SVSM configuration");
-    setup_env(&config, &mut *platform, launch_info);
+    let config = get_svsm_config(launch_info, platform).expect("Failed to get SVSM configuration");
+    setup_env(&config, platform, launch_info);
 
     // Get the available physical memory region for the kernel
     let kernel_region = config
@@ -392,7 +392,7 @@ pub extern "C" fn stage2_main(launch_info: &Stage2LaunchInfo) -> ! {
 
     // Load first the kernel ELF and update the loaded physical region
     let (kernel_entry, mut loaded_kernel_vregion) =
-        load_kernel_elf(launch_info, &mut loaded_kernel_pregion, &*platform, &config)
+        load_kernel_elf(launch_info, &mut loaded_kernel_pregion, platform, &config)
             .expect("Failed to load kernel ELF");
 
     // Load the IGVM params, if present. Update loaded region accordingly.
@@ -402,7 +402,7 @@ pub extern "C" fn stage2_main(launch_info: &Stage2LaunchInfo) -> ! {
             igvm_params,
             &loaded_kernel_vregion,
             &loaded_kernel_pregion,
-            &*platform,
+            platform,
             &config,
         )
         .expect("Failed to load IGVM params");
@@ -423,7 +423,7 @@ pub extern "C" fn stage2_main(launch_info: &Stage2LaunchInfo) -> ! {
         kernel_region,
         loaded_kernel_pregion,
         loaded_kernel_vregion,
-        &*platform,
+        platform,
         &config,
     )
     .expect("Failed to map and validate heap");

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -178,7 +178,8 @@ extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) -> ! {
         .init_from_ref(li)
         .expect("Already initialized launch info");
 
-    let mut platform = SvsmPlatformCell::new(li.platform_type, li.suppress_svsm_interrupts);
+    let mut platform_cell = SvsmPlatformCell::new(li.suppress_svsm_interrupts);
+    let platform = platform_cell.platform_mut();
 
     init_cpuid_table(VirtAddr::from(launch_info.cpuid_page));
 
@@ -192,8 +193,8 @@ extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) -> ! {
     }
 
     cr0_init();
-    determine_cet_support(&*platform);
-    cr4_init(&*platform);
+    determine_cet_support(platform);
+    cr4_init(platform);
 
     install_console_logger("SVSM").expect("Console logger already initialized");
     platform
@@ -216,7 +217,7 @@ extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) -> ! {
         Err(e) => panic!("error reading kernel ELF: {}", e),
     };
 
-    paging_init(&*platform, false).expect("Failed to initialize paging");
+    paging_init(platform, false).expect("Failed to initialize paging");
     let init_pgtable =
         init_page_table(&launch_info, &kernel_elf).expect("Could not initialize the page table");
     // SAFETY: we are initializing the state, including stack and registers
@@ -227,10 +228,10 @@ extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) -> ! {
     let bsp_percpu = PerCpu::alloc(0).expect("Failed to allocate BSP per-cpu data");
 
     bsp_percpu
-        .setup(&*platform, init_pgtable)
+        .setup(platform, init_pgtable)
         .expect("Failed to setup BSP per-cpu area");
     bsp_percpu
-        .setup_on_cpu(&*platform)
+        .setup_on_cpu(platform)
         .expect("Failed to run percpu.setup_on_cpu()");
     bsp_percpu.load();
     // Now the stack unwinder can be used
@@ -266,9 +267,7 @@ extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) -> ! {
         .configure_alternate_injection(launch_info.use_alternate_injection)
         .expect("Alternate injection required but not available");
 
-    SVSM_PLATFORM
-        .init(platform)
-        .expect("Failed to initialize SVSM platform object");
+    platform_cell.global_init();
 
     sse_init();
 
@@ -306,7 +305,7 @@ pub extern "C" fn svsm_main() {
         None
     };
 
-    let config = SvsmConfig::new(SVSM_PLATFORM.platform(), igvm_params);
+    let config = SvsmConfig::new(*SVSM_PLATFORM, igvm_params);
 
     init_memory_map(&config, &LAUNCH_INFO).expect("Failed to init guest memory map");
 


### PR DESCRIPTION
All callers of `SVSM_PLATFORM` expect to call through a dynamic `SvsmPlatform` trait reference.  For efficiency, the dynamic trait reference should be stored in the global.  This is better than storing a cell containing an enum which must be matched every time the static platform is referenced.