### PR TITLE
scripts/launch_guest.sh: add option to launch in native mode

### DIFF
--- a/scripts/launch_guest.sh
+++ b/scripts/launch_guest.sh
@@ -18,6 +18,7 @@ COM3_SERIAL="-serial null"  # used by hyper-v
 COM4_SERIAL="-serial null"  # used by in-SVSM tests
 QEMU_EXIT_DEVICE=""
 QEMU_TEST_IO_DEVICE=""
+CGS=sev
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -47,6 +48,10 @@ while [[ $# -gt 0 ]]; do
       shift
       shift
       ;;
+    --nocc)
+      CGS=nocc
+      shift
+      ;;
     -*|--*)
       echo "Unknown option $1"
       exit 1
@@ -65,22 +70,37 @@ QEMU_BUILD=${QEMU_VERSION##*.}
 QEMU_MINOR=${QEMU_VERSION##$QEMU_MAJOR.}
 QEMU_MINOR=${QEMU_MINOR%%.$QEMU_BUILD}
 
+if (( QEMU_MAJOR < 9)) && [ "$CGS" = "nocc" ]; then
+  echo "Error: --nocc requires Qemu 9 or newer (with patches)." >&2
+  exit 1
+fi
+
 # The QEMU machine and memory command line changed after QEMU 8.2.0 from
 # the coconut-svsm git repository.
 if (( QEMU_MAJOR >= 9 )); then
-  MACHINE=q35,confidential-guest-support=sev0,memory-backend=mem0,igvm-cfg=igvm0
+  case "$CGS" in
+    nocc)
+      SNP_GUEST="-object nocc,id=cgs0"
+      ;;
+    sev)
+      SNP_GUEST="-object sev-snp-guest,id=cgs0,cbitpos=$C_BIT_POS,reduced-phys-bits=1"
+      ;;
+    *)
+      echo "Error: Unexpected CGS value '$CGS'"
+      exit 1
+  esac
+  MACHINE=q35,confidential-guest-support=cgs0,memory-backend=mem0,igvm-cfg=igvm0
   MEMORY=memory-backend-memfd,size=8G,id=mem0,share=true,prealloc=false,reserve=false
-  SNP_GUEST="sev-snp-guest,id=sev0,cbitpos=$C_BIT_POS,reduced-phys-bits=1"
   IGVM_OBJ="-object igvm-cfg,id=igvm0,file=$IGVM"
 elif (( (QEMU_MAJOR > 8) || ((QEMU_MAJOR == 8) && (QEMU_MINOR >= 2)) )); then
   MACHINE=q35,confidential-guest-support=sev0,memory-backend=mem0
   MEMORY=memory-backend-memfd,size=8G,id=mem0,share=true,prealloc=false,reserve=false
-  SNP_GUEST="sev-snp-guest,id=sev0,cbitpos=$C_BIT_POS,reduced-phys-bits=1,init-flags=5,igvm-file=$IGVM"
+  SNP_GUEST="-object sev-snp-guest,id=sev0,cbitpos=$C_BIT_POS,reduced-phys-bits=1,init-flags=5,igvm-file=$IGVM"
   IGVM_OBJ=""
 else
   MACHINE=q35,confidential-guest-support=sev0,memory-backend=mem0,kvm-type=protected
   MEMORY=memory-backend-memfd-private,size=8G,id=mem0,share=true
-  SNP_GUEST="sev-snp-guest,id=sev0,cbitpos=$C_BIT_POS,reduced-phys-bits=1,init-flags=5,igvm-file=$IGVM"
+  SNP_GUEST="-object sev-snp-guest,id=sev0,cbitpos=$C_BIT_POS,reduced-phys-bits=1,init-flags=5,igvm-file=$IGVM"
   IGVM_OBJ=""
 fi
 
@@ -122,7 +142,7 @@ $SUDO_CMD \
     -machine $MACHINE \
     -object $MEMORY \
     $IGVM_OBJ \
-    -object $SNP_GUEST \
+    $SNP_GUEST \
     -smp 4 \
     -no-reboot \
     -netdev user,id=vmnic -device e1000,netdev=vmnic,romfile= \


### PR DESCRIPTION
Add the `-nocc` option to the Qemu launcher script to use the "native
mode", aka run on regular hardware without memory encryption.

