### PR TITLE
Use rust-toolchain.toml version in the CI and bump it to 1.84.1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,8 +19,11 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install specified rust toolchain
-        run: rustup toolchain install 1.84.0 -t x86_64-unknown-none --profile minimal -c rustfmt,rust-src,clippy
+      - name: Install rust toolchain
+        run: rustup toolchain install --profile minimal
+
+      - name: Add rust components
+        run: rustup component add rustfmt clippy rust-src
 
       - name: Check that Cargo.lock is up to date.
         run: cargo update --workspace --locked
@@ -96,8 +99,11 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install specified rust toolchain
-        run: rustup toolchain install 1.84.0 -t x86_64-unknown-none --profile minimal --force -c rustfmt,rust-src,clippy
+      - name: Install rust toolchain
+        run: rustup toolchain install --profile minimal
+
+      - name: Add rust components
+        run: rustup component add clippy
 
       - name: Install TPM 2.0 Reference Implementation build dependencies
         run: sudo apt install -y autoconf autoconf-archive pkg-config build-essential automake

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
           submodules: recursive
 
       - name: Install specified rust toolchain
-        run: rustup toolchain install 1.82.0 -t x86_64-unknown-none --profile minimal -c rustfmt,rust-src,clippy
+        run: rustup toolchain install 1.84.0 -t x86_64-unknown-none --profile minimal -c rustfmt,rust-src,clippy
 
       - name: Check that Cargo.lock is up to date.
         run: cargo update --workspace --locked
@@ -97,7 +97,7 @@ jobs:
           submodules: recursive
 
       - name: Install specified rust toolchain
-        run: rustup toolchain install 1.82.0 -t x86_64-unknown-none --profile minimal --force -c rustfmt,rust-src,clippy
+        run: rustup toolchain install 1.84.0 -t x86_64-unknown-none --profile minimal --force -c rustfmt,rust-src,clippy
 
       - name: Install TPM 2.0 Reference Implementation build dependencies
         run: sudo apt install -y autoconf autoconf-archive pkg-config build-essential automake

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,22 +20,13 @@ jobs:
           submodules: recursive
 
       - name: Install specified rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-            toolchain: '1.82.0'
-            target: x86_64-unknown-none
-            profile: minimal
-            override: true
-            components: rustfmt, rust-src, clippy
+        run: rustup toolchain install 1.82.0 -t x86_64-unknown-none --profile minimal -c rustfmt,rust-src,clippy
+
+      - name: Check that Cargo.lock is up to date.
+        run: cargo update --workspace --locked
 
       - name: Install TPM 2.0 Reference Implementation build dependencies
         run: sudo apt install -y autoconf autoconf-archive pkg-config build-essential automake
-
-      - name: Check that Cargo.lock is up to date
-        uses: actions-rs/cargo@v1
-        with:
-          command: update
-          args: --workspace --locked
 
       # ubuntu-latest does not have binutils 2.39, which we need for
       # ld to work, so build all the objects without performing the
@@ -47,42 +38,24 @@ jobs:
         run: make test
 
       - name: Format
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Clippy on no_std x86_64-unknown-none
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --workspace --exclude igvmbuilder --exclude igvmmeasure --exclude svsm-fuzz --exclude packit --exclude stage1 --all-features -- -D warnings
+        run: cargo clippy --workspace --exclude igvmbuilder --exclude igvmmeasure --exclude svsm-fuzz --exclude packit --exclude stage1 --all-features -- -D warnings
 
       - name: Clippy on std x86_64-unknown-linux-gnu
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --workspace --all-features --exclude svsm --exclude svsm-fuzz --exclude packit --exclude stage1 --target=x86_64-unknown-linux-gnu -- -D warnings
+        run: cargo clippy --workspace --all-features --exclude svsm --exclude svsm-fuzz --exclude packit --exclude stage1 --target=x86_64-unknown-linux-gnu -- -D warnings
 
       - name: Clippy on stage1
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --package stage1 --all-features --target=x86_64-unknown-linux-gnu -- -D warnings -C panic=abort
+        run: cargo clippy --package stage1 --all-features --target=x86_64-unknown-linux-gnu -- -D warnings -C panic=abort
 
       - name: Clippy on svsm-fuzz
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --package svsm-fuzz --all-features --target=x86_64-unknown-linux-gnu -- -D warnings
+        run: cargo clippy --package svsm-fuzz --all-features --target=x86_64-unknown-linux-gnu -- -D warnings
         env:
           RUSTFLAGS: --cfg fuzzing
 
       - name: Clippy on tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --workspace --exclude packit --exclude user* --all-features --tests --target=x86_64-unknown-linux-gnu -- -D warnings
+        run: cargo clippy --workspace --exclude packit --exclude user* --all-features --tests --target=x86_64-unknown-linux-gnu -- -D warnings
 
       - name: Check documentation
         run: make doc
@@ -98,13 +71,7 @@ jobs:
           submodules: recursive
 
       - name: Install latest nightly
-        uses: actions-rs/toolchain@v1
-        with:
-            toolchain: nightly
-            target: x86_64-unknown-none
-            profile: minimal
-            override: true
-            components: rustfmt
+        run: rustup toolchain install nightly -t x86_64-unknown-none --profile minimal --force -c rustfmt
 
       # release/src/git_version.rs is auto-generated via a build.rs file. Touch
       # it here to avoid CI failures.
@@ -112,10 +79,7 @@ jobs:
         run: echo "" > release/src/git_version.rs
 
       - name: Format doctests
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check --config "format_code_in_doc_comments=true"
+        run: cargo fmt --all -- --check --config "format_code_in_doc_comments=true"
 
   # Check for new undocumented unsafe blocks. This is to prevent them from
   # growing before we add comments for all of them and manage to enable
@@ -133,13 +97,7 @@ jobs:
           submodules: recursive
 
       - name: Install specified rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-            toolchain: '1.82.0'
-            target: x86_64-unknown-none
-            profile: minimal
-            override: true
-            components: rustfmt, rust-src, clippy
+        run: rustup toolchain install 1.82.0 -t x86_64-unknown-none --profile minimal --force -c rustfmt,rust-src,clippy
 
       - name: Install TPM 2.0 Reference Implementation build dependencies
         run: sudo apt install -y autoconf autoconf-archive pkg-config build-essential automake

--- a/elf/src/load_segments.rs
+++ b/elf/src/load_segments.rs
@@ -103,11 +103,7 @@ impl Elf64LoadSegments {
     /// Returns [`Some((phdr_index, offset))`] if the address range is found within a segment,
     /// where `phdr_index` is the program header index, and `offset` is the offset within
     pub fn lookup_vaddr_range(&self, range: &Elf64AddrRange) -> Option<(Elf64Half, Elf64Xword)> {
-        let i = self.find_first_not_before(range);
-        let i = match i {
-            Some(i) => i,
-            None => return None,
-        };
+        let i = self.find_first_not_before(range)?;
 
         let segment = &self.segments[i];
         if segment.0.vaddr_begin <= range.vaddr_begin && range.vaddr_end <= segment.0.vaddr_end {

--- a/igvmbuilder/src/igvm_firmware.rs
+++ b/igvmbuilder/src/igvm_firmware.rs
@@ -314,7 +314,7 @@ impl IgvmFirmware {
                     let e = format!("Memory map address {:#018x} is larger than 32 bits", gpa);
                     return Err(e.into());
                 }
-                let page_count = (parameter_area.number_of_bytes + PAGE_SIZE_4K - 1) / PAGE_SIZE_4K;
+                let page_count = parameter_area.number_of_bytes.div_ceil(PAGE_SIZE_4K);
                 // Truncate the page count if it is too large to fit into a
                 // 32-bit number.  It is acceptable for the SVSM to provide a
                 // smaller set of data than the firmware is capable of

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -2,7 +2,7 @@
 name = "svsm"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.82.0"
+rust-version = "1.84.0"
 
 [[bin]]
 name = "stage2"

--- a/kernel/src/cpu/ipi.rs
+++ b/kernel/src/cpu/ipi.rs
@@ -52,7 +52,7 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 /// processed simultaneously by multiple CPUs, requiring cross-thread
 /// synchronization.  `Sync` is not required for unicast messages, since those
 /// messages can only be processed by a single processor at a time.
-
+///
 /// The `IpiTarget` enum describes the set of CPUs that should receive a
 /// multicast IPI.  There are four variants.
 /// * `Single` indicates a single CPU, described by CPU index (*not* APIC ID).

--- a/kernel/src/debug/gdbstub.rs
+++ b/kernel/src/debug/gdbstub.rs
@@ -44,6 +44,8 @@ pub mod svsm_gdbstub {
     const INT3_INSTR: u8 = 0xcc;
     const MAX_BREAKPOINTS: usize = 32;
 
+    // The static mutable reference to the stack is protected by the GDB_STATE lock.
+    #[allow(static_mut_refs)]
     pub fn gdbstub_start(platform: &'static dyn SvsmPlatform) -> Result<(), u64> {
         unsafe {
             let mut target = GdbStubTarget::new();
@@ -55,7 +57,9 @@ pub mod svsm_gdbstub {
                 .run_state_machine(&mut target)
                 .expect("Failed to start GDB state machine");
             *GDB_STATE.lock() = Some(SvsmGdbStub { gdb, target });
-            GDB_STACK_TOP = GDB_STACK.as_mut_ptr().offset(GDB_STACK.len() as isize - 1) as u64;
+            GDB_STACK_TOP = GDB_STACK
+                .as_mut_ptr()
+                .offset(core::mem::size_of_val(&GDB_STACK) as isize - 1);
         }
         GDB_INITIALISED.store(true, Ordering::Relaxed);
         Ok(())
@@ -120,6 +124,9 @@ pub mod svsm_gdbstub {
                 }
             }
 
+            // SAFETY: swaps the stack with GDB_STACK_TOP, which is held uniquely mutably
+            // under the GDB_STACK_LOCK, and then sets the stack to the result of handle_stop,
+            // which is the expected behavior.
             unsafe {
                 asm!(
                     r#"
@@ -132,7 +139,7 @@ pub mod svsm_gdbstub {
                     in("rsi") exception_type as u64,
                     in("rdi") &mut task_ctx,
                     in("rdx") &mut gdb_state,
-                    in("rax") GDB_STACK_TOP,
+                    in("rax") GDB_STACK_TOP.expose_provenance(),
                     options(att_syntax));
             }
 
@@ -175,7 +182,7 @@ pub mod svsm_gdbstub {
     static mut PACKET_BUFFER: [u8; 4096] = [0; 4096];
     // Allocate the GDB stack as an array of u64's to ensure 8 byte alignment of the stack.
     static mut GDB_STACK: [u64; 8192] = [0; 8192];
-    static mut GDB_STACK_TOP: u64 = 0;
+    static mut GDB_STACK_TOP: *mut u64 = core::ptr::null_mut();
 
     struct GdbTaskContext {
         cr3: usize,

--- a/kernel/src/mm/alloc.rs
+++ b/kernel/src/mm/alloc.rs
@@ -2014,7 +2014,7 @@ mod test {
                 assert_eq!(layout.size(), size);
 
                 // Allocate four pages worth of objects from each Slab.
-                let n = (4 * PAGE_SIZE + size - 1) / size;
+                let n = (4 * PAGE_SIZE).div_ceil(size);
                 for _k in 0..n {
                     let p = unsafe { ALLOCATOR.alloc(layout) };
                     assert_ne!(p, ptr::null_mut());
@@ -2091,7 +2091,7 @@ mod test {
 
         let mut allocs: Vec<*mut u8> = Vec::new();
         let mut null_seen = false;
-        for _i in 0..((TEST_MEMORY_SIZE + OBJECT_SIZE - 1) / OBJECT_SIZE) {
+        for _i in 0..TEST_MEMORY_SIZE.div_ceil(OBJECT_SIZE) {
             let p = unsafe { ALLOCATOR.alloc(layout) };
             if p.is_null() {
                 null_seen = true;

--- a/kernel/src/mm/vm/mapping/api.rs
+++ b/kernel/src/mm/vm/mapping/api.rs
@@ -83,7 +83,7 @@ pub trait VirtualMapping: core::fmt::Debug {
     /// # Returns
     ///
     /// A combination of:
-
+    ///
     /// * PTEntryFlags::WRITABLE
     /// * PTEntryFlags::NX,
     /// * PTEntryFlags::ACCESSED

--- a/kernel/src/utils/immut_after_init.rs
+++ b/kernel/src/utils/immut_after_init.rs
@@ -175,7 +175,7 @@ unsafe impl<T: Send + Sync> Sync for ImmutAfterInitCell<T> {}
 
 /// A reference to a memory location which is effectively immutable after
 /// initalization code has run.
-
+///
 /// A `ImmutAfterInitRef` can either get initialized statically at link time or
 /// once from initialization code, basically following the protocol of a
 /// [`ImmutAfterInitCell`] itself:
@@ -208,13 +208,13 @@ unsafe impl<T: Send + Sync> Sync for ImmutAfterInitCell<T> {}
 /// from another `ImmutAfterInitRef`:
 /// ```
 /// # use svsm::utils::immut_after_init::ImmutAfterInitRef;
-/// static RX : ImmutAfterInitRef::<'static, i32> = ImmutAfterInitRef::uninit();
-//
-/// fn init_rx(r : ImmutAfterInitRef<'static, i32>) {
+/// static RX: ImmutAfterInitRef<'static, i32> = ImmutAfterInitRef::uninit();
+///
+/// fn init_rx(r: ImmutAfterInitRef<'static, i32>) {
 ///     unsafe { RX.init_from_ref(r.get()) };
 /// }
 ///
-/// static X : i32 = 123;
+/// static X: i32 = 123;
 ///
 /// fn main() {
 ///     let local = ImmutAfterInitRef::<i32>::uninit();
@@ -223,7 +223,6 @@ unsafe impl<T: Send + Sync> Sync for ImmutAfterInitCell<T> {}
 ///     assert_eq!(*RX, 123);
 /// }
 /// ```
-///
 #[derive(Debug)]
 pub struct ImmutAfterInitRef<'a, T: Copy> {
     #[doc(hidden)]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.82.0"
+channel = "1.84.0"
 targets = [ "x86_64-unknown-none" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.84.0"
+channel = "1.84.1"
 targets = [ "x86_64-unknown-none" ]

--- a/user/init/Cargo.toml
+++ b/user/init/Cargo.toml
@@ -3,6 +3,11 @@ name = "userinit"
 version = "0.1.0"
 edition = "2021"
 
+[[bin]]
+name = "init"
+path = "src/main.rs"
+test = false
+
 [dependencies]
 userlib.workspace = true
 

--- a/user/lib/src/lib.rs
+++ b/user/lib/src/lib.rs
@@ -10,6 +10,7 @@ pub mod console;
 pub mod locking;
 
 pub use console::*;
+#[cfg(not(test))]
 use core::panic::PanicInfo;
 pub use locking::*;
 pub use syscall::*;
@@ -28,6 +29,7 @@ macro_rules! declare_main {
     };
 }
 
+#[cfg(not(test))]
 #[panic_handler]
 fn panic(info: &PanicInfo<'_>) -> ! {
     println!("Panic: {}", info);


### PR DESCRIPTION
`rustup` will use the toolchain defined in rust-toolchain.toml if
no version is specified when installing a toolchain.

Without the specified version and using minimal profile, `rustup`
does not install the components specified with `-c`, so add another
step to install them. Also remove unnecessary components for the
`unsafe-check` job.

There is a patch release for the 1.84 toolchain, let's use it.

Based on #671