### PR TITLE
cpu: resolve safety issues with `PERCPU_AREAS`

### DIFF
--- a/kernel/src/cpu/apic.rs
+++ b/kernel/src/cpu/apic.rs
@@ -473,8 +473,7 @@ impl LocalApic {
         // Enumerate all CPUs to see which have APIC IDs that match the
         // requested destination. Skip the current CPU, since it was checked
         // above.
-        for cpu_ref in PERCPU_AREAS.iter() {
-            let cpu = cpu_ref.as_cpu_ref();
+        for cpu in PERCPU_AREAS.iter() {
             let this_apic_id = cpu.apic_id();
             if (this_apic_id != apic_id)
                 && Self::logical_destination_match(destination, this_apic_id)
@@ -547,8 +546,7 @@ impl LocalApic {
             // Enumerate all processors in the system except for the
             // current CPU and indicate that an IPI has been requested.
             let apic_id = this_cpu().get_apic_id();
-            for cpu_ref in PERCPU_AREAS.iter() {
-                let cpu = cpu_ref.as_cpu_ref();
+            for cpu in PERCPU_AREAS.iter() {
                 if cpu.apic_id() != apic_id {
                     Self::post_ipi_one_target(cpu, icr);
                 }

--- a/kernel/src/cpu/ipi.rs
+++ b/kernel/src/cpu/ipi.rs
@@ -382,10 +382,9 @@ pub fn send_ipi(
             let mut target_count: usize = 0;
             for cpu in PERCPU_AREAS.iter() {
                 // Ignore the current CPU and CPUs that are not online.
-                let cpu_shared = cpu.as_cpu_ref();
-                if cpu_shared.is_online() && cpu_shared.apic_id() != this_cpu().get_apic_id() {
+                if cpu.is_online() && cpu.apic_id() != this_cpu().get_apic_id() {
                     target_count += 1;
-                    cpu_shared.ipi_from(sender_cpu_index);
+                    cpu.ipi_from(sender_cpu_index);
                 }
             }
 


### PR DESCRIPTION
The `PERCPU_AREAS` structure is not multi-thread safe because it contains a `Vec` that is modified as additional CPUs are started.  This would be safe when executing in a single-processor environment, but as each processor is started, additional CPU state is pushed onto `PERCPU_AREAS`, causing it to continue to change even after other processors have started running.  In order for `PERCPU_AREAS` to be sound, it must be fully populated before any additional processor can begin running.