### PR TITLE
request: create all request processing tasks from the primary loop

### DIFF
--- a/kernel/src/cpu/ipi.rs
+++ b/kernel/src/cpu/ipi.rs
@@ -382,7 +382,7 @@ pub fn send_ipi(
             let mut target_count: usize = 0;
             for cpu in PERCPU_AREAS.iter() {
                 // Ignore the current CPU and CPUs that are not online.
-                if cpu.is_online() && cpu.apic_id() != this_cpu().get_apic_id() {
+                if cpu.is_online() && cpu.cpu_index() != this_cpu().get_cpu_index() {
                     target_count += 1;
                     cpu.ipi_from(sender_cpu_index);
                 }
@@ -606,7 +606,7 @@ mod tests {
             Self {
                 value,
                 drop_count,
-                cpu_index: this_cpu().shared().cpu_index(),
+                cpu_index: this_cpu().get_cpu_index(),
             }
         }
     }
@@ -616,7 +616,7 @@ mod tests {
             // Drop must only be called on the CPU that created the message.
             // Otherwise, the drop count reference may point to the wrong
             // data.
-            assert_eq!(this_cpu().shared().cpu_index(), self.cpu_index);
+            assert_eq!(this_cpu().get_cpu_index(), self.cpu_index);
             *self.drop_count += 1;
         }
     }

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -896,8 +896,8 @@ impl PerCpu {
         Ok(())
     }
 
-    pub fn setup_idle_task(&self, entry: extern "C" fn()) -> Result<(), SvsmError> {
-        let idle_task = Task::create(self, entry, String::from("idle"))?;
+    pub fn setup_idle_task(&self, entry: extern "C" fn(usize)) -> Result<(), SvsmError> {
+        let idle_task = Task::create(self, entry, self.shared.cpu_index, String::from("idle"))?;
         self.runqueue.lock_read().set_idle_task(idle_task);
         Ok(())
     }
@@ -1420,17 +1420,16 @@ pub fn current_task() -> TaskPointer {
     this_cpu().runqueue.lock_read().current_task()
 }
 
-#[no_mangle]
-pub extern "C" fn cpu_idle_loop() {
+pub extern "C" fn cpu_idle_loop(cpu_index: usize) {
+    debug_assert_eq!(cpu_index, this_cpu().get_cpu_index());
     // Start request processing on this CPU if required.
     if SVSM_PLATFORM.start_svsm_request_loop() {
         // Start request processing on this CPU.
-        let cpu_index = this_cpu().get_cpu_index();
         let processing_name = format!("request-processing on CPU {}", cpu_index);
-        start_kernel_task(request_processing_main, processing_name)
+        start_kernel_task(request_processing_main, cpu_index, processing_name)
             .expect("Failed to launch request processing task");
         let loop_name = format!("request-loop on CPU {}", cpu_index);
-        start_kernel_task(request_loop_main, loop_name)
+        start_kernel_task(request_loop_main, cpu_index, loop_name)
             .expect("Failed to launch request loop task");
     }
 

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -674,7 +674,7 @@ impl PerCpu {
     }
 
     pub fn get_cpu_index(&self) -> usize {
-        self.shared().cpu_index()
+        self.shared.cpu_index()
     }
 
     pub fn get_apic_id(&self) -> u32 {
@@ -995,13 +995,13 @@ impl PerCpu {
     }
 
     pub fn unmap_guest_vmsa(&self) {
-        assert!(self.shared().apic_id == this_cpu().get_apic_id());
+        assert!(self.shared().cpu_index == this_cpu().get_cpu_index());
         // Ignore errors - the mapping might or might not be there
         let _ = self.vm_range.remove(SVSM_PERCPU_VMSA_BASE);
     }
 
     pub fn map_guest_vmsa(&self, paddr: PhysAddr) -> Result<(), SvsmError> {
-        assert!(self.shared().apic_id == this_cpu().get_apic_id());
+        assert!(self.shared().cpu_index == this_cpu().get_cpu_index());
         let vmsa_mapping = Arc::new(VMPhysMem::new_mapping(paddr, PAGE_SIZE, true));
         self.vm_range
             .insert_at(SVSM_PERCPU_VMSA_BASE, vmsa_mapping)?;
@@ -1425,11 +1425,11 @@ pub extern "C" fn cpu_idle_loop() {
     // Start request processing on this CPU if required.
     if SVSM_PLATFORM.start_svsm_request_loop() {
         // Start request processing on this CPU.
-        let apic_id = this_cpu().get_apic_id();
-        let processing_name = format!("request-processing on CPU {}", apic_id);
+        let cpu_index = this_cpu().get_cpu_index();
+        let processing_name = format!("request-processing on CPU {}", cpu_index);
         start_kernel_task(request_processing_main, processing_name)
             .expect("Failed to launch request processing task");
-        let loop_name = format!("request-loop on CPU {}", apic_id);
+        let loop_name = format!("request-loop on CPU {}", cpu_index);
         start_kernel_task(request_loop_main, loop_name)
             .expect("Failed to launch request loop task");
     }

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -45,20 +45,16 @@ use crate::mm::{
     SVSM_STACK_IST_DF_BASE,
 };
 use crate::platform::{halt, SvsmPlatform, SVSM_PLATFORM};
-use crate::requests::{request_loop_main, request_processing_main};
 use crate::sev::ghcb::{GhcbPage, GHCB};
 use crate::sev::hv_doorbell::{allocate_hv_doorbell_page, HVDoorbell};
 use crate::sev::utils::RMPFlags;
 use crate::sev::vmsa::{VMSAControl, VmsaPage};
-use crate::task::{
-    schedule, schedule_task, start_kernel_task, RunQueue, Task, TaskPointer, WaitQueue,
-};
+use crate::task::{schedule, schedule_task, RunQueue, Task, TaskPointer, WaitQueue};
 use crate::types::{
     PAGE_SHIFT, PAGE_SHIFT_2M, PAGE_SIZE, PAGE_SIZE_2M, SVSM_TR_ATTRIBUTES, SVSM_TSS,
 };
 use crate::utils::MemoryRegion;
 use alloc::boxed::Box;
-use alloc::format;
 use alloc::string::String;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
@@ -122,6 +118,22 @@ impl PerCpuAreas {
         areas.push(percpu_shared);
 
         percpu_shared
+    }
+
+    pub fn len(&self) -> usize {
+        // SAFETY: it is safe to obtain a shared reference to the areas
+        // vector because callers attempting to mutate the vector guarantee
+        // that they cannot race with iteration.
+        let areas = unsafe { self.get_areas() };
+        areas.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        // SAFETY: it is safe to obtain a shared reference to the areas
+        // vector because callers attempting to mutate the vector guarantee
+        // that they cannot race with iteration.
+        let areas = unsafe { self.get_areas() };
+        areas.is_empty()
     }
 
     pub fn iter(&self) -> Iter<'_, &'static PerCpuShared> {
@@ -1422,16 +1434,6 @@ pub fn current_task() -> TaskPointer {
 
 pub extern "C" fn cpu_idle_loop(cpu_index: usize) {
     debug_assert_eq!(cpu_index, this_cpu().get_cpu_index());
-    // Start request processing on this CPU if required.
-    if SVSM_PLATFORM.start_svsm_request_loop() {
-        // Start request processing on this CPU.
-        let processing_name = format!("request-processing on CPU {}", cpu_index);
-        start_kernel_task(request_processing_main, cpu_index, processing_name)
-            .expect("Failed to launch request processing task");
-        let loop_name = format!("request-loop on CPU {}", cpu_index);
-        start_kernel_task(request_loop_main, cpu_index, loop_name)
-            .expect("Failed to launch request loop task");
-    }
 
     loop {
         // Go idle

--- a/kernel/src/cpu/smp.rs
+++ b/kernel/src/cpu/smp.rs
@@ -182,7 +182,7 @@ extern "C" fn start_ap() -> ! {
         .expect("Failed to allocate idle task for AP");
 
     // Send a life-sign
-    log::info!("AP with APIC-ID {} is online", this_cpu().get_apic_id());
+    log::info!("CPU {} is online", this_cpu().get_cpu_index());
 
     // Mark this CPU as participating in IPI usage.
     ipi_start_cpu();

--- a/kernel/src/hyperv/hv.rs
+++ b/kernel/src/hyperv/hv.rs
@@ -484,7 +484,7 @@ fn enable_vp_vtl_hypercall(
     let input_header = HvInputEnableVpVtl {
         partition_id: HV_PARTITION_ID_SELF,
         vtl,
-        vp_index: cpu.get_apic_id(),
+        vp_index: cpu.get_cpu_index().try_into().unwrap(),
         context: *context,
         ..Default::default()
     };
@@ -524,7 +524,7 @@ fn start_vp_hypercall(
     let input_header = HvInputStartVirtualProcessor {
         partition_id: HV_PARTITION_ID_SELF,
         vtl,
-        vp_index: cpu.get_apic_id(),
+        vp_index: cpu.get_cpu_index().try_into().unwrap(),
         context: *context,
         ..Default::default()
     };

--- a/kernel/src/mm/virtualrange.rs
+++ b/kernel/src/mm/virtualrange.rs
@@ -74,7 +74,7 @@ pub fn virt_log_usage() {
 
     log::info!(
         "[CPU {}] Virtual memory pages used: {} * 4K, {} * 2M",
-        this_cpu().get_apic_id(),
+        this_cpu().get_cpu_index(),
         this_cpu().vrange_4k.borrow().used_pages() - unused_cap_4k,
         this_cpu().vrange_2m.borrow().used_pages() - unused_cap_2m
     );

--- a/kernel/src/platform/tdp.rs
+++ b/kernel/src/platform/tdp.rs
@@ -46,11 +46,11 @@ pub struct TdMailbox {
 const _: () = assert!(mem::size_of::<TdMailbox>() + mem::size_of::<ApStartContext>() <= PAGE_SIZE);
 
 // SAFETY: caller must ensure `mailbox` points to a valid memory address.
-unsafe fn wakeup_ap(mailbox: *mut TdMailbox, index: usize) {
+unsafe fn wakeup_ap(mailbox: *mut TdMailbox, cpu_index: usize) {
     // SAFETY: caller must ensure the address is valid and not aliased.
     unsafe {
         // PerCpu's CPU index has a direct mapping to TD vCPU index
-        (*mailbox).vcpu_index = index.try_into().expect("CPU index too large");
+        (*mailbox).vcpu_index = cpu_index.try_into().unwrap();
     }
 }
 
@@ -266,7 +266,7 @@ impl SvsmPlatform for TdpPlatform {
             let size = mem::size_of::<ApStartContext>();
             let context_ptr = (mbx_va + PAGE_SIZE - size).as_mut_ptr::<ApStartContext>();
             ptr::copy_nonoverlapping(&ap_context, context_ptr, 1);
-            wakeup_ap(mbx_va.as_mut_ptr::<TdMailbox>(), cpu.shared().cpu_index());
+            wakeup_ap(mbx_va.as_mut_ptr::<TdMailbox>(), cpu.get_cpu_index());
         }
         Ok(())
     }

--- a/kernel/src/requests.rs
+++ b/kernel/src/requests.rs
@@ -149,13 +149,13 @@ fn check_requests() -> Result<bool, SvsmReqError> {
     }
 }
 
-#[no_mangle]
-pub extern "C" fn request_loop_main() {
+pub extern "C" fn request_loop_main(cpu_index: usize) {
+    debug_assert_eq!(cpu_index, this_cpu().get_cpu_index());
+
     // Suppress the use of IPIs before entering the guest, and ensure that all
     // other CPUs have done the same.
     wait_for_ipi_block();
 
-    let cpu_index = this_cpu().get_cpu_index();
     log::info!("Launching request loop task on CPU {}", cpu_index);
 
     loop {
@@ -244,9 +244,8 @@ pub extern "C" fn request_loop_main() {
     }
 }
 
-#[no_mangle]
-pub extern "C" fn request_processing_main() {
-    let cpu_index = this_cpu().get_cpu_index();
+pub extern "C" fn request_processing_main(cpu_index: usize) {
+    debug_assert_eq!(cpu_index, this_cpu().get_cpu_index());
     log::info!("Launching request-processing task on CPU {}", cpu_index);
 
     loop {

--- a/kernel/src/requests.rs
+++ b/kernel/src/requests.rs
@@ -155,8 +155,8 @@ pub extern "C" fn request_loop_main() {
     // other CPUs have done the same.
     wait_for_ipi_block();
 
-    let apic_id = this_cpu().get_apic_id();
-    log::info!("Launching request loop task on CPU {}", apic_id);
+    let cpu_index = this_cpu().get_cpu_index();
+    log::info!("Launching request loop task on CPU {}", cpu_index);
 
     loop {
         // Determine whether the guest is runnable.  If not, halt and wait for
@@ -246,9 +246,8 @@ pub extern "C" fn request_loop_main() {
 
 #[no_mangle]
 pub extern "C" fn request_processing_main() {
-    let apic_id = this_cpu().get_apic_id();
-
-    log::info!("Launching request-processing task on CPU {}", apic_id);
+    let cpu_index = this_cpu().get_cpu_index();
+    log::info!("Launching request-processing task on CPU {}", cpu_index);
 
     loop {
         wait_for_requests();

--- a/kernel/src/requests.rs
+++ b/kernel/src/requests.rs
@@ -4,8 +4,10 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
+extern crate alloc;
+
 use crate::cpu::ipi::wait_for_ipi_block;
-use crate::cpu::percpu::{process_requests, this_cpu, wait_for_requests};
+use crate::cpu::percpu::{process_requests, this_cpu, wait_for_requests, PERCPU_AREAS};
 use crate::cpu::{flush_tlb_global_sync, IrqGuard};
 use crate::error::SvsmError;
 use crate::mm::GuestPtr;
@@ -13,7 +15,7 @@ use crate::protocols::apic::apic_protocol_request;
 use crate::protocols::core::core_protocol_request;
 use crate::protocols::errors::{SvsmReqError, SvsmResultCode};
 use crate::sev::ghcb::switch_to_vmpl;
-use crate::task::go_idle;
+use crate::task::{go_idle, set_affinity, start_kernel_task};
 
 use crate::protocols::attest::attest_protocol_request;
 #[cfg(all(feature = "vtpm", not(test)))]
@@ -24,6 +26,8 @@ use crate::protocols::{
 use crate::sev::vmsa::VMSAControl;
 use crate::types::GUEST_VMPL;
 use cpuarch::vmsa::GuestVMExit;
+
+use alloc::format;
 
 /// The SVSM Calling Area (CAA)
 #[repr(C, packed)]
@@ -150,11 +154,30 @@ fn check_requests() -> Result<bool, SvsmReqError> {
 }
 
 pub extern "C" fn request_loop_main(cpu_index: usize) {
+    if cpu_index != 0 {
+        // Send this task to the correct CPU.
+        set_affinity(cpu_index);
+    } else {
+        // When starting the request loop on the BSP, start an additional
+        // request loop task for each other processor in the system.
+        let cpu_count = PERCPU_AREAS.len();
+        for task_index in 1..cpu_count {
+            let loop_name = format!("request-loop on CPU {}", task_index);
+            start_kernel_task(request_loop_main, task_index, loop_name)
+                .expect("Failed to launch request loop task");
+        }
+    }
+
     debug_assert_eq!(cpu_index, this_cpu().get_cpu_index());
 
     // Suppress the use of IPIs before entering the guest, and ensure that all
     // other CPUs have done the same.
     wait_for_ipi_block();
+
+    // Start the request processing task for this CPU.
+    let processing_name = format!("request-processing on CPU {}", cpu_index);
+    start_kernel_task(request_processing_main, cpu_index, processing_name)
+        .expect("Failed to launch request processing task");
 
     log::info!("Launching request loop task on CPU {}", cpu_index);
 

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -323,15 +323,6 @@ pub extern "C" fn svsm_main() {
     init_capabilities();
 
     let cpus = config.load_cpu_info().expect("Failed to load ACPI tables");
-    let mut nr_cpus = 0;
-
-    for cpu in cpus.iter() {
-        if cpu.enabled {
-            nr_cpus += 1;
-        }
-    }
-
-    log::info!("{} CPU(s) present", nr_cpus);
 
     start_secondary_cpus(&**SVSM_PLATFORM, &cpus);
 
@@ -377,7 +368,7 @@ fn panic(info: &PanicInfo<'_>) -> ! {
     if let Some(cpu) = try_this_cpu() {
         log::error!(
             "Panic on CPU[{}]! COCONUT-SVSM Version: {}",
-            cpu.get_apic_id(),
+            cpu.get_cpu_index(),
             COCONUT_VERSION
         );
     } else {

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -286,8 +286,9 @@ extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) -> ! {
     unreachable!("SVSM entry point terminated unexpectedly");
 }
 
-#[no_mangle]
-pub extern "C" fn svsm_main() {
+pub extern "C" fn svsm_main(cpu_index: usize) {
+    debug_assert_eq!(cpu_index, 0);
+
     // If required, the GDB stub can be started earlier, just after the console
     // is initialised in svsm_start() above.
     gdbstub_start(&**SVSM_PLATFORM).expect("Could not start GDB stub");
@@ -355,7 +356,7 @@ pub extern "C" fn svsm_main() {
         Err(e) => log::info!("Failed to launch /init: {e:#?}"),
     }
 
-    cpu_idle_loop();
+    cpu_idle_loop(cpu_index);
 }
 
 #[panic_handler]

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -11,8 +11,8 @@ mod waiting;
 
 pub use schedule::{
     create_user_task, current_task, current_task_terminated, finish_user_task, go_idle,
-    is_current_task, schedule, schedule_init, schedule_task, start_kernel_task, terminate,
-    RunQueue, TASKLIST,
+    is_current_task, schedule, schedule_init, schedule_task, set_affinity, start_kernel_task,
+    terminate, RunQueue, TASKLIST,
 };
 
 pub use tasks::{

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -259,9 +259,13 @@ pub static TASKLIST: SpinLock<TaskList> = SpinLock::new(TaskList::new());
 /// # Returns
 ///
 /// A new instance of [`TaskPointer`] on success, [`SvsmError`] on failure.
-pub fn start_kernel_task(entry: extern "C" fn(), name: String) -> Result<TaskPointer, SvsmError> {
+pub fn start_kernel_task(
+    entry: extern "C" fn(usize),
+    start_parameter: usize,
+    name: String,
+) -> Result<TaskPointer, SvsmError> {
     let cpu = this_cpu();
-    let task = Task::create(cpu, entry, name)?;
+    let task = Task::create(cpu, entry, start_parameter, name)?;
     TASKLIST.lock().list().push_back(task.clone());
 
     // Put task on the runqueue of this CPU

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -438,9 +438,9 @@ pub fn schedule() {
     // !!! Runqueue lock must be release here !!!
     if let Some((current, next)) = work {
         // Update per-cpu mappings if needed
-        let apic_id = this_cpu().get_apic_id();
+        let cpu_index = this_cpu().get_cpu_index();
 
-        if next.update_cpu(apic_id) != apic_id {
+        if next.update_cpu(cpu_index) != cpu_index {
             // Task has changed CPU, update per-cpu mappings
             let mut pt = next.page_table.lock();
             this_cpu().populate_page_table(&mut pt);

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -144,7 +144,7 @@ struct TaskSchedState {
     state: TaskState,
 
     /// CPU this task is currently assigned to
-    cpu: u32,
+    cpu_index: usize,
 }
 
 impl TaskSchedState {
@@ -341,7 +341,7 @@ impl Task {
             sched_state: RWLock::new(TaskSchedState {
                 idle_task: false,
                 state: TaskState::RUNNING,
-                cpu: cpu.get_apic_id(),
+                cpu_index: cpu.get_cpu_index(),
             }),
             name: args.name,
             id: TASK_ID_ALLOCATOR.next_id(),
@@ -437,11 +437,11 @@ impl Task {
         self.sched_state.lock_read().idle_task
     }
 
-    pub fn update_cpu(&self, new_cpu: u32) -> u32 {
+    pub fn update_cpu(&self, new_cpu_index: usize) -> usize {
         let mut state = self.sched_state.lock_write();
-        let old_cpu = state.cpu;
-        state.cpu = new_cpu;
-        old_cpu
+        let old_cpu_index = state.cpu_index;
+        state.cpu_index = new_cpu_index;
+        old_cpu_index
     }
 
     pub fn handle_pf(&self, vaddr: VirtAddr, write: bool) -> Result<(), SvsmError> {

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -41,7 +41,7 @@ use crate::utils::bitmap_allocator::{BitmapAllocator, BitmapAllocator1024};
 use crate::utils::{is_aligned, MemoryRegion};
 use intrusive_collections::{intrusive_adapter, LinkedListAtomicLink};
 
-use super::schedule::{current_task_terminated, schedule};
+use super::schedule::{after_task_switch, current_task_terminated, schedule};
 
 pub static KTASK_VADDR_BITMAP: SpinLock<BitmapAllocator1024> =
     SpinLock::new(BitmapAllocator1024::new_empty());
@@ -827,6 +827,9 @@ unsafe fn setup_new_task_common(xsa_addr: u64) {
     // is dropped, re-enabling IRQs.
 
     irqs_enable();
+
+    // Perform housekeeping actions following a task switch.
+    after_task_switch();
 
     // SAFETY: The caller takes responsibility for the correctness of the save
     // area address.

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -239,6 +239,9 @@ struct CreateTaskArguments {
     // address, and for kernel tasks, it is a kernel address,
     entry: usize,
 
+    // A start parameter for kernel tasks.
+    start_parameter: usize,
+
     // The name of the task.
     name: String,
 
@@ -312,7 +315,7 @@ impl Task {
         let (stack, raw_bounds, rsp_offset) = if args.vm_user_range.is_some() {
             Self::allocate_utask_stack(cpu, args.entry, xsa_addr)?
         } else {
-            Self::allocate_ktask_stack(cpu, args.entry, xsa_addr)?
+            Self::allocate_ktask_stack(cpu, args.entry, xsa_addr, args.start_parameter)?
         };
         let stack_start = vaddr_region.start() + SVSM_PERTASK_STACK_BASE_OFFSET;
         vm_kernel_range.insert_at(stack_start, stack)?;
@@ -354,11 +357,13 @@ impl Task {
 
     pub fn create(
         cpu: &PerCpu,
-        entry: extern "C" fn(),
+        entry: extern "C" fn(usize),
+        start_parameter: usize,
         name: String,
     ) -> Result<TaskPointer, SvsmError> {
         let create_args = CreateTaskArguments {
             entry: entry as usize,
+            start_parameter,
             name,
             vm_user_range: None,
             rootdir: opendir("/")?,
@@ -380,6 +385,7 @@ impl Task {
         }
         let create_args = CreateTaskArguments {
             entry: user_entry,
+            start_parameter: 0,
             name,
             vm_user_range: Some(vm_user_range),
             rootdir: root,
@@ -473,6 +479,7 @@ impl Task {
         cpu: &PerCpu,
         entry: usize,
         xsa_addr: usize,
+        start_parameter: usize,
     ) -> Result<(Arc<Mapping>, MemoryRegion<VirtAddr>, usize), SvsmError> {
         let (mapping, bounds) = Task::allocate_stack_common()?;
 
@@ -509,6 +516,8 @@ impl Task {
             (*task_context).regs.rdi = entry;
             // xsave area addr
             (*task_context).regs.rsi = xsa_addr;
+            // start argument parameter.
+            (*task_context).regs.rdx = start_parameter;
             (*task_context).ret_addr = run_kernel_task as *const () as u64;
             // Task termination handler for when entry point returns
             stack_ptr.cast::<u64>().write(task_exit as *const () as u64);
@@ -826,13 +835,13 @@ unsafe fn setup_new_task_common(xsa_addr: u64) {
     }
 }
 
-extern "C" fn run_kernel_task(entry: extern "C" fn(), xsa_addr: u64) {
+extern "C" fn run_kernel_task(entry: extern "C" fn(usize), xsa_addr: u64, start_parameter: usize) {
     // SAFETY: the save area address is provided by the context switch assembly
     // code.
     unsafe {
         setup_new_task_common(xsa_addr);
     }
-    entry();
+    entry(start_parameter);
 }
 
 extern "C" fn task_exit() {
@@ -937,17 +946,19 @@ mod tests {
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn test_fpu_context_switch() {
-        start_kernel_task(task1, String::from("task1"))
+        start_kernel_task(task1, 1, String::from("task1"))
             .expect("Failed to launch request processing task");
     }
 
-    extern "C" fn task1() {
+    extern "C" fn task1(start_parameter: usize) {
+        assert_eq!(start_parameter, 1);
+
         let ret: u64;
         unsafe {
             asm!("call test_fpu", options(att_syntax));
         }
 
-        start_kernel_task(task2, String::from("task2"))
+        start_kernel_task(task2, 2, String::from("task2"))
             .expect("Failed to launch request processing task");
 
         unsafe {
@@ -956,7 +967,8 @@ mod tests {
         assert_eq!(ret, 0);
     }
 
-    extern "C" fn task2() {
+    extern "C" fn task2(start_parameter: usize) {
+        assert_eq!(start_parameter, 2);
         unsafe {
             asm!("call alter_fpu", options(att_syntax));
         }


### PR DESCRIPTION
This change modifies the request processing loop startup process to create a single request processing task (when the configuration requires it), and that single task starts all other request processing tasks, with affinity to each vCPU as necessary.  This models the behavior that will be used when request processing is moved out of the kernel and into a user-mode process.