### PR TITLE
Add verification for page frame allocator with safe permission-based memory access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1915,6 +1915,7 @@ dependencies = [
  "bitflags 2.9.1",
  "bootlib",
  "builtin",
+ "builtin_macros",
  "cocoon-tpm-crypto",
  "cocoon-tpm-tpm2-interface",
  "cocoon-tpm-utils-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2284,6 +2284,7 @@ dependencies = [
  "builtin_macros",
  "paste",
  "seq-macro",
+ "state_machines_macros",
  "vstd",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ zerocopy = { version = "0.8.2", features = ["derive"] }
 # Verus repos
 builtin = { git = "https://github.com/verus-lang/verus", rev ="6c66898", default-features = false }
 builtin_macros = { git = "https://github.com/verus-lang/verus", rev ="6c66898", default-features = false }
+state_machines_macros = { git = "https://github.com/verus-lang/verus", rev ="6c66898", default-features = false }
 vstd = { git = "https://github.com/verus-lang/verus", rev ="6c66898", features = ["alloc"], default-features = false }
 
 # Verification libs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,9 +85,9 @@ zerocopy = { version = "0.8.2", features = ["derive"] }
 
 # Verus repos
 builtin = { git = "https://github.com/verus-lang/verus", rev ="6c66898", default-features = false }
-builtin_macros = { git = "https://github.com/verus-lang/verus", rev ="6c66898", default-features = false }
+builtin_macros = { git = "https://github.com/verus-lang/verus", rev ="6c66898", features = ["vpanic"], default-features = false }
 state_machines_macros = { git = "https://github.com/verus-lang/verus", rev ="6c66898", default-features = false }
-vstd = { git = "https://github.com/verus-lang/verus", rev ="6c66898", features = ["alloc"], default-features = false }
+vstd = { git = "https://github.com/verus-lang/verus", rev ="6c66898", features = ["alloc", "allow_panic"], default-features = false }
 
 # Verification libs
 verify_proof = { path = "verify_proof", default-features = false  }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -61,6 +61,7 @@ uuid.workspace = true
 virtio-drivers = { workspace = true, optional = true }
 
 builtin = { workspace = true, optional = true }
+builtin_macros = { workspace = true, optional = true }
 vstd = { workspace = true, optional = true}
 verify_proof = { workspace = true, optional = true}
 verify_external = { workspace = true, optional = true}
@@ -77,7 +78,7 @@ enable-gdb = ["dep:gdbstub", "dep:gdbstub_arch"]
 vtpm = ["dep:libtcgtpm"]
 nosmep = []
 nosmap = []
-verus_all = ["builtin", "vstd", "verify_proof/verus", "verify_external/verus", "verus_stub/disable"]
+verus_all = ["builtin", "builtin_macros", "vstd", "verify_proof/verus", "verify_external/verus", "verus_stub/disable"]
 verus = ["verus_all", "verify_proof/noverify", "verify_external/noverify"]
 noverify = []
 virtio-drivers = ["dep:virtio-drivers"]

--- a/kernel/src/address.rs
+++ b/kernel/src/address.rs
@@ -358,12 +358,22 @@ impl VirtAddr {
 
     #[inline]
     #[verus_verify(external_body)]
+    #[verus_spec(ret =>
+        with Tracked(provenance): Tracked<vstd::raw_ptr::IsExposed>
+        ensures
+            ret == ptr_from_data::<T>(PtrData { addr: self@, provenance: provenance@, metadata: () }),
+    )]
     pub fn as_ptr<T>(&self) -> *const T {
         self.0 as *const T
     }
 
     #[inline]
     #[verus_verify(external_body)]
+    #[verus_spec(ret =>
+        with Tracked(provenance): Tracked<vstd::raw_ptr::IsExposed>
+        ensures
+            ret == ptr_mut_from_data::<T>(PtrData { addr: self@, provenance: provenance@, metadata: () }),
+    )]
     pub fn as_mut_ptr<T>(&self) -> *mut T {
         self.0 as *mut T
     }

--- a/kernel/src/address.rs
+++ b/kernel/src/address.rs
@@ -364,7 +364,7 @@ impl VirtAddr {
             ret == ptr_from_data::<T>(PtrData { addr: self@, provenance: provenance@, metadata: () }),
     )]
     pub fn as_ptr<T>(&self) -> *const T {
-        self.0 as *const T
+        core::ptr::with_exposed_provenance(self.0)
     }
 
     #[inline]
@@ -375,7 +375,7 @@ impl VirtAddr {
             ret == ptr_mut_from_data::<T>(PtrData { addr: self@, provenance: provenance@, metadata: () }),
     )]
     pub fn as_mut_ptr<T>(&self) -> *mut T {
-        self.0 as *mut T
+        core::ptr::with_exposed_provenance_mut(self.0)
     }
 
     #[inline]

--- a/kernel/src/address.verus.rs
+++ b/kernel/src/address.verus.rs
@@ -9,6 +9,7 @@ use crate::utils::util::{
 };
 use verify_external::convert::{exists_into, forall_into, FromSpec};
 use verify_external::hw_spec::SpecVAddrImpl;
+use vstd::raw_ptr::{ptr_from_data, ptr_mut_from_data, PtrData};
 use vstd::set_lib::set_int_range;
 use vstd::std_specs::cmp::PartialOrdSpec;
 use vstd::std_specs::ops::AddSpec;
@@ -402,6 +403,7 @@ impl vstd::std_specs::ops::AddSpecImpl<InnerAddr> for PhysAddr {
     }
 }
 
+/// Assumptions for PartialOrd since it is derived.
 impl vstd::std_specs::cmp::PartialOrdSpecImpl<VirtAddr> for VirtAddr {
     open spec fn obeys_partial_cmp_spec() -> bool {
         true
@@ -412,6 +414,7 @@ impl vstd::std_specs::cmp::PartialOrdSpecImpl<VirtAddr> for VirtAddr {
     }
 }
 
+/// Assumptions for PartialOrd since it is derived.
 impl vstd::std_specs::cmp::PartialOrdSpecImpl<PhysAddr> for PhysAddr {
     open spec fn obeys_partial_cmp_spec() -> bool {
         true
@@ -419,6 +422,42 @@ impl vstd::std_specs::cmp::PartialOrdSpecImpl<PhysAddr> for PhysAddr {
 
     open spec fn partial_cmp_spec(&self, other: &PhysAddr) -> Option<core::cmp::Ordering> {
         PartialOrdSpec::partial_cmp_spec(&self@, &other@)
+    }
+}
+
+/// Assumptions for PartialEq since it is derived.
+pub assume_specification[ <VirtAddr as PartialEq<VirtAddr>>::eq ](
+    x: &VirtAddr,
+    y: &VirtAddr,
+) -> bool
+;
+
+/// Assumptions for PartialEq since it is derived.
+impl vstd::std_specs::cmp::PartialEqSpecImpl<VirtAddr> for VirtAddr {
+    open spec fn obeys_eq_spec() -> bool {
+        true
+    }
+
+    open spec fn eq_spec(&self, other: &VirtAddr) -> bool {
+        self@ == other@
+    }
+}
+
+/// Assumptions for PartialEq since it is derived.
+pub assume_specification[ <PhysAddr as PartialEq<PhysAddr>>::eq ](
+    x: &PhysAddr,
+    y: &PhysAddr,
+) -> bool
+;
+
+/// Assumptions for PartialEq since it is derived.
+impl vstd::std_specs::cmp::PartialEqSpecImpl<PhysAddr> for PhysAddr {
+    open spec fn obeys_eq_spec() -> bool {
+        true
+    }
+
+    open spec fn eq_spec(&self, other: &PhysAddr) -> bool {
+        self@ == other@
     }
 }
 

--- a/kernel/src/address_inner.verus.rs
+++ b/kernel/src/address_inner.verus.rs
@@ -18,7 +18,16 @@ pub spec const VADDR_MAX_BITS: nat = 48;
 pub spec const VADDR_LOWER_MASK: InnerAddr = 0x7fff_ffff_ffff as InnerAddr;
 
 #[verifier(inline)]
-pub spec const VADDR_UPPER_MASK: InnerAddr = !VADDR_LOWER_MASK;
+pub spec const VADDR_UPPER_MASK: InnerAddr = 0xffff_8000_0000_0000u64 as InnerAddr;
+
+// Prove the relationship among max_bits, upper and lower masks.
+proof fn lemma_bit_mask_relationship()
+    ensures
+        VADDR_UPPER_MASK == !VADDR_LOWER_MASK,
+        VADDR_LOWER_MASK == (1usize << (VADDR_MAX_BITS - 1) as usize) - 1,
+{
+    assert(VADDR_UPPER_MASK == !VADDR_LOWER_MASK) by (bit_vector);
+}
 
 #[verifier(inline)]
 pub spec const VADDR_RANGE_SIZE: InnerAddr = 0x1_0000_0000_0000u64 as InnerAddr;

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -9,6 +9,7 @@
 #![cfg_attr(all(test, test_in_svsm), feature(custom_test_frameworks))]
 #![cfg_attr(all(test, test_in_svsm), test_runner(crate::testing::svsm_test_runner))]
 #![cfg_attr(all(test, test_in_svsm), reexport_test_harness_main = "test_main")]
+#![cfg_attr(verus_keep_ghost, feature(proc_macro_hygiene))]
 
 pub mod acpi;
 pub mod address;

--- a/kernel/src/mm/address_space.rs
+++ b/kernel/src/mm/address_space.rs
@@ -8,6 +8,11 @@ use crate::address::{PhysAddr, VirtAddr};
 use crate::mm::pagetable::{PageFrame, PageTable};
 use crate::utils::immut_after_init::ImmutAfterInitCell;
 
+use verus_stub::*;
+#[cfg(verus_keep_ghost)]
+include!("address_space.verus.rs");
+
+#[verus_verify]
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(not(any(test, target_os = "none")), expect(dead_code))]
 pub struct FixedAddressMappingRange {
@@ -17,6 +22,12 @@ pub struct FixedAddressMappingRange {
 }
 
 impl FixedAddressMappingRange {
+    #[verus_spec(ret =>
+        requires
+            Self::req_new(virt_start, virt_end, phys_start),
+        ensures
+            ret@ == LinearMap::spec_new(virt_start, virt_end, phys_start)
+    )]
     pub fn new(virt_start: VirtAddr, virt_end: VirtAddr, phys_start: PhysAddr) -> Self {
         Self {
             virt_start,
@@ -26,12 +37,17 @@ impl FixedAddressMappingRange {
     }
 
     #[cfg(target_os = "none")]
+    #[verus_spec(ret =>
+        ensures
+            ret == self@.spec_phys_to_virt(paddr@ as int)
+    )]
     fn phys_to_virt(&self, paddr: PhysAddr) -> Option<VirtAddr> {
+        proof! {self.use_type_invariant();}
         if paddr < self.phys_start {
             None
         } else {
             let size: usize = self.virt_end - self.virt_start;
-            if paddr >= self.phys_start + size {
+            if paddr - self.phys_start >= size {
                 None
             } else {
                 let offset: usize = paddr - self.phys_start;

--- a/kernel/src/mm/address_space.verus.rs
+++ b/kernel/src/mm/address_space.verus.rs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Ziqiao Zhou <ziqiaozhou@microsoft.com>
+//
+// This module defines specification helper functions to verify the correct use of memory.
+//
+// Trusted Assumptions:
+// - hw_spec::SpecMemMapTr is correct
+// Proofs:
+// - FixedAddressMappingRange is viewed as LinearMap
+// - LinearMap satisfies all properties in hw_spec::SpecMemMapTr
+use verify_external::convert::FromSpec;
+use verify_external::hw_spec::SpecMemMapTr;
+
+use crate::address::VADDR_RANGE_SIZE;
+
+mod address_space_spec {
+    use super::*;
+    include!("address_space_spec.verus.rs");
+}
+
+pub use address_space_spec::LinearMap;
+
+verus! {
+
+impl FixedAddressMappingRange {
+    pub closed spec fn view(&self) -> LinearMap {
+        LinearMap::spec_new(self.virt_start, self.virt_end, self.phys_start)
+    }
+
+    pub open spec fn req_new(
+        virt_start: VirtAddr,
+        virt_end: VirtAddr,
+        phys_start: PhysAddr,
+    ) -> bool {
+        &&& virt_start@ % crate::types::PAGE_SIZE == phys_start@ % crate::types::PAGE_SIZE
+        &&& virt_end@ > virt_start@
+        &&& virt_end@ - virt_start@ + phys_start@ < usize::MAX + 1
+    }
+
+    #[verifier::type_invariant]
+    pub closed spec fn wf(&self) -> bool {
+        &&& Self::req_new(self.virt_start, self.virt_end, self.phys_start)
+    }
+
+    pub proof fn use_type_invariant(tracked &self)
+        ensures
+            self@.wf(),
+            self.wf(),
+    {
+        broadcast use verify_proof::bits::lemma_bit_usize_shl_values;
+
+        use_type_invariant(self);
+        use_type_invariant(self.virt_start);
+        use_type_invariant(self.virt_end);
+        assert(crate::address::VADDR_UPPER_MASK == 0xffff_8000_0000_0000) by (compute);
+        reveal(LinearMap::wf_virt_phy_page);
+    }
+}
+
+} // verus!

--- a/kernel/src/mm/address_space_spec.verus.rs
+++ b/kernel/src/mm/address_space_spec.verus.rs
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Ziqiao Zhou <ziqiaozhou@microsoft.com>
+//
+// This module defines specification helper functions to verify the correct use of memory.
+//
+// Trusted Assumptions:
+// - hw_spec::SpecMemMapTr is correct
+// Proofs:
+// - LinearMap satisfy all properties in hw_spec::SpecMemMapTr
+verus! {
+
+#[allow(missing_debug_implementations)]
+pub ghost struct LinearMap {
+    pub virt_start: VirtAddr,
+    pub phys_start: int,
+    pub size: nat,
+}
+
+impl LinearMap {
+    pub open spec fn is_identity_map(&self) -> bool {
+        self.virt_start@ == VirtAddr::from_spec(self.phys_start as usize)@
+    }
+
+    pub open spec fn spec_phys_to_virt(&self, paddr: int) -> Option<VirtAddr> {
+        let offset = paddr - self.phys_start;
+        if 0 <= offset < self.size && (self.virt_start.offset() + offset < VADDR_RANGE_SIZE) {
+            let inner = (self.virt_start.offset() + offset) as usize;
+            Some(VirtAddr::from_spec(inner))
+        } else {
+            None
+        }
+    }
+
+    pub open spec fn spec_virt_to_phys(&self, vaddr: VirtAddr) -> Option<int> {
+        let offset = vaddr.offset() - self.virt_start.offset();
+        if 0 <= offset < self.size && (self.virt_start.offset() + offset < VADDR_RANGE_SIZE)
+            && self.virt_start.is_canonical() && vaddr.is_canonical() {
+            Some(self.phys_start + offset)
+        } else {
+            None
+        }
+    }
+
+    pub open spec fn spec_new(
+        virt_start: VirtAddr,
+        virt_end: VirtAddr,
+        phys_start: PhysAddr,
+    ) -> LinearMap {
+        LinearMap {
+            virt_start: virt_start,
+            phys_start: phys_start@ as int,
+            size: (virt_end.offset() - virt_start.offset()) as nat,
+        }
+    }
+
+    #[verifier(opaque)]
+    pub open spec fn wf_virt_phy_page(&self) -> bool {
+        self.virt_start@ % crate::types::PAGE_SIZE == self.phys_start
+            % crate::types::PAGE_SIZE as int
+    }
+
+    pub open spec fn wf(&self) -> bool {
+        &&& self.wf_virt_phy_page()
+        &&& self.virt_start.is_canonical()
+        &&& self.virt_start.offset() + self.size <= crate::address::VADDR_RANGE_SIZE
+        &&& self.phys_start + self.size <= usize::MAX + 1
+    }
+
+    pub open spec fn try_get_virt(&self, pfn: usize) -> Option<VirtAddr> {
+        let phy = self.phys_start + pfn * crate::types::PAGE_SIZE;
+        self.to_vaddr(phy)
+    }
+
+    pub proof fn lemma_get_virt(&self, pfn: usize) -> (ret: VirtAddr)
+        requires
+            self.wf(),
+            pfn < self.size / crate::types::PAGE_SIZE as nat,
+        ensures
+            ret == self.try_get_virt(pfn).unwrap(),
+            self.try_get_virt(pfn).is_some(),
+            ret.is_canonical(),
+            ret.offset() == self.virt_start.offset() + (pfn * crate::types::PAGE_SIZE),
+            ret == VirtAddr::from_spec(
+                (self.virt_start.offset() + (pfn * crate::types::PAGE_SIZE)) as usize,
+            ),
+    {
+        broadcast use crate::types::lemma_page_size;
+
+        reveal(<LinearMap as SpecMemMapTr>::to_vaddr);
+        VirtAddr::lemma_wf((self.virt_start.offset() + (pfn * crate::types::PAGE_SIZE)) as usize);
+        self.try_get_virt(pfn).unwrap()
+    }
+
+    pub broadcast proof fn lemma_get_paddr(&self, vaddr: VirtAddr)
+        requires
+            self.wf(),
+            vaddr.is_canonical(),
+            self.virt_start.offset() <= vaddr.offset() < self.virt_start.offset() + self.size,
+        ensures
+            (#[trigger] self.to_paddr(vaddr)).is_some(),
+            self.phys_start <= self.to_paddr(vaddr).unwrap() <= self.phys_start + self.size,
+    {
+        reveal(<LinearMap as SpecMemMapTr>::to_paddr);
+    }
+
+    pub open spec fn get_pfn(&self, vaddr: VirtAddr) -> Option<usize> {
+        if let Some(paddr) = self.to_paddr(vaddr) {
+            Some(((paddr - self.phys_start) / crate::types::PAGE_SIZE as int) as usize)
+        } else {
+            None
+        }
+    }
+
+    pub broadcast proof fn lemma_get_pfn_get_virt(&self, vaddr: VirtAddr)
+        requires
+            self.wf(),
+            vaddr.is_canonical(),
+            self.virt_start.offset() <= vaddr.offset() < self.virt_start.offset() + self.size,
+        ensures
+            (self.virt_start@ % 0x1000 == 0) && (vaddr@ % 0x1000 == 0) ==> (#[trigger] self.get_pfn(
+                vaddr,
+            )).is_some() ==> self.try_get_virt(self.get_pfn(vaddr).unwrap()) == Some(vaddr),
+            (#[trigger] self.get_pfn(vaddr)).is_some() ==> self.try_get_virt(
+                self.get_pfn(vaddr).unwrap(),
+            ).is_some(),
+    {
+        broadcast use crate::types::lemma_page_size;
+
+        reveal(<LinearMap as SpecMemMapTr>::to_paddr);
+        reveal(<LinearMap as SpecMemMapTr>::to_vaddr);
+        if vaddr@ % 0x1000 == 0 && self.virt_start@ % 0x1000 == 0 {
+            assert(vaddr.offset() - self.virt_start.offset() == (vaddr.offset()
+                - self.virt_start.offset()) / 0x1000 * 0x1000) by {
+                vaddr.property_canonical();
+                self.virt_start.property_canonical();
+                assert(self.virt_start.offset() % 0x1000 == 0);
+                broadcast use verify_proof::bits::lemma_bit_usize_not_is_sub;
+
+            }
+        }
+        self.proof_one_to_one_mapping_vaddr(vaddr);
+    }
+}
+
+impl SpecMemMapTr for LinearMap {
+    type VAddr = VirtAddr;
+
+    type PAddr = int;
+
+    open spec fn to_vaddrs(&self, paddr: int) -> Set<VirtAddr> {
+        let s = self.to_vaddr(paddr);
+        if s.is_some() {
+            Set::empty().insert(s.unwrap())
+        } else {
+            Set::empty()
+        }
+    }
+
+    #[verifier(opaque)]
+    open spec fn to_vaddr(&self, paddr: int) -> Option<VirtAddr> {
+        if self.virt_start.is_canonical() {
+            self.spec_phys_to_virt(paddr)
+        } else {
+            None
+        }
+    }
+
+    #[verifier(opaque)]
+    open spec fn to_paddr(&self, vaddr: VirtAddr) -> Option<int> {
+        if self.virt_start.is_canonical() && vaddr.is_canonical() {
+            self.spec_virt_to_phys(vaddr)
+        } else {
+            None
+        }
+    }
+
+    open spec fn is_one_to_one_mapping(&self) -> bool {
+        true
+    }
+
+    proof fn proof_one_to_one_mapping(&self, paddr: Self::PAddr) {
+        reveal(<LinearMap as SpecMemMapTr>::to_vaddr);
+        reveal(<LinearMap as SpecMemMapTr>::to_paddr);
+        let offset = paddr - self.phys_start;
+        let inner = (self.virt_start.offset() + offset) as usize;
+        VirtAddr::lemma_wf(inner);
+    }
+
+    proof fn proof_one_to_one_mapping_vaddr(&self, vaddr: Self::VAddr) {
+        reveal(<LinearMap as SpecMemMapTr>::to_vaddr);
+        reveal(<LinearMap as SpecMemMapTr>::to_paddr);
+        if self.to_paddr(vaddr).is_some() {
+            self.proof_correct_mapping_vaddr(vaddr);
+        }
+    }
+
+    proof fn proof_correct_mapping_vaddr(&self, addr: Self::VAddr) {
+        reveal(<LinearMap as SpecMemMapTr>::to_vaddr);
+        reveal(<LinearMap as SpecMemMapTr>::to_paddr);
+        let offset = self.to_paddr(addr).unwrap() - self.phys_start;
+        let inner = (self.virt_start.offset() + offset) as usize;
+        addr.property_canonical();
+    }
+
+    proof fn proof_correct_mapping_paddr(&self, paddr: Self::PAddr) {
+        reveal(<LinearMap as SpecMemMapTr>::to_vaddr);
+        reveal(<LinearMap as SpecMemMapTr>::to_vaddrs);
+        reveal(<LinearMap as SpecMemMapTr>::to_paddr);
+        assert(Set::empty().insert(self.to_vaddr(paddr).unwrap()).contains(
+            self.to_vaddr(paddr).unwrap(),
+        ));
+        if self.to_vaddr(paddr).is_some() {
+            assert(self.to_vaddrs(paddr).contains(self.to_vaddr(paddr).unwrap()));
+        }
+        assert(Set::<VirtAddr>::empty().is_empty());
+        VirtAddr::lemma_wf((self.virt_start.offset() + paddr - self.phys_start) as usize);
+    }
+
+    proof fn proof_correct_mapping_addrs(&self, paddr: Self::PAddr, vaddr: Self::VAddr) {
+        reveal(<LinearMap as SpecMemMapTr>::to_vaddr);
+        reveal(<LinearMap as SpecMemMapTr>::to_vaddrs);
+        reveal(<LinearMap as SpecMemMapTr>::to_paddr);
+        VirtAddr::lemma_wf((self.virt_start.offset() + paddr - self.phys_start) as usize);
+    }
+}
+
+} // verus!

--- a/kernel/src/mm/alloc.rs
+++ b/kernel/src/mm/alloc.rs
@@ -19,6 +19,9 @@ use core::{cmp, ptr, slice};
 #[cfg(any(test, fuzzing))]
 use crate::locking::LockGuard;
 
+#[cfg(verus_keep_ghost)]
+include!("alloc.verus.rs");
+
 /// Represents possible errors that can occur during memory allocation.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AllocError {

--- a/kernel/src/mm/alloc.rs
+++ b/kernel/src/mm/alloc.rs
@@ -104,7 +104,6 @@ impl PageStorageType {
     const TYPE_SHIFT: u64 = 4;
     const TYPE_MASK: u64 = (1u64 << Self::TYPE_SHIFT) - 1;
     const NEXT_SHIFT: u64 = 12;
-    const NEXT_MASK: u64 = !((1u64 << Self::NEXT_SHIFT) - 1);
     const ORDER_MASK: u64 = (1u64 << (Self::NEXT_SHIFT - Self::TYPE_SHIFT)) - 1;
     // Slab item sizes are encoded in a u16
     const SLAB_MASK: u64 = 0xffff;
@@ -182,7 +181,7 @@ impl PageStorageType {
 
     /// Decodes the index of the next page.
     fn decode_next(&self) -> usize {
-        ((self.0 & Self::NEXT_MASK) >> Self::NEXT_SHIFT) as usize
+        (self.0 >> Self::NEXT_SHIFT) as usize
     }
 
     /// Decodes the slab

--- a/kernel/src/mm/alloc.rs
+++ b/kernel/src/mm/alloc.rs
@@ -735,14 +735,10 @@ impl MemoryRegion {
 
     /// Allocates a slab page.
     fn allocate_slab_page(&mut self, item_size: u16) -> Result<VirtAddr, AllocError> {
-        self.refill_page_list(0)?;
-
-        let pfn = self.get_next_page(0)?;
         let pg = PageInfo::Slab(SlabPageInfo {
             item_size: u64::from(item_size),
         });
-        self.write_page_info(pfn, pg);
-        Ok(self.start_virt + (pfn * PAGE_SIZE))
+        self.allocate_pages_info(0, pg)
     }
 
     /// Allocates a file page with initial reference count.

--- a/kernel/src/mm/alloc.rs
+++ b/kernel/src/mm/alloc.rs
@@ -553,30 +553,23 @@ impl MemoryRegion {
     /// Gets a mutable pointer to the page information for a given page frame
     /// number.
     ///
-    /// # Safety
-    ///
-    /// The caller must provide a valid pfn, otherwise the returned pointer is
-    /// undefined, as the compiler is allowed to optimize assuming there will
-    /// be no arithmetic overflows.
-    unsafe fn page_info_mut_ptr(&mut self, pfn: usize) -> *mut PageStorageType {
-        // SAFETY: The start of the managed virtual address space always
-        // contains the meta-data about the pages. So this is safe, given the
-        // caller supplied a valid pfn.
-        unsafe { self.start_virt.as_mut_ptr::<PageStorageType>().add(pfn) }
+    /// The caller must provide a valid pfn, otherwise the returned pointer
+    /// is not valid for access.
+    #[expect(clippy::needless_pass_by_ref_mut)]
+    fn page_info_mut_ptr(&mut self, pfn: usize) -> *mut PageStorageType {
+        self.start_virt
+            .as_mut_ptr::<PageStorageType>()
+            .wrapping_add(pfn)
     }
 
     /// Gets a pointer to the page information for a given page frame number.
     ///
-    /// # Safety
-    ///
-    /// The caller must provide a valid pfn, otherwise the returned pointer is
-    /// undefined, as the compiler is allowed to optimize assuming there will
-    /// be no arithmetic overflows.
-    unsafe fn page_info_ptr(&self, pfn: usize) -> *const PageStorageType {
-        // SAFETY: The start of the managed virtual address space always
-        // contains the meta-data about the pages. So this is safe, given the
-        // caller supplied a valid pfn.
-        unsafe { self.start_virt.as_ptr::<PageStorageType>().add(pfn) }
+    /// The caller must provide a valid pfn, otherwise the returned pointer
+    /// is not valid for access
+    fn page_info_ptr(&self, pfn: usize) -> *const PageStorageType {
+        self.start_virt
+            .as_ptr::<PageStorageType>()
+            .wrapping_add(pfn)
     }
 
     /// Checks if a page frame number is valid.

--- a/kernel/src/mm/alloc.rs
+++ b/kernel/src/mm/alloc.rs
@@ -11,6 +11,7 @@ use crate::fs::Buffer;
 use crate::locking::SpinLock;
 use crate::mm::virt_to_phys;
 use crate::types::{PAGE_SHIFT, PAGE_SIZE};
+use crate::utils::tcb_ptr::{ptr_read, ptr_write};
 use crate::utils::{align_down, align_up, zero_mem_region};
 use core::alloc::{GlobalAlloc, Layout};
 use core::mem::size_of;
@@ -595,7 +596,9 @@ impl MemoryRegion {
 
         let info: PageStorageType = pi.to_mem();
         // SAFETY: we have checked that the pfn is valid via check_pfn() above.
-        unsafe { self.page_info_mut_ptr(pfn).write(info) };
+        unsafe {
+            ptr_write(self.page_info_mut_ptr(pfn), info);
+        }
     }
 
     /// Reads page information for a given page frame number.
@@ -603,7 +606,7 @@ impl MemoryRegion {
         self.check_pfn(pfn);
 
         // SAFETY: we have checked that the pfn is valid via check_pfn() above.
-        let info = unsafe { self.page_info_ptr(pfn).read() };
+        let info = unsafe { ptr_read(self.page_info_ptr(pfn)) };
         PageInfo::from_mem(info)
     }
 

--- a/kernel/src/mm/alloc.rs
+++ b/kernel/src/mm/alloc.rs
@@ -495,6 +495,7 @@ impl PageInfo {
 }
 
 /// Represents info about allocated and free pages in different orders.
+#[verus_verify]
 #[derive(Debug, Default, Clone, Copy)]
 pub struct MemInfo {
     total_pages: [usize; MAX_ORDER],
@@ -503,7 +504,8 @@ pub struct MemInfo {
 
 /// Memory region with its physical/virtual addresses, page count, as well
 /// as other details.
-#[derive(Debug, Default)]
+#[verus_verify]
+#[derive(Debug)]
 struct MemoryRegion {
     start_phys: PhysAddr,
     start_virt: VirtAddr,
@@ -511,10 +513,19 @@ struct MemoryRegion {
     nr_pages: [usize; MAX_ORDER],
     next_page: [usize; MAX_ORDER],
     free_pages: [usize; MAX_ORDER],
+    #[cfg(verus_keep_ghost_body)]
+    perms: Tracked<MemoryRegionPerms>, // tracks all memory region permissions
 }
 
+#[verus_verify]
 impl MemoryRegion {
     /// Creates a new [`MemoryRegion`] with default values.
+    #[verus_spec(ret =>
+        ensures
+            ret.wf_next_pages(),
+            ret.page_count == 0,
+    )]
+    #[verus_verify(external_body)]
     const fn new() -> Self {
         Self {
             start_phys: PhysAddr::null(),
@@ -523,12 +534,25 @@ impl MemoryRegion {
             nr_pages: [0; MAX_ORDER],
             next_page: [0; MAX_ORDER],
             free_pages: [0; MAX_ORDER],
+            #[cfg(verus_keep_ghost_body)]
+            perms: Tracked::assume_new(),
         }
     }
 
     /// Converts a physical address within this memory region to a virtual address.
     #[expect(dead_code)]
+    #[verus_spec(ret =>
+        requires
+            self.wf_params(),
+        ensures
+            self.ens_phys_to_virt(paddr, ret),
+    )]
     fn phys_to_virt(&self, paddr: PhysAddr) -> Option<VirtAddr> {
+        proof! {
+            reveal(<LinearMap as SpecMemMapTr>::to_vaddr);
+            use_type_invariant(self.start_virt);
+            broadcast use group_addr_proofs;
+        }
         if paddr < self.start_phys || (paddr - self.start_phys) >= (self.page_count * PAGE_SIZE) {
             // For the initial stage2 identity mapping, the root page table
             // pages are static and outside of the heap memory region.
@@ -545,7 +569,15 @@ impl MemoryRegion {
 
     /// Converts a virtual address to a physical address within the memory region.
     #[expect(dead_code)]
+    #[verus_spec(ret =>
+        requires
+            self.wf_params(),
+        ensures
+            ret.is_some() == self.map().to_paddr(vaddr).is_some(),
+            ret.is_some() ==> ret.unwrap()@ == self.map().to_paddr(vaddr).unwrap(),
+    )]
     fn virt_to_phys(&self, vaddr: VirtAddr) -> Option<PhysAddr> {
+        proof! {reveal(<LinearMap as SpecMemMapTr>::to_paddr);}
         let offset = self.get_virt_offset(vaddr)?;
         Some(self.start_phys + offset)
     }
@@ -555,21 +587,50 @@ impl MemoryRegion {
     ///
     /// The caller must provide a valid pfn, otherwise the returned pointer
     /// is not valid for access.
+    ///
+    /// The pfn is confirmed to be valid via verification since the code already
+    /// checked the pfn (check_pfn) before reaching here. The access will be
+    /// later proved to be safe when using with memory perm to write memory.
+    #[verus_spec(ret =>
+        requires
+            old(self).wf_params(),
+            pfn < old(self).page_count,
+        ensures
+            ret == self@.page_info_ptr(pfn),
+            *self == *old(self),
+    )]
     #[expect(clippy::needless_pass_by_ref_mut)]
     fn page_info_mut_ptr(&mut self, pfn: usize) -> *mut PageStorageType {
-        self.start_virt
-            .as_mut_ptr::<PageStorageType>()
-            .wrapping_add(pfn)
+        proof! { self.lemma_page_info_ptr(pfn);}
+        {
+            proof_with!(Tracked(self.perms.borrow().info_ptr_exposed));
+            self.start_virt.as_mut_ptr::<PageStorageType>()
+        }
+        .wrapping_add(pfn)
     }
 
     /// Gets a pointer to the page information for a given page frame number.
     ///
     /// The caller must provide a valid pfn, otherwise the returned pointer
-    /// is not valid for access
+    /// is not valid for access.
+    ///
+    /// The pfn is confirmed to be valid via verification since the code already
+    /// checked the pfn (check_pfn) before reaching here. The access will be
+    /// later proved to be safe when using with memory perm to read memory.
+    #[verus_spec(ret =>
+        requires
+            pfn < self.page_count,
+            self.wf_params(),
+        ensures
+            ret == self@.page_info_ptr(pfn),
+    )]
     fn page_info_ptr(&self, pfn: usize) -> *const PageStorageType {
-        self.start_virt
-            .as_ptr::<PageStorageType>()
-            .wrapping_add(pfn)
+        proof! { self.lemma_page_info_ptr(pfn);}
+        {
+            proof_with!(Tracked(self.perms.borrow().info_ptr_exposed));
+            self.start_virt.as_ptr::<PageStorageType>()
+        }
+        .wrapping_add(pfn)
     }
 
     /// Checks if a page frame number is valid.
@@ -577,6 +638,11 @@ impl MemoryRegion {
     /// # Panics
     ///
     /// Panics if the page frame number is invalid.
+    #[verus_spec(
+        ensures pfn < self.page_count
+        no_unwind when pfn < self.page_count
+    )]
+    #[verus_verify(spinoff_prover)]
     fn check_pfn(&self, pfn: usize) {
         if pfn >= self.page_count {
             panic!("Invalid Page Number {}", pfn);
@@ -584,39 +650,114 @@ impl MemoryRegion {
     }
 
     /// Writes page information for a given page frame number.
+    #[verus_spec(
+        with Tracked(perm): Tracked<&mut FracTypedPerm<PageStorageType>>
+        requires
+            pi.spec_order() < MAX_ORDER,
+            old(self).writable_page_info(pfn, *old(perm)),
+        ensures
+            old(self).ens_write_page_info(*self, pfn, pi, *old(perm), *perm),
+    )]
     fn write_page_info(&mut self, pfn: usize, pi: PageInfo) {
+        proof! {
+            pi.use_type_invariant();
+            reveal(spec_page_info);
+        }
         self.check_pfn(pfn);
 
         let info: PageStorageType = pi.to_mem();
         // SAFETY: we have checked that the pfn is valid via check_pfn() above.
+        // Proved to be safe enough if passing valid tracked perm.
         unsafe {
+            proof_with!(Tracked(perm));
             ptr_write(self.page_info_mut_ptr(pfn), info);
         }
     }
 
     /// Reads page information for a given page frame number.
+    #[verus_spec(ret =>
+        requires
+            self.req_read_any_info(),
+            pfn < self.page_count,
+        ensures
+            self.ens_read_page_info(pfn, ret),
+    )]
+    #[verus_verify(spinoff_prover)]
     fn read_page_info(&self, pfn: usize) -> PageInfo {
         self.check_pfn(pfn);
 
+        proof_decl! {
+            reveal(spec_page_info);
+            use_type_invariant(&self.perms.borrow().info);
+            let tracked perm = self.perms.borrow().info.tracked_borrow(pfn);
+        }
         // SAFETY: we have checked that the pfn is valid via check_pfn() above.
-        let info = unsafe { ptr_read(self.page_info_ptr(pfn)) };
+        // Verification makes it safe enough.
+        // Proved to be safe enough if passing valid tracked perm.
+        let info = unsafe {
+            proof_with!(Tracked(perm));
+            ptr_read(self.page_info_ptr(pfn))
+        };
         PageInfo::from_mem(info)
     }
 
     /// Gets the virtual offset of a virtual address within the memory region.
+    /// TODO(verus): dual_spec mode for closure to avoid annotations.
+    #[verus_spec(ret =>
+        requires
+            self.wf_params(),
+        ensures
+            ret.is_some() ==> ret.unwrap() == vaddr.offset() - self.start_virt.offset(),
+            ret.is_some() == self.map().to_paddr(vaddr).is_some(),
+    )]
     fn get_virt_offset(&self, vaddr: VirtAddr) -> Option<usize> {
-        (self.start_virt <= vaddr && (vaddr - self.start_virt) < self.page_count * PAGE_SIZE)
-            .then(|| vaddr - self.start_virt)
+        proof! {
+            broadcast use crate::address::group_addr_proofs;
+            reveal(<LinearMap as SpecMemMapTr>::to_paddr);
+        };
+        (self.start_virt <= vaddr && (vaddr - self.start_virt) < self.page_count * PAGE_SIZE).then(
+            #[cfg_attr(verus_keep_ghost_body, verus_spec(ret: usize =>
+                requires
+                    vaddr.offset() > self.start_virt.offset()
+                ensures
+                    ret == vaddr.offset() - self.start_virt.offset()
+            ))]
+            || vaddr - self.start_virt,
+        )
     }
 
     /// Gets the page frame number for a given virtual address.
+    /// TODO(verus): dual_spec mode for closure to avoid annotations.
+    #[verus_spec(ret =>
+        requires
+            self.wf_params(),
+        ensures
+            self.ens_get_pfn(vaddr, ret),
+    )]
     fn get_pfn(&self, vaddr: VirtAddr) -> Result<usize, AllocError> {
+        proof_decl! {
+            lemma_get_pfn!(self, vaddr);
+        }
         self.get_virt_offset(vaddr)
-            .map(|off| off / PAGE_SIZE)
+            .map(
+                #[cfg_attr(verus_keep_ghost_body, verus_spec(ret: usize =>
+                    ensures ret == off / PAGE_SIZE
+                ))]
+                |off: usize| off / PAGE_SIZE,
+            )
             .ok_or(AllocError::InvalidHeapAddress(vaddr))
     }
 
     /// Gets the next available page frame number for a given order.
+    #[verus_spec(ret =>
+        with Tracked(perm): Tracked<&mut PgUnitPerm<DeallocUnit>>
+        requires
+            order < MAX_ORDER,
+            old(self).wf_next_pages(),
+        ensures
+            old(self).ens_get_next_page(&*self, order, ret, *perm),
+    )]
+    #[verus_verify(spinoff_prover)]
     fn get_next_page(&mut self, order: usize) -> Result<usize, AllocError> {
         let pfn = self.next_page[order];
 
@@ -624,14 +765,25 @@ impl MemoryRegion {
             return Err(AllocError::OutOfMemory);
         }
 
+        proof! {
+            *perm = self.perms.borrow_mut().free.tracked_pop(order);
+            // Prove the pageinfo must be FreeInfo
+            self.perms.borrow().info.tracked_is_same_info(&*perm, pfn);
+        }
+
         let pg = self.read_page_info(pfn);
         let PageInfo::Free(fi) = pg else {
+            proof! { assert(false); } // prove it is unreachable
             panic!(
                 "Unexpected page type in MemoryRegion::get_next_page() {:?}",
                 pg
             );
         };
 
+        proof! {
+            // prove fi.next_page < MAX_PAGE_COUNT.
+            use_type_invariant(fi);
+        }
         self.next_page[order] = fi.next_page;
 
         self.free_pages[order] -= 1;
@@ -640,27 +792,76 @@ impl MemoryRegion {
     }
 
     /// Marks a compound page and updates page information for neighboring pages.
+    #[verus_spec(
+        with Tracked(perms): Tracked<&mut Map<usize, PInfoPerm>>
+        requires
+            old(self).req_mark_compound_page(pfn, order, *old(perms)),
+        ensures
+            old(self).ens_mark_compound_page(*self, pfn, order, *old(perms), *perms),
+    )]
+    #[verus_verify(spinoff_prover)]
     fn mark_compound_page(&mut self, pfn: usize, order: usize) {
         let nr_pages: usize = 1 << order;
         let compound = PageInfo::Compound(CompoundInfo { order });
+        #[cfg_attr(verus_keep_ghost_body, verus_spec(
+            invariant
+                old(self).ens_mark_compound_page_loop(*self, pfn, i, order, *old(perms), *perms),
+            decreases
+                nr_pages - i,
+        ))]
+        #[cfg_attr(verus_keep_ghost_body, verifier::loop_isolation(false))]
         for i in 1..nr_pages {
+            proof_decl! {
+                let ghost current = (pfn + i) as usize;
+                let tracked mut perm = perms.tracked_remove(current);
+            }
+            proof_with!(Tracked(&mut perm));
             self.write_page_info(pfn + i, compound);
+            proof! {
+                perms.tracked_insert(current, perm);
+            }
         }
     }
 
     /// Initializes a compound page with given page frame numbers and order.
+    #[verus_spec(
+        with
+            Tracked(perms): Tracked<&mut Map<usize, PInfoPerm>>
+        requires
+            old(self).req_init_compound_page(pfn, order, next_pfn, *old(perms)),
+        ensures
+            old(self).ens_init_compound_page(*self, pfn, order, next_pfn, *old(perms), *perms),
+    )]
     fn init_compound_page(&mut self, pfn: usize, order: usize, next_pfn: usize) {
         let head = PageInfo::Free(FreeInfo {
             next_page: next_pfn,
             order,
         });
+        proof_decl! {
+            let tracked mut perm = perms.tracked_remove(pfn);
+        }
+        proof_with!(Tracked(&mut perm));
         self.write_page_info(pfn, head);
+        proof_with!(Tracked(perms));
         self.mark_compound_page(pfn, order);
+        proof! {
+            perms.tracked_insert(pfn, perm);
+        }
     }
 
     /// Splits a page into two pages of the next lower order.
+    #[verus_spec(ret =>
+        with Tracked(perm): Tracked<PgUnitPerm<DeallocUnit>>
+        requires
+            old(self).req_split_page(pfn, order, perm),
+        ensures
+            old(self).ens_split_page_ok(&*self, pfn, order),
+            ret.is_ok(),
+    )]
+    #[verus_verify(spinoff_prover, rlimit(2))]
     fn split_page(&mut self, pfn: usize, order: usize) -> Result<(), AllocError> {
         if !(1..MAX_ORDER).contains(&order) {
+            proof! {assert(false);} // unreachable
             return Err(AllocError::InvalidPageOrder(order));
         }
 
@@ -669,9 +870,25 @@ impl MemoryRegion {
         let pfn2 = pfn + (1usize << new_order);
 
         let next_pfn = self.next_page[new_order];
+
+        proof_decl! {
+            let ghost x = seq![1u8, 2u8];
+            lemma_split_pre!(self, perm, pfn1, pfn2, order, new_order => mem, mem2, reserved, reserved2, info, id);
+        }
+        proof_with!(Tracked(&mut reserved));
         self.init_compound_page(pfn1, new_order, pfn2);
+
+        proof_decl! {
+            revoke_info_write!(self, pfn1, new_order, mem, reserved, id => p1);
+        }
+
+        proof_with!(Tracked(&mut reserved2));
         self.init_compound_page(pfn2, new_order, next_pfn);
         self.next_page[new_order] = pfn1;
+
+        proof_decl! {
+            lemma_split_post!(self, pfn1, pfn2, new_order, mem, mem2, reserved, reserved2, id, p1);
+        }
 
         // Do the accounting
         self.nr_pages[order] -= 1;
@@ -682,7 +899,21 @@ impl MemoryRegion {
     }
 
     /// Refills the free page list for a given order.
+    #[verus_verify(spinoff_prover)]
+    #[verus_spec(ret =>
+        requires
+            old(self).wf_next_pages(),
+            0 <= order <= MAX_ORDER,
+        ensures
+            old(self).ens_refill_page_list(*self, ret.is_ok(), order),
+        decreases
+            MAX_ORDER - order,
+    )]
     fn refill_page_list(&mut self, order: usize) -> Result<(), AllocError> {
+        proof! {
+            self.perms.borrow().free.tracked_next(order);
+        }
+
         let next_page = *self
             .next_page
             .get(order)
@@ -692,30 +923,72 @@ impl MemoryRegion {
         }
 
         self.refill_page_list(order + 1)?;
+        proof_decl! {
+            let tracked mut perm = PgUnitPerm::empty(arbitrary());
+        }
+        proof_with!(Tracked(&mut perm));
         let pfn = self.get_next_page(order + 1)?;
+        proof_with!(Tracked(perm));
         self.split_page(pfn, order + 1)
     }
 
     /// Allocates pages with a specific order and page information.
+    #[verus_spec(ret =>
+        with Tracked(ret_perm): Tracked<&mut Option<UnitDeallocPerm>>
+        requires
+            old(self).req_allocate_pages_info(order, pg),
+        ensures
+            old(self).ens_allocate_pages_info(self, order, pg, ret, *ret_perm),
+    )]
     fn allocate_pages_info(&mut self, order: usize, pg: PageInfo) -> Result<VirtAddr, AllocError> {
+        proof_decl! {
+            let tracked mut perm = PgUnitPerm::<DeallocUnit>::empty(arbitrary());
+        }
         self.refill_page_list(order)?;
+        proof_with!(Tracked(&mut perm));
         let pfn = self.get_next_page(order)?;
+        proof_decl! {
+            // Grant write access to the page info.
+            lemma_alloc_pages_info_pre!(self, pfn, perm => mem, info, reserved, info_head);
+        }
+        proof_with!(Tracked(&mut info_head));
         self.write_page_info(pfn, pg);
+        proof_decl! {
+            lemma_alloc_pages_info_post!(self, order, pfn, mem, info, reserved, info_head, ret_perm);
+        }
         Ok(self.start_virt + (pfn * PAGE_SIZE))
     }
 
     /// Allocates pages with a specific order.
+    #[verus_spec(ret =>
+        with Tracked(perm): Tracked<&mut Option<UnitDeallocPerm>>
+        requires
+            old(self).wf_next_pages(),
+            order < MAX_ORDER,
+        ensures
+            old(self).ens_allocate_pages_info(self, order, PageInfo::Allocated(AllocatedInfo { order }), ret, *perm),
+    )]
     fn allocate_pages(&mut self, order: usize) -> Result<VirtAddr, AllocError> {
         let pg = PageInfo::Allocated(AllocatedInfo { order });
+        proof_with!(Tracked(perm));
         self.allocate_pages_info(order, pg)
     }
 
     /// Allocates a single page.
+    #[verus_spec(ret =>
+        with Tracked(perm): Tracked<&mut Option<UnitDeallocPerm>>
+        requires
+            old(self).wf_next_pages(),
+        ensures
+            old(self).ens_allocate_pages_info(self, 0, PageInfo::Allocated(AllocatedInfo { order: 0 }), ret, *perm),
+    )]
     fn allocate_page(&mut self) -> Result<VirtAddr, AllocError> {
+        proof_with!(Tracked(perm));
         self.allocate_pages(0)
     }
 
     /// Allocates a zeroed page.
+    #[verus_verify(external_body)]
     fn allocate_zeroed_page(&mut self) -> Result<VirtAddr, AllocError> {
         let vaddr = self.allocate_page()?;
 
@@ -730,20 +1003,39 @@ impl MemoryRegion {
     }
 
     /// Allocates a slab page.
+    #[verus_spec(ret =>
+        with Tracked(perm): Tracked<&mut Option<UnitDeallocPerm>>
+        requires
+            old(self).wf_next_pages(),
+        ensures
+            old(self).ens_allocate_pages_info(self, 0, PageInfo::Slab(SlabPageInfo {
+                item_size: item_size as u64,
+            }) , ret, *perm),
+    )]
     fn allocate_slab_page(&mut self, item_size: u16) -> Result<VirtAddr, AllocError> {
         let pg = PageInfo::Slab(SlabPageInfo {
             item_size: u64::from(item_size),
         });
+        proof_with!(Tracked(perm));
         self.allocate_pages_info(0, pg)
     }
 
     /// Allocates a file page with initial reference count.
+    #[verus_spec(ret =>
+        with Tracked(perm): Tracked<&mut Option<UnitDeallocPerm>>
+        requires
+            old(self).wf_next_pages(),
+        ensures
+            old(self).ens_allocate_pages_info(self, 0, PageInfo::File(FileInfo::spec_new(1)), ret, *perm),
+    )]
     fn allocate_file_page(&mut self) -> Result<VirtAddr, AllocError> {
         let pg = PageInfo::File(FileInfo::new(1));
+        proof_with!(Tracked(perm));
         self.allocate_pages_info(0, pg)
     }
 
     /// Gets a file page and increments its reference count.
+    #[verus_verify(external_body)]
     fn get_file_page(&mut self, vaddr: VirtAddr) -> Result<(), AllocError> {
         let pfn = self.get_pfn(vaddr)?;
         let page = self.read_page_info(pfn);
@@ -759,6 +1051,7 @@ impl MemoryRegion {
     }
 
     /// Releases a file page and decrements its reference count.
+    #[verus_verify(external_body)]
     fn put_file_page(&mut self, vaddr: VirtAddr) -> Result<(), AllocError> {
         let pfn = self.get_pfn(vaddr)?;
         let page = self.read_page_info(pfn);
@@ -780,11 +1073,24 @@ impl MemoryRegion {
     }
 
     /// Finds the neighboring page frame number for a compound page.
+    #[verus_spec(ret =>
+        requires
+            self.valid_pfn_order(pfn, order),
+        ensures
+            self.ens_compound_neighbor(pfn, order, ret),
+    )]
+    #[verus_verify(spinoff_prover)]
     fn compound_neighbor(&self, pfn: usize, order: usize) -> Result<usize, AllocError> {
+        proof! {
+            // replace assert_eq! with a proof.
+            broadcast use lemma_bit_usize_and_mask_is_mod;
+            assert(pfn & ((1usize << order) - 1) as usize == 0);
+        }
         if order >= MAX_ORDER - 1 {
             return Err(AllocError::InvalidPageOrder(order));
         }
 
+        #[cfg(not(verus_keep_ghost))]
         assert_eq!(pfn & ((1usize << order) - 1), 0);
         let pfn = pfn ^ (1usize << order);
         if pfn >= self.page_count {
@@ -795,6 +1101,14 @@ impl MemoryRegion {
     }
 
     /// Merges two pages of the same order into a new compound page.
+    #[verus_spec(ret =>
+        with Tracked(perm): Tracked<&mut PgUnitPerm<DeallocUnit>>, Tracked(p2): Tracked<PgUnitPerm<DeallocUnit>>
+        requires
+            old(self).req_merge_pages(pfn1, pfn2, order, *old(perm), p2),
+        ensures
+            old(self).ens_merge_pages(self, pfn1, pfn2, order, ret, *perm),
+    )]
+    #[verus_verify(spinoff_prover, rlimit(2))]
     fn merge_pages(&mut self, pfn1: usize, pfn2: usize, order: usize) -> Result<usize, AllocError> {
         if order >= MAX_ORDER - 1 {
             return Err(AllocError::InvalidPageOrder(order));
@@ -803,12 +1117,23 @@ impl MemoryRegion {
         let new_order = order + 1;
         let pfn = pfn1.min(pfn2);
 
+        proof_decl! {
+            lemma_merge_pre!(self, perm, p2, pfn1, pfn2, pfn, order, new_order => mem, reserved, head_info, id);
+        }
+
         // Write new compound head
         let pg = PageInfo::Allocated(AllocatedInfo { order: new_order });
+
+        proof_with!(Tracked(&mut head_info));
         self.write_page_info(pfn, pg);
 
         // Write compound pages
+        proof_with!(Tracked(&mut reserved));
         self.mark_compound_page(pfn, new_order);
+
+        proof_decl! {
+            lemma_merge_post!(self, perm, pfn, order, new_order, mem, reserved, head_info, id);
+        }
 
         // Do the accounting - none of the pages is free yet, so free_pages is
         // not updated here.
@@ -819,12 +1144,25 @@ impl MemoryRegion {
     }
 
     /// Gets the next free page frame number from the free list.
+    #[verus_spec(next_page =>
+        with Tracked(perm): Tracked<&PgUnitPerm<DeallocUnit>>
+        requires
+            self.req_next_free_pfn(pfn, order, perm),
+        ensures
+            perm.page_info() == Some(PageInfo::Free(FreeInfo { order, next_page })),
+            next_page < MAX_PAGE_COUNT,
+    )]
     fn next_free_pfn(&self, pfn: usize, order: usize) -> usize {
+        proof! {
+            self.perms.borrow().info.tracked_is_same_info(&*perm, pfn);
+        }
         let page = self.read_page_info(pfn);
         let PageInfo::Free(fi) = page else {
+            proof! {assert(false);} // prove it is unreachable.
             panic!("Unexpected page type in free-list for order {}", order);
         };
 
+        proof! {use_type_invariant(fi);}
         fi.next_page
     }
 
@@ -837,7 +1175,20 @@ impl MemoryRegion {
     /// # Panics
     ///
     /// Panics if `order` is greater than [`MAX_ORDER`].
+    #[verus_spec(ret =>
+        with Tracked(perm): Tracked<&mut PgUnitPerm<DeallocUnit>>
+        requires
+            old(self).req_allocate_pfn(pfn, order)
+        ensures
+            ret.is_ok() ==> old(self).ens_allocate_pfn(self, pfn, order, *perm),
+            !ret.is_ok() ==> old(self) === self,
+    )]
+    #[verus_verify(spinoff_prover, rlimit(2))]
     fn allocate_pfn(&mut self, pfn: usize, order: usize) -> Result<(), AllocError> {
+        proof_decl! {
+            let ghost mut idx_ = self@.free.next_lists()[order as int].len() - 1;
+            if idx_ >= 0 { self.perms.borrow().free.tracked_borrow(order, idx_); }
+        }
         let first_pfn = self.next_page[order];
 
         // Handle special cases first
@@ -846,13 +1197,41 @@ impl MemoryRegion {
             return Err(AllocError::OutOfMemory);
         } else if first_pfn == pfn {
             // Requested pfn is first in list
-            self.get_next_page(order).unwrap();
+            {
+                proof_with!(Tracked(perm));
+                self.get_next_page(order)
+            }
+            .unwrap();
             return Ok(());
         }
 
         // Now walk the list
         let mut old_pfn = first_pfn;
+        proof! {
+            idx_ = idx_ - 1;
+        }
+
+        #[cfg_attr(verus_keep_ghost, verus_spec(
+            invariant
+                self === old(self),
+                self.wf_next_pages(),
+                self.req_allocate_pfn(pfn, order),
+                self.req_allocate_pfn(old_pfn, order),
+                old_pfn != pfn,
+                old_pfn != 0,
+                old_pfn == self@.free.avail[order as int][idx_ + 1].pfn(),
+                -1 <= idx_ < self@.free.avail[order as int].len() - 1,
+            decreases (idx_ + 1),
+        ))]
         loop {
+            proof_decl! {
+                use_type_invariant(&self.perms.borrow().free);
+                let tracked current_perm = self.perms.borrow().free.tracked_borrow(order, idx_ + 1);
+                if idx_ >= 0 {
+                    self.perms.borrow().free.tracked_borrow(order, idx_);
+                }
+            }
+            proof_with!(Tracked(&current_perm));
             let current_pfn = self.next_free_pfn(old_pfn, order);
             if current_pfn == 0 {
                 return Err(AllocError::OutOfMemory);
@@ -860,20 +1239,38 @@ impl MemoryRegion {
 
             if current_pfn != pfn {
                 old_pfn = current_pfn;
+                proof! {
+                    idx_ = idx_ - 1;
+                }
                 continue;
             }
 
+            proof_decl! {
+                let tracked current_perm = self.perms.borrow().free.tracked_borrow(order, idx_);
+            }
+            proof_with!(Tracked(current_perm));
             let next_pfn = self.next_free_pfn(current_pfn, order);
+            proof_decl! {
+                lemma_alloc_pfn_loop_pre!(self, perm, old_pfn, current_pfn, order, idx_
+                    => prev_mem, prev_id, prev_reserved, prev_head_info, mem, id, reserved, head_info);
+            }
             let pg = PageInfo::Free(FreeInfo {
                 next_page: next_pfn,
                 order,
             });
+            proof_with!(Tracked(&mut prev_head_info));
             self.write_page_info(old_pfn, pg);
 
             let pg = PageInfo::Allocated(AllocatedInfo { order });
+            proof_with!(Tracked(&mut head_info));
             self.write_page_info(current_pfn, pg);
 
             self.free_pages[order] -= 1;
+
+            proof_decl! {
+                lemma_alloc_pfn_loop_post!(self, perm, old_pfn, current_pfn, order, idx_,
+                    prev_mem, prev_id, prev_reserved, prev_head_info, mem, id, reserved, head_info);
+            }
 
             return Ok(());
         }
@@ -884,14 +1281,31 @@ impl MemoryRegion {
     /// # Panics
     ///
     /// Panics if `order` is greater than [`MAX_ORDER`].
+    #[verus_spec(
+        with Tracked(perm): Tracked<PgUnitPerm<DeallocUnit>>
+        requires
+            old(self).req_free_page_raw(pfn, order, perm)
+        ensures
+            old(self).ens_free_page_raw(self, pfn, order),
+    )]
+    #[verus_verify(spinoff_prover, rlimit(2))]
     fn free_page_raw(&mut self, pfn: usize, order: usize) {
         let old_next = self.next_page[order];
+        proof_decl! {
+            lemma_free_page_pre!(self, perm, pfn => mem, other_info, head_info, id);
+        }
         let pg = PageInfo::Free(FreeInfo {
             next_page: old_next,
             order,
         });
 
+        proof_with!(Tracked(&mut head_info));
         self.write_page_info(pfn, pg);
+
+        proof_decl! {
+            lemma_free_page_post!(self, pfn, order, mem, other_info, head_info, id);
+        }
+
         self.next_page[order] = pfn;
 
         self.free_pages[order] += 1;
@@ -900,6 +1314,14 @@ impl MemoryRegion {
     /// Attempts to merge a given page with its neighboring page.
     /// If successful, returns the new page frame number after merging.
     /// If unsuccessful, the page remains unmerged, and an error is returned.
+    #[verus_spec(ret =>
+        with Tracked(perm): Tracked<&mut PgUnitPerm<DeallocUnit>>
+        requires
+            old(self).req_try_to_merge_page(pfn, order, *old(perm)),
+        ensures
+            old(self).ens_try_to_merge_page(self, pfn, order, ret,  *old(perm), *perm),
+    )]
+    #[verus_verify(spinoff_prover, rlimit(2))]
     fn try_to_merge_page(&mut self, pfn: usize, order: usize) -> Result<usize, AllocError> {
         let neighbor_pfn = self.compound_neighbor(pfn, order)?;
         let neighbor_page = self.read_page_info(neighbor_pfn);
@@ -912,8 +1334,14 @@ impl MemoryRegion {
             return Err(AllocError::InvalidPageOrder(fi.order));
         }
 
+        proof_decl! {
+            broadcast use lemma_bit_usize_shl_values;
+            let tracked mut p2 = PgUnitPerm::<DeallocUnit>::empty(arbitrary());
+        }
+        proof_with!(Tracked(&mut p2));
         self.allocate_pfn(neighbor_pfn, order)?;
 
+        proof_with!(Tracked(perm), Tracked(p2));
         let new_pfn = self.merge_pages(pfn, neighbor_pfn, order)?;
 
         Ok(new_pfn)
@@ -922,12 +1350,30 @@ impl MemoryRegion {
     /// Frees a page of a specific order. If merging is successful, it
     /// continues merging until merging is no longer possible. If merging
     /// fails, the page is marked as a free page.
+    #[verus_spec(
+        with Tracked(perm): Tracked<PgUnitPerm<DeallocUnit>>
+        requires
+            old(self).req_try_to_merge_page(pfn, order, perm),
+        ensures
+            old(self).ens_free_page_order(self, pfn, order),
+        decreases
+            MAX_ORDER - order,
+    )]
+    #[verus_verify(spinoff_prover)]
     fn free_page_order(&mut self, pfn: usize, order: usize) {
-        match self.try_to_merge_page(pfn, order) {
+        proof_decl! {
+            let tracked mut perm = perm;
+        }
+
+        proof_with!(Tracked(&mut perm));
+        let merged = self.try_to_merge_page(pfn, order);
+        match merged {
             Err(_) => {
+                proof_with!(Tracked(perm));
                 self.free_page_raw(pfn, order);
             }
             Ok(new_pfn) => {
+                proof_with!(Tracked(perm));
                 self.free_page_order(new_pfn, order + 1);
             }
         }
@@ -935,6 +1381,14 @@ impl MemoryRegion {
 
     /// Frees a page based on its virtual address, determining the page
     /// order and freeing accordingly.
+    #[verus_spec(
+        with Tracked(alloced_perm): Tracked<AllocatedPagesPerm>
+        requires
+            old(self).wf_next_pages(),
+            alloced_perm.with_vaddr(vaddr),
+        ensures
+            old(self).ens_free_page(self, vaddr, alloced_perm),
+    )]
     fn free_page(&mut self, vaddr: VirtAddr) {
         let Ok(pfn) = self.get_pfn(vaddr) else {
             return;
@@ -942,14 +1396,21 @@ impl MemoryRegion {
 
         let res = self.read_page_info(pfn);
 
+        proof_decl! {
+            lemma_free_page!(self, alloced_perm, pfn, res => perm);
+        }
+
         match res {
             PageInfo::Allocated(ai) => {
+                proof_with!(Tracked(perm));
                 self.free_page_order(pfn, ai.order);
             }
             PageInfo::Slab(_si) => {
+                proof_with!(Tracked(perm));
                 self.free_page_order(pfn, 0);
             }
             PageInfo::File(_) => {
+                proof_with!(Tracked(perm));
                 self.free_page_order(pfn, 0);
             }
             _ => {
@@ -960,6 +1421,7 @@ impl MemoryRegion {
 
     /// Retrieves information about memory, including total and free pages
     /// in different orders.
+    #[verus_verify(external_body)]
     fn memory_info(&self) -> MemInfo {
         MemInfo {
             total_pages: self.nr_pages,
@@ -970,6 +1432,7 @@ impl MemoryRegion {
     /// Initializes memory by marking certain pages as reserved and the rest
     /// as allocated. It then frees all pages and organizes them into their
     /// respective order buckets.
+    #[verus_verify(external_body)]
     fn init_memory(&mut self) {
         let size = size_of::<PageStorageType>();
         let meta_pages = align_up(self.page_count * size, PAGE_SIZE) / PAGE_SIZE;
@@ -1314,6 +1777,7 @@ pub fn memory_info() -> MemInfo {
 
 /// Represents a slab memory page, used for efficient allocation of
 /// fixed-size objects.
+#[verus_verify]
 #[derive(Debug, Default)]
 struct SlabPage<const N: u16> {
     vaddr: VirtAddr,

--- a/kernel/src/mm/alloc.rs
+++ b/kernel/src/mm/alloc.rs
@@ -11,6 +11,7 @@ use crate::fs::Buffer;
 use crate::locking::SpinLock;
 use crate::mm::virt_to_phys;
 use crate::types::{PAGE_SHIFT, PAGE_SIZE};
+#[cfg_attr(verus_keep_ghost, allow(unused_imports))]
 use crate::utils::tcb_ptr::{ptr_read, ptr_write};
 use crate::utils::{align_down, align_up, zero_mem_region};
 use core::alloc::{GlobalAlloc, Layout};

--- a/kernel/src/mm/alloc.rs
+++ b/kernel/src/mm/alloc.rs
@@ -960,11 +960,6 @@ impl MemoryRegion {
             PageInfo::Slab(_si) => {
                 self.free_page_order(pfn, 0);
             }
-            PageInfo::Compound(ci) => {
-                let mask = (1usize << ci.order) - 1;
-                let start_pfn = pfn & !mask;
-                self.free_page_order(start_pfn, ci.order);
-            }
             PageInfo::File(_) => {
                 self.free_page_order(pfn, 0);
             }

--- a/kernel/src/mm/alloc.verus.rs
+++ b/kernel/src/mm/alloc.verus.rs
@@ -15,9 +15,44 @@
 //   observes the same PageInfo.
 // - LinearMap is correct and is used for all memory managed.
 //
-use verus_stub::*;
+use crate::mm::address_space::LinearMap;
+use crate::types::lemma_page_size;
+use verify_external::convert::FromSpec;
+use verify_proof::bits::*;
+use verify_proof::frac_ptr::FracTypedPerm;
+use vstd::arithmetic::mul::*;
+use vstd::modes::tracked_swap;
+use vstd::raw_ptr::IsExposed;
+
 verus! {
 
 mod alloc_spec { include!("alloc_inner.verus.rs");  }
+
+use alloc_spec::*;
+
+broadcast group set_len_group {
+    verify_proof::set::lemma_len_filter,
+    verify_proof::set::lemma_len_subset,
+}
+
+broadcast group alloc_broadcast_group {
+    LinearMap::lemma_get_paddr,
+    lemma_bit_usize_shl_values,
+    lemma_page_size,
+    set_len_group,
+    //lemma_bit_u64_and_bound,
+    alloc_spec::lemma_compound_neighbor,
+}
+
+broadcast use alloc_broadcast_group;
+
+include!("alloc_info.verus.rs");
+
+include!("alloc_free.verus.rs");
+
+include!("alloc_perms.verus.rs");
+
+//include!("alloc_mr.verus.rs");
+include!("alloc_types.verus.rs");
 
 } // verus!

--- a/kernel/src/mm/alloc.verus.rs
+++ b/kernel/src/mm/alloc.verus.rs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Ziqiao Zhou <ziqiaozhou@microsoft.com>
+//
+// This module defines specification functions for MemoryRegion implementations
+//
+// How the proof works:
+// - Upon entry to the SVSM (Secure Virtual Machine Monitor) kernel, we ensure there exists a set of unique
+//   memory permissions that are predefined and trusted.
+// - Memory permissions are unforgeable, ensuring their integrity during execution.
+// - The memory region tracks the memory page permissions and their page info permissions.
+// - The PageInfo's permission will be shared as read-only permissions if the page is allocated.
+//   observes the same PageInfo.
+// - LinearMap is correct and is used for all memory managed.
+//
+use verus_stub::*;
+verus! {
+
+mod alloc_spec { include!("alloc_inner.verus.rs");  }
+
+} // verus!

--- a/kernel/src/mm/alloc.verus.rs
+++ b/kernel/src/mm/alloc.verus.rs
@@ -15,9 +15,12 @@
 //   observes the same PageInfo.
 // - LinearMap is correct and is used for all memory managed.
 //
+use crate::address::group_addr_proofs;
 use crate::mm::address_space::LinearMap;
 use crate::types::lemma_page_size;
+use crate::utils::tcb_ptr::*;
 use verify_external::convert::FromSpec;
+use verify_external::hw_spec::SpecMemMapTr;
 use verify_proof::bits::*;
 use verify_proof::frac_ptr::FracTypedPerm;
 use vstd::arithmetic::mul::*;
@@ -55,4 +58,755 @@ include!("alloc_perms.verus.rs");
 //include!("alloc_mr.verus.rs");
 include!("alloc_types.verus.rs");
 
+impl View for MemoryRegion {
+    type V = MemoryRegionPerms;
+
+    closed spec fn view(&self) -> MemoryRegionPerms {
+        self.perms@
+    }
+}
+
+impl MemoryRegion {
+    spec fn wf_next_pages(&self) -> bool {
+        &&& self.wf_perms()
+        &&& self.wf_params()
+        &&& self.next_page@ =~= self@.free.next_pages()
+        &&& forall|o| 0 <= o < MAX_ORDER ==> #[trigger] self.next_page[o] < MAX_PAGE_COUNT
+        &&& self@.free.wf_strict()
+    }
+
+    spec fn wf_perms(&self) -> bool {
+        let info = self@.info;
+        &&& self@.wf()
+        &&& forall|order|
+            0 <= order < MAX_ORDER ==> info.nr_page(order) == (
+            #[trigger] self.nr_pages[order as int])
+        &&& self@.free.nr_free() =~= self.free_pages@
+        &&& info.dom() =~= Set::new(|idx| 0 <= idx < self.page_count)
+        &&& self.page_count == self@.npages()
+    }
+
+    spec fn wf_params(&self) -> bool {
+        &&& self.page_count <= MAX_PAGE_COUNT
+        &&& self.start_virt@ % PAGE_SIZE == 0
+        &&& self.start_virt@ + (self.page_count * PAGE_SIZE) as int
+            <= crate::address::VADDR_LOWER_MASK || self.start_virt@
+            >= crate::address::VADDR_UPPER_MASK
+        &&& self@.mr_map.wf()
+        &&& self@.info_ptr_exposed@ == self@.mr_map@.provenance
+        &&& self.map() == self@.mr_map@.map
+        &&& self.map().wf()
+    }
+
+    proof fn lemma_page_info_ptr(&self, pfn: usize)
+        requires
+            #[trigger] self.wf_params(),
+            pfn < self.page_count,
+        ensures
+            self.start_virt@ + #[trigger] (pfn * size_of::<PageStorageType>()) <= usize::MAX,
+    {
+        let unit = size_of::<PageStorageType>() as int;
+        vstd::arithmetic::mul::lemma_mul_is_commutative(pfn as int, unit);
+        vstd::arithmetic::mul::lemma_mul_is_commutative(pfn as int, PAGE_SIZE as int);
+        vstd::arithmetic::mul::lemma_mul_inequality(unit, PAGE_SIZE as int, pfn as int);
+        vstd::arithmetic::mul::lemma_mul_inequality(
+            pfn as int,
+            self.page_count as int,
+            PAGE_SIZE as int,
+        );
+    }
+}
+
+impl MemoryRegion {
+    spec fn map(&self) -> LinearMap {
+        LinearMap {
+            virt_start: self.start_virt,
+            phys_start: self.start_phys@ as int,
+            size: (self.page_count * PAGE_SIZE) as nat,
+        }
+    }
+
+    spec fn with_same_mapping(&self, new: &Self) -> bool {
+        self@.mr_map === new@.mr_map
+    }
+}
+
+impl MemoryRegion {
+    spec fn writable_page_info(&self, pfn: usize, perm: FracTypedPerm<PageStorageType>) -> bool {
+        &&& perm.valid()
+        &&& perm.writable()
+        &&& perm.ptr() == self@.page_info_ptr(pfn)
+        &&& self.wf_params()
+    }
+
+    spec fn writable_page_infos(
+        &self,
+        pfn: usize,
+        npage: usize,
+        perms: Map<usize, PInfoPerm>,
+    ) -> bool {
+        &&& forall|i| pfn <= i < pfn + npage ==> #[trigger] perms.contains_key(i)
+        &&& forall|i|
+            #![trigger perms[i]]
+            pfn <= i < pfn + npage ==> {
+                &&& self.writable_page_info(i, (#[trigger] perms[i]))
+            }
+    }
+
+    spec fn ens_write_page_info(
+        &self,
+        new: Self,
+        pfn: usize,
+        pi: PageInfo,
+        old_perm: FracTypedPerm<PageStorageType>,
+        perm: FracTypedPerm<PageStorageType>,
+    ) -> bool {
+        &&& *self == new
+        &&& old_perm.ens_write_page_info(&perm, pfn, pi)
+    }
+
+    spec fn req_mark_compound_page(
+        &self,
+        pfn: usize,
+        order: usize,
+        perms: Map<usize, PInfoPerm>,
+    ) -> bool {
+        let size = (1usize << order);
+        &&& self.writable_page_infos((pfn + 1) as usize, (size - 1) as usize, perms)
+        &&& self.inbound_pfn_order(pfn, order)
+        &&& self.wf_params()
+    }
+
+    spec fn ens_mark_compound_page(
+        &self,
+        new: Self,
+        pfn: usize,
+        order: usize,
+        perms: Map<usize, PInfoPerm>,
+        new_perms: Map<usize, PInfoPerm>,
+    ) -> bool {
+        self.ens_mark_compound_page_loop(new, pfn, 1usize << order, order, perms, new_perms)
+    }
+
+    spec fn ens_mark_compound_page_loop(
+        &self,
+        new: Self,
+        pfn: usize,
+        size: usize,
+        order: usize,
+        perms: Map<usize, PInfoPerm>,
+        new_perms: Map<usize, PInfoPerm>,
+    ) -> bool {
+        let pi = PageInfo::Compound(CompoundInfo { order });
+        &&& *self == new
+        &&& new_perms.dom() =~= perms.dom()
+        &&& forall|i: usize|
+            #![trigger new_perms[i]]
+            perms.contains_key(i) ==> if pfn < i < pfn + size {
+                perms[i].ens_write_page_info(&new_perms[i], i, pi)
+            } else {
+                new_perms[i] == perms[i]
+            }
+    }
+
+    spec fn req_init_compound_page(
+        &self,
+        pfn: usize,
+        order: usize,
+        next_pfn: usize,
+        perms: Map<usize, PInfoPerm>,
+    ) -> bool {
+        &&& next_pfn < MAX_PAGE_COUNT
+        &&& self.inbound_pfn_order(pfn, order)
+        &&& self.writable_page_infos(pfn, 1usize << order, perms)
+        &&& self.wf_params()
+    }
+
+    spec fn ens_init_compound_page(
+        &self,
+        new: Self,
+        pfn: usize,
+        order: usize,
+        next_pfn: usize,
+        perms: Map<usize, PInfoPerm>,
+        new_perms: Map<usize, PInfoPerm>,
+    ) -> bool {
+        let size = 1usize << order;
+        let pi = PageInfo::Free(FreeInfo { next_page: next_pfn, order });
+        &&& *self == new
+        &&& new_perms.dom() =~= perms.dom()
+        &&& forall|i: usize|
+            #![trigger new_perms[i]]
+            pfn <= i < pfn + size ==> perms[i].ens_write_page_info(
+                &new_perms[i],
+                i,
+                if i == pfn {
+                    pi
+                } else {
+                    PageInfo::Compound(CompoundInfo { order })
+                },
+            )
+    }
+
+    spec fn req_merge_pages(
+        &self,
+        pfn1: usize,
+        pfn2: usize,
+        order: usize,
+        p1: PgUnitPerm<DeallocUnit>,
+        p2: PgUnitPerm<DeallocUnit>,
+    ) -> bool {
+        let pfn = vstd::math::min(pfn1 as int, pfn2 as int);
+        &&& self.wf_next_pages()
+        &&& self.valid_pfn_order(pfn as usize, (order + 1) as usize)
+        &&& 0 <= order < MAX_ORDER - 1
+        &&& p1.wf_pfn_order(self@.mr_map, pfn1, order)
+        &&& p2.wf_pfn_order(self@.mr_map, pfn2, order)
+        &&& (pfn1 == pfn2 + (1usize << order)) || (pfn1 == pfn2 - (1usize << order))
+    }
+
+    spec fn ens_merge_pages_ok(
+        &self,
+        new: &Self,
+        pfn1: usize,
+        pfn2: usize,
+        order: usize,
+        ret: usize,
+        perm: PgUnitPerm<DeallocUnit>,
+    ) -> bool {
+        let pfn = vstd::math::min(pfn1 as int, pfn2 as int) as usize;
+        let new_order = (order + 1) as usize;
+        &&& new.wf_next_pages()
+        &&& ret == pfn
+        &&& self.with_same_mapping(new)
+        &&& perm.wf_pfn_order(self@.mr_map, pfn, new_order)
+    }
+
+    spec fn ens_merge_pages(
+        &self,
+        new: &Self,
+        pfn1: usize,
+        pfn2: usize,
+        order: usize,
+        ret: Result<usize, AllocError>,
+        perm: PgUnitPerm<DeallocUnit>,
+    ) -> bool {
+        &&& ret.is_ok()
+        &&& self.ens_merge_pages_ok(new, pfn1, pfn2, order, ret.unwrap(), perm)
+    }
+
+    spec fn req_split_page(&self, pfn: usize, order: usize, perm: PgUnitPerm<DeallocUnit>) -> bool {
+        let new_size = (1usize << (order - 1) as usize);
+        &&& self.wf_next_pages()
+        &&& perm.wf_pfn_order(self@.mr_map, pfn, order)
+        &&& perm.page_type() == PageType::Free
+        &&& self.valid_pfn_order(pfn, order)
+        &&& order >= 1
+    }
+
+    spec fn ens_split_page_ok(&self, new: &Self, pfn: usize, order: usize) -> bool {
+        let rhs_pfn = (pfn + (1usize << order) / 2) as usize;
+        let new_order = order - 1;
+        let order = order as int;
+        &&& new.wf_next_pages()
+        &&& new.next_page[order - 1] != 0
+        &&& self.with_same_mapping(new)
+    }
+
+    spec fn spec_get_pfn(&self, vaddr: VirtAddr) -> Option<usize> {
+        self.map().get_pfn(vaddr)
+    }
+
+    spec fn spec_try_get_virt(&self, pfn: int) -> Option<VirtAddr> {
+        self.map().try_get_virt(pfn as usize)
+    }
+
+    /// virt_offset == physical_offset
+    spec fn ens_get_pfn(&self, vaddr: VirtAddr, ret: Result<usize, AllocError>) -> bool {
+        &&& ret.is_ok() == self.spec_get_pfn(vaddr).is_some()
+        &&& ret.is_ok() ==> {
+            &&& ret.unwrap() == self.spec_get_pfn(vaddr).unwrap()
+            &&& ret.unwrap() < self.page_count
+            &&& vaddr@ % 0x1000 == 0 ==> self.spec_try_get_virt(ret.unwrap() as int) == Some(vaddr)
+        }
+    }
+
+    spec fn ens_get_next_page(
+        &self,
+        new: &Self,
+        order: usize,
+        ret: Result<usize, AllocError>,
+        perm: PgUnitPerm<DeallocUnit>,
+    ) -> bool {
+        let order = order as int;
+        &&& new.wf_next_pages()
+        &&& ret.is_err() == ((self.next_page[order] == 0))
+        &&& ret.is_err() ==> self === new
+        &&& ret.is_ok() ==> {
+            &&& perm.wf_pfn_order(new@.mr_map, ret.unwrap(), order as usize)
+            &&& perm.page_type() == PageType::Free
+            &&& ret.unwrap() == self.next_page[order]
+            &&& new.valid_pfn_order(ret.unwrap(), order as usize)
+            &&& new.next_page@ =~= self.next_page@.update(order, new.next_page[order])
+            &&& new.free_pages@ =~= self.free_pages@.update(order, new.free_pages@[order])
+            &&& new.free_pages@[order] == self.free_pages[order] - 1
+            &&& self.with_same_mapping(new)
+        }
+    }
+
+    spec fn req_read_any_info(&self) -> bool {
+        &&& self.page_count == self@.npages()
+        &&& self.wf_params()
+        &&& self@.wf()
+    }
+
+    spec fn ens_read_page_info(self, pfn: usize, ret: PageInfo) -> bool {
+        let pi = self@.get_info(pfn);
+        &&& pi === Some(ret)
+        &&& pfn < self.page_count
+    }
+
+    spec fn spec_alloc_fails(&self, order: int) -> bool {
+        forall|i| #![trigger self.next_page[i]] order <= i < MAX_ORDER ==> self.next_page[i] == 0
+    }
+
+    spec fn pg_params(&self) -> PageCountParam<MAX_ORDER> {
+        PageCountParam { page_count: self.page_count }
+    }
+
+    spec fn inbound_pfn_order(&self, pfn: usize, order: usize) -> bool {
+        &&& pfn + (1usize << order) <= self.pg_params().page_count
+        &&& order < MAX_ORDER
+        &&& pfn < MAX_PAGE_COUNT
+    }
+
+    spec fn valid_pfn_order(&self, pfn: usize, order: usize) -> bool {
+        &&& self.pg_params().valid_pfn_order(pfn, order)
+        &&& 0 < pfn < MAX_PAGE_COUNT
+    }
+
+    spec fn ens_refill_page_list(&self, new: Self, ret: bool, order: usize) -> bool {
+        // No available if no slot >= order
+        let valid_order = (0 <= order < MAX_ORDER);
+        &&& (valid_order && !self.spec_alloc_fails(order as int)) == ret
+        &&& ret ==> valid_order
+        &&& ret ==> new.next_page[order as int] != 0
+        &&& self.with_same_mapping(&new)
+        &&& new.wf_next_pages()
+    }
+
+    spec fn ens_compound_neighbor(
+        &self,
+        pfn: usize,
+        order: usize,
+        ret: Result<usize, AllocError>,
+    ) -> bool {
+        let ret_pfn = ret.unwrap();
+        ret.is_ok() ==> {
+            &&& ret_pfn < self.page_count
+            &&& order < (MAX_ORDER - 1)
+            &&& ens_find_neighbor(pfn, order, ret_pfn)
+        }
+    }
+
+    spec fn req_next_free_pfn(
+        self,
+        pfn: usize,
+        order: usize,
+        perm: &PgUnitPerm<DeallocUnit>,
+    ) -> bool {
+        &&& self.req_read_any_info()
+        &&& perm.page_type() == PageType::Free
+        &&& perm.wf_pfn_order(self@.mr_map, pfn, order)
+        &&& order < MAX_ORDER
+        &&& pfn < self.page_count
+    }
+
+    spec fn req_allocate_pfn(&self, pfn: usize, order: usize) -> bool {
+        &&& order < MAX_ORDER
+        &&& pfn < self.page_count
+        &&& self.wf_next_pages()
+    }
+
+    spec fn ens_allocate_pfn(
+        &self,
+        new: &Self,
+        pfn: usize,
+        order: usize,
+        perm: PgUnitPerm<DeallocUnit>,
+    ) -> bool {
+        &&& perm.wf_pfn_order(new@.mr_map, pfn, order)
+        &&& new.wf_next_pages()
+        &&& new.valid_pfn_order(pfn, order)
+        &&& self.with_same_mapping(new)
+    }
+
+    spec fn req_try_to_merge_page(
+        &self,
+        pfn: usize,
+        order: usize,
+        perm: PgUnitPerm<DeallocUnit>,
+    ) -> bool {
+        &&& self.wf_next_pages()
+        &&& self.valid_pfn_order(pfn, order)
+        &&& perm.wf_pfn_order(self@.mr_map, pfn, order)
+    }
+
+    spec fn ens_try_to_merge_page_ok(
+        &self,
+        new: &Self,
+        pfn: usize,
+        order: usize,
+        ret: Result<usize, AllocError>,
+        perm: PgUnitPerm<DeallocUnit>,
+    ) -> bool {
+        let new_pfn = ret.unwrap();
+        let order = order as int;
+        let new_order = (order + 1) as usize;
+        &&& new_pfn == pfn || new_pfn == pfn - (1usize << order)
+        &&& new.wf_next_pages()
+        &&& perm.wf_pfn_order(new@.mr_map, new_pfn, new_order)
+        &&& new.valid_pfn_order(new_pfn, new_order)
+        &&& self.with_same_mapping(new)
+    }
+
+    spec fn ens_try_to_merge_page(
+        &self,
+        new: &Self,
+        pfn: usize,
+        order: usize,
+        ret: Result<usize, AllocError>,
+        old_perm: PgUnitPerm<DeallocUnit>,
+        perm: PgUnitPerm<DeallocUnit>,
+    ) -> bool {
+        &&& ret.is_ok() ==> self.ens_try_to_merge_page_ok(new, pfn, order, ret, perm)
+        &&& ret.is_err() ==> (self == new) && perm == old_perm
+        &&& self.with_same_mapping(new)
+    }
+
+    spec fn ens_free_page_order(&self, new: &Self, pfn: usize, order: usize) -> bool {
+        &&& new.wf_next_pages()
+        &&& self.with_same_mapping(
+            new,
+        )
+        //&&& new@.contains_range(pfn, order)
+
+    }
+
+    spec fn req_free_page(&self, vaddr: VirtAddr, perm: AllocatedPagesPerm) -> bool {
+        &&& self.wf_next_pages()
+    }
+
+    spec fn ens_free_page(&self, new: &Self, vaddr: VirtAddr, perm: AllocatedPagesPerm) -> bool {
+        self@.mr_map@ == new@.mr_map@
+    }
+
+    spec fn req_free_page_raw(
+        &self,
+        pfn: usize,
+        order: usize,
+        perm: PgUnitPerm<DeallocUnit>,
+    ) -> bool {
+        &&& self.wf_next_pages()
+        &&& self.valid_pfn_order(pfn, order)
+        &&& perm.wf_pfn_order(self@.mr_map, pfn, order)
+    }
+
+    spec fn ens_free_page_raw(&self, new: &Self, pfn: usize, order: usize) -> bool {
+        let end = pfn + (1usize << order);
+        &&& new.wf_next_pages()
+        &&& self.with_same_mapping(new)
+    }
+
+    spec fn req_allocate_pages_info(&self, order: usize, pg: PageInfo) -> bool {
+        &&& self.wf_next_pages()
+        &&& order < MAX_ORDER
+        &&& pg.spec_order() == order
+        &&& pg.spec_type().spec_is_deallocatable()
+        &&& !matches!(pg, PageInfo::Compound(_))
+    }
+
+    spec fn ens_allocate_pages_info(
+        &self,
+        new: &Self,
+        order: usize,
+        pg: PageInfo,
+        ret: Result<VirtAddr, AllocError>,
+        perm_with_dealloc: Option<UnitDeallocPerm>,
+    ) -> bool {
+        let pfn = self.spec_get_pfn(ret.unwrap()).unwrap();
+        let UnitDeallocPerm(perm) = perm_with_dealloc.unwrap();
+        &&& self.with_same_mapping(new)
+        &&& new.wf_next_pages()
+        &&& ret.is_ok() ==> {
+            &&& perm.page_info() == Some(pg)
+            &&& perm.wf_pfn_order(new@.mr_map, pfn, order)
+        }
+    }
+
+    spec fn ens_phys_to_virt(&self, paddr: PhysAddr, ret: Option<VirtAddr>) -> bool {
+        let identity_map = self.map().is_identity_map();
+        let valid_identity_map = identity_map && (self.start_phys@ == self.start_virt.offset());
+        &&& !identity_map ==> (ret.is_some() == self.map().to_vaddr(paddr@ as int).is_some())
+        &&& (!identity_map && ret.is_some()) ==> (ret.unwrap() == self.map().to_vaddr(
+            paddr@ as int,
+        ).unwrap())
+        &&& valid_identity_map ==> (ret == Some(VirtAddr::from_spec(paddr@)))
+    }
+}
+
 } // verus!
+/*********************************************************************************
+ * Defines inline proofs to simplify annotations inside executable functions.
+ * Those proof blocks are close to implementations and are not performance critical.
+ * Thus, instead of define a new proof function, we define inline proofs.
+ * TODO(verus): support real inline proof functions instead of using macros.
+ */
+#[cfg(verus_keep_ghost_body)]
+macro_rules! grant_info_write {
+    ($mr: ident, $perm: ident => $mem: ident, $reserved: ident, $id: ident) => {
+        proof_decl! {
+            let tracked mut $perm = $perm;
+            let tracked ($mem, mut info) = $perm.tracked_take();
+            $mr.perms.borrow_mut().info.tracked_unshare_for_write(&mut info);
+            let tracked mut $reserved = info.tracked_expose();
+            let ghost $id = info.id();
+        }
+    };
+}
+
+#[cfg(verus_keep_ghost_body)]
+macro_rules! revoke_info_write {
+    ($mr: ident, $pfn: ident, $order: ident, $mem: ident, $reserved: ident, $id: ident => $p: ident) => {
+        proof_decl!{
+            let tracked info = $mr.perms.borrow_mut().info.tracked_insert_unit($order, $pfn, $id, $reserved);
+            let tracked mut $p = PgUnitPerm {mem: $mem, info, typ: arbitrary()};
+        }
+    }
+}
+
+#[cfg(verus_keep_ghost_body)]
+macro_rules! lemma_free_page_pre {
+    ($mr: ident, $perm: ident, $pfn: ident => $mem: ident, $reserved: ident, $head_info: ident, $id: ident) => {
+        proof_decl! {
+            grant_info_write!($mr, $perm => $mem, $reserved, $id);
+            let tracked mut $head_info = $reserved.tracked_remove($pfn);
+        }
+    };
+}
+
+#[cfg(verus_keep_ghost_body)]
+macro_rules! lemma_free_page_post {
+    ($mr: ident, $pfn: ident, $order: ident, $mem: ident, $reserved: ident, $head_info: ident, $id: ident) => {
+        proof_decl! {
+            $reserved.tracked_insert($pfn, $head_info);
+            revoke_info_write!($mr, $pfn, $order, $mem, $reserved, $id => pfn_perm);
+            $mr.perms.borrow_mut().free.tracked_push($order, $pfn, pfn_perm);
+        }
+    };
+}
+
+#[cfg(verus_keep_ghost_body)]
+macro_rules! lemma_split_pre {
+    ($mr: ident, $perm: ident, $pfn1: ident, $pfn2: ident, $order: ident, $new_order: ident => $mem: ident, $mem2: ident, $reserved: ident, $reserved2: ident, $info: ident, $id: ident) => {
+        proof_decl!{
+            // To prove that nr_pages[new_order] < usize::MAX - 2.
+            $mr.perms.borrow().info.tracked_nr_page_pair($new_order, $order);
+
+            // Grant write access to the page info.
+            use_type_invariant(&$perm.info);
+            grant_info_write!($mr, $perm => $mem, $reserved2, $id);
+
+            let tracked mut $reserved = $reserved2.tracked_remove_keys(Set::new(|i: usize| $pfn1 <= i < $pfn2));
+
+            // Prove the next page is valid.
+            $mr.perms.borrow().free.tracked_next($new_order);
+
+            // Split the memory permission to two.
+            let tracked ($mem, $mem2) = $mr.perms.borrow().mr_map.tracked_split_pages($mem, $pfn1, $order);
+        }
+    }
+}
+
+#[cfg(verus_keep_ghost_body)]
+macro_rules! lemma_split_post {
+    ($mr: ident, $pfn1: ident, $pfn2: ident, $new_order: ident, $mem: ident, $mem2: ident, $reserved: ident, $reserved2: ident, $id: ident, $p1: ident) => {
+        proof_decl! {
+            // Insert the readonly share of info perm for the right pages into
+            // the tracked info perm to avoid future write outside.
+            revoke_info_write!($mr, $pfn2, $new_order, $mem2, $reserved2, $id => p2);
+
+            // Add the new free perms into the free list.
+            use_type_invariant(&p2.info);
+            $mr.perms.borrow_mut().free.tracked_push($new_order, $pfn2, p2);
+            use_type_invariant(&$p1.info);
+            $mr.perms.borrow_mut().free.tracked_push($new_order, $pfn1, $p1);
+        }
+    };
+}
+
+#[cfg(verus_keep_ghost_body)]
+macro_rules! lemma_merge_pre {
+    ($mr: ident, $perm: ident, $p2: ident, $pfn1: ident, $pfn2: ident, $pfn: ident, $order: ident, $new_order: ident => $mem: ident, $reserved: ident, $head_info: ident, $id: ident) => {
+        proof_decl! {
+            // Proves that nr_page[new_order] <= usize:MAX - 1.
+            $mr.perms.borrow().info.tracked_nr_page_pair($order, $new_order);
+
+            let tracked (mut $mem, mut info) = $perm.tracked_take();
+
+            // Grant write access to the pfn1 page info.
+            // prove nr_page[order] >= 1.
+            $mr.perms.borrow_mut().info.tracked_unshare_for_write(&mut info);
+
+            let tracked mut $p2 = $p2;
+            let tracked (mut mem2, mut info2) = $p2.tracked_take();
+
+            // Grant write access to the pfn1 page info.
+            // prove that nr_page[order] >= 2.
+            $mr.perms.borrow_mut().info.tracked_unshare_for_write(&mut info2);
+
+            // Merge mem2 permissions into mem to cover the merged pages.
+            $mr.perms.borrow().mr_map.tracked_merge_pages(&mut $mem, mem2, $pfn1, $pfn2, $order);
+
+            // Split info perms into two groups:
+            // one for the allocinfo and another for compound pages.
+            let ghost $id = info.id();
+            let tracked mut $reserved = info.tracked_expose();
+            let tracked reserved2 = info2.tracked_expose();
+            $reserved.tracked_union_prefer_right(reserved2);
+            let tracked mut $head_info = $reserved.tracked_remove($pfn);
+        }
+    };
+}
+
+#[cfg(verus_keep_ghost_body)]
+macro_rules! lemma_merge_post {
+    ($mr: ident, $perm: ident, $pfn: ident, $order: ident, $new_order: ident, $mem: ident, $reserved: ident, $head_info: ident, $id: ident) => {
+        proof_decl! {
+            // Insert the readonly share of info perm for the merged memory
+            // back into the tracked info perm to avoid future write outside.
+            $reserved.tracked_insert($pfn, $head_info);
+            revoke_info_write!($mr, $pfn, $new_order, $mem, $reserved, $id => tmp_perm);
+            *$perm = tmp_perm;
+
+            // Prove the nr_page counter is correct.
+            assert(2 * (1usize << $order) == (1usize << ($new_order)));
+            assert($mr@.info.nr_page($order) == old($mr)@.info.nr_page($order) - 2);
+            assert($mr@.info.nr_page($new_order) == old($mr)@.info.nr_page($new_order) + 1);
+        }
+    };
+}
+
+#[cfg(verus_keep_ghost_body)]
+macro_rules! lemma_alloc_pfn_loop_pre {
+    ($mr: ident, $perm: ident, $old_pfn: ident, $current_pfn: ident, $order: ident, $idx_: ident =>
+        $prev_mem: ident,  $prev_id: ident, $prev_reserved: ident, $prev_head_info:ident,
+        $mem: ident, $id: ident, $reserved: ident, $head_info: ident) => {
+        proof_decl!{
+            // prove the next_pfn is disjont with current_pfn.
+            $mr.perms.borrow_mut().free.tracked_disjoint_pfn($order, $idx_ + 1, $order, $idx_);
+
+            // Get prev mem and info perms and grant write to info perm.
+            let tracked mut prev_perm = $mr.perms.borrow_mut().free.tracked_remove($order, $idx_ + 1);
+            lemma_free_page_pre!($mr, prev_perm, $old_pfn => $prev_mem, $prev_reserved, $prev_head_info, $prev_id);
+
+            // Get current mem and info perms and grant write to info perm.
+            let tracked mut current_perm = $mr.perms.borrow_mut().free.tracked_remove($order, $idx_);
+            lemma_free_page_pre!($mr, current_perm, $current_pfn => $mem, $reserved, $head_info, $id);
+        }
+    }
+}
+
+#[cfg(verus_keep_ghost_body)]
+macro_rules! lemma_alloc_pfn_loop_post {
+    ($mr: ident, $perm: ident, $old_pfn: ident, $current_pfn: ident, $order: ident, $idx_: ident, $prev_mem: ident, $prev_info_id: ident,
+        $prev_reserved: ident, $prev_head_info: ident, $mem: ident, $info_id: ident, $reserved: ident,
+        $head_info: ident) => {
+        proof_decl!{
+            // Insert the readonly share of info perm for prev free pages
+            $prev_reserved.tracked_insert($old_pfn, $prev_head_info);
+
+            let tracked prev_info = $mr.perms.borrow_mut().info.tracked_insert_unit($order, $old_pfn, $prev_info_id, $prev_reserved);
+
+            // Insert the prev_mem back to free list.
+            let tracked mut prev_perm = PgUnitPerm {mem: $prev_mem, info: prev_info, typ: arbitrary()};
+            $mr.perms.borrow_mut().free.tracked_insert($order, $idx_, $old_pfn, prev_perm);
+
+            // Insert the readonly share of info perm for the allocated
+            // pages to avoid future change from inside and outside of MR.
+            $reserved.tracked_insert($current_pfn, $head_info);
+
+            revoke_info_write!($mr, $current_pfn, $order, $mem, $reserved, $info_id => tmp_perm);
+            *$perm = tmp_perm;
+            // Prove free list is still strictly wellformed.
+            old($mr)@.free.lemma_wf_restrict_remove(&$mr.perms.borrow().free, $order, $idx_);
+        }
+    }
+}
+
+#[cfg(verus_keep_ghost_body)]
+macro_rules! lemma_free_page {
+    ($mr: ident, $inperm: ident, $pfn: ident, $res: ident => $perm: ident) => {
+        proof_decl! {
+            // Prove the passed pages are valid.
+            use_type_invariant(&$inperm);
+            let tracked AllocatedPagesPerm{mut $perm, mr_map} = $inperm;
+
+            // Prove the passed pages shares the same mapping and page info,
+            // tracked inside the MemoryRegion.
+            $mr.perms.borrow().mr_map.is_same(&mr_map);
+            $mr.perms.borrow().info.tracked_is_same_info(&$perm, $pfn);
+
+            // Prove the pfn is valid.
+            assert($mr.valid_pfn_order($pfn, $res.spec_order())) by {
+                mr_map.pg_params().lemma_reserved_pfn_count();
+            }
+        }
+    };
+}
+
+#[cfg(verus_keep_ghost_body)]
+macro_rules! lemma_get_pfn {
+    ($mr: ident, $vaddr: ident) => {
+        proof! {
+            use_type_invariant($vaddr);
+            reveal(<LinearMap as SpecMemMapTr>::to_paddr);
+            if $mr@.map().virt_start.offset() <= $vaddr.offset() < $mr@.map().virt_start.offset() + $mr@.map().size {
+                $mr@.map().lemma_get_pfn_get_virt($vaddr);
+            }
+        }
+    }
+}
+
+#[cfg(verus_keep_ghost_body)]
+macro_rules! lemma_alloc_pages_info_pre {
+    ($self: ident, $pfn: ident, $perm: ident => $mem: ident, $info: ident, $reserved: ident, $info_head: ident) => {
+        proof_decl! {
+            // Grant write access to the page info.
+            let tracked ($mem, mut $info) = $perm.tracked_take();
+            $self.perms.borrow_mut().info.tracked_unshare_for_write(&mut $info);
+            let tracked mut $reserved = $info.tracked_expose();
+            let tracked mut $info_head = $reserved.tracked_remove($pfn);
+        }
+    };
+}
+
+#[cfg(verus_keep_ghost_body)]
+macro_rules! lemma_alloc_pages_info_post {
+    ($self: ident, $order: ident, $pfn: ident, $mem: ident, $info: ident, $reserved: ident, $info_head: ident, $ret_perm: ident) => {
+        proof!{
+            // Insert the readonly share of info perm into the tracked info perm
+            $reserved.tracked_insert($pfn, $info_head);
+            let tracked info = $self.perms.borrow_mut().info.tracked_insert_unit($order, $pfn, $info.id(), $reserved);
+
+            // Return the memory permission with a readonly share of info.
+            let tracked perm = PgUnitPerm {$mem, info, typ: arbitrary()};
+            *$ret_perm = Some(UnitDeallocPerm(perm));
+
+            // Prove the relationship between vaddr and pfn.
+            // assert(pfn == self.spec_get_pfn(vaddr).unwrap()) by {
+            reveal(<LinearMap as SpecMemMapTr>::to_paddr);
+            // };
+        }
+    }
+}

--- a/kernel/src/mm/alloc_free.verus.rs
+++ b/kernel/src/mm/alloc_free.verus.rs
@@ -1,0 +1,589 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Ziqiao Zhou <ziqiaozhou@microsoft.com>
+//
+// Proofs for the free pages.
+// The allocator should have memory permissions for all free pages.
+// The free_page counter should be consistant with the actual free pages defined by nr_free.
+verus! {
+
+/// Each free memory page block should include PgUnitPerm to define
+/// 1. the full permission to access the free memory page block. The free memory
+/// access permission (`avail`) is defined in a structure to reflect the list of
+/// free list structure used in MemoryRegion. Each free list is a sequence of
+/// free pages with the same order.
+/// 2. Remaining shares of page info for the free page.
+///
+/// The mr_map defines one share of memory mapping permission to indicate that
+/// the allocator should remain at least one share of memory mapping permission.
+tracked struct MRFreePerms {
+    tracked avail: Seq<Seq<PgUnitPerm<DeallocUnit>>>,
+    ghost mr_map: MemRegionMapping,
+}
+
+impl MRFreePerms {
+    /// The list of number of free page block for each order.
+    spec fn nr_free(&self) -> Seq<usize> {
+        self.avail.map_values(|perms: Seq<PgUnitPerm<DeallocUnit>>| perms.len() as usize)
+    }
+
+    /// The list of free pages for each order.
+    /// ret[order][i] is the pfn of the i-th free page in the order-th free list.
+    #[verifier(inline)]
+    spec fn next_lists(&self) -> Seq<Seq<usize>> {
+        Seq::new(self.avail.len(), |i| Seq::new(self.avail[i].len(), |k| self.avail[i][k].pfn()))
+    }
+
+    /// The next free page for the given order.
+    spec fn next_page(&self, order: usize) -> usize {
+        let perms = self.avail[order as int];
+        if perms.len() > 0 {
+            perms.last().pfn()
+        } else {
+            0
+        }
+    }
+
+    /// The next free page for each order.
+    spec fn next_pages(&self) -> Seq<usize> {
+        self.avail.map_values(
+            |perms: Seq<PgUnitPerm<DeallocUnit>>|
+                if perms.len() > 0 {
+                    perms.last().pfn()
+                } else {
+                    0
+                },
+        )
+    }
+
+    spec fn mr_map(&self) -> MemRegionMapping {
+        self.mr_map
+    }
+
+    spec fn pg_params(&self) -> PageCountParam<MAX_ORDER> {
+        self.mr_map.pg_params()
+    }
+
+    #[verifier(inline)]
+    spec fn valid_pfn_order(&self, pfn: usize, order: usize) -> bool {
+        &&& self.pg_params().valid_pfn_order(pfn, order)
+        &&& pfn > 0
+    }
+
+    /// Create a new MRFreePerms with an empty free list.
+    proof fn tracked_empty(mr_map: MemRegionMapping) -> (tracked ret: Self)
+        requires
+            mr_map.wf(),
+        ensures
+            ret.nr_free() == Seq::new(MAX_ORDER as nat, |order| 0usize),
+            ret.avail === Seq::new(MAX_ORDER as nat, |order| Seq::empty()),
+            ret.mr_map() == mr_map,
+    {
+        let tracked ret = MRFreePerms { avail: tracked_empty_seq_of_seq(MAX_ORDER as nat), mr_map };
+        assert(ret.nr_free() =~= Seq::new(MAX_ORDER as nat, |order| 0usize));
+        ret
+    }
+
+    spec fn wf_next(&self, order: usize, i: int) -> bool {
+        &&& self.ens_perm_next(order, i, self.avail[order as int][i])
+    }
+
+    #[verifier(opaque)]
+    spec fn wf_strict(&self) -> bool {
+        let avail = self.avail;
+        forall|o: int, i: int|
+            #![trigger avail[o][i]]
+            0 <= o < MAX_ORDER && 0 <= i < avail[o].len() ==> self.wf_next(o as usize, i)
+    }
+
+    /// Prove that the permission is valid for the given order and index.
+    /// The PFN and order must be valid within the memory region.
+    /// The permission should be a valid to cover page block.
+    /// The PFN must be larger than 0 and the PageInfo must indicate the PageType is Free.
+    #[verifier(inline)]
+    spec fn ens_perm_valid(&self, order: usize, i: int, perm: PgUnitPerm<DeallocUnit>) -> bool {
+        let pfn = perm.info.unit_start();
+        &&& perm == self.avail[order as int][i]
+        &&& self.pg_params().valid_pfn_order(pfn, order)
+        &&& perm.wf_pfn_order(self.mr_map, pfn, order)
+        &&& perm.page_type() == PageType::Free
+        &&& pfn > 0
+    }
+
+    #[verifier(inline)]
+    spec fn ens_perm_next(&self, order: usize, i: int, perm: PgUnitPerm<DeallocUnit>) -> bool {
+        let next_perm = self.avail[order as int][i - 1];
+        &&& match perm.page_info() {
+            Some(PageInfo::Free(FreeInfo { order, next_page })) => {
+                &&& (next_page == 0 <==> i == 0)
+                &&& next_page > 0 ==> {
+                    &&& next_page == next_perm.pfn()
+                }
+            },
+            _ => { false },
+        }
+    }
+
+    #[verifier(inline)]
+    spec fn ens_perm_strict(&self, order: usize, i: int, perm: PgUnitPerm<DeallocUnit>) -> bool {
+        &&& self.ens_perm_valid(order, i, perm)
+        &&& self.ens_perm_next(order, i, perm)
+    }
+
+    #[verifier(opaque)]
+    spec fn wf_at(&self, order: usize, i: int) -> bool {
+        let perm = self.avail[order as int][i];
+        self.ens_perm_valid(order, i, perm)
+    }
+
+    #[verifier::type_invariant]
+    spec fn wf(&self) -> bool {
+        &&& self.mr_map.wf()
+        &&& self.avail.len() == MAX_ORDER
+        &&& forall|o: int, i: int|
+            #![trigger self.avail[o][i]]
+            0 <= o < MAX_ORDER && 0 <= i < self.avail[o].len() ==> self.wf_at(o as usize, i)
+    }
+
+    proof fn tracked_perm_disjoint_rec1(
+        tracked &self,
+        pfn: usize,
+        order: usize,
+        tracked perm: &mut RawPerm,
+        o: usize,
+        len: nat,
+    )
+        requires
+            old(perm).wf_pfn_order(self.mr_map, pfn, order),
+            0 <= len <= self.avail[o as int].len(),
+            0 <= o < MAX_ORDER,
+            0 <= order < MAX_ORDER,
+        ensures
+            *perm == *old(perm),
+            forall|i: int|
+                #![trigger self.avail[o as int][i]]
+                0 <= i < len ==> order_disjoint(self.avail[o as int][i].pfn(), o, pfn, order),
+        decreases len,
+    {
+        reveal(MRFreePerms::wf_at);
+        if len > 0 {
+            self.tracked_perm_disjoint_rec1(pfn, order, perm, o, (len - 1) as nat);
+            use_type_invariant(&*self);
+            let pfn2 = self.avail[o as int][len - 1].pfn();
+            let tracked perm2 = self.avail.tracked_borrow(o as int).tracked_borrow(len - 1);
+            self.mr_map.raw_perm_order_disjoint(pfn, order, pfn2, o, perm, &perm2.mem);
+        }
+    }
+
+    proof fn tracked_perm_disjoint_rec2(
+        tracked &self,
+        pfn: usize,
+        order: usize,
+        tracked perm: &mut RawPerm,
+        max_order: usize,
+    )
+        requires
+            old(perm).wf_pfn_order(self.mr_map(), pfn, order),
+            0 <= order < MAX_ORDER,
+            0 <= max_order <= MAX_ORDER,
+        ensures
+            *perm == *old(perm),
+            forall|o: usize, i: int|
+                #![trigger self.avail[o as int][i].pfn()]
+                0 <= o < max_order && 0 <= i < self.avail[o as int].len() ==> order_disjoint(
+                    self.avail[o as int][i].pfn(),
+                    o,
+                    pfn,
+                    order,
+                ),
+        decreases max_order,
+    {
+        if max_order > 0 {
+            self.tracked_perm_disjoint_rec2(pfn, order, perm, (max_order - 1) as usize);
+            let o = (max_order - 1) as usize;
+            self.tracked_perm_disjoint_rec1(pfn, order, perm, o, self.avail[o as int].len());
+        }
+    }
+
+    // If providing a mutable tracked perm, the tracked free perms must be disjoint with it.
+    proof fn tracked_perm_disjoint(
+        tracked &self,
+        tracked perm: &mut RawPerm,
+        pfn: usize,
+        order: usize,
+    )
+        requires
+            old(perm).wf_pfn_order(self.mr_map(), pfn, order),
+            0 <= order < MAX_ORDER,
+        ensures
+            *perm == *old(perm),
+            forall|o: usize, i: int|
+                #![trigger self.avail[o as int][i].pfn()]
+                0 <= o < MAX_ORDER && 0 <= i < self.avail[o as int].len() ==> order_disjoint(
+                    self.avail[o as int][i].pfn(),
+                    o,
+                    pfn,
+                    order,
+                ),
+    {
+        self.tracked_perm_disjoint_rec2(pfn, order, perm, MAX_ORDER);
+    }
+
+    // Any pair of free pages in the free lists are disjoint.
+    proof fn tracked_disjoint_pfn(tracked &mut self, o1: usize, i: int, o2: usize, j: int)
+        requires
+            (o1, i) != (o2, j),
+            0 <= o1 < MAX_ORDER,
+            0 <= o2 < MAX_ORDER,
+            0 <= i < old(self).avail[o1 as int].len() as int,
+            0 <= j < old(self).avail[o2 as int].len() as int,
+        ensures
+            *self == *old(self),
+            order_disjoint(self.avail[o1 as int][i].pfn(), o1, self.avail[o2 as int][j].pfn(), o2),
+    {
+        reveal(MRFreePerms::wf_at);
+        use_type_invariant(&*self);
+        let pfn1 = self.avail[o1 as int][i].pfn();
+        let pfn2 = self.avail[o2 as int][j].pfn();
+        let tracked mut tmp = MRFreePerms::tracked_empty(old(self).mr_map);
+        tracked_swap(&mut tmp, self);
+        let tracked MRFreePerms { mut avail, mr_map } = tmp;
+
+        let tracked mut a = avail.tracked_remove(o1 as int);
+        let olda = a;
+        let tracked mut p1 = a.tracked_remove(i);
+        let tracked p2 = if o1 < o2 {
+            avail.tracked_borrow(o2 - 1).tracked_borrow(j)
+        } else if o1 > o2 {
+            avail.tracked_borrow(o2 as int).tracked_borrow(j)
+        } else {
+            if i < j {
+                a.tracked_borrow(j - 1)
+            } else {
+                a.tracked_borrow(j)
+            }
+        };
+        use_type_invariant(&p1);
+        self.mr_map.raw_perm_order_disjoint(pfn1, o1, pfn2, o2, &mut p1.mem, &p2.mem);
+        a.tracked_insert(i, p1);
+        avail.tracked_insert(o1 as int, a);
+        assert(a =~= olda);
+        assert(avail =~= old(self).avail);
+        *self = MRFreePerms { avail, mr_map };
+    }
+
+    proof fn tracked_next_no_dup_len(tracked &mut self, o: usize)
+        requires
+            0 <= o < MAX_ORDER,
+        ensures
+            *self == *old(self),
+            self.next_lists()[o as int].no_duplicates(),
+            self.avail[o as int].len() <= self.pg_params().page_count,
+            self.avail[o as int].len() * (1usize << o) <= self.pg_params().page_count + (1usize
+                << o) - 1,
+    {
+        reveal(MRFreePerms::wf_at);
+        use_type_invariant(&*self);
+
+        let next_seq = self.next_lists()[o as int];
+        assert(next_seq.len() == self.avail[o as int].len());
+        self.tracked_next_is_disjoint_rec(o, 0, next_seq.len() as int);
+        lemma_order_disjoint_len(next_seq, o, self.pg_params().page_count);
+    }
+
+    proof fn tracked_next_is_disjoint_rec(tracked &mut self, o: usize, start: int, end: int)
+        requires
+            0 <= o < MAX_ORDER,
+            0 <= start <= end <= old(self).avail[o as int].len(),
+        ensures
+            *self == *old(self),
+            forall|i, j|
+                #![trigger self.avail[o as int][i], self.avail[o as int][j]]
+                start <= i < end && start <= j < end && i != j ==> order_disjoint(
+                    self.avail[o as int][i].pfn(),
+                    o,
+                    self.avail[o as int][j].pfn(),
+                    o,
+                ),
+        decreases end - start,
+    {
+        if start + 1 < end {
+            self.tracked_next_is_disjoint_rec(o, start + 1, end);
+            self.tracked_next_is_disjoint_rec(o, start, end - 1);
+            self.tracked_disjoint_pfn(o, start, o, end - 1);
+            assert forall|i, j|
+                #![trigger self.avail[o as int][i], self.avail[o as int][j]]
+                start <= i < end && start <= j < end && i != j ==> order_disjoint(
+                    self.avail[o as int][i].pfn(),
+                    o,
+                    self.avail[o as int][j].pfn(),
+                    o,
+                ) by {}
+        }
+    }
+
+    /// Prove the side effect of inserting a new free page block into the free list.
+    #[verifier::spinoff_prover]
+    proof fn tracked_insert(
+        tracked &mut self,
+        order: usize,
+        idx: int,
+        pfn: usize,
+        tracked perm: PgUnitPerm<DeallocUnit>,
+    )
+        requires
+            0 <= order < MAX_ORDER,
+            0 <= idx <= old(self).avail[order as int].len() as int,
+            old(self).valid_pfn_order(pfn, order),
+            perm.wf_pfn_order(old(self).mr_map, pfn, order),
+            perm.page_type() == PageType::Free,
+        ensures
+            self.avail == old(self).avail.update(
+                order as int,
+                old(self).avail[order as int].insert(idx, perm),
+            ),
+            self.avail[order as int] == old(self).avail[order as int].insert(idx, perm),
+            self.mr_map() == old(self).mr_map(),
+            self.pg_params() == old(self).pg_params(),
+            self.nr_free() == old(self).nr_free().update(
+                order as int,
+                (old(self).nr_free()[order as int] + 1) as usize,
+            ),
+            old(self).nr_free()[order as int] <= old(self).pg_params().page_count - 1,
+            old(self).nr_free()[order as int] * (1usize << order) <= old(
+                self,
+            ).pg_params().page_count - 1,
+    {
+        reveal(MRFreePerms::wf_at);
+        use_type_invariant(&*self);
+        let tracked mut tmp = MRFreePerms::tracked_empty(old(self).mr_map());
+        tracked_swap(&mut tmp, self);
+        let tracked MRFreePerms { mut avail, mr_map } = tmp;
+        let tracked mut a = avail.tracked_remove(order as int);
+        a.tracked_insert(idx, perm);
+        avail.tracked_insert(order as int, a);
+
+        *self = MRFreePerms { avail, mr_map: mr_map };
+        assert(self.avail =~= old(self).avail.update(
+            order as int,
+            old(self).avail[order as int].insert(idx, perm),
+        ));
+        assert(old(self).nr_free()[order as int] == old(self).avail[order as int].len() as usize);
+        self.tracked_next_no_dup_len(order);
+        let gap = 1usize << order;
+        lemma_mul_is_distributive_add_other_way(
+            gap as int,
+            old(self).nr_free()[order as int] as int,
+            1,
+        );
+
+        assert(self.avail[order as int].len() as usize == (old(self).nr_free()[order as int]
+            + 1) as usize);
+        assert forall|o: usize| 0 <= o < MAX_ORDER implies #[trigger] self.nr_free()[o as int]
+            == if o != order {
+            old(self).nr_free()[o as int]
+        } else {
+            (old(self).nr_free()[order as int] + 1) as usize
+        } by {}
+        assert(self.nr_free() =~= old(self).nr_free().update(
+            order as int,
+            (old(self).nr_free()[order as int] + 1) as usize,
+        ));
+    }
+
+    #[verifier::spinoff_prover]
+    proof fn tracked_push(
+        tracked &mut self,
+        order: usize,
+        pfn: usize,
+        tracked perm: PgUnitPerm<DeallocUnit>,
+    )
+        requires
+            0 <= order < MAX_ORDER,
+            old(self).valid_pfn_order(pfn, order),
+            perm.wf_pfn_order(old(self).mr_map, pfn, order),
+            perm.page_type() == PageType::Free,
+            old(self).wf_strict(),
+            perm.page_info() == Some(
+                PageInfo::Free(FreeInfo { order, next_page: old(self).next_page(order) }),
+            ),
+        ensures
+            self.avail == old(self).avail.update(
+                order as int,
+                old(self).avail[order as int].push(perm),
+            ),
+            self.mr_map() == old(self).mr_map(),
+            self.pg_params() == old(self).pg_params(),
+            self.nr_free() == old(self).nr_free().update(
+                order as int,
+                (old(self).nr_free()[order as int] + 1) as usize,
+            ),
+            old(self).nr_free()[order as int] <= old(self).pg_params().page_count - 1,
+            old(self).nr_free()[order as int] * (1usize << order) <= old(
+                self,
+            ).pg_params().page_count - 1,
+            self.wf_strict(),
+    {
+        reveal(MRFreePerms::wf_strict);
+        reveal(MRFreePerms::wf_at);
+        use_type_invariant(&*self);
+        self.tracked_insert(order, self.avail[order as int].len() as int, pfn, perm);
+        assert(old(self).avail[order as int].push(perm) =~= old(self).avail[order as int].insert(
+            old(self).avail[order as int].len() as int,
+            perm,
+        ));
+        assert(self.avail[order as int].last() == perm);
+
+    }
+
+    #[verifier::spinoff_prover]
+    proof fn tracked_pop(tracked &mut self, order: usize) -> (tracked perm: PgUnitPerm<DeallocUnit>)
+        requires
+            0 <= order < MAX_ORDER,
+            old(self).next_page(order) > 0,
+            old(self).wf_strict(),
+        ensures
+            self.wf_strict(),
+            self.avail == old(self).avail.update(order as int, self.avail[order as int]),
+            self.avail[order as int] == old(self).avail[order as int].take(
+                old(self).avail[order as int].len() - 1,
+            ),
+            old(self).ens_perm_strict(order, old(self).avail[order as int].len() - 1, perm),
+            self.mr_map() == old(self).mr_map(),
+            self.nr_free() == old(self).nr_free().update(
+                order as int,
+                (old(self).nr_free()[order as int] - 1) as usize,
+            ),
+            old(self).nr_free()[order as int] > 0,
+    {
+        self.tracked_remove(order, self.avail[order as int].len() - 1)
+    }
+
+    /// Prove the property of i-th free page block at a specific order
+    #[verifier::spinoff_prover]
+    proof fn tracked_borrow(tracked &self, order: usize, i: int) -> (tracked perm: &PgUnitPerm<
+        DeallocUnit,
+    >)
+        requires
+            0 <= order < MAX_ORDER,
+            0 <= i < self.avail[order as int].len(),
+        ensures
+            self.wf_strict() ==> self.ens_perm_strict(order, i, *perm),
+            self.ens_perm_valid(order, i, *perm),
+    {
+        reveal(MRFreePerms::wf_at);
+        use_type_invariant(self);
+        reveal(MRFreePerms::wf_strict);
+        let tracked p = self.avail.tracked_borrow(order as int).tracked_borrow(i);
+        use_type_invariant(&p);
+        p
+    }
+
+    /// Prove the property of the next free page at a specific order
+    proof fn tracked_next(tracked &self, order: usize)
+        requires
+            self.wf_strict(),
+        ensures
+            (order < MAX_ORDER && self.next_page(order) != 0) ==> self.pg_params().valid_pfn_order(
+                self.next_page(order),
+                order as usize,
+            ),
+    {
+        use_type_invariant(self);
+        if order < MAX_ORDER && self.next_page(order) != 0 {
+            self.tracked_borrow(order, self.avail[order as int].len() - 1);
+        }
+    }
+
+    /// Prove the side effect of removing a free page block from the free list.
+    #[verifier::spinoff_prover]
+    proof fn tracked_remove(tracked &mut self, order: usize, idx: int) -> (tracked perm: PgUnitPerm<
+        DeallocUnit,
+    >)
+        requires
+            0 <= order < MAX_ORDER,
+            0 <= idx < old(self).avail[order as int].len(),
+        ensures
+            self.avail == old(self).avail.update(order as int, self.avail[order as int]),
+            self.avail[order as int] == old(self).avail[order as int].remove(idx),
+            old(self).ens_perm_valid(order, idx, perm),
+            self.mr_map() == old(self).mr_map(),
+            self.nr_free() == old(self).nr_free().update(
+                order as int,
+                (old(self).nr_free()[order as int] - 1) as usize,
+            ),
+            old(self).nr_free()[order as int] > 0,
+            old(self).wf_strict() ==> old(self).ens_perm_strict(order, idx, perm),
+            old(self).wf_strict() ==> (idx == self.avail[order as int].len() ==> self.wf_strict()),
+    {
+        reveal(MRFreePerms::wf_at);
+        use_type_invariant(&*self);
+        let p = self.avail[order as int][idx];
+        let tracked mut tmp = MRFreePerms::tracked_empty(old(self).mr_map());
+        tracked_swap(&mut tmp, self);
+        tmp.tracked_next_no_dup_len(order);
+        assert(old(self).nr_free()[order as int] == old(self).avail[order as int].len());
+
+        let tracked MRFreePerms { mut avail, mr_map } = tmp;
+        let len = avail[order as int].len();
+        let tracked mut a = avail.tracked_remove(order as int);
+        let olda = a;
+        let tracked perm = a.tracked_remove(idx);
+        avail.tracked_insert(order as int, a);
+        *self = MRFreePerms { avail, mr_map: mr_map };
+        assert(self.avail =~= old(self).avail.update(
+            order as int,
+            old(self).avail[order as int].remove(idx),
+        ));
+        assert(self.nr_free() =~= old(self).nr_free().update(
+            order as int,
+            (old(self).nr_free()[order as int] - 1) as usize,
+        ));
+        use_type_invariant(&*self);
+        if old(self).wf_strict() {
+            assert(old(self).ens_perm_strict(order, idx, perm)) by {
+                reveal(MRFreePerms::wf_strict);
+            }
+            assert((idx == self.avail[order as int].len() ==> self.wf_strict())) by {
+                reveal(MRFreePerms::wf_strict);
+            }
+        }
+        perm
+    }
+
+    #[verifier::spinoff_prover]
+    #[verifier::rlimit(2)]
+    proof fn lemma_wf_restrict_remove(&self, tracked new: &Self, order: usize, idx: int)
+        requires
+            self.wf_strict(),
+            self.wf(),
+            new.avail =~= self.avail.update(order as int, new.avail[order as int]),
+            order < MAX_ORDER,
+            0 <= idx < self.avail[order as int].len(),
+            idx < self.avail[order as int].len() ==> new.avail[order as int]
+                =~= self.avail[order as int].remove(idx).update(idx, new.avail[order as int][idx]),
+            idx == self.avail[order as int].len() - 1 ==> new.avail[order as int]
+                =~= self.avail[order as int].remove(idx),
+            new.avail[order as int][idx].pfn() == self.avail[order as int][idx + 1].pfn(),
+            new.ens_perm_strict(order, idx, new.avail[order as int][idx]),
+        ensures
+            new.wf_strict(),
+    {
+        use_type_invariant(new);
+        reveal(MRFreePerms::wf_strict);
+        reveal(MRFreePerms::wf_at);
+        assert(idx > 0 ==> self.avail[order as int][idx - 1].pfn() == new.avail[order as int][idx
+            - 1].pfn());
+        assert forall|o: usize, i: int|
+            #![trigger new.avail[o as int][i]]
+            0 <= o < MAX_ORDER && 0 <= i < new.avail[o as int].len() implies new.wf_next(o, i) by {
+            let old_a = self.avail[o as int][i];
+            let old_prev_a = self.avail[o as int][i - 1];
+            let old_prev_a = self.avail[o as int][i + 1];
+        }
+    }
+}
+
+} // verus!

--- a/kernel/src/mm/alloc_info.verus.rs
+++ b/kernel/src/mm/alloc_info.verus.rs
@@ -1,0 +1,985 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Ziqiao Zhou <ziqiaozhou@microsoft.com>
+//
+// Proofs for tracking the page info in reserved memory regions.
+// To ensure the global allocator and the locally allocated heap memory
+// have consistent page info, we use `FracPtr` to share the page info
+// and guarantee that the page info is immutable once shared.
+// PageInfoDb is the main data structure to track the page info with the same
+// shared status.
+use verify_proof::frac_ptr::tracked_map_merge_right_shares;
+use verify_proof::frac_ptr::tracked_map_shares;
+use verify_proof::set::{lemma_set_usize_range, set_usize_range};
+use vstd::raw_ptr::PtrData;
+
+verus! {
+
+type PInfoPerm = FracTypedPerm<PageStorageType>;
+
+/// Defines the identifier of the page info and permission share state.
+#[allow(missing_debug_implementations)]
+ghost struct PInfoGroupId {
+    pub ptr_data: PtrData<PageStorageType>,
+    pub shares: nat,
+    pub total: nat,
+}
+
+impl PInfoGroupId {
+    spec fn update_shares(&self, shares: nat) -> PInfoGroupId {
+        PInfoGroupId { ptr_data: self.ptr_data, shares, total: self.total }
+    }
+
+    spec fn base_ptr(&self) -> *const PageStorageType {
+        vstd::raw_ptr::ptr_from_data(self.ptr_data)
+    }
+
+    #[verifier(inline)]
+    spec fn ptr(&self, idx: usize) -> *const PageStorageType {
+        self.base_ptr().add(idx)
+    }
+}
+
+trait ValidPageInfo {
+    spec fn is_valid_pginfo(&self) -> bool;
+
+    spec fn page_info(&self) -> Option<PageInfo>;
+
+    spec fn page_storage(&self) -> Option<PageStorageType>;
+
+    spec fn order(&self) -> usize;
+
+    spec fn size(&self) -> usize;
+
+    spec fn is_head(&self) -> bool;
+
+    spec fn is_free(&self) -> bool;
+
+    spec fn ens_write_page_info(&self, new: &Self, pfn: usize, pi: PageInfo) -> bool;
+}
+
+impl ValidPageInfo for PInfoPerm {
+    spec fn is_valid_pginfo(&self) -> bool {
+        &&& self.page_info().is_some()
+        &&& self.page_info().unwrap().spec_order() < MAX_ORDER
+        &&& self.valid()
+    }
+
+    spec fn ens_write_page_info(&self, perm: &Self, pfn: usize, pi: PageInfo) -> bool {
+        let old_perm = *self;
+        &&& perm@ == old_perm@.update_value(perm.opt_value())
+        &&& perm.is_valid_pginfo()
+        &&& perm.page_info() == Some(pi)
+    }
+
+    spec fn page_info(&self) -> Option<PageInfo> {
+        spec_page_info(self.opt_value())
+    }
+
+    spec fn page_storage(&self) -> Option<PageStorageType> {
+        spec_page_storage_type(self.opt_value())
+    }
+
+    spec fn order(&self) -> usize {
+        self.page_info().unwrap().spec_order()
+    }
+
+    #[verifier(inline)]
+    spec fn size(&self) -> usize {
+        1usize << self.order()
+    }
+
+    spec fn is_head(&self) -> bool {
+        !matches!(self.page_info(), Some(PageInfo::Compound(_)))
+    }
+
+    spec fn is_free(&self) -> bool {
+        matches!(self.page_info(), Some(PageInfo::Free(_)))
+    }
+}
+
+// The `PageInfoDb` is a map of page info with the same shared status.
+// It is used to track the page info stored in reserved memory regions.
+// Those permissions should be grouped as (1usize<<order) continuous physical
+// pages with consistent page type and order information (see
+// new_unit_requires).
+// When page info DB is a unit, it only contains one unit (see is_unit).
+tracked struct PageInfoDb {
+    ghost unit_start: usize,  // only for unit
+    ghost id: PInfoGroupId,
+    reserved: Map<usize, PInfoPerm>,
+}
+
+impl PageInfoDb {
+    /*** Basic spec functions ***/
+    closed spec fn view(&self) -> Map<usize, PInfoPerm> {
+        self.reserved
+    }
+
+    closed spec fn id(&self) -> PInfoGroupId {
+        self.id
+    }
+
+    closed spec fn unit_start(&self) -> usize {
+        self.unit_start
+    }
+
+    /*** Useful spec functions ***/
+    #[verifier(inline)]
+    spec fn order(&self) -> usize {
+        self@[self.unit_start].order()
+    }
+
+    #[verifier(inline)]
+    spec fn dom(&self) -> Set<usize> {
+        self@.dom()
+    }
+
+    spec fn npages(&self) -> nat {
+        self.dom().len()
+    }
+
+    #[verifier(inline)]
+    spec fn base_ptr(&self) -> *const PageStorageType {
+        self.id().base_ptr()
+    }
+
+    #[verifier(inline)]
+    spec fn ptr(&self, idx: usize) -> *const PageStorageType {
+        self.id().ptr(idx)
+    }
+
+    #[verifier::inline]
+    spec fn share_total(&self) -> (nat, nat) {
+        (self.id().shares, self.id().total)
+    }
+
+    #[verifier(inline)]
+    spec fn end(&self) -> int {
+        self.unit_start + (1usize << self@[self.unit_start()].order())
+    }
+
+    #[verifier(inline)]
+    spec fn page_info(&self, idx: usize) -> Option<PageInfo> {
+        self@[idx].page_info()
+    }
+
+    #[verifier(inline)]
+    spec fn is_head(&self, idx: usize) -> bool {
+        self@[idx].is_head()
+    }
+
+    /// The condition to be a unit.
+    /// page number: [unit_start, unit_start+(1usize<<order))
+    /// the order is stored in first page info and is consistent across all
+    /// page info.
+    spec fn _is_unit(reserved: Map<usize, PInfoPerm>, unit_start: usize) -> bool {
+        let item = reserved[unit_start];
+        let order = item.order();
+        let npages = reserved.dom().len();
+        let end = unit_start + (1usize << order);
+        &&& end <= usize::MAX + 1
+        &&& !reserved.dom().is_empty()
+        &&& reserved.dom() =~= Set::new(|k| unit_start <= k < end)
+        &&& item.is_head()
+    }
+
+    #[verifier(inline)]
+    spec fn is_unit(&self) -> bool {
+        &&& Self::_is_unit(self@, self.unit_start)
+    }
+
+    #[verifier(inline)]
+    spec fn unit_head(&self) -> PInfoPerm
+        recommends
+            self.is_unit(),
+    {
+        self@[self.unit_start]
+    }
+
+    /// When idx is the head of a unit, it returns the unit range.
+    #[verifier(inline)]
+    spec fn dom_at(&self, idx: usize) -> Set<usize> {
+        set_usize_range(idx, idx + self@[idx].size())
+    }
+
+    spec fn writable(&self) -> bool {
+        self.id().shares == self.id().total > DEALLOC_PGINFO_SHARES
+    }
+
+    spec fn is_readonly_allocator_shares(&self) -> bool {
+        AllocatorUnit::wf_share_total(self.id().shares, self.id().total)
+    }
+
+    spec fn marked_compound(
+        reserved: Map<usize, PInfoPerm>,
+        head_idx: usize,
+        order: usize,
+    ) -> bool {
+        let n = 1usize << order;
+        &&& order < MAX_ORDER
+        &&& forall|i|
+            #![trigger reserved[i]]
+            head_idx < i < head_idx + n ==> reserved[i].page_info() == Some(
+                PageInfo::Compound(CompoundInfo { order }),
+            )
+    }
+
+    spec fn wf_basic_at(item: PInfoPerm, idx: usize, id: PInfoGroupId) -> bool {
+        &&& item.is_valid_pginfo()
+        &&& item.shares() == id.shares
+        &&& item.total() == id.total
+        &&& item.ptr() == id.ptr(idx)
+    }
+
+    #[verifier(inline)]
+    spec fn wf_basic(&self, idx: usize) -> bool {
+        Self::wf_basic_at(self@[idx], idx, self.id())
+    }
+
+    /// If self@[idx].is_head(),
+    /// the PageInfoDB must include all pages in that unit group. In addition,
+    /// if PageInfoDB contains the page (`next`) that is just after the the end
+    /// page of the unit, `next` must be the head of the next unit.
+    /// If PageInfoDB contains a page at idx,
+    /// it must be part of a unit group and so PageInfoDB must contains a page
+    /// at idx-1 if the page at idx is not the head.
+    spec fn wf_follows(&self, idx: usize) -> bool {
+        let next = idx + self@[idx].size();
+        &&& self@[idx].is_head() ==> self.dom_at(idx).subset_of(self@.dom())
+        &&& !self@[idx].is_head() ==> idx > 0 && self@.dom().contains((idx - 1) as usize)
+        &&& (self@[idx].is_head() && next <= usize::MAX && self@.dom().contains(next as usize))
+            ==> self@[next as usize].is_head()
+    }
+
+    /// A memory "unit" is a block of contiguous pages. This function ensures:
+    /// - All pages within the unit are continuous and well-formed.
+    /// - All pages within the unit have the same sharing state.
+    /// - The unit is properly aligned.
+    /// - If the unit contains compound pages, they follow the head page
+    ///   correctly and consistently.
+    spec fn new_unit_requires(
+        reserved: Map<usize, PInfoPerm>,
+        id: PInfoGroupId,
+        unit_start: usize,
+        order: usize,
+    ) -> bool {
+        let item = reserved[unit_start];
+        let info = item.page_info().unwrap();
+        let end = (1usize << order) + unit_start;
+        &&& item.order() == order
+        &&& item.shares() == id.shares
+        &&& item.total() == id.total
+        &&& Self::_is_unit(reserved, unit_start)
+        &&& forall|idx: usize|
+            #![trigger reserved[idx]]
+            unit_start <= idx < end ==> Self::wf_basic_at(reserved[idx], idx, id)
+        &&& match info {
+            PageInfo::Reserved(_) => true,
+            PageInfo::Compound(ci) => { false },
+            PageInfo::Slab(_) | PageInfo::File(_) => true,
+            PageInfo::Allocated(ai) => { Self::marked_compound(reserved, unit_start, order) },
+            PageInfo::Free(fi) => { Self::marked_compound(reserved, unit_start, order) },
+        }
+    }
+
+    spec fn wf_unit(&self) -> bool {
+        &&& Self::new_unit_requires(self@, self.id(), self.unit_start, self.order())
+    }
+
+    spec fn remove(&self, idx: usize) -> PageInfoDb {
+        PageInfoDb {
+            unit_start: self.unit_start,
+            id: self.id,
+            reserved: self@.remove_keys(self.dom_at(idx)),
+        }
+    }
+
+    /// Extract a unit from the `PageInfoDb` at the given index.
+    #[verifier(opaque)]
+    spec fn restrict(&self, idx: usize) -> PageInfoDb {
+        if self@[idx].is_head() {
+            PageInfoDb {
+                unit_start: idx,
+                id: self.id(),
+                reserved: self@.restrict(self.dom_at(idx)),
+            }
+        } else {
+            PageInfoDb::empty(self.id)
+        }
+    }
+
+    /// The invariant of the `PageInfoDb`
+    #[verifier::type_invariant]
+    spec fn wf(&self) -> bool {
+        &&& forall|idx: usize|
+            #![trigger self@[idx]]
+            self@.dom().contains(idx) && self@[idx].is_head() ==> {
+                &&& idx + self@[idx].size() <= usize::MAX + 1
+            }
+        &&& !self.is_unit() ==> forall|idx: usize|
+            #![trigger self@[idx]]
+            self@.dom().contains(idx) ==> {
+                &&& self.wf_follows(idx)
+                &&& self@[idx].is_head() ==> self.restrict(idx).wf_unit()
+                &&& self.wf_basic(idx)
+            }
+        &&& self.is_unit() ==> self.wf_unit()
+    }
+
+    spec fn empty(id: PInfoGroupId) -> PageInfoDb {
+        PageInfoDb { unit_start: 0, id, reserved: Map::empty() }
+    }
+
+    spec fn _info_dom(&self, order: usize) -> Set<usize> {
+        self@.dom().filter(|i| self@[i].order() == order && self@[i].is_head())
+    }
+
+    /// The number of page blocks (unit) of the given order.
+    #[verifier(opaque)]
+    spec fn nr_page(&self, order: usize) -> nat {
+        self._info_dom(order).len()
+    }
+
+    spec fn _info_head_dom(&self, order: usize) -> Set<usize> {
+        self@.dom().filter(|i| self@[i].order() == order && self@[i].is_head())
+    }
+
+    /// Prove that for any two orders: `order` and `order2`,
+    /// the number of page blocks (unit) with the given two orders should be
+    /// less than the total number of pages.
+    proof fn tracked_nr_page_pair(tracked &self, order: usize, order2: usize)
+        requires
+            order < order2 < 64,
+        ensures
+            self.nr_page(order) + self.nr_page(order2) * 2 <= self.npages(),
+    {
+        use_type_invariant(self);
+        self.lemma_nr_page_pair(order, order2);
+    }
+
+    proof fn lemma_nr_page_pair(&self, order: usize, order2: usize)
+        requires
+            self.wf(),
+            order < order2 < 64,
+        ensures
+            self.nr_page(order) + self.nr_page(order2) * 2 <= self.dom().len(),
+    {
+        reveal(PageInfoDb::nr_page);
+        let s1 = self._info_dom(order);
+        let s2 = self._info_dom(order2);
+        assert(order2 >= 1);
+        assert((1usize << order2) > 1);
+        let r = |i: usize|
+            if i < usize::MAX {
+                (i + 1) as usize
+            } else {
+                0usize
+            };
+        let s3 = s2.map(r);
+        assert forall|x1: usize, x2: usize| #[trigger] r(x1) == #[trigger] r(x2) implies x1
+            == x2 by {}
+        vstd::set_lib::lemma_map_size(s2, s3, r);
+        assert forall|i| #[trigger] s3.contains(i) implies !s1.contains(i) && !s2.contains(i)
+            && self.dom().contains(i) by {
+            let head_i = (i - 1) as usize;
+            assert(s2.contains(head_i));
+            self.lemma_restrict(head_i);
+            reveal(PageInfoDb::restrict);
+            let e2 = self@[head_i];
+            let e3 = self@[i];
+            assert(self.is_head(head_i));
+            assert(!self.is_head(i));
+        }
+        assert(s1.disjoint(s2));
+        vstd::set_lib::lemma_set_disjoint_lens(s1, s2);
+        vstd::set_lib::lemma_set_disjoint_lens(s1 + s2, s3);
+        let s = s1 + s2 + s3;
+        assert(s.subset_of(self@.dom()));
+    }
+
+    /// the number of page blocks with any given orders should be less than the
+    /// total number of pages.
+    proof fn lemma_nr_page_npages(&self, order: usize)
+        requires
+            self.wf(),
+        ensures
+            self.nr_page(order) <= self.npages(),
+    {
+        reveal(PageInfoDb::nr_page);
+        assert(self._info_dom(order).subset_of(self@.dom()));
+    }
+
+    spec fn const_nr_page(npages: nat, order: usize) -> nat {
+        if order < MAX_ORDER && (1usize << order) == npages {
+            1
+        } else {
+            0
+        }
+    }
+
+    proof fn tracked_unit_nr_pages(tracked &self)
+        requires
+            self.is_unit(),
+        ensures
+            forall|order| #[trigger]
+                self.nr_page(order) == Self::const_nr_page(self.npages(), order),
+            self.npages() == 1usize << (self@[self.unit_start()].order()),
+    {
+        use_type_invariant(self);
+        self.proof_unit_nr_page();
+    }
+
+    proof fn proof_unit_nr_page(&self)
+        requires
+            self.wf(),
+            self.is_unit(),
+        ensures
+            forall|order| #[trigger]
+                self.nr_page(order) == Self::const_nr_page(self.npages(), order),
+            self.npages() == 1usize << (self@[self.unit_start()].order()),
+    {
+        reveal(PageInfoDb::nr_page);
+
+        assert(1usize << self@[self.unit_start()].order() == self.npages()) by {
+            lemma_set_usize_range(
+                self.unit_start,
+                self.unit_start + (1usize << self@[self.unit_start()].order()),
+            );
+        }
+        assert forall|order| #[trigger]
+            self.nr_page(order) == Self::const_nr_page(self.npages(), order) by {
+            if (order < MAX_ORDER && (1usize << order) == self.npages()) {
+                assert(order == self@[self.unit_start()].order());
+            }
+            self.lemma_unit_nr_page(order);
+        }
+    }
+
+    proof fn lemma_unit_nr_page(&self, order: usize)
+        requires
+            self.wf(),
+            self.is_unit(),
+        ensures
+            self.nr_page(order) == Self::const_nr_page(self.npages(), order),
+            self.npages() == 1usize << (self@[self.unit_start()].order()),
+    {
+        reveal(PageInfoDb::nr_page);
+        if order == self@[self.unit_start()].order() {
+            assert(self._info_dom(order) =~= set![self.unit_start]);
+            //assert(self._info_dom(order) =~= self@.dom());
+        } else {
+            assert(self._info_dom(order).is_empty());
+        }
+        lemma_set_usize_range(self.unit_start, self.unit_start + (1usize << self.order()));
+    }
+
+    proof fn lemma_restrict(&self, idx: usize)
+        requires
+            self.wf(),
+            self.is_head(idx),
+            self@.dom().contains(idx),
+        ensures
+            self.restrict(idx).wf(),
+            self.restrict(idx).is_unit(),
+            self.restrict(idx)@.dom() =~= self.dom_at(idx),
+            forall|i|
+                #![trigger self@[i]]
+                #![trigger self.restrict(idx)@[i]]
+                idx <= i < idx + self@[idx].size() ==> self.restrict(idx)@[i] == self@[i],
+    {
+        reveal(PageInfoDb::restrict);
+        if self.is_unit() {
+            assert(idx == self.unit_start);
+            assert(self.restrict(idx)@ =~= self@);
+            assert(self.restrict(idx).wf());
+        } else {
+            assert(self.restrict(idx).is_unit());
+            assert(self.restrict(idx).wf_unit());
+        }
+    }
+
+    spec fn new(unit_start: usize, id: PInfoGroupId, reserved: Map<usize, PInfoPerm>) -> Self {
+        PageInfoDb { unit_start, id, reserved }
+    }
+
+    spec fn ens_split_inner(&self, left: Self, right: Self) -> bool {
+        &&& left.dom().disjoint(right.dom())
+        &&& left@ =~= self@.restrict(left.dom())
+        &&& right@ =~= self@.restrict(right.dom())
+        &&& left.dom() + right.dom() =~= self.dom()
+        &&& left.id() == self.id()
+        &&& right.id() == self.id()
+    }
+
+    spec fn ens_split(&self, left: Self, right: Self) -> bool {
+        &&& left.dom().disjoint(right.dom())
+        &&& left@ == self@.restrict(left.dom())
+        &&& right@ == self@.restrict(right.dom())
+        &&& left.dom() + right.dom() == self.dom()
+        &&& left.id() == self.id()
+        &&& right.id() == self.id()
+    }
+
+    spec fn ens_add_nr_pages(&self, left: Self, right: Self) -> bool {
+        &&& self.npages() == left.npages() + right.npages()
+        &&& forall|o: usize| #[trigger] self.nr_page(o) == left.nr_page(o) + right.nr_page(o)
+    }
+
+    spec fn ens_add_unit_nr_pages(&self, left: Self, order: usize) -> bool {
+        &&& self.npages() == left.npages() + (1usize << order)
+        &&& forall|o: usize| order != o ==> #[trigger] self.nr_page(o) == left.nr_page(o)
+        &&& self.nr_page(order) == left.nr_page(order) + 1
+    }
+
+    /** Constructors **/
+    proof fn tracked_empty(id: PInfoGroupId) -> (tracked ret: PageInfoDb)
+        ensures
+            ret == PageInfoDb::empty(id),
+    {
+        let tracked reserved = Map::tracked_empty();
+        PageInfoDb { unit_start: 0, id, reserved }
+    }
+
+    proof fn proof_split_nr_page(&self, left: Self, right: Self)
+        requires
+            self.wf(),
+            self.ens_split_inner(left, right),
+        ensures
+            self.ens_add_nr_pages(left, right),
+    {
+        self.lemma_split_nr_page(left, right, 0);
+        assert forall|order: usize| #[trigger]
+            self.nr_page(order) == left.nr_page(order) + right.nr_page(order) by {
+            self.lemma_split_nr_page(left, right, order);
+        }
+    }
+
+    proof fn lemma_split_nr_page(&self, left: Self, right: Self, order: usize)
+        requires
+            self.wf(),
+            self.ens_split_inner(left, right),
+        ensures
+            self.nr_page(order) == left.nr_page(order) + right.nr_page(order),
+            self.npages() == left.npages() + right.npages(),
+    {
+        reveal(PageInfoDb::nr_page);
+        let s1 = left._info_dom(order);
+        let s2 = right._info_dom(order);
+        let s = self._info_dom(order);
+        vstd::set_lib::lemma_set_disjoint_lens(left.dom(), right.dom());
+        vstd::set_lib::lemma_set_disjoint_lens(s1, s2);
+        assert(s1 + s2 =~= s);
+    }
+
+    proof fn lemma_remove(&self, i: usize)
+        requires
+            self.wf(),
+            self.dom().contains(i),
+            self.is_head(i),
+        ensures
+            self.remove(i).npages() == self.npages() - self@[i].size(),
+            forall|j|
+                self.is_head(j) && i != j && self.dom().contains(j) ==> #[trigger] self.remove(
+                    i,
+                ).restrict(j) == self.restrict(j),
+    {
+        let left = self.remove(i);
+        assert forall|j|
+            self.is_head(j) && i != j && self.dom().contains(j) implies #[trigger] left.restrict(j)
+            == self.restrict(j) by {
+            self.lemma_remove_restrict(i, j);
+        }
+        let s = self.dom_at(i);
+        assert(left.dom() + s =~= self@.dom());
+        vstd::set_lib::lemma_set_disjoint_lens(left.dom(), s);
+        lemma_set_usize_range(i, i + self@[i].size());
+    }
+
+    spec fn merge(&self, other: Self) -> Self {
+        PageInfoDb {
+            unit_start: self.unit_start,
+            id: self.id,
+            reserved: self@.union_prefer_right(other@),
+        }
+    }
+
+    #[verifier(spinoff_prover)]
+    proof fn lemma_merge_wf(&self, other: Self)
+        requires
+            self.wf(),
+            other.wf(),
+            other.is_unit(),
+            self.id() == other.id(),
+            self.dom().disjoint(other.dom()),
+        ensures
+            self.merge(other).wf(),
+    {
+        reveal(PageInfoDb::restrict);
+        let new = self.merge(other);
+
+        if !new.is_unit() {
+            assert forall|idx: usize| #![trigger new@[idx]] new@.dom().contains(idx) implies {
+                &&& new.wf_follows(idx)
+            } by {
+                let next = idx + new@[idx].size();
+                let item = new@[next as usize];
+                assert(other@[other.unit_start].is_head());
+                if (new@[idx].is_head() && next <= usize::MAX && new@.dom().contains(
+                    next as usize,
+                )) {
+                    if other.unit_start <= next < other.end() {
+                        if (!item.is_head()) {
+                            assert(new@[next as usize] == other@[next as usize]);
+                            assert(next > other.unit_start);
+                            assert(self.dom().contains((next - 1) as usize));
+                        }
+                    } else if other.unit_start <= idx < other.end() {
+                        assert(item.is_head());
+                    }
+                }
+            }
+            assert forall|idx: usize|
+                #![trigger new@[idx]]
+                new@.dom().contains(idx) && new@[idx].is_head() implies {
+                new.restrict(idx).wf_unit()
+            } by {
+                if self.dom().contains(idx) {
+                    self.lemma_restrict(idx);
+                    assert(self.restrict(idx).wf());
+                    assert(self.restrict(idx)@ =~= new.restrict(idx)@);
+                } else {
+                    assert(other.dom().contains(idx));
+                    other.lemma_restrict(idx);
+                    assert(other.restrict(idx).wf());
+                    assert(other.restrict(idx)@ =~= new.restrict(idx)@);
+                }
+            }
+        } else {
+            if new.unit_start() != other.unit_start() {
+                assert(other.dom().subset_of(new.dom()));
+                assert(other@[other.unit_start()].is_head());
+                assert(new@[other.unit_start()].is_head());
+            }
+            assert(new@ =~= other@);
+        }
+    }
+
+    #[verifier(spinoff_prover)]
+    proof fn lemma_remove_wf(&self, i: usize)
+        requires
+            self.wf(),
+            self.dom().contains(i),
+            self.is_head(i),
+        ensures
+            self.remove(i).wf(),
+    {
+        reveal(PageInfoDb::restrict);
+        self.lemma_restrict(i);
+        lemma_set_usize_range(i, i + self@[i].size());
+        broadcast use lemma_set_usize_range;
+
+        self.lemma_remove(i);
+    }
+
+    #[verifier(spinoff_prover)]
+    proof fn lemma_remove_restrict(&self, i: usize, j: usize)
+        requires
+            self.wf(),
+            self.dom().contains(i),
+            self.dom().contains(j),
+            self.is_head(i),
+            self.is_head(j),
+            i != j,
+        ensures
+            self.remove(i).restrict(j) == self.restrict(j),
+    {
+        reveal(PageInfoDb::restrict);
+        self.lemma_head_no_overlap(i, j);
+        assert(self.remove(i).restrict(j)@ =~= self.restrict(j)@);
+    }
+
+    broadcast proof fn lemma_head_no_overlap(&self, i: usize, j: usize)
+        requires
+            self.wf(),
+            self.is_head(i),
+            self.is_head(j),
+            i != j,
+            self.dom().contains(i),
+            self.dom().contains(j),
+        ensures
+            #![trigger self@[i], self@[j]]
+            i + self@[i].size() <= j || i >= j + self@[j].size(),
+    {
+        reveal(PageInfoDb::restrict);
+        self.lemma_restrict(i);
+        self.lemma_restrict(j);
+    }
+
+    proof fn lemma_wf_recursive(&self)
+        requires
+            self.wf(),
+        ensures
+            forall|idx| #![trigger self@[idx]] self.dom().contains(idx) ==> self.restrict(idx).wf(),
+    {
+        reveal(PageInfoDb::restrict);
+        assert forall|idx| #![trigger self@[idx]] self.dom().contains(idx) implies self.restrict(
+            idx,
+        ).wf() by {
+            if self.is_head(idx) {
+                self.lemma_restrict(idx);
+            }
+        }
+    }
+
+    proof fn tracked_new_unit(
+        order: usize,
+        unit_start: usize,
+        id: PInfoGroupId,
+        tracked reserved: Map<usize, PInfoPerm>,
+    ) -> (tracked ret: Self)
+        requires
+            order < MAX_ORDER,
+            unit_start + (1usize << order) <= usize::MAX + 1,
+            reserved.dom() =~= Set::new(|k| unit_start <= k < unit_start + (1usize << order)),
+            reserved[unit_start].is_head(),
+            reserved[unit_start].order() == order,
+            PageInfoDb::new_unit_requires(reserved, id, unit_start, order),
+        ensures
+            ret.is_unit(),
+            ret == PageInfoDb::new(unit_start, id, reserved),
+            ret@ == reserved,
+            ret.npages() == (1usize << order),
+            forall|order| #[trigger] ret.nr_page(order) == Self::const_nr_page(ret.npages(), order),
+    {
+        reveal(PageInfoDb::restrict);
+        lemma_set_usize_range(unit_start, unit_start + (1usize << order));
+        let tracked ret = PageInfoDb { unit_start, id, reserved };
+        ret.proof_unit_nr_page();
+        ret
+    }
+
+    proof fn tracked_remove_unit(tracked &mut self, idx: usize) -> (tracked unit: PageInfoDb)
+        requires
+            old(self).dom().contains(idx),
+            old(self).is_head(idx),
+        ensures
+            old(self).ens_split(*self, unit),
+            self@ == old(self)@.remove_keys(unit@.dom()),
+            self.id() == old(self).id(),
+            self.npages() == old(self).npages() - old(self)@[idx].size(),
+            unit.is_unit(),
+            unit.unit_start() == idx,
+            old(self).ens_add_nr_pages(*self, unit),
+    {
+        use_type_invariant(&*self);
+        reveal(PageInfoDb::restrict);
+        self.lemma_restrict(idx);
+        self.lemma_remove(idx);
+        self.lemma_remove_wf(idx);
+        let order = self@[idx].order();
+        let s = self.dom_at(idx);
+        let tracked ret = self.reserved.tracked_remove_keys(s);
+        assert(ret.dom() == s);
+        assert(order == ret[idx].order());
+        let tracked ret = PageInfoDb::tracked_new_unit(order, idx, self.id(), ret);
+        assert(old(self).ens_split_inner(*self, ret));
+        old(self).proof_split_nr_page(*self, ret);
+        ret
+    }
+
+    spec fn ens_unshare_for_write(&self, new: Self, unit: &PageInfoDb) -> bool {
+        &&& new@ == self@.remove_keys(unit@.dom())
+        &&& new.id() == self.id()
+        &&& self.ens_add_unit_nr_pages(new, unit.order())
+    }
+
+    /// Remove the permission for the specified unit from the `PageInfoDb` and merge
+    /// the shares into the unit.
+    /// This function is used when we need to recover theh write permission of the unit.
+    proof fn tracked_unshare_for_write(tracked &mut self, tracked unit: &mut PageInfoDb)
+        requires
+            old(self).dom().contains(old(unit).unit_start()),
+            old(unit).is_unit(),
+            old(unit).id().ptr_data == old(self).id().ptr_data,
+        ensures
+            unit.is_unit(),
+            unit.npages() == old(unit).npages(),
+            unit.unit_start() == old(unit).unit_start(),
+            unit.id() == old(unit).id().update_shares(
+                old(unit).id().shares + old(self).id().shares,
+            ),
+            unit.unit_head()@ == old(unit).unit_head()@.update_shares(unit.id().shares),
+            forall|order: usize| #[trigger] old(unit).nr_page(order) == unit.nr_page(order),
+            self@ == old(self)@.remove_keys(unit@.dom()),
+            self.id() == old(self).id(),
+            old(self).ens_add_unit_nr_pages(*self, unit.order()),
+    {
+        let idx = unit.unit_start();
+        use_type_invariant(&*self);
+        use_type_invariant(&*unit);
+
+        assert(self@[idx].ptr() == unit@[idx].ptr());
+        self.reserved.tracked_borrow(idx).is_same(unit.reserved.tracked_borrow(idx));
+
+        assert(self@[idx].valid());
+        assert(unit@[idx].valid());
+        unit.tracked_unit_nr_pages();
+        let order = unit@[idx].order();
+        let tracked unit2 = self.tracked_remove_unit(idx);
+        unit2.tracked_unit_nr_pages();
+        let tracked mut tmp = PageInfoDb::tracked_empty(arbitrary());
+        tracked_swap(unit, &mut tmp);
+        let tracked PageInfoDb { unit_start, mut reserved, mut id } = tmp;
+        tracked_map_merge_right_shares(&mut reserved, unit2.reserved);
+        id.shares = id.shares + unit2.id().shares;
+        *unit = PageInfoDb::tracked_new_unit(order, unit_start, id, reserved);
+    }
+
+    /// Insert a new unit with the same share into the `PageInfoDb` and
+    /// returns remaining shares.
+    proof fn tracked_insert_unit(
+        tracked &mut self,
+        order: usize,
+        unit_start: usize,
+        id: PInfoGroupId,
+        tracked reserved: Map<usize, PInfoPerm>,
+    ) -> (tracked unit: PageInfoDb)
+        requires
+            order < MAX_ORDER,
+            unit_start + (1usize << order) <= usize::MAX + 1,
+            reserved.dom() =~= Set::new(|k| unit_start <= k < unit_start + (1usize << order)),
+            reserved[unit_start].is_head(),
+            reserved[unit_start].order() == order,
+            PageInfoDb::new_unit_requires(reserved, id, unit_start, order),
+            old(self).dom().disjoint(reserved.dom()),
+            old(self).id() == id.update_shares(old(self).id().shares),
+            0 < old(self).id().shares < id.shares,
+        ensures
+            unit.is_unit(),
+            unit.id() == id.update_shares((id.shares - old(self).id().shares) as nat),
+            unit.unit_head()@ == reserved[unit_start]@.update_shares(unit.id().shares),
+            unit.unit_start() == unit_start,
+            unit.npages() == (1usize << order),
+            self.id() == old(self).id(),
+            self@.dom() == old(self)@.dom() + reserved.dom(),
+            self@ =~= old(self)@.union_prefer_right(self@.restrict(reserved.dom())),
+            self.ens_add_unit_nr_pages(*old(self), order),
+    {
+        let tracked mut info = PageInfoDb::tracked_new_unit(order, unit_start, id, reserved);
+        self.tracked_insert_shares(&mut info);
+        info
+    }
+
+    #[verifier(spinoff_prover)]
+    proof fn tracked_insert_shares(tracked &mut self, tracked unit: &mut PageInfoDb)
+        requires
+            old(unit).is_unit(),
+            0 < old(self).id().shares < old(unit).id().shares,
+            old(self).dom().disjoint(old(unit).dom()),
+            old(self).id() == old(unit).id().update_shares(old(self).id().shares),
+        ensures
+            unit.is_unit(),
+            unit.unit_head()@ == old(unit).unit_head()@.update_shares(unit.id().shares),
+            unit.id() == old(unit).id().update_shares(
+                (old(unit).id().shares - old(self).id().shares) as nat,
+            ),
+            unit.unit_start() == old(unit).unit_start(),
+            self.id() == old(self).id(),
+            self@.dom() == old(self)@.dom() + old(unit)@.dom(),
+            self@ =~= old(self)@.union_prefer_right(self@.restrict(unit@.dom())),
+            forall|order: usize| #[trigger] old(unit).nr_page(order) == unit.nr_page(order),
+            self.ens_add_unit_nr_pages(*old(self), unit.order()),
+    {
+        use_type_invariant(&*unit);
+        unit.tracked_unit_nr_pages();
+        let tracked new_unit = unit.tracked_split_shares(self.id().shares);
+        assert(old(unit).dom() == new_unit.dom());
+        use_type_invariant(&*self);
+        use_type_invariant(&new_unit);
+        self.lemma_merge_wf(new_unit);
+        new_unit.tracked_unit_nr_pages();
+        unit.tracked_unit_nr_pages();
+        self.reserved.tracked_union_prefer_right(new_unit.reserved);
+        self.proof_split_nr_page(*old(self), new_unit);
+        assert(self@.dom() =~= old(self)@.dom() + old(unit)@.dom());
+    }
+
+    proof fn tracked_split_shares(tracked &mut self, shares: nat) -> (tracked unit: PageInfoDb)
+        requires
+            old(self).is_unit(),
+            0 < shares < old(self).id().shares,
+        ensures
+            self.is_unit(),
+            self.unit_head()@ == old(self).unit_head()@.update_shares(self.id().shares),
+            unit.unit_head()@ == old(self).unit_head()@.update_shares(shares),
+            self.unit_start() == old(self).unit_start() == unit.unit_start(),
+            old(self).npages() == self.npages() == unit.npages(),
+            self.id() == old(self).id().update_shares((old(self).id().shares - shares) as nat),
+            unit.is_unit(),
+            unit.id() == old(self).id().update_shares(shares),
+            forall|order: usize| #[trigger]
+                old(self).nr_page(order) == self.nr_page(order) == unit.nr_page(order),
+    {
+        use_type_invariant(&*self);
+        self.proof_unit_nr_page();
+        let idx = self.unit_start();
+        let order = self@[idx].order();
+        let tracked mut tmp = PageInfoDb::tracked_empty(arbitrary());
+        tracked_swap(self, &mut tmp);
+        let tracked PageInfoDb { unit_start, mut reserved, mut id } = tmp;
+        let tracked new_reserved = tracked_map_shares(&mut reserved, shares);
+        let mut ret_id = id;
+        ret_id.shares = shares;
+        id.shares = (id.shares - shares) as nat;
+        *self = PageInfoDb::tracked_new_unit(order, unit_start, id, reserved);
+        use_type_invariant(&*self);
+        self.proof_unit_nr_page();
+        PageInfoDb::tracked_new_unit(order, unit_start, ret_id, new_reserved)
+    }
+
+    proof fn tracked_is_same_info<T: UnitType>(
+        tracked &self,
+        tracked other: &PgUnitPerm<T>,
+        pfn: usize,
+    )
+        requires
+            self.dom().contains(pfn),
+            !other.info@.is_empty(),
+            other.info.unit_start() <= pfn < other.info.end(),
+            self.base_ptr() == other.info.base_ptr(),
+        ensures
+            self@[pfn].points_to() == other.info@[pfn].points_to(),
+    {
+        use_type_invariant(self);
+        use_type_invariant(other);
+        use_type_invariant(&other.info);
+        self.reserved.tracked_borrow(pfn).is_same(other.info.reserved.tracked_borrow(pfn));
+    }
+
+    proof fn tracked_borrow(tracked &self, idx: usize) -> (tracked item: &PInfoPerm)
+        requires
+            self.dom().contains(idx),
+        ensures
+            item == self@[idx],
+            item.is_valid_pginfo(),
+    {
+        use_type_invariant(self);
+        reveal(PageInfoDb::wf_basic_at);
+        self.reserved.tracked_borrow(idx)
+    }
+
+    proof fn tracked_expose(tracked self) -> (tracked ret: Map<usize, PInfoPerm>)
+        ensures
+            ret == self.reserved,
+            self.wf(),
+    {
+        use_type_invariant(&self);
+        let tracked PageInfoDb { id, reserved, .. } = self;
+        reserved
+    }
+}
+
+} // verus!

--- a/kernel/src/mm/alloc_inner.verus.rs
+++ b/kernel/src/mm/alloc_inner.verus.rs
@@ -1,0 +1,432 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Ziqiao Zhou <ziqiaozhou@microsoft.com>
+//
+// Spec and proofs that does not need private types in alloc.rs
+use crate::mm::alloc::VirtAddr;
+use crate::mm::LinearMap;
+use crate::types::{lemma_page_size, PAGE_SIZE};
+use crate::utils::util::spec_align_up;
+
+use crate::mm::alloc::MAX_ORDER;
+use verify_external::hw_spec::SpecVAddrImpl;
+use verify_proof::bits::*;
+use verify_proof::frac_ptr::*;
+use verify_proof::nonlinear::*;
+use vstd::arithmetic::div_mod::*;
+use vstd::arithmetic::mul::lemma_mul_is_distributive_add_other_way;
+use vstd::math::min;
+use vstd::modes::tracked_swap;
+use vstd::prelude::*;
+use vstd::raw_ptr::*;
+verus! {
+
+pub type RawPerm = PointsToRaw;
+
+pub spec const MAX_PAGE_COUNT: u64 = 1u64 << (u64::BITS - 12) as u64;
+
+pub spec const MAX_PGINFO_SHARES: nat = 2;
+
+pub spec const ALLOCATOR_PGINFO_SHARES: nat = 1;
+
+pub spec const DEALLOC_PGINFO_SHARES: nat = 1;
+
+pub uninterp spec fn allocator_provenance() -> Provenance;
+
+pub proof fn tracked_empty_seq_of_seq<T>(n: nat) -> (tracked ret: Seq<Seq<T>>)
+    requires
+        n >= 0,
+    ensures
+        ret.len() == n,
+        ret == Seq::new(n, |i| Seq::<T>::empty()),
+    decreases n,
+{
+    if n == 0 {
+        assert(Seq::empty() =~= Seq::new(n, |i| Seq::<T>::empty()));
+        Seq::tracked_empty()
+    } else {
+        let tracked mut ret = tracked_empty_seq_of_seq((n - 1) as nat);
+        ret.tracked_push(Seq::tracked_empty());
+        assert(ret =~= Seq::new(n, |i| Seq::<T>::empty()));
+        ret
+    }
+}
+
+pub open spec fn ens_find_neighbor(pfn: usize, order: usize, ret_pfn: usize) -> bool {
+    let lower_neighbor = pfn - (1usize << order);
+    let upper_neighbor = pfn + (1usize << order);
+    &&& ret_pfn == lower_neighbor || ret_pfn == upper_neighbor
+    &&& ret_pfn == lower_neighbor ==> ret_pfn % (1usize << (order + 1) as usize) == 0
+    &&& ret_pfn == upper_neighbor ==> pfn % (1usize << (order + 1) as usize) == 0
+    &&& ret_pfn % (1usize << order) == 0
+}
+
+#[verifier::spinoff_prover]
+#[verifier::rlimit(4)]
+pub broadcast proof fn lemma_compound_neighbor(pfn: usize, order: usize, ret_pfn: usize)
+    requires
+        pfn % (1usize << order) == 0,
+        pfn + (1usize << order) <= usize::MAX,
+        ret_pfn == pfn ^ (1usize << order),
+        0 <= order < 63,
+    ensures
+        (ret_pfn == pfn - (1usize << order)) ==> ret_pfn % (1usize << (order + 1)) == 0,
+        #[trigger] ens_find_neighbor(pfn, order, ret_pfn),
+{
+    broadcast use lemma_bit_usize_shl_values;
+
+    assert(pfn % (1usize << order) == 0);
+    let n = 1usize << (order + 1);
+    assert(1usize << (order + 1) == 2 * (1usize << order));
+    lemma_bit_usize_and_mask_is_mod(pfn, ((1usize << order) - 1) as usize);
+    lemma_bit_usize_and_mask_is_mod(pfn, ((1usize << (order + 1) as usize) - 1) as usize);
+    lemma_bit_usize_xor_neighbor(pfn, order);
+    lemma_modulus_add_sub_m(pfn as int, (1usize << order) as int);
+    if ret_pfn == pfn - (1usize << order) {
+        let x = pfn;
+        let m = 1usize << order;
+        if x as int % (2 * m) == 0 {
+            assert(x & (2 * m - 1) as usize == 0);
+            assert(x & (n - 1) as usize == 0);
+            assert(x ^ m == sub(x, m));
+        }
+        assert(x as int % (2 * m) != 0);
+        assert(((x - m) % (2 * m) == 0 && (x >= m || x <= -m)))
+    }
+}
+
+pub open spec fn order_disjoint(
+    start1: usize,
+    order1: usize,
+    start2: usize,
+    order2: usize,
+) -> bool {
+    let end1 = start1 + (1usize << order1);
+    let end2 = start2 + (1usize << order2);
+    (end1 <= start2 || end2 <= start1)
+}
+
+pub proof fn lemma_order_disjoint_len(s: Seq<usize>, o: usize, max_count: usize)
+    requires
+        o < 64,
+        // s has a upper bound
+        forall|i| #![trigger s[i]] 0 <= i < s.len() ==> s[i] < max_count,
+        // s is order-disjoint
+        forall|i, j|
+            #![trigger s[i], s[j]]
+            0 <= i < s.len() && 0 <= j < s.len() && i != j ==> order_disjoint(s[i], o, s[j], o),
+    ensures
+        s.len() * (1usize << o) <= max_count + (1usize << o) - 1,
+        s.len() <= max_count,
+    decreases s.len(),
+{
+    broadcast use lemma_bit_usize_shl_values;
+
+    let gap = (1usize << o);
+    let int_s = s.map_values(|x| x as int);
+    assert(int_s.len() == s.len());
+    if s.len() > 1 {
+        int_s.max_ensures();
+        let idx = choose|i| 0 <= i < int_s.len() && int_s[i] == int_s.max();
+        assert(int_s[idx] == int_s.max());
+        assert(s.remove(idx).len() < s.len());
+        assert forall|i| #![trigger s[i]] 0 <= i < s.len() && i != idx implies s[i] < max_count
+            - gap by {
+            assert(s[idx] <= max_count);
+            assert(int_s[i] <= int_s[idx]);
+            assert(s[i] <= s[idx]);
+            assert(order_disjoint(s[i], o, s[idx], o));
+        }
+        let s2 = s.remove(idx);
+        if idx > 0 {
+            assert(order_disjoint(s[idx], o, s[idx - 1], o));
+        } else {
+            assert(order_disjoint(s[idx], o, s[idx + 1], o));
+        }
+        assert(max_count >= gap);
+        lemma_order_disjoint_len(s2, o, (max_count - gap) as usize);
+        assert(s2.len() <= max_count - gap);
+        assert(s2.len() * gap <= max_count - 1);
+        assert(s.len() == s2.len() + 1);
+        assert(s.len() * gap == s2.len() * gap + 1 * gap) by {
+            lemma_mul_is_distributive_add_other_way(gap as int, s2.len() as int, 1);
+        }
+    } else if s.len() == 1 {
+        assert(s[0] < max_count);
+        assert(max_count > 0);
+        assert(s.len() <= max_count);
+        assert(1 * gap == gap);
+        assert(s.len() * gap <= max_count + gap - 1);
+    } else {
+        assert(0 * gap == 0);
+    }
+}
+
+#[allow(missing_debug_implementations)]
+pub ghost struct PageCountParam<const N: usize> {
+    pub page_count: usize,
+}
+
+impl<const N: usize> PageCountParam<N> {
+    #[verifier(opaque)]
+    pub open spec fn reserved_pfn_count(&self) -> nat {
+        (spec_align_up(self.page_count * 8 as int, PAGE_SIZE as int) / PAGE_SIZE as int) as nat
+    }
+
+    pub open spec fn valid_pfn_order(&self, pfn: usize, order: usize) -> bool {
+        let n = 1usize << order;
+        &&& self.reserved_pfn_count() <= pfn < self.page_count
+        &&& pfn + n <= self.page_count
+        &&& n > 0
+        &&& pfn % n == 0
+        &&& order < N
+    }
+
+    pub proof fn lemma_reserved_pfn_count(&self)
+        ensures
+            self.reserved_pfn_count() == self.page_count / 512 || self.reserved_pfn_count() == 1 + (
+            self.page_count / 512),
+            self.page_count > 0 ==> self.reserved_pfn_count() > 0,
+    {
+        broadcast use lemma_page_size;
+
+        reveal(PageCountParam::reserved_pfn_count);
+
+        let x = self.page_count * 8 as int;
+        assert(PAGE_SIZE == 0x1000);
+        let count = spec_align_up(x, PAGE_SIZE as int);
+        verify_proof::nonlinear::lemma_align_up_properties(x, PAGE_SIZE as int, count);
+        assert(self.page_count * 8 / 0x1000 == self.page_count / 512);
+    }
+
+    #[verifier::spinoff_prover]
+    proof fn lemma_valid_pfn_order_split(&self, pfn: usize, order: usize)
+        requires
+            self.valid_pfn_order(pfn, order),
+            0 < order < N <= 64,
+        ensures
+            self.valid_pfn_order(pfn, (order - 1) as usize),
+            self.valid_pfn_order(
+                (pfn + (1usize << (order - 1) as usize)) as usize,
+                (order - 1) as usize,
+            ),
+    {
+        broadcast use lemma_bit_usize_shl_values;
+
+        let n = 1usize << order;
+        let lower_n = 1usize << (order - 1) as usize;
+        assert(1usize << order == 2 * (1usize << (order - 1) as usize)) by (bit_vector)
+            requires
+                0 < order < 64,
+        ;
+        if self.valid_pfn_order(pfn, order) && order > 0 {
+            verify_proof::nonlinear::lemma_modulus_product_divisibility(
+                pfn as int,
+                lower_n as int,
+                2,
+            );
+        }
+        lemma_add_mod_noop(pfn as int, lower_n as int, lower_n as int);
+        lemma_mod_self_0(lower_n as int);
+        lemma_small_mod(0, lower_n as nat);
+        assert((pfn + lower_n) % lower_n as int == 0);
+    }
+}
+
+pub trait MemPermWithVAddrOrder<VAddr: SpecVAddrImpl> {
+    spec fn wf_vaddr_order(&self, map: MemRegionMapping, vaddr: VAddr, order: usize) -> bool;
+}
+
+pub trait MemPermWithPfnOrder {
+    spec fn wf_pfn_order(&self, map: MemRegionMapping, pfn: usize, order: usize) -> bool;
+}
+
+impl<VAddr: SpecVAddrImpl> MemPermWithVAddrOrder<VAddr> for RawPerm {
+    open spec fn wf_vaddr_order(&self, map: MemRegionMapping, vaddr: VAddr, order: usize) -> bool {
+        let size = ((1usize << order) * PAGE_SIZE) as nat;
+        &&& self.dom() =~= vaddr.region_to_dom(size)
+        &&& self.provenance() === map@.provenance
+    }
+}
+
+impl MemPermWithPfnOrder for RawPerm {
+    open spec fn wf_pfn_order(&self, map: MemRegionMapping, pfn: usize, order: usize) -> bool {
+        let vaddr = map@.map.try_get_virt(pfn);
+        &&& vaddr.is_some()
+        &&& pfn + (1usize << order) <= map@.map.size / PAGE_SIZE as nat
+        &&& self.wf_vaddr_order(map, vaddr.unwrap(), order)
+    }
+}
+
+// A ghost global layout for global allocator
+// Add more global variables here as needed
+// It could be a real global variable or a global invariant.
+// We store LinearMap here to ensure that the mapping will not be modified by accident.
+// For example, allocator must update this ghost variable if it needs to
+// change the base_ptr defined in LinearMap.
+#[allow(missing_debug_implementations)]
+pub ghost struct MemRegionMappingView {
+    pub map: LinearMap,
+    pub provenance: Provenance,
+}
+
+// Since the allocated memory will have partial ownership (defined via
+// FracTypedPerm) of MemRegionMappingView and so the allocator cannot obtain
+// full ownership to change mapping if the allocator does not free all memory.
+#[allow(missing_debug_implementations)]
+pub tracked struct MemRegionMapping(FracTypedPerm<Tracked<MemRegionMappingView>>);
+
+impl MemRegionMapping {
+    pub uninterp spec fn const_ptr() -> *const Tracked<MemRegionMappingView>;
+
+    #[verifier::type_invariant]
+    pub closed spec fn wf(&self) -> bool {
+        &&& self.0.ptr() == Self::const_ptr()
+        &&& self.0.valid()
+        &&& self@.map.wf()
+    }
+
+    pub closed spec fn view(&self) -> MemRegionMappingView {
+        self.0.value()@
+    }
+
+    pub closed spec fn shares(&self) -> nat {
+        self.0.shares()
+    }
+
+    pub open spec fn pg_params(&self) -> PageCountParam<MAX_ORDER> {
+        PageCountParam { page_count: (self@.map.size / PAGE_SIZE as nat) as usize }
+    }
+
+    pub open spec fn base_ptr<T>(&self) -> *const T {
+        vstd::raw_ptr::ptr_from_data(
+            vstd::raw_ptr::PtrData {
+                addr: self@.map.virt_start@,
+                provenance: self@.provenance,
+                metadata: (),
+            },
+        )
+    }
+
+    pub proof fn is_same(tracked &self, tracked other: &Self)
+        ensures
+            self@ == other@,
+    {
+        use_type_invariant(&*self);
+        use_type_invariant(other);
+        self.0.is_same(&other.0);
+    }
+
+    #[verifier::spinoff_prover]
+    pub proof fn tracked_merge_pages(
+        tracked &self,
+        tracked perm1: &mut RawPerm,
+        tracked perm2: RawPerm,
+        p1: usize,
+        p2: usize,
+        order: usize,
+    )
+        requires
+            0 <= order < 64,
+            p1 == p2 + (1usize << order) || p2 == p1 + (1usize << order),
+            perm2.wf_pfn_order(*self, p2, order),
+            old(perm1).wf_pfn_order(*self, p1, order),
+        ensures
+            perm1.wf_pfn_order(*self, min(p1 as int, p2 as int) as usize, (order + 1) as usize),
+    {
+        use_type_invariant(self);
+        broadcast use lemma_bit_usize_shl_values;
+
+        let map = self@.map;
+        let vaddr1 = map.lemma_get_virt(p1);
+        let vaddr2 = map.lemma_get_virt(p2);
+        let size = ((1usize << order) * PAGE_SIZE) as nat;
+        if p1 < p2 {
+            vaddr1.lemma_region_to_dom_merge(size, vaddr2, size);
+        } else {
+            vaddr2.lemma_region_to_dom_merge(size, vaddr1, size);
+        }
+        let tracked mut owned_perm1 = RawPerm::empty(perm1.provenance());
+        tracked_swap(&mut owned_perm1, perm1);
+        *perm1 = owned_perm1.join(perm2);
+    }
+
+    #[verifier::spinoff_prover]
+    pub proof fn tracked_split_pages(
+        tracked &self,
+        tracked p: RawPerm,
+        pfn: usize,
+        order: usize,
+    ) -> (tracked perms: (RawPerm, RawPerm))
+        requires
+            1 <= order < 64,
+            p.wf_pfn_order(*self, pfn, order),
+        ensures
+            perms.0.wf_pfn_order(*self, pfn, (order - 1) as usize),
+            perms.1.wf_pfn_order(
+                *self,
+                (pfn + (1usize << (order - 1))) as usize,
+                (order - 1) as usize,
+            ),
+            self.pg_params().valid_pfn_order(pfn, order) ==> (self.pg_params().valid_pfn_order(
+                pfn,
+                (order - 1) as usize,
+            ) && self.pg_params().valid_pfn_order(
+                (pfn + (1usize << (order - 1))) as usize,
+                (order - 1) as usize,
+            )),
+    {
+        use_type_invariant(self);
+        broadcast use lemma_bit_usize_shl_values;
+
+        let map = self@.map;
+        reveal(<VirtAddr as SpecVAddrImpl>::region_to_dom);
+        let p1 = pfn;
+        let p2 = (pfn + (1usize << (order - 1))) as usize;
+        let vaddr1 = map.lemma_get_virt(p1);
+        assert(p2 + (1usize << (order - 1)) == pfn + (1usize << order));
+        let vaddr2 = map.lemma_get_virt(p2);
+        let size = (1usize << (order - 1)) * PAGE_SIZE;
+        if self.pg_params().valid_pfn_order(pfn, order) {
+            self.pg_params().lemma_valid_pfn_order_split(p1, order);
+        }
+        p.split(vaddr1.region_to_dom(size as nat))
+    }
+
+    pub proof fn raw_perm_order_disjoint(
+        &self,
+        p1: usize,
+        o1: usize,
+        p2: usize,
+        o2: usize,
+        tracked perm1: &mut RawPerm,
+        tracked perm2: &RawPerm,
+    )
+        requires
+            self.wf(),
+            0 <= o1 < 64,
+            0 <= o2 < 64,
+            old(perm1).wf_pfn_order(*self, p1, o1),
+            perm2.wf_pfn_order(*self, p2, o2),
+        ensures
+            order_disjoint(p1, o1, p2, o2),
+            *old(perm1) == *perm1,
+    {
+        broadcast use lemma_bit_usize_shl_values;
+
+        let vaddr1 = self@.map.lemma_get_virt(p1);
+        let vaddr2 = self@.map.lemma_get_virt(p2);
+        let size1 = ((1usize << o1) * PAGE_SIZE) as nat;
+        let size2 = ((1usize << o2) * PAGE_SIZE) as nat;
+        vaddr1.lemma_vaddr_region_len(size1);
+        vaddr2.lemma_vaddr_region_len(size2);
+        raw_perm_is_disjoint(perm1, perm2);
+        reveal(<VirtAddr as SpecVAddrImpl>::region_to_dom);
+        assert(perm1.dom().contains(vaddr1@ as int));
+        assert(perm2.dom().contains(vaddr2@ as int));
+    }
+}
+
+} // verus!

--- a/kernel/src/mm/alloc_perms.verus.rs
+++ b/kernel/src/mm/alloc_perms.verus.rs
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Ziqiao Zhou <ziqiaozhou@microsoft.com>
+//
+// Defines memory region permissions.
+verus! {
+
+spec fn spec_map_page_info_addr(map: LinearMap, pfn: usize) -> VirtAddr {
+    let reserved_unit_size = size_of::<PageStorageType>();
+    let start = map.virt_start;
+    VirtAddr::from_spec((start@ + (pfn * reserved_unit_size)) as usize)
+}
+
+spec fn spec_map_page_info_ptr(map: LinearMap, pfn: usize) -> *const PageStorageType {
+    let addr = spec_map_page_info_addr(map, pfn)@;
+    vstd::raw_ptr::ptr_from_data(
+        vstd::raw_ptr::PtrData { addr, provenance: allocator_provenance(), metadata: () },
+    )
+}
+
+/// Defines ghost tracked memory region permissions.
+///
+/// `info` is a readonly share of reserved memory storing PageInfo which allows
+/// the allocator to access the page info of all pfns in this region at any
+/// time.
+///
+/// `free` contains permissions related to all free memory pages. Each memory
+/// page should have the full permission to access the free memory page in this
+/// region, and all remaining permission shares of page info for the free page.
+/// Thus the allocator will be able to recover the full share of permission to
+/// modify the PageInfo when the memory is not allocated. When allocating a
+/// memory, the allocator will give one such permission set to the external.
+///
+/// `mr_map` defines all remaining shares of memory mapping permission for this
+/// region. If the allocator has not yet allocated any memory, the allocator
+/// will be able to merge all memory mapping permission to change the desired
+/// base pointer and mapping for this region. If the allocator has allocated
+/// memory, the allocator will not be able to change the base pointer and
+/// mapping for this region.
+tracked struct MemoryRegionPerms {
+    info: PageInfoDb,  // readonly share of pginfo for all pfns in this region.
+    free: MRFreePerms,  // free mem perms + remaining share of pginfo
+    info_ptr_exposed: IsExposed,  // provenance of this region.
+    mr_map: MemRegionMapping,  // The memory mapping for this region.
+}
+
+/// Defines the permission returned by the allocator when allocating memory.
+#[allow(missing_debug_implementations)]
+pub tracked struct AllocatedPagesPerm {
+    perm: PgUnitPerm<DeallocUnit>,
+    mr_map: MemRegionMapping,
+}
+
+impl AllocatedPagesPerm {
+    spec fn pfn(&self) -> usize {
+        self.perm.info.unit_start()
+    }
+
+    spec fn with_vaddr(&self, vaddr: VirtAddr) -> bool {
+        self.mr_map@.map.get_pfn(vaddr) == Some(self.pfn())
+    }
+
+    spec fn vaddr(&self) -> VirtAddr {
+        self.mr_map@.map.try_get_virt(self.pfn()).unwrap()
+    }
+
+    spec fn size(&self) -> nat {
+        (self.perm.info.npages() * PAGE_SIZE as nat)
+    }
+
+    #[verifier::type_invariant]
+    spec fn wf(&self) -> bool {
+        let order = self.perm.info.order();
+        let pfn = self.pfn();
+        &&& order < MAX_ORDER
+        &&& self.mr_map.pg_params().valid_pfn_order(pfn, order)
+        &&& self.mr_map.shares() == self.size()
+        &&& self.mr_map.base_ptr() === self.perm.info.base_ptr()
+        &&& self.perm.wf_pfn_order(self.mr_map, pfn, order)
+        &&& self.perm.page_type().spec_is_deallocatable()
+    }
+}
+
+#[allow(missing_debug_implementations)]
+pub ghost struct AllocatorUnit {}
+
+#[allow(missing_debug_implementations)]
+pub ghost struct DeallocUnit {}
+
+pub trait UnitType {
+    spec fn wf_share_total(shares: nat, total: nat) -> bool;
+}
+
+/// Defines the number of shares of PageInfo permission for deallocatable unit
+/// for (to-be) allocated memory.
+impl UnitType for DeallocUnit {
+    closed spec fn wf_share_total(shares: nat, total: nat) -> bool {
+        &&& shares == DEALLOC_PGINFO_SHARES
+        &&& total == MAX_PGINFO_SHARES
+        &&& 0 < shares < total
+    }
+}
+
+/// Defines the number of shares of PageInfo permission remains in the allocator.
+impl UnitType for AllocatorUnit {
+    closed spec fn wf_share_total(shares: nat, total: nat) -> bool {
+        &&& shares == total - DEALLOC_PGINFO_SHARES
+        &&& total == MAX_PGINFO_SHARES
+        &&& 0 < shares < total
+    }
+}
+
+#[allow(missing_debug_implementations)]
+pub tracked struct PgUnitPerm<T: UnitType> {
+    mem: RawPerm,
+    info: PageInfoDb,
+    ghost typ: T,
+}
+
+#[allow(missing_debug_implementations)]
+pub tracked struct UnitDeallocPerm(PgUnitPerm<DeallocUnit>);
+
+impl UnitDeallocPerm {
+    pub closed spec fn view(&self) -> PgUnitPerm<DeallocUnit> {
+        self.0
+    }
+}
+
+impl<T: UnitType> PgUnitPerm<T> {
+    #[verifier::type_invariant]
+    pub closed spec fn wf(&self) -> bool {
+        &&& self.info.npages() > 0 ==> self.info.is_unit()
+        &&& self.info.npages() > 0 ==> T::wf_share_total(
+            self.info.id().shares,
+            self.info.id().total,
+        )
+    }
+
+    pub closed spec fn pfn(&self) -> usize {
+        self.info.unit_start()
+    }
+
+    #[verifier(inline)]
+    spec fn page_info(&self) -> Option<PageInfo> {
+        self.info.unit_head().page_info()
+    }
+
+    spec fn page_type(&self) -> PageType {
+        let pageinfo = self.info.unit_head().page_info().unwrap();
+        pageinfo.spec_type()
+    }
+
+    pub closed spec fn from_mr(&self, map: MemRegionMapping, pfn: usize, order: usize) -> bool {
+        self.wf_pfn_order(map, pfn, order)
+    }
+
+    pub closed spec fn wf_pfn_order(
+        &self,
+        map: MemRegionMapping,
+        pfn: usize,
+        order: usize,
+    ) -> bool {
+        &&& self.mem.wf_pfn_order(map, pfn, order)
+        &&& self.info.unit_start() == pfn
+        &&& self.info.order() == order
+        &&& self.info.base_ptr() === map.base_ptr()
+        &&& !self.info@.is_empty()
+    }
+
+    proof fn empty(id: PInfoGroupId) -> (tracked ret: Self) {
+        PgUnitPerm {
+            mem: RawPerm::empty(id.ptr_data.provenance),
+            info: PageInfoDb::tracked_empty(id),
+            typ: arbitrary(),
+        }
+    }
+
+    proof fn tracked_take(tracked &mut self) -> (tracked ret: (RawPerm, PageInfoDb))
+        ensures
+            ret == (old(self).mem, old(self).info),
+            ret.1.npages() > 0 ==> ret.1.is_unit(),
+            ret.1.npages() > 0 ==> T::wf_share_total(ret.1.id().shares, ret.1.id().total),
+            ret.1.wf(),
+    {
+        use_type_invariant(&*self);
+        let tracked mut tmp = PgUnitPerm::empty(self.info.id);
+        tracked_swap(self, &mut tmp);
+        use_type_invariant(&tmp.info);
+        (tmp.mem, tmp.info)
+    }
+}
+
+impl MemoryRegionPerms {
+    spec fn npages(&self) -> usize {
+        self.mr_map.pg_params().page_count
+    }
+
+    spec fn map(&self) -> LinearMap {
+        self.mr_map@.map
+    }
+
+    spec fn base_ptr(&self) -> *const PageStorageType {
+        self.mr_map.base_ptr()
+    }
+
+    spec fn wf_base_ptr(&self) -> bool {
+        &&& self.mr_map@ == self.free.mr_map()@
+        &&& self.info_ptr_exposed@ == self.mr_map@.provenance
+        &&& self.info.base_ptr() == self.base_ptr()
+    }
+
+    spec fn page_info_ptr(&self, pfn: usize) -> *const PageStorageType {
+        self.base_ptr().add(pfn)
+    }
+
+    #[verifier(inline)]
+    spec fn get_info(&self, pfn: usize) -> Option<PageInfo> {
+        self.info@[pfn].page_info()
+    }
+
+    #[verifier(inline)]
+    spec fn get_free_info(&self, pfn: usize) -> Option<FreeInfo> {
+        self.info@[pfn].page_info().unwrap().spec_get_free()
+    }
+
+    spec fn get_page_storage_type(&self, pfn: usize) -> Option<PageStorageType> {
+        self.info@[pfn].page_storage()
+    }
+
+    /** Invariants for page info **/
+    spec fn wf_info(&self) -> bool {
+        let info = self.info;
+        &&& info.is_readonly_allocator_shares()
+        &&& self.npages() == info.npages()
+        &&& info@.dom() =~= Set::new(|idx| 0 <= idx < self.npages())
+        &&& self.wf_base_ptr()
+    }
+
+    spec fn wf(&self) -> bool {
+        self.wf_info()
+    }
+}
+
+} // verus!

--- a/kernel/src/mm/alloc_types.verus.rs
+++ b/kernel/src/mm/alloc_types.verus.rs
@@ -1,0 +1,462 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Ziqiao Zhou <ziqiaozhou@microsoft.com>
+//
+// Proves the encode/decode functions for PageInfo used in alloc.rs.
+use vstd::simple_pptr::MemContents;
+verus! {
+
+// prove the size of PageStorageType
+global size_of PageStorageType == 8;
+
+spec fn spec_page_storage_type(mem: MemContents<PageStorageType>) -> Option<PageStorageType> {
+    if mem.is_init() {
+        Some(mem.value())
+    } else {
+        None
+    }
+}
+
+#[verifier(opaque)]
+spec fn spec_page_info(mem: MemContents<PageStorageType>) -> Option<PageInfo> {
+    let mem = spec_page_storage_type(mem);
+    if mem.is_some() {
+        PageInfo::spec_decode(mem.unwrap())
+    } else {
+        None
+    }
+}
+
+spec fn spec_free_info(perm: MemContents<PageStorageType>) -> Option<FreeInfo> {
+    let p_info = spec_page_info(perm);
+    if p_info.is_some() {
+        let pi = p_info.unwrap();
+        pi.spec_get_free()
+    } else {
+        None
+    }
+}
+
+impl PageType {
+    spec fn spec_is_deallocatable(&self) -> bool {
+        matches!(self, PageType::Allocated | PageType::SlabPage | PageType::File)
+    }
+}
+
+impl PageInfo {
+    spec fn spec_order(&self) -> usize {
+        match *self {
+            PageInfo::Compound(CompoundInfo { order }) => order,
+            PageInfo::Allocated(AllocatedInfo { order }) => order,
+            PageInfo::Free(FreeInfo { order, .. }) => order,
+            _ => 0,
+        }
+    }
+
+    spec fn spec_type(&self) -> PageType {
+        match *self {
+            PageInfo::Free(_) => PageType::Free,
+            PageInfo::Allocated(_) => PageType::Allocated,
+            PageInfo::Slab(_) => PageType::SlabPage,
+            PageInfo::Compound(_) => PageType::Compound,
+            PageInfo::File(_) => PageType::File,
+            PageInfo::Reserved(_) => PageType::Reserved,
+        }
+    }
+
+    spec fn spec_get_free(&self) -> Option<FreeInfo> {
+        match *self {
+            PageInfo::Free(info) => { Some(info) },
+            _ => { None },
+        }
+    }
+}
+
+// Prove the encode/decode functions.
+// The implementation must satisfying the proof.
+trait SpecDecoderProof<T>: core::marker::Sized {
+    spec fn spec_decode(mem: T) -> Option<Self> {
+        if exists|x: Self| #[trigger] x.spec_encode() === Some(mem) {
+            Some(choose|x: Self| #[trigger] x.spec_encode() === Some(mem))
+        } else {
+            None
+        }
+    }
+
+    spec fn spec_encode(&self) -> Option<T>;
+
+    proof fn lemma_encode_decode(&self)
+        requires
+            self.spec_encode().is_some(),
+        ensures
+            Self::spec_decode(self.spec_encode().unwrap()) === Some(*self),
+    ;
+
+    proof fn proof_encode_decode(&self)
+        ensures
+            self.spec_encode().is_some() ==> Self::spec_decode(self.spec_encode().unwrap())
+                === Some(*self),
+    {
+        if self.spec_encode().is_some() {
+            self.lemma_encode_decode();
+        }
+    }
+}
+
+impl AllocatedInfo {
+    #[verifier::type_invariant]
+    spec fn inv(&self) -> bool {
+        self.order < MAX_ORDER
+    }
+}
+
+impl CompoundInfo {
+    #[verifier::type_invariant]
+    spec fn inv(&self) -> bool {
+        self.order < MAX_ORDER
+    }
+}
+
+impl FileInfo {
+    #[verifier::type_invariant]
+    spec fn inv(&self) -> bool {
+        self.ref_count < (1u64 << (u64::BITS - PageStorageType::TYPE_SHIFT) as u64)
+    }
+}
+
+impl SlabPageInfo {
+    #[verifier::type_invariant]
+    spec fn inv(&self) -> bool {
+        self.item_size <= PageStorageType::SLAB_MASK
+    }
+}
+
+impl FreeInfo {
+    #[verifier::type_invariant]
+    spec fn inv(&self) -> bool {
+        &&& self.next_page < MAX_PAGE_COUNT
+        &&& self.order < MAX_ORDER
+    }
+}
+
+impl PageInfo {
+    spec fn inv(&self) -> bool {
+        match self {
+            PageInfo::Free(info) => info.inv(),
+            PageInfo::Allocated(info) => info.inv(),
+            PageInfo::Slab(info) => info.inv(),
+            PageInfo::Compound(info) => info.inv(),
+            PageInfo::File(info) => info.inv(),
+            PageInfo::Reserved(info) => true,
+        }
+    }
+
+    proof fn use_type_invariant(tracked &self)
+        ensures
+            self.inv(),
+    {
+        match self {
+            PageInfo::Free(info) => {
+                use_type_invariant(info);
+            },
+            PageInfo::Allocated(info) => {
+                use_type_invariant(info);
+            },
+            PageInfo::Slab(info) => {
+                use_type_invariant(info);
+            },
+            PageInfo::Compound(info) => {
+                use_type_invariant(info);
+            },
+            PageInfo::File(info) => {
+                use_type_invariant(info);
+            },
+            _ => {},
+        }
+    }
+}
+
+impl PageStorageType {
+    spec fn wf(&self) -> bool {
+        let mem_type = PageType::spec_decode(*self);
+        if mem_type.is_none() {
+            false
+        } else {
+            match mem_type.unwrap() {
+                (PageType::Free
+                | PageType::Allocated
+                | PageType::Compound) => self.spec_decode_order() < MAX_ORDER,
+                _ => true,
+            }
+        }
+    }
+}
+
+impl SpecDecoderProof<PageStorageType> for FreeInfo {
+    spec fn spec_decode(mem: PageStorageType) -> Option<Self> {
+        Some(Self::spec_decode_impl(mem))
+    }
+
+    spec fn spec_encode(&self) -> Option<PageStorageType> {
+        if self.inv() {
+            Some(self.spec_encode_impl())
+        } else {
+            None
+        }
+    }
+
+    proof fn lemma_encode_decode(&self)
+        ensures
+            PageType::spec_decode(self.spec_encode().unwrap()) === Some(PageType::Free),
+    {
+        let info = *self;
+        let order = info.order as u64;
+        let next_page = info.next_page as u64;
+        let mem = PageType::Free as u64;
+        let bit1 = PageStorageType::TYPE_SHIFT;
+        let bit2 = (PageStorageType::NEXT_SHIFT - PageStorageType::TYPE_SHIFT) as u64;
+        let bit3 = (u64::BITS - PageStorageType::NEXT_SHIFT) as u64;
+        lemma_u64_and_bitmask_lower(order, bit2);
+        let ret = mem | (order << bit1) | (next_page << (bit1 + bit2)) as u64;
+        lemma_bit_u64_extract_fields2(mem, order, bit1, bit2);
+        lemma_bit_u64_extract_fields2(
+            mem | (order << bit1),
+            next_page,
+            PageStorageType::NEXT_SHIFT,
+            (u64::BITS - PageStorageType::NEXT_SHIFT) as u64,
+        );
+        lemma_bit_u64_extract_mid_field(ret, bit1, bit2);
+    }
+}
+
+impl SpecDecoderProof<PageStorageType> for AllocatedInfo {
+    spec fn spec_decode(mem: PageStorageType) -> Option<Self> {
+        Some(Self::spec_decode_impl(mem))
+    }
+
+    spec fn spec_encode(&self) -> Option<PageStorageType> {
+        if self.inv() {
+            Some(self.spec_encode_impl())
+        } else {
+            None
+        }
+    }
+
+    proof fn lemma_encode_decode(&self)
+        ensures
+            PageType::spec_decode(self.spec_encode().unwrap()) === Some(PageType::Allocated),
+    {
+        PageType::Allocated.lemma_encode_decode();
+        lemma_bit_u64_extract_fields2(
+            PageType::Allocated as u64,
+            self.order as u64,
+            PageStorageType::TYPE_SHIFT,
+            (PageStorageType::NEXT_SHIFT - PageStorageType::TYPE_SHIFT) as u64,
+        );
+    }
+}
+
+impl SpecDecoderProof<PageStorageType> for SlabPageInfo {
+    spec fn spec_decode(mem: PageStorageType) -> Option<Self> {
+        Some(Self::spec_decode_impl(mem))
+    }
+
+    spec fn spec_encode(&self) -> Option<PageStorageType> {
+        if self.inv() {
+            Some(self.spec_encode_impl())
+        } else {
+            None
+        }
+    }
+
+    proof fn lemma_encode_decode(&self)
+        ensures
+            PageType::spec_decode(self.spec_encode().unwrap()) === Some(PageType::SlabPage),
+    {
+        PageType::SlabPage.lemma_encode_decode();
+        assert(self.item_size <= (1u64 << 16)) by (compute);
+        lemma_bit_u64_extract_fields2(
+            PageType::SlabPage as u64,
+            self.item_size as u64,
+            PageStorageType::TYPE_SHIFT,
+            16,
+        );
+    }
+}
+
+impl SpecDecoderProof<PageStorageType> for CompoundInfo {
+    spec fn spec_decode(mem: PageStorageType) -> Option<Self> {
+        Some(Self::spec_decode_impl(mem))
+    }
+
+    spec fn spec_encode(&self) -> Option<PageStorageType> {
+        if self.inv() {
+            Some(self.spec_encode_impl())
+        } else {
+            None
+        }
+    }
+
+    proof fn lemma_encode_decode(&self)
+        ensures
+            PageType::spec_decode(self.spec_encode().unwrap()) === Some(PageType::Compound),
+    {
+        PageType::Compound.lemma_encode_decode();
+        lemma_bit_u64_extract_fields2(
+            PageType::Compound as u64,
+            self.order as u64,
+            PageStorageType::TYPE_SHIFT,
+            8,
+        );
+    }
+}
+
+impl SpecDecoderProof<PageStorageType> for FileInfo {
+    spec fn spec_decode(mem: PageStorageType) -> Option<Self> {
+        Some(Self::spec_decode_impl(mem))
+    }
+
+    spec fn spec_encode(&self) -> Option<PageStorageType> {
+        if self.inv() {
+            Some(self.spec_encode_impl())
+        } else {
+            None
+        }
+    }
+
+    proof fn lemma_encode_decode(&self)
+        ensures
+            PageType::spec_decode(self.spec_encode().unwrap()) === Some(PageType::File),
+    {
+        PageType::File.lemma_encode_decode();
+        let ref_count = self.ref_count as u64;
+        let tbits = PageStorageType::TYPE_SHIFT;
+        let bits = (u64::BITS - PageStorageType::TYPE_SHIFT) as u64;
+        let mem = self.spec_encode().unwrap().0;
+        lemma_bit_u64_extract_fields2(
+            PageType::File as u64,
+            ref_count,
+            PageStorageType::TYPE_SHIFT,
+            bits,
+        );
+    }
+}
+
+impl SpecDecoderProof<PageStorageType> for ReservedInfo {
+    spec fn spec_encode(&self) -> Option<PageStorageType> {
+        Some(self.spec_encode_impl())
+    }
+
+    spec fn spec_decode(mem: PageStorageType) -> Option<Self> {
+        Some(Self::spec_decode_impl(mem))
+    }
+
+    proof fn lemma_encode_decode(&self)
+        ensures
+            PageType::spec_decode(self.spec_encode().unwrap()) === Some(PageType::Reserved),
+    {
+        PageType::Reserved.lemma_encode_decode();
+        lemma_u64_and_bitmask_lower(PageType::Reserved as u64, PageStorageType::TYPE_SHIFT);
+    }
+}
+
+impl PageType {
+    spec fn spec_try_from(val: u64) -> Option<Self> {
+        match val {
+            v if v == Self::Free as u64 => Some(Self::Free),
+            v if v == Self::Allocated as u64 => Some(Self::Allocated),
+            v if v == Self::SlabPage as u64 => Some(Self::SlabPage),
+            v if v == Self::Compound as u64 => Some(Self::Compound),
+            v if v == Self::File as u64 => Some(Self::File),
+            v if v == Self::Reserved as u64 => Some(Self::Reserved),
+            _ => None,
+        }
+    }
+
+    pub closed spec fn ens_try_from(val: u64, ret: Result<Self, AllocError>) -> bool {
+        &&& ret.is_ok() == PageType::spec_try_from(val).is_some()
+        &&& ret.is_ok() ==> ret.unwrap() == PageType::spec_try_from(val).unwrap()
+    }
+}
+
+impl SpecDecoderProof<PageStorageType> for PageType {
+    spec fn spec_encode(&self) -> Option<PageStorageType> {
+        Some(PageStorageType(*self as u64))
+    }
+
+    spec fn spec_decode(mem: PageStorageType) -> Option<Self> {
+        let val = mem.0 & PageStorageType::TYPE_MASK;
+        PageType::spec_try_from(val)
+    }
+
+    proof fn lemma_encode_decode(&self) {
+        let mem = self.spec_encode().unwrap();
+        let val = mem.0;
+        assert(val & 0xf == val) by (bit_vector)
+            requires
+                val < 16,
+        ;
+        assert(PageType::spec_decode(mem) == Some(*self));
+    }
+}
+
+impl SpecDecoderProof<PageStorageType> for PageInfo {
+    closed spec fn spec_encode(&self) -> Option<PageStorageType> {
+        match self {
+            Self::Free(fi) => fi.spec_encode(),
+            Self::Allocated(ai) => ai.spec_encode(),
+            Self::Slab(si) => si.spec_encode(),
+            Self::Compound(ci) => ci.spec_encode(),
+            Self::File(fi) => fi.spec_encode(),
+            Self::Reserved(ri) => ri.spec_encode(),
+        }
+    }
+
+    spec fn spec_decode(v: PageStorageType) -> Option<PageInfo> {
+        let mem_type = PageType::spec_decode(v);
+        if mem_type.is_none() {
+            None
+        } else {
+            match mem_type.unwrap() {
+                PageType::Free => Some(PageInfo::Free(FreeInfo::spec_decode_impl(v))),
+                PageType::Allocated => Some(
+                    PageInfo::Allocated(AllocatedInfo::spec_decode_impl(v)),
+                ),
+                PageType::SlabPage => Some(PageInfo::Slab(SlabPageInfo::spec_decode_impl(v))),
+                PageType::Compound => Some(PageInfo::Compound(CompoundInfo::spec_decode_impl(v))),
+                PageType::File => Some(PageInfo::File(FileInfo::spec_decode_impl(v))),
+                PageType::Reserved => Some(PageInfo::Reserved(ReservedInfo::spec_decode_impl(v))),
+            }
+        }
+    }
+
+    proof fn lemma_encode_decode(&self) {
+        let info = *self;
+        let mem = info.spec_encode().unwrap();
+        let memval = mem.0;
+        match info {
+            PageInfo::Free(finfo) => {
+                finfo.lemma_encode_decode();
+            },
+            PageInfo::Reserved(rinfo) => {
+                rinfo.lemma_encode_decode();
+            },
+            PageInfo::Allocated(ainfo) => {
+                ainfo.lemma_encode_decode();
+            },
+            PageInfo::Slab(sinfo) => {
+                sinfo.lemma_encode_decode();
+            },
+            PageInfo::Compound(cinfo) => {
+                cinfo.lemma_encode_decode();
+            },
+            PageInfo::File(finfo) => {
+                finfo.lemma_encode_decode();
+            },
+        }
+    }
+}
+
+} // verus!

--- a/kernel/src/types.verus.rs
+++ b/kernel/src/types.verus.rs
@@ -11,4 +11,11 @@ pub broadcast group group_types_proof {
 
 broadcast use group_types_proof;
 
+pub broadcast proof fn lemma_page_size()
+    ensures
+        #[trigger] PAGE_SIZE == 0x1000,
+{
+    assert(1usize << 12 == 0x1000);
+}
+
 } // verus!

--- a/kernel/src/utils/mod.rs
+++ b/kernel/src/utils/mod.rs
@@ -8,6 +8,7 @@ pub mod bitmap_allocator;
 pub mod immut_after_init;
 pub mod memory_region;
 pub mod scoped;
+pub mod tcb_ptr;
 pub mod util;
 pub mod vec;
 

--- a/kernel/src/utils/tcb_ptr.rs
+++ b/kernel/src/utils/tcb_ptr.rs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Ziqiao Zhou <ziqiaozhou@microsoft.com>
+// The safe pointer lib as trusted verification TCB.
+// It provides a safe interface to access a pointer with a tracked memory permission.
+// This is a basic support for read and write access to private memory.
+// TODO:
+// - Move the spec into verify_external after verus supports extra arguments in external functions.
+// - Extend FracTypedPointer to support memory operations for confidential VMs.
+
+use verus_stub::*;
+
+#[cfg(verus_keep_ghost)]
+use verify_proof::frac_ptr::FracTypedPerm;
+
+/// Trusted API to write a value at the pointer.
+/// Do not use this outside verified code.
+/// # Safety
+///
+/// without providing the tracked memory permission, this is unsafe.
+/// Must ensure that the pointer is valid and writable.
+/// It is safe with verification since it
+/// - checks the correct permission for accessing the memory is writable.
+/// - guarantees that there is no concurrent read/write access to the same memory location
+///   while the mutable permission reference is in use.
+#[verus_verify(external_body)]
+#[verus_spec(
+    with Tracked(perm): Tracked<&mut FracTypedPerm<T>>
+    requires
+        old(perm).ptr() == ptr,
+        old(perm).writable(),
+        old(perm).valid(),
+    ensures
+        perm@ == old(perm)@.update_value(vstd::simple_pptr::MemContents::Init(v)),
+    opens_invariants none
+    no_unwind
+)]
+#[inline(always)]
+pub(crate) unsafe fn ptr_write<T>(ptr: *mut T, v: T) {
+    // # Safety: guard by the tracked memory permission
+    unsafe {
+        ptr.write(v);
+    }
+}
+
+/// Trusted API to write a value at the pointer.
+/// Do not use this outside verified code.
+/// # Safety
+///
+/// without providing the tracked memory permission, this is unsafe.
+/// Must ensure that the pointer is valid and readable.
+/// It is safe with verification.
+#[verus_verify(external_body)]
+#[verus_spec(ret =>
+    with Tracked(perm): Tracked<&FracTypedPerm<T>>
+    requires
+        perm.readable(),
+        perm.valid(),
+    ensures
+        ret == perm.value(),
+    opens_invariants none
+    no_unwind
+)]
+#[inline(always)]
+pub(crate) unsafe fn ptr_read<T>(ptr: *const T) -> T {
+    // # Safety: guard by the tracked memory permission
+    unsafe { ptr.read() }
+}

--- a/verify_external/src/hw_spec/mm.verus.rs
+++ b/verify_external/src/hw_spec/mm.verus.rs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Ziqiao Zhou <ziqiaozhou@microsoft.com>
+//
+// Defines trusted specifications related to address translation.
+// Address and AddressMap implementations should implement those traits to demonstrate their correctness.
+use vstd::prelude::*;
+
+verus! {
+
+/// A specification trait for addresses.
+/// It defines the properties of an address, such as its integer representation,
+/// the region it covers, and the properties of the region.
+pub trait SpecVAddrImpl {
+    spec fn spec_int_addr(&self) -> Option<int>;
+
+    /// An address region can be represented as a set of integers.
+    spec fn region_to_dom(&self, size: nat) -> Set<int>;
+
+    /// The region is finite, i.e., it has a finite number of elements.
+    /// If the region size is 1, then the region contains at most one valid address.
+    proof fn lemma_vaddr_region_len(&self, size: nat)
+        requires
+            self.spec_int_addr().is_some(),
+            size > 0,
+        ensures
+            self.region_to_dom(size).finite(),
+            self.region_to_dom(1).len() > 0 <==> self.region_to_dom(1).contains(
+                self.spec_int_addr().unwrap(),
+            ),
+            self.region_to_dom(size).len() >= self.region_to_dom(1).len(),
+    ;
+
+    /// Unique when casting to int address
+    proof fn lemma_unique(v1: &Self, v2: &Self)
+        ensures
+            (v1.spec_int_addr() == v2.spec_int_addr()) == (v1 === v2),
+    ;
+
+    /// If a size is valid, then smaller size must be valid
+    proof fn lemma_valid_small_size(&self, size1: nat, size2: nat)
+        requires
+            size2 >= size1,
+        ensures
+            self.region_to_dom(size1).subset_of(self.region_to_dom(size2)),
+    ;
+}
+
+// Define a trait describing the memory mapping groundtruth
+pub trait SpecMemMapTr {
+    type VAddr;
+
+    type PAddr;
+
+    spec fn to_paddr(&self, vaddr: Self::VAddr) -> Option<Self::PAddr>;
+
+    spec fn to_vaddr(&self, paddr: Self::PAddr) -> Option<Self::VAddr>;
+
+    /// Whether the mapping should be a one-to-one mapping.
+    /// If true, then the mapping is injective.
+    /// If false, then the mapping can be many-to-one.
+    open spec fn is_one_to_one_mapping(&self) -> bool {
+        true
+    }
+
+    // The default one is for one-to-one mapping.
+    // If the mapping is not one-to-one, then this function should be overridden.
+    open spec fn to_vaddrs(&self, paddr: Self::PAddr) -> Set<Self::VAddr> {
+        let s = self.to_vaddr(paddr);
+        if s.is_some() {
+            set!{s.unwrap()}
+        } else {
+            Set::empty()
+        }
+    }
+
+    proof fn proof_one_to_one_mapping(&self, a: Self::PAddr)
+        requires
+            self.is_one_to_one_mapping(),
+        ensures
+            self.to_vaddrs(a).len() <= 1,
+            self.to_vaddr(a).is_some() ==> self.to_paddr(self.to_vaddr(a).unwrap()).is_some(),
+    ;
+
+    proof fn proof_one_to_one_mapping_vaddr(&self, a: Self::VAddr)
+        requires
+            self.is_one_to_one_mapping(),
+        ensures
+            self.to_paddr(a).is_some() ==> self.to_vaddr(self.to_paddr(a).unwrap()) == Some(a),
+    ;
+
+    /// The mapping is correct if the following properties hold: If a virtual
+    /// address maps to a physical address, then the physical address maps back
+    /// to an virtual address that can map to the physical.
+    proof fn proof_correct_mapping_vaddr(&self, a: Self::VAddr)
+        requires
+            self.to_paddr(a).is_some(),
+        ensures
+            self.to_vaddrs(self.to_paddr(a).unwrap()).contains(a),
+    ;
+
+    /// If a physical address is mapped by a virtual address,
+    /// then the virtual address maps back to the same physical address.
+    proof fn proof_correct_mapping_paddr(&self, a: Self::PAddr)
+        ensures
+            (self.to_vaddrs(a).len() > 0) == self.to_vaddr(a).is_some(),
+            self.to_vaddr(a).is_some() ==> self.to_vaddrs(a).contains(self.to_vaddr(a).unwrap()),
+            self.to_vaddrs(a).len() > 0 ==> self.to_vaddrs(a).contains(self.to_vaddr(a).unwrap()),
+    ;
+
+    proof fn proof_correct_mapping_addrs(&self, a: Self::PAddr, vaddr: Self::VAddr)
+        requires
+            self.to_vaddrs(a).contains(vaddr),
+        ensures
+            self.to_paddr(vaddr) === Some(a),
+    ;
+}
+
+} // verus!

--- a/verify_external/src/hw_spec/mod.rs
+++ b/verify_external/src/hw_spec/mod.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Ziqiao Zhou <ziqiaozhou@microsoft.com>
+#[cfg(verus_keep_ghost)]
+include!("mm.verus.rs");

--- a/verify_external/src/lib.rs
+++ b/verify_external/src/lib.rs
@@ -18,6 +18,8 @@
 // Add spec for convert traits
 pub mod convert;
 
+pub mod hw_spec;
+
 use builtin_macros::*;
 
 verus! {

--- a/verify_external/src/lib.rs
+++ b/verify_external/src/lib.rs
@@ -20,6 +20,8 @@ pub mod convert;
 
 pub mod hw_spec;
 
+pub mod ptr;
+
 use builtin_macros::*;
 
 verus! {

--- a/verify_external/src/ptr.rs
+++ b/verify_external/src/ptr.rs
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Ziqiao Zhou <ziqiaozhou@microsoft.com>
+
+#[cfg(verus_keep_ghost)]
+include!("ptr.verus.rs");

--- a/verify_external/src/ptr.verus.rs
+++ b/verify_external/src/ptr.verus.rs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Ziqiao Zhou <ziqiaozhou@microsoft.com>
+use vstd::prelude::*;
+use vstd::raw_ptr::*;
+
+macro_rules! pointer_specs {
+    ($mod_ident:ident, $ptr_from_data:ident, $mu:tt) => {
+        #[cfg(verus_keep_ghost)]
+        mod $mod_ident {
+            use super::*;
+
+            verus!{
+            pub open spec fn spec_add<T: Sized>(p: *$mu T, offset: usize) -> *$mu T {
+                $ptr_from_data(PtrData { addr: (p@.addr + offset * size_of::<T>()) as usize, .. p@ })
+            }
+
+            pub open spec fn spec_wrapping_add<T: Sized>(p: *$mu T, offset: usize) -> *$mu T {
+                let addr = if (p@.addr + offset * size_of::<T>()) <= usize::MAX {
+                    (p@.addr + offset * size_of::<T>()) as usize
+                } else {
+                    (p@.addr + offset * size_of::<T>() - usize::MAX - 1) as usize
+                };
+                $ptr_from_data(PtrData { addr, .. p@ })
+            }
+
+            /// TODO(verus): Allow passing tracked variable to avoid all UB.
+            /// # Safety:
+            ///   * Avoid UB due to overflow.
+            ///   * UB due to unallocated memory is only avoidable later when memory is accessed with memory permission.
+            #[verifier::when_used_as_spec(spec_add)]
+            pub assume_specification<T: Sized>[<*$mu T>::add](p: *$mu T, offset: usize) -> (q: *$mu T)
+                requires
+                    (p@.addr + offset * size_of::<T>()) <= usize::MAX,
+                ensures
+                    q == spec_add(p, offset)
+                opens_invariants none
+                no_unwind;
+
+            #[verifier::when_used_as_spec(spec_wrapping_add)]
+            pub assume_specification<T: Sized>[<*$mu T>::wrapping_add](p: *$mu T, offset: usize) -> (q: *$mu T)
+                returns
+                    spec_wrapping_add(p, offset)
+                opens_invariants none
+                no_unwind;
+            }
+        }
+    };
+}
+
+pointer_specs!(ptr_mut_specs, ptr_mut_from_data, mut);
+
+pointer_specs!(ptr_const_specs, ptr_from_data, const);

--- a/verify_proof/Cargo.toml
+++ b/verify_proof/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 builtin = { workspace = true, optional = true }
 builtin_macros = { workspace = true }
 vstd = { workspace = true, optional = true }
+state_machines_macros = { workspace = true }
 paste = "1.0"
 seq-macro = "0.3"
 

--- a/verify_proof/src/bits.verus.rs
+++ b/verify_proof/src/bits.verus.rs
@@ -8,6 +8,13 @@ use vstd::bits::low_bits_mask;
 use vstd::prelude::*;
 
 #[macro_export]
+macro_rules! BIT64_MASK {
+    ($n: expr) => {
+        ((1u64 << ($n)) - 1)
+    };
+}
+
+#[macro_export]
 macro_rules! POW2_VALUE {
     (0) => {
         0x1u64
@@ -206,6 +213,23 @@ macro_rules! POW2_VALUE {
     };
 }
 
+macro_rules! bit_xor_neighbor {
+    ($typ:ty, $pname: ident) => {
+        verus!{
+        #[verifier::bit_vector]
+        pub proof fn $pname(pfn: $typ, order: $typ)
+        requires
+            pfn & sub((1u8 as $typ) << order, 1) == 0,
+        ensures
+            ((pfn & sub((1u8 as $typ) << add(order, 1), 1)) == 0) ==>  (pfn ^ ((1u8 as $typ) << order)) == add(pfn, ((1u8 as $typ) << order)),
+            ((pfn & sub((1u8 as $typ) << add(order, 1), 1)) != 0) ==>  (pfn ^ ((1u8 as $typ) << order)) == sub(pfn, ((1u8 as $typ) << order)),
+        {}
+        }
+    };
+}
+
+bit_xor_neighbor! {usize, lemma_bit_usize_xor_neighbor}
+
 verus! {
 
 #[verifier(inline)]
@@ -278,7 +302,7 @@ macro_rules! bit_not_properties {
 }
 
 macro_rules! bit_set_clear_mask {
-    ($typ:ty, $styp:ty, $pname_or_mask: ident, $pname_and_mask: ident) => {
+    ($typ:ty, $styp:ty, $pname_or_mask: ident, $pname_and_mask: ident, $pname_and_mask_bound: ident) => {
         verus! {
         #[doc = "Proof that a mask m is set with or operation."]
         #[verifier(bit_vector)]
@@ -288,7 +312,10 @@ macro_rules! bit_set_clear_mask {
                 (a | m) & (!m) == a & (!m),
                 a | m >= a,
                 a | m >= m,
-                a == (a|m) - m + (a|!m) - !m
+                a | m <= a + m,
+                a == (a|m) - m + (a|!m) - !m,
+                m == 0 ==> (a | m) == a,
+                a == 0 ==> (a | m) == m,
         {}
 
         #[doc = "Proof that a mask m is cleared with and operation."]
@@ -300,12 +327,32 @@ macro_rules! bit_set_clear_mask {
                 a & m <= m,
                 a & m <= a,
                 a == (a & m) + (a & !m),
+                a == 0 | m == 0 ==> #[trigger](a & m) == 0,
+        {}
+
+        #[doc = "Proof that a & m <= a and a & m <= m."]
+        #[verifier(bit_vector)]
+        pub broadcast proof fn $pname_and_mask_bound(a: $typ, m: $typ)
+            ensures
+                (#[trigger](a & m)) <= m,
+                a & m <= a,
         {}
         }
     };
 }
 
 verus! {
+
+#[verifier(bit_vector)]
+pub proof fn lemma_bit_u64_bitmask_and_min_effect(x: u64, n: u64, m: u64)
+    requires
+        n < u64::BITS,
+        m < u64::BITS,
+    ensures
+        n <= m ==> x & BIT64_MASK!(m) & BIT64_MASK!(n) == x & BIT64_MASK!(n),
+        n >= m ==> x & BIT64_MASK!(n) & BIT64_MASK!(m) == x & BIT64_MASK!(m),
+{
+}
 
 pub broadcast proof fn lemma_bit_u64_and_mask_is_mod(x: u64, mask: u64)
     requires
@@ -349,16 +396,16 @@ macro_rules! bit_and_mask_is_mod {
 
 bit_shl_values! {u64, u64, 1u64, lemma_bit_u64_shl_values}
 bit_not_properties! {u64, u64, spec_bit_u64_not_properties, lemma_bit_u64_not_is_sub}
-bit_set_clear_mask! {u64, u64, lemma_bit_u64_or_mask, lemma_bit_u64_and_mask}
+bit_set_clear_mask! {u64, u64, lemma_bit_u64_or_mask, lemma_bit_u64_and_mask, lemma_bit_u64_and_bound}
 
 bit_shl_values! {usize, u64, 1usize, lemma_bit_usize_shl_values}
 bit_not_properties! {usize, u64, spec_bit_usize_not_properties, lemma_bit_usize_not_is_sub}
-bit_set_clear_mask! {usize, u64, lemma_bit_usize_or_mask, lemma_bit_usize_and_mask}
+bit_set_clear_mask! {usize, u64, lemma_bit_usize_or_mask, lemma_bit_usize_and_mask, lemma_bit_usize_and_bound}
 bit_and_mask_is_mod! {usize, lemma_bit_usize_and_mask_is_mod}
 
 bit_shl_values! {u32, u32, 1usize, lemma_bit_u32_shl_values}
 bit_not_properties! {u32, u32, spec_bit_u32_not_properties, lemma_bit_u32_not_is_sub}
-bit_set_clear_mask! {u32, u32, lemma_bit_u32_or_mask, lemma_bit_u32_and_mask}
+bit_set_clear_mask! {u32, u32, lemma_bit_u32_or_mask, lemma_bit_u32_and_mask, lemma_bit_u32_and_bound}
 bit_and_mask_is_mod! {u32, lemma_bit_u32_and_mask_is_mod}
 verus! {
 
@@ -386,6 +433,308 @@ pub broadcast proof fn lemma_bit_usize_shr_is_div(v: usize, n: usize)
 {
     vstd::bits::lemma_u64_shr_is_div(v as u64, n as u64);
     lemma_pow2_eq_bit_value(n as nat);
+}
+
+#[verifier(bit_vector)]
+pub broadcast proof fn lemma_bit_u64_shr_bound(v: u64, n: u64)
+    requires
+        n < u64::BITS,
+    ensures
+        n > 0 ==> (#[trigger] (v >> n)) < 1u64 << (u64::BITS - n) as u64,
+        n == 0 ==> (v >> n) == v,
+        v >> n <= v,
+{
+}
+
+pub broadcast proof fn lemma_bit_u64_shr_properties(v: u64, n: u64)
+    requires
+        n < u64::BITS,
+    ensures
+        (#[trigger] (v >> n)) == v as int / bit_value(n as u64) as int,
+        v < (1u64 << n) <==> v >> n == 0,
+        0 >> n == 0,
+{
+    vstd::bits::lemma_u64_shr_is_div(v as u64, n as u64);
+    lemma_pow2_eq_bit_value(n as nat);
+    broadcast use lemma_bit_u64_shl_values;
+
+    assert(0 >> n == 0) by (bit_vector);
+}
+
+#[verifier(bit_vector)]
+pub broadcast proof fn lemma_bit_u64_shl_properties(v: u64, n: u64)
+    requires
+        n < u64::BITS,
+        n > 0 ==> v < 1u64 << (u64::BITS - n) as u64,
+    ensures
+        #![trigger (v << n)]
+        v > 0 ==> (v << n) >= 1u64 << n,
+        0 << n == 0,
+{
+}
+
+#[verifier(bit_vector)]
+pub proof fn lemma_u64_or_shl(x: u64, y: u64, n: u64)
+    requires
+        n < u64::BITS,
+    ensures
+        (x | y) << n == (x << n) | (y << n),
+{
+}
+
+#[verifier(bit_vector)]
+pub broadcast proof fn lemma_u64_or_is_associative(x: u64, y: u64, z: u64)
+    ensures
+        #![trigger (x | y | z)]
+        (x | y) | z == x | (y | z),
+{
+}
+
+#[verifier(bit_vector)]
+pub broadcast proof fn lemma_u64_shl_is_distributive_or(x: u64, y: u64, n: u64)
+    requires
+        n < u64::BITS,
+    ensures
+        #![trigger (x | y) << n]
+        #![trigger (x << n) | (y << n)]
+        (x | y) << n == (x << n) | (y << n),
+{
+}
+
+#[verifier(bit_vector)]
+pub broadcast proof fn lemma_u64_shr_is_distributive_or(x: u64, y: u64, n: u64)
+    requires
+        n < u64::BITS,
+    ensures
+        #![trigger (x | y) >> n]
+        (x | y) >> n == (x >> n) | (y >> n),
+{
+}
+
+#[verifier(bit_vector)]
+pub proof fn lemma_u64_and_is_distributive_or(x: u64, y: u64, z: u64)
+    ensures
+        #![trigger (x | y) & z]
+        (x | y) & z == (x & z) | (y & z),
+{
+}
+
+#[verifier(bit_vector)]
+pub proof fn lemma_u64_and_bitmask_lower(x: u64, n: u64)
+    requires
+        n < u64::BITS,
+        x < (1u64 << n),
+    ensures
+        x & ((1u64 << n) - 1) as u64 == x,
+{
+}
+
+#[verifier(bit_vector)]
+pub proof fn lemma_u64_and_bitmask_higher(x: u64, n: u64, m: u64)
+    requires
+        n <= m < u64::BITS,
+    ensures
+        (x << m) & ((1u64 << n) - 1) as u64 == 0,
+{
+}
+
+pub broadcast proof fn lemma_u64_or_low_high_bitmask_lower(x: u64, y: u64, n: u64, m: u64)
+    requires
+        n <= m < u64::BITS,
+        x <= (1u64 << n) - 1,
+    ensures
+        #[trigger] ((x | y << m) & ((1u64 << n) - 1) as u64) == x,
+{
+    let mask = ((1u64 << n) - 1) as u64;
+    let tmpy = y << m;
+    let ret = (x | tmpy) & mask as u64;
+    lemma_u64_and_is_distributive_or(x, y << m, mask as u64);
+    assert(ret == (x & mask) | (tmpy & mask));
+    lemma_u64_and_bitmask_higher(y, n, m);
+    assert((tmpy & mask) == 0);
+    lemma_u64_and_bitmask_lower(x, n);
+    assert(x | 0 == x) by (bit_vector);
+}
+
+#[verifier(bit_vector)]
+pub proof fn lemma_u64_shl_add(x: u64, n: u64, m: u64)
+    requires
+        n + m < u64::BITS,
+    ensures
+        (x << n) << m == (x << (n + m)),
+        (x << m) << n == (x << (m + n)),
+{
+}
+
+#[verifier(bit_vector)]
+proof fn lemma_u64_shr_add_one(x: u64, n: u64)
+    requires
+        n + 1 < u64::BITS,
+    ensures
+        (x >> n) >> 1 == (x >> (n + 1)),
+{
+}
+
+pub proof fn lemma_u64_shr_add(x: u64, n: u64, m: u64)
+    requires
+        n + m < u64::BITS,
+    ensures
+        (x >> n) >> m == (x >> (n + m)),
+    decreases m,
+{
+    if m > 0 {
+        lemma_u64_shr_add(x, n, (m - 1) as u64);
+        lemma_u64_shr_add_one(x >> n, (m - 1) as u64);
+        lemma_u64_shr_add_one(x, (n + m - 1) as u64);
+        assert((x >> n) >> m == (x >> (n + m - 1)) >> 1);
+    } else {
+        assert((x >> n) >> 0 == x >> n) by (bit_vector);
+    }
+}
+
+#[verifier(bit_vector)]
+proof fn lemma_u64_shlr_same(x: u64, n: u64)
+    requires
+        n > 0 ==> x < 1usize << (u64::BITS - n) as u64,
+        n < u64::BITS,
+    ensures
+        (x << n) >> n == x,
+{
+}
+
+pub broadcast proof fn lemma_u64_shl_shr(x: u64, n: u64, m: u64)
+    requires
+        n > 0 ==> x < 1usize << (u64::BITS - n),
+        n < u64::BITS,
+        m < u64::BITS,
+        n <= m,
+    ensures
+        n < m ==> #[trigger] ((x << n) >> m) == (x >> (m - n)),
+        n == m ==> (x << n) >> m == x,
+    decreases m,
+{
+    if m == 0 || n == 0 {
+        assert((x << n) >> 0 == x << n) by (bit_vector);
+        assert(x << 0 == x) by (bit_vector);
+        assert(x >> 0 == x) by (bit_vector);
+    } else if n == m {
+        lemma_u64_shlr_same(x, n);
+    } else {
+        let mm = (m - 1) as u64;
+        lemma_u64_shl_shr(x, n, mm);
+        lemma_u64_shr_add_one(x << n, mm);
+        if n < m {
+            let diff = (mm - n) as u64;
+            lemma_u64_shr_add_one(x, diff);
+        }
+    }
+}
+
+proof fn lemma_bit_u64_shl_bit_bound(x: u64, n: u64, m: u64)
+    requires
+        x < (1u64 << m),
+        n + m < u64::BITS,
+    ensures
+        (x << n) <= (1usize << (m + n)) - (1u64 << n),
+        x == ((1u64 << m) - 1) ==> (x << n) == (1usize << (m + n)) - (1u64 << n),
+{
+    broadcast use lemma_bit_u64_shl_values;
+    broadcast use vstd::bits::lemma_u64_pow2_no_overflow;
+
+    let upper = ((1u64 << m) - 1) as u64;
+    vstd::bits::lemma_u64_shl_is_mul(1u64, m);
+    vstd::bits::lemma_u64_shl_is_mul(1u64, n);
+    vstd::bits::lemma_u64_shl_is_mul(1u64, (n + m) as u64);
+    vstd::arithmetic::mul::lemma_mul_strict_inequality(
+        x as int,
+        pow2(m as nat) as int,
+        pow2(n as nat) as int,
+    );
+    vstd::arithmetic::power2::lemma_pow2_adds(m as nat, n as nat);
+    vstd::bits::lemma_u64_shl_is_mul(x, n);
+    vstd::bits::lemma_u64_shl_is_mul(1u64, (m + n) as u64);
+    vstd::arithmetic::mul::lemma_mul_inequality(
+        x as int,
+        pow2(m as nat) - 1,
+        pow2(n as nat) as int,
+    );
+    vstd::arithmetic::mul::lemma_mul_is_distributive_sub_other_way(
+        pow2(n as nat) as int,
+        pow2(m as nat) as int,
+        1,
+    );
+}
+
+/// a is the low part, b is the high part
+/// n is the number of bits in a
+/// m is the number of bits in b
+/// a and b are both less than 2^n and 2^m respectively
+/// Proves that a and b can be extracted from a | (b << n) using bitwise operations
+pub proof fn lemma_bit_u64_extract_fields2(a: u64, b: u64, n: u64, m: u64)
+    requires
+        a < (1u64 << n),
+        n < u64::BITS,
+        b < 1u64 << m,
+        n + m <= u64::BITS,
+        n > 0,
+        m > 0,
+    ensures
+        ((a | (b << n)) >> n) & sub(1u64 << m, 1) == b,
+        (a | (b << n)) & sub((1u64 << n), 1) == a,
+        (b & sub(1u64 << m, 1)) == b,
+        a & sub(1u64 << n, 1) == a,
+        (a | (b << n)) >> n == b,
+        a >> n == 0,
+        (n + m) < u64::BITS ==> (a | b << n) < (1u64 << (n + m)),
+{
+    let mask1 = sub(1u64 << n, 1);
+    let mask2 = sub(1u64 << m, 1);
+    let field2 = (b & mask2);
+    assert((b << n) <= BIT64_MASK!(m) << n) by (bit_vector)
+        requires
+            b <= BIT64_MASK!(m),
+            n < u64::BITS,
+            m < u64::BITS,
+    ;
+    if (n + m) < u64::BITS {
+        lemma_bit_u64_or_mask(a, b << n);
+        lemma_bit_u64_shl_bit_bound(b, n, m);
+    }
+    lemma_u64_and_bitmask_lower(b, m);
+    lemma_u64_and_bitmask_lower(a, n);
+    lemma_u64_and_bitmask_higher(b, n, n);
+    lemma_bit_u64_and_mask(b, mask2);
+    lemma_u64_shr_is_distributive_or(a, b << n, n);
+    lemma_u64_and_is_distributive_or(a, b << n, mask1);
+    lemma_bit_u64_shr_properties(a, n);
+    assert(1u64 << m <= 1usize << (u64::BITS - n)) by {
+        broadcast use lemma_bit_u64_shl_values;
+
+    };
+    lemma_u64_shl_shr(b, n, n);
+    lemma_bit_u64_or_mask(0, b);
+    lemma_bit_u64_or_mask(a, 0);
+}
+
+pub proof fn lemma_bit_u64_extract_mid_field(x: u64, bits1: u64, bits2: u64)
+    requires
+        bits1 + bits2 < u64::BITS,
+    ensures
+        (((x & BIT64_MASK!(bits2 + bits1)) >> bits1) & BIT64_MASK!(bits2)) == ((x >> bits1)
+            & BIT64_MASK!(bits2)),
+        ((x & BIT64_MASK!(bits2 + bits1)) & BIT64_MASK!(bits1)) == (x & BIT64_MASK!(bits1)),
+{
+    let m = (bits1 + bits2) as u64;
+    let mask = BIT64_MASK!(m);
+    let mask2 = BIT64_MASK!(bits2);
+    assert((x & mask) >> bits1 == (x >> bits1) & (mask >> bits1)) by (bit_vector);
+    assert(BIT64_MASK!(m) >> bits1 == BIT64_MASK!(bits2)) by (bit_vector)
+        requires
+            bits2 <= m < u64::BITS,
+            bits1 == m - bits2,
+    ;
+    lemma_bit_u64_bitmask_and_min_effect(x >> bits1, bits2, bits2);
+    lemma_bit_u64_bitmask_and_min_effect(x, bits1, m);
 }
 
 } // verus!

--- a/verify_proof/src/frac_perm.rs
+++ b/verify_proof/src/frac_perm.rs
@@ -1,0 +1,401 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Ziqiao Zhou <ziqiaozhou@microsoft.com>
+//
+// A fully verified frac-based ownership to share tracked ghost permissions.
+// This is motivated by PCM lib from vstd.
+// The state-machine proofs are motivated from the proof for Rc in vstd.
+use crate::sum::{lemma_sum_insert, lemma_sum_remove, sum, CountTrait};
+use state_machines_macros::*;
+use vstd::modes::tracked_swap;
+use vstd::multiset::*;
+use vstd::prelude::*;
+
+verus! {
+
+impl<T> CountTrait for (T, nat) {
+    open spec fn count(&self) -> nat {
+        self.1
+    }
+}
+
+} // verus!
+tokenized_state_machine!(frac_inner<Perm> {
+    fields {
+        #[sharding(storage_option)]
+        pub storage: Option<Perm>,
+
+        #[sharding(multiset)]
+        pub reader: Multiset<(Option<Perm>, nat)>, // read token and number of shares
+
+        #[sharding(constant)]
+        pub total: nat, // maximum number of shares, must be sum of readers
+    }
+
+    #[invariant]
+    pub fn frac_positive(&self) -> bool {
+        forall |s| #[trigger] self.reader.count(s) > 0 ==> s.1 > 0
+    }
+
+    #[invariant]
+    pub fn frac_agrees_total(&self) -> bool {
+        sum(self.reader) == self.total
+    }
+
+    #[invariant]
+    pub fn reader_agrees_storage(&self) -> bool {
+        forall |v| #[trigger] self.reader.count(v) > 0 ==> self.storage == v.0
+    }
+
+    #[invariant]
+    pub fn reader_agrees_total(&self) -> bool {
+        forall |v| #[trigger] self.reader.count(v) > 0 ==> v.1 <= self.total
+    }
+
+    init!{
+        initialize_once(total: nat) {
+            require total > 0;
+            init storage = Option::None;
+            init reader = Multiset::empty().insert((Option::None, total));
+            init total = total;
+        }
+    }
+
+    #[inductive(initialize_once)]
+    fn initialize_once_inductive(post: Self, total: nat) {
+        let frac = Multiset::empty().insert((Option::<Perm>::None, total));
+        lemma_sum_remove(frac, (Option::None, total));
+    }
+
+    property! {
+        is_same(p1: (Option<Perm>, nat), p2: (Option<Perm>, nat)) {
+            have reader >= {p1};
+            have reader >= {p2};
+            birds_eye let r1 = pre.reader.contains(p1);
+            birds_eye let r2 = pre.reader.contains(p2);
+            assert p1.0 == p2.0;
+        }
+    }
+
+    property! {
+        shares_agree_totals(p: (Option<Perm>, nat)) {
+            have reader >= {p};
+            birds_eye let r1 = pre.reader.contains(p);
+            assert p.1 <= pre.total;
+        }
+    }
+
+    property! {
+        reader_guard(x: Option<Perm>, shares: nat) {
+            require x.is_some();
+            have reader >= {(x, shares)};
+            guard storage >= Some(x.unwrap());
+        }
+    }
+
+    transition! {
+        do_share(x: Option<Perm>, shares: nat, new_shares: nat) {
+            remove reader -= {(x, shares)};
+            require(0 < new_shares < shares);
+            add reader += {(x, new_shares)};
+            add reader += {(x, (shares - new_shares) as nat)};
+        }
+    }
+
+
+    #[inductive(do_share)]
+    fn do_share_inductive(pre: Self, post: Self, x: Option<Perm>, shares: nat, new_shares: nat) {
+        let reader1 = pre.reader.remove((x, shares));
+        let reader2 = reader1.insert((x, new_shares));
+        lemma_sum_remove(pre.reader, (x, shares));
+        lemma_sum_insert(reader1, (x, new_shares));
+        lemma_sum_insert(reader2, (x, (shares - new_shares) as nat));
+    }
+
+    transition! {
+        take(x: Option<Perm>) {
+            remove reader -= {(x, pre.total)};
+            require x.is_some();
+            add reader += {(None, pre.total)};
+            withdraw storage -= Some(x.unwrap());
+        }
+    }
+
+    #[inductive(take)]
+    fn take_inductive(pre: Self, post: Self, x: Option<Perm>) {
+        lemma_sum_remove(pre.reader, (x, pre.total));
+        let reader1 = pre.reader.remove((x, pre.total));
+        assert(reader1.len() == 0) by {
+            let e = reader1.choose();
+            if (reader1.contains(e)) {
+                lemma_sum_remove(reader1, e);
+            }
+        }
+        lemma_sum_insert(reader1, (None, pre.total));
+    }
+
+    transition!{
+        update(x: Option<Perm>) {
+            remove reader -= {(None, pre.total)};
+            require x.is_some();
+            add reader += {(x, pre.total)};
+            deposit storage += Some(x.unwrap());
+        }
+    }
+
+    #[inductive(update)]
+    fn update_inductive(pre: Self, post: Self, x: Option<Perm>) {
+        let oldx = None;
+        assert(sum(pre.reader) == pre.total);
+        lemma_sum_remove(pre.reader, (oldx, pre.total));
+        assert(pre.storage.is_none());
+        let reader1 = pre.reader.remove((oldx, pre.total));
+        assert(sum(reader1) == 0);
+        if (reader1.len() != 0) {
+            let e = reader1.choose();
+            vstd::multiset::axiom_choose_count(reader1);
+            lemma_sum_remove(reader1, e);
+        }
+        lemma_sum_insert(reader1, (x, pre.total));
+    }
+
+
+    transition!{
+        merge(x: Option<Perm>, shares1: nat, shares2: nat) {
+            let new_shares = (shares1 + shares2) as nat;
+            remove reader -= {(x, shares1)};
+            remove reader -= {(x, shares2)};
+            add reader += {(x, new_shares)};
+        }
+    }
+
+    #[inductive(merge)]
+    fn merge_inductive(pre: Self, post: Self, x: Option<Perm>, shares1: nat, shares2: nat) {
+        let new_shares = (shares1 + shares2) as nat;
+        let reader1 = pre.reader.remove((x, shares1));
+        let reader2 = reader1.remove((x, shares2));
+        lemma_sum_remove(pre.reader, (x, shares1));
+        lemma_sum_remove(reader1, (x, shares2));
+        lemma_sum_insert(reader2, (x, (shares1 + shares2) as nat));
+    }
+});
+
+verus! {
+
+/// A `tracked ghost` container that you can put a ghost object in.
+/// A `Shared<T>` is duplicable and lets you get a `&T` out.
+/// Refer to FracTypedPerm.
+pub(crate) tracked struct FracPerm<T> {
+    tracked inst: frac_inner::Instance<T>,
+    tracked reader: frac_inner::reader<T>,
+}
+
+impl<T> FracPerm<T> {
+    #[verifier::type_invariant]
+    pub closed spec fn wf(self) -> bool {
+        &&& self.reader.instance_id() == self.inst.id()
+        &&& self.inst.total() > 0
+    }
+
+    pub closed spec fn view(self) -> Option<T> {
+        self.reader.element().0
+    }
+
+    pub closed spec fn id(self) -> InstanceId {
+        self.inst.id()
+    }
+
+    pub closed spec fn shares(&self) -> nat {
+        self.reader.element().1
+    }
+
+    pub closed spec fn total(&self) -> nat {
+        self.inst.total()
+    }
+
+    pub open spec fn valid(&self) -> bool {
+        self@.is_some()
+    }
+
+    pub proof fn new(total: nat, tracked v: T) -> (tracked s: Self)
+        requires
+            total > 0,
+        ensures
+            s.valid(),
+            s@ == Some(v),
+    {
+        let tracked (Tracked(inst), Tracked(mut readers)) = frac_inner::Instance::initialize_once(
+            total,
+            None,
+        );
+        let tracked reader = readers.remove((None, total));
+        let tracked reader = inst.update(Some(v), v, reader);
+        FracPerm { inst, reader }
+    }
+
+    pub proof fn empty(total: nat) -> (tracked s: Self)
+        requires
+            total > 0,
+        ensures
+            !s.valid(),
+    {
+        let tracked (Tracked(inst), Tracked(mut readers)) = frac_inner::Instance::initialize_once(
+            total,
+            None,
+        );
+        let tracked reader = readers.remove((None, total));
+        FracPerm { inst, reader }
+    }
+
+    pub proof fn borrow(tracked &self) -> (tracked t: &T)
+        requires
+            self.valid(),
+        ensures
+            Some(*t) == self@,
+    {
+        use_type_invariant(&*self);
+        self.inst.reader_guard(self.view(), self.shares(), &self.reader)
+    }
+
+    pub proof fn is_same(tracked &self, tracked other: &Self)
+        requires
+            self.id() == other.id(),
+        ensures
+            self@ == other@,
+    {
+        use_type_invariant(self);
+        use_type_invariant(other);
+        self.inst.is_same(
+            (self@, self.shares()),
+            (other@, other.shares()),
+            &self.reader,
+            &other.reader,
+        );
+    }
+
+    pub proof fn shares_agree_totals(tracked &self)
+        ensures
+            self.shares() <= self.total(),
+    {
+        use_type_invariant(self);
+        self.inst.shares_agree_totals((self@, self.shares()), &self.reader);
+    }
+
+    pub proof fn share(tracked &mut self, n: nat) -> (tracked ret: Self)
+        requires
+            0 < n < old(self).shares(),
+        ensures
+            ret@ == old(self)@,
+            self@ == old(self)@,
+            self.id() == old(self).id(),
+            self.total() == old(self).total(),
+            ret.id() == old(self).id(),
+            ret.shares() + self.shares() == old(self).shares(),
+            ret.shares() == n,
+            ret.total() == old(self).total(),
+    {
+        use_type_invariant(&*self);
+        let tracked mut perm = FracPerm::empty(self.total());
+        tracked_swap(self, &mut perm);
+        let tracked (Tracked(r1), Tracked(r2)) = perm.inst.do_share(
+            perm.view(),
+            perm.shares(),
+            n,
+            perm.reader,
+        );
+        *self = FracPerm { inst: perm.inst, reader: r2 };
+        FracPerm { inst: perm.inst, reader: r1 }
+    }
+
+    pub proof fn merge(tracked &mut self, tracked other: Self)
+        requires
+            old(self)@ == other@,
+            old(self).valid(),
+            other.valid(),
+            old(self).id() == other.id(),
+        ensures
+            self@ == old(self)@,
+            self.shares() == old(self).shares() + other.shares(),
+            self.total() == old(self).total(),
+            self.id() == old(self).id(),
+            self.valid(),
+    {
+        use_type_invariant(&*self);
+        use_type_invariant(&other);
+        let tracked mut perm = FracPerm::empty(self.total());
+        tracked_swap(self, &mut perm);
+        let shares = perm.shares();
+        let tracked FracPerm { inst, reader } = perm;
+        let tracked (new_reader) = inst.merge(other@, shares, other.shares(), reader, other.reader);
+        *self = FracPerm { inst: inst, reader: new_reader }
+    }
+
+    pub proof fn udpate(tracked &mut self, tracked v: T)
+        requires
+            !old(self).valid(),
+            old(self).shares() == old(self).total(),
+        ensures
+            self.valid(),
+            self@ == Some(v),
+            self.id() == old(self).id(),
+            self.shares() == old(self).shares(),
+            self.total() == old(self).total(),
+    {
+        use_type_invariant(&*self);
+        let tracked mut perm = FracPerm::empty(self.total());
+        tracked_swap(self, &mut perm);
+        let tracked FracPerm { inst, reader } = perm;
+        let tracked reader = inst.update(Some(v), v, reader);
+        *self = FracPerm { inst, reader };
+    }
+
+    pub proof fn extract(tracked self) -> (tracked ret: (T, Self))
+        requires
+            self.valid(),
+            self.shares() == self.total(),
+        ensures
+            Some(ret.0) == self@,
+            ret.1.id() == self.id(),
+            !ret.1.valid(),
+            ret.1.shares() == ret.1.total(),
+            self.total() == ret.1.total(),
+    {
+        use_type_invariant(&self);
+        let tracked FracPerm { mut inst, mut reader } = self;
+        let tracked (Tracked(ret), Tracked(reader)) = inst.take(reader.element().0, reader);
+
+        (ret, FracPerm { inst, reader })
+    }
+
+    pub proof fn take(tracked &mut self) -> (tracked ret: T)
+        requires
+            old(self).valid(),
+            old(self).shares() == old(self).total(),
+        ensures
+            Some(ret) == old(self)@,
+            self.id() == old(self).id(),
+            !self.valid(),
+            self.shares() == old(self).total(),
+            self.total() == old(self).total(),
+    {
+        use_type_invariant(&*self);
+        let tracked mut perm = FracPerm::empty(self.total());
+        tracked_swap(self, &mut perm);
+        let tracked (ret, mut new) = perm.extract();
+        tracked_swap(self, &mut new);
+        ret
+    }
+}
+
+impl<T> FracPerm<vstd::raw_ptr::PointsTo<T>> {
+    pub open spec fn addr(&self) -> int
+        recommends
+            self.valid(),
+    {
+        self@.unwrap().ptr()@.addr as int
+    }
+}
+
+} // verus!

--- a/verify_proof/src/frac_ptr.rs
+++ b/verify_proof/src/frac_ptr.rs
@@ -1,0 +1,534 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Ziqiao Zhou <ziqiaozhou@microsoft.com>
+//
+// A fully verified ghost and non-forgeable frac-based pointer permission to
+// share tracked memory permissions.
+use state_machines_macros::*;
+
+use vstd::prelude::*;
+use vstd::raw_ptr::{MemContents, PointsTo, PointsToData, PointsToRaw};
+use vstd::tokens::InstanceId;
+
+use crate::frac_perm::FracPerm;
+
+verus! {
+
+use vstd::multiset::Multiset;
+
+tokenized_state_machine!(addr_unique {
+    fields {
+        #[sharding(map)]
+        pub addr_to: Map<int, Option<InstanceId>>,
+        #[sharding(map)]
+        pub to_addr: Map<InstanceId, Option<int>>,
+
+        #[sharding(multiset)]
+        pub ptr_readers: Multiset<(int, InstanceId)>,
+    }
+
+    #[invariant]
+    pub fn ptr_readers_agrees(&self) -> bool {
+        forall |addr, id| #[trigger]self.ptr_readers.contains((addr, id)) ==>
+            self.addr_to[addr] === Some(id) && self.to_addr[id] === Some(addr)
+    }
+
+    #[invariant]
+    pub fn dom_cover_all(&self) -> bool {
+        self.addr_to.dom() =~= Set::full() &&
+        self.to_addr.dom() =~= Set::full()
+    }
+
+    #[invariant]
+    pub fn unique_id(&self) -> bool {
+        forall |addr: int| (#[trigger]self.addr_to[addr]).is_some() ==>
+            self.to_addr[self.addr_to[addr].unwrap()] == Some(addr)
+    }
+
+    transition! {
+        check_ids(addr: int, id1: InstanceId, id2: InstanceId) {
+            have ptr_readers >= {(addr, id1)};
+            have ptr_readers >= {(addr, id2)};
+            birds_eye let c1 = pre.ptr_readers.contains(((addr, id1)));
+            birds_eye let c2 = pre.ptr_readers.contains(((addr, id2)));
+            birds_eye let id = pre.addr_to[addr];
+            assert Some(id2) == id;
+            assert Some(id1) == id;
+        }
+    }
+
+    #[inductive(check_ids)]
+    fn check_ids_inductive(pre: Self, post: Self, addr: int, id1: InstanceId, id2: InstanceId) {
+        assert(pre.ptr_readers.contains((addr, id1)));
+        assert(pre.ptr_readers.contains((addr, id2)));
+        assert(pre.addr_to[addr] == Some(id1));
+        assert(pre.addr_to[addr] == Some(id2));
+        assert(id1 == id2);
+    }
+
+    init!{
+        empty() {
+            init addr_to = Map::new(|addr| true, |addr|None);
+            init to_addr = Map::new(|id| true, |addr|None);
+            init ptr_readers = Multiset::empty();
+        }
+    }
+
+    #[inductive(empty)]
+    fn empty_inductive(post: Self) {
+        assert(post.addr_to =~= Map::new(|addr| true, |addr|None));
+    }
+
+    transition!{
+        update(addr: int, id: InstanceId) {
+            remove addr_to -= [addr => None];
+            remove to_addr -= [id => None];
+            add addr_to += [ addr => Some(id) ];
+            add to_addr += [ id => Some(addr) ];
+        }
+    }
+
+    #[inductive(update)]
+    fn update_inductive(pre: Self, post: Self, addr: int, id: InstanceId) {
+        assert forall |addr: int| (#[trigger]post.addr_to[addr]).is_some()
+        implies
+            post.to_addr[post.addr_to[addr].unwrap()] == Some(addr)
+        by {}
+    }
+
+    transition!{
+        add_reader(addr: int, id: InstanceId) {
+            have ptr_readers >= {(addr, id)};
+            add ptr_readers += {(addr, id)};
+        }
+    }
+
+    #[inductive(add_reader)]
+    fn add_reader_inductive(pre: Self, post: Self, addr: int, id: InstanceId) {
+        assert(pre.ptr_readers.contains((addr, id)));
+        assert forall |addr, id| #[trigger]post.ptr_readers.contains((addr, id))
+        implies
+            post.addr_to[addr] === Some(id) && post.to_addr[id] === Some(addr)
+        by {
+            assert(pre.ptr_readers.contains((addr, id)));
+        }
+    }
+}
+);
+
+// A single inst + addr_unique::addr_to, addr_unique::to_addr are created at entry.
+pub struct UniqueByPtr {
+    tracked inst: addr_unique::Instance,
+    tracked id: addr_unique::ptr_readers,
+    ghost addr_id_map: Option<(addr_unique::addr_to, addr_unique::to_addr)>,
+}
+
+impl UniqueByPtr {
+    // inst is only created once at the begining and thus all share the same inst_id;
+    pub uninterp spec fn spec_uniq_inst_id() -> InstanceId;
+
+    #[verifier::type_invariant]
+    pub closed spec fn wf(&self) -> bool {
+        &&& self.inst.id() == UniqueByPtr::spec_uniq_inst_id()
+        &&& self.id.instance_id() == UniqueByPtr::spec_uniq_inst_id()
+        &&& if let Some((id_map, addr_map)) = self.addr_id_map {
+            &&& id_map.instance_id() == UniqueByPtr::spec_uniq_inst_id()
+            &&& addr_map.instance_id() == UniqueByPtr::spec_uniq_inst_id()
+        } else {
+            true
+        }
+    }
+
+    pub proof fn tracked_clone(tracked &self) -> (tracked ret: Self)
+        ensures
+            ret@ == self@,
+    {
+        use_type_invariant(&*self);
+        let (addr, id) = self.id.element();
+        let tracked reader = self.inst.add_reader(addr, id, &self.id);
+        UniqueByPtr { inst: self.inst, id: reader, addr_id_map: self.addr_id_map }
+    }
+
+    pub closed spec fn view(&self) -> (int, InstanceId) {
+        self.id.element()
+    }
+
+    pub open spec fn id(&self) -> InstanceId {
+        self@.1
+    }
+}
+
+/// FracTypedPerm<T> is a ghost tracked permission type that tracks a fraction
+/// of memory permission. It is used to share memory permissions between
+/// different components and allowing concurrent read. In most cases, we rely on
+/// Rust existing ownership system to track the memory permissions. This is only
+/// used when we need to deal with raw pointers and unsafe codes. For example,
+/// in memory allocator, we need to share the read access to some raw memory but
+/// we do not really store PageInfo inside allocator, or share reference to
+/// external. Instead, we can use this ghost type to define the ownership and
+/// share the read access to the PageInfo without causing memory overhead.
+///
+/// In addition, we proved that the frac-based permissions pointing to the same
+/// address are always from the same instance. Thus, we can safely merge the
+/// local and global permissions if they point to the same address.
+pub struct FracTypedPerm<T> {
+    p: FracPerm<PointsTo<T>>,
+    unique: UniqueByPtr,
+}
+
+pub struct FracTypedPermData<T> {
+    pub shares: nat,
+    pub total: nat,
+    pub addr: int,
+    pub id: InstanceId,
+    pub points_to: Option<PointsToData<T>>,
+}
+
+impl<T> FracTypedPermData<T> {
+    pub open spec fn update_points_to(self, p: Option<PointsToData<T>>) -> Self {
+        FracTypedPermData {
+            shares: self.shares,
+            total: self.total,
+            addr: self.addr,
+            id: self.id,
+            points_to: p,
+        }
+    }
+
+    pub open spec fn update_value(self, opt_value: MemContents<T>) -> Self
+        recommends
+            self.points_to.is_some(),
+    {
+        FracTypedPermData {
+            shares: self.shares,
+            total: self.total,
+            addr: self.addr,
+            id: self.id,
+            points_to: Some(PointsToData { ptr: self.points_to.unwrap().ptr, opt_value }),
+        }
+    }
+
+    pub open spec fn update_shares(self, shares: nat) -> Self {
+        FracTypedPermData {
+            shares,
+            total: self.total,
+            addr: self.addr,
+            id: self.id,
+            points_to: self.points_to,
+        }
+    }
+
+    pub open spec fn data_view(&self) -> Self {
+        self.update_shares(0)
+    }
+}
+
+impl<T> FracTypedPerm<T> {
+    pub closed spec fn view(&self) -> FracTypedPermData<T> {
+        FracTypedPermData {
+            shares: self.p.shares(),
+            total: self.p.total(),
+            id: self.p.id(),
+            addr: self.unique@.0,
+            points_to: match self.p@ {
+                Some(p) => Some(p@),
+                None => None,
+            },
+        }
+    }
+
+    pub open spec fn shares(&self) -> nat {
+        self@.shares
+    }
+
+    pub open spec fn total(&self) -> nat {
+        self@.total
+    }
+
+    pub open spec fn points_to(&self) -> Option<PointsToData<T>> {
+        self@.points_to
+    }
+
+    pub open spec fn addr(&self) -> int {
+        self@.addr
+    }
+
+    pub open spec fn id(&self) -> InstanceId {
+        self@.id
+    }
+
+    #[verifier::inline]
+    pub open spec fn ptr(&self) -> *mut T {
+        self@.points_to.unwrap().ptr
+    }
+
+    #[verifier::inline]
+    pub open spec fn opt_value(&self) -> MemContents<T> {
+        self@.points_to.unwrap().opt_value
+    }
+
+    #[verifier::inline]
+    pub open spec fn is_init(&self) -> bool {
+        self.opt_value().is_init()
+    }
+
+    #[verifier::inline]
+    pub open spec fn is_uninit(&self) -> bool {
+        self.opt_value().is_uninit()
+    }
+
+    #[verifier::inline]
+    pub open spec fn value(&self) -> T {
+        self.opt_value().value()
+    }
+}
+
+impl<T> FracTypedPerm<T> {
+    #[verifier::type_invariant]
+    pub closed spec fn wf(&self) -> bool {
+        &&& self@.id == self.unique.id()
+        &&& self.valid() ==> ((self.ptr() as int) == self.addr())
+    }
+
+    pub open spec fn readable(&self) -> bool {
+        self.is_init()
+    }
+
+    pub open spec fn writable(&self) -> bool {
+        self.shares() == self.total()
+    }
+
+    pub open spec fn valid(&self) -> bool {
+        &&& self@.points_to.is_some()
+    }
+
+    proof fn has_same_id(tracked &self, tracked other: &Self)
+        requires
+            self.valid(),
+            other.valid(),
+            self.addr() == other.addr(),
+        ensures
+            self@.id == other@.id,
+    {
+        use_type_invariant(&*self);
+        use_type_invariant(&*other);
+        use_type_invariant(&self.unique);
+        use_type_invariant(&other.unique);
+        self.unique.inst.check_ids(
+            self.addr(),
+            self.id(),
+            other.id(),
+            &self.unique.id,
+            &other.unique.id,
+        );
+    }
+
+    pub proof fn is_same(tracked &self, tracked other: &Self)
+        requires
+            self.valid(),
+            other.valid(),
+            self.ptr() == other.ptr(),
+        ensures
+            self@.points_to == other@.points_to,
+            self@.id == other@.id,
+    {
+        use_type_invariant(&*self);
+        use_type_invariant(&*other);
+        self.has_same_id(&other);
+        self.p.is_same(&other.p);
+    }
+
+    pub proof fn extract(tracked &mut self) -> (tracked ret: PointsTo<T>)
+        requires
+            old(self).valid(),
+            old(self).writable(),
+        ensures
+            Some(ret@) == old(self).points_to(),
+            ret.ptr() as int == self.addr(),
+            !self.valid(),
+            self@ == old(self)@.update_points_to(None),
+    {
+        use_type_invariant(&*self);
+        self.p.take()
+    }
+
+    pub proof fn update(tracked &mut self, tracked val: PointsTo<T>)
+        requires
+            old(self).writable(),
+            (val@.ptr as int) == old(self).addr(),
+            !old(self).valid(),
+        ensures
+            self@ === old(self)@.update_points_to(Some(val@)),
+    {
+        use_type_invariant(&*self);
+        use_type_invariant(&self.p);
+        self.p.udpate(val)
+    }
+
+    pub proof fn borrow(tracked &self) -> (tracked ret: &PointsTo<T>)
+        requires
+            self.valid(),
+        ensures
+            Some(ret@) == self.points_to(),
+    {
+        use_type_invariant(&*self);
+        self.p.borrow()
+    }
+
+    pub proof fn share(tracked &mut self, shares: nat) -> (tracked ret: Self)
+        requires
+            old(self).valid(),
+            0 < shares < old(self).shares(),
+        ensures
+            self@ === old(self)@.update_shares((old(self).shares() - shares) as nat),
+            ret@ === old(self)@.update_shares(shares),
+    {
+        use_type_invariant(&*self);
+        use_type_invariant(&self.p);
+        use_type_invariant(&self.unique);
+        let id = self.unique.id();
+        let tracked p = self.p.share(shares);
+        assert(p.id() == id);
+        let tracked unique = self.unique.tracked_clone();
+        assert(unique.id() == id);
+        use_type_invariant(&p);
+        use_type_invariant(&unique);
+        FracTypedPerm { p, unique }
+    }
+
+    pub proof fn merge(tracked &mut self, tracked other: Self)
+        requires
+            other.valid(),
+            old(self).valid(),
+            old(self).ptr() == other.ptr(),
+        ensures
+            self@ === old(self)@.update_shares(old(self).shares() + other.shares()),
+            old(self).shares() + other.shares() <= old(self).total(),
+    {
+        use_type_invariant(&*self);
+        use_type_invariant(&other);
+        let tracked mut other = other;
+        self.is_same(&other);
+        self.p.is_same(&other.p);
+        self.p.merge(other.p);
+        use_type_invariant(&self.p);
+        self.p.shares_agree_totals();
+    }
+}
+
+pub proof fn raw_perm_is_disjoint(tracked p1: &mut PointsToRaw, p2: &PointsToRaw)
+    requires
+        old(p1).dom().len() > 0,
+    ensures
+        *old(p1) == *p1,
+        p1.dom().disjoint(p2.dom()),
+{
+    admit();
+}
+
+pub proof fn tracked_map_shares<Idx, T>(
+    tracked m: &mut Map<Idx, FracTypedPerm<T>>,
+    shares: nat,
+) -> (tracked ret: Map<Idx, FracTypedPerm<T>>)
+    requires
+        old(m).dom().finite(),
+        shares > 0,
+        forall|i|
+            old(m).dom().contains(i) ==> shares < (#[trigger] old(m)[i]).shares() && old(
+                m,
+            )[i].valid(),
+    ensures
+        ret.dom() == m.dom(),
+        m.dom() == old(m).dom(),
+        forall|i: Idx|
+            #![trigger m[i]]
+            #![trigger old(m)[i]]
+            m.contains_key(i) ==> m[i]@ == old(m)[i]@.update_shares(
+                (old(m)[i].shares() - shares) as nat,
+            ),
+        forall|i: Idx|
+            #![trigger ret[i]]
+            #![trigger old(m)[i]]
+            ret.contains_key(i) ==> ret[i]@ == old(m)[i]@.update_shares(shares),
+{
+    _tracked_map_shares(m, shares, m.dom())
+}
+
+pub proof fn _tracked_map_shares<Idx, T>(
+    tracked m: &mut Map<Idx, FracTypedPerm<T>>,
+    shares: nat,
+    s: Set<Idx>,
+) -> (tracked ret: Map<Idx, FracTypedPerm<T>>)
+    requires
+        shares > 0,
+        forall|i| #[trigger] s.contains(i) ==> old(m).contains_key(i),
+        forall|i| s.contains(i) ==> (#[trigger] old(m)[i]).valid(),
+        forall|i| s.contains(i) ==> shares < (#[trigger] old(m)[i]).shares(),
+        s.finite(),
+    ensures
+        forall|i: Idx|
+            #![trigger m[i]]
+            #![trigger old(m)[i]]
+            s.contains(i) ==> m[i]@ == old(m)[i]@.update_shares(
+                (old(m)[i].shares() - shares) as nat,
+            ),
+        *m =~= old(m).union_prefer_right(m.restrict(s)),
+        m.dom() =~= old(m).dom(),
+        ret.dom() =~= s,
+        forall|i: Idx| s.contains(i) ==> (#[trigger] ret[i])@ == old(m)[i]@.update_shares(shares),
+    decreases s.len(),
+{
+    if !s.is_empty() {
+        let idx = s.choose();
+        assert(s.contains(idx));
+        assert(m.contains_key(idx));
+        let tracked mut ret = _tracked_map_shares(m, shares, s.remove(idx));
+        let old_m = *m;
+        let tracked mut tmp = m.tracked_remove(idx);
+        let tracked shared = tmp.share(shares);
+        m.tracked_insert(idx, tmp);
+        ret.tracked_insert(idx, shared);
+        ret
+    } else {
+        assert(s =~= Set::empty());
+        Map::tracked_empty()
+    }
+}
+
+pub proof fn tracked_map_merge_right_shares<Idx, T>(
+    tracked m: &mut Map<Idx, FracTypedPerm<T>>,
+    tracked right: Map<Idx, FracTypedPerm<T>>,
+)
+    requires
+        right.dom().subset_of(old(m).dom()),
+        right.dom().finite(),
+        forall|i|
+            right.contains_key(i) ==> (#[trigger] old(m)[i]).valid() && old(m)[i].ptr()
+                == right[i].ptr(),
+        forall|i| right.contains_key(i) ==> (#[trigger] right[i]).valid(),
+    ensures
+        forall|i: Idx|
+            #![trigger m[i]]
+            #![trigger old(m)[i]]
+            old(m).contains_key(i) && right.contains_key(i) ==> m[i]@ == old(m)[i]@.update_shares(
+                (old(m)[i].shares() + right[i].shares()) as nat,
+            ),
+        m.dom() =~= old(m).dom(),
+    decreases right.dom().len(),
+{
+    let s = right.dom();
+    if !s.is_empty() {
+        let idx = s.choose();
+        assert(right.contains_key(idx));
+        let tracked mut right = right;
+        let tracked mut right_tmp = right.tracked_remove(idx);
+        let tracked mut tmp = m.tracked_remove(idx);
+        tmp.merge(right_tmp);
+        tracked_map_merge_right_shares(m, right);
+        m.tracked_insert(idx, tmp);
+    }
+}
+
+} // verus!

--- a/verify_proof/src/lib.rs
+++ b/verify_proof/src/lib.rs
@@ -16,6 +16,10 @@ pub mod frac_perm;
 #[cfg(verus_keep_ghost)]
 pub mod frac_ptr;
 #[cfg(verus_keep_ghost)]
+pub mod nonlinear;
+#[cfg(verus_keep_ghost)]
+pub mod set;
+#[cfg(verus_keep_ghost)]
 pub mod sum;
 
 verus! {
@@ -24,6 +28,7 @@ global size_of usize == 8;
 
 #[cfg_attr(verus_keep_ghost, verifier::broadcast_use_by_default_when_this_crate_is_imported)]
 pub broadcast group group_axioms {
+    set::lemma_set_usize_finite,
 }
 
 } // verus!

--- a/verify_proof/src/lib.rs
+++ b/verify_proof/src/lib.rs
@@ -7,12 +7,23 @@
 #![no_std]
 #![allow(unused_braces)]
 #![allow(unexpected_cfgs)]
+#![allow(missing_debug_implementations)]
 use builtin_macros::*;
 
 pub mod bits;
+#[cfg(verus_keep_ghost)]
+pub mod frac_perm;
+#[cfg(verus_keep_ghost)]
+pub mod frac_ptr;
+#[cfg(verus_keep_ghost)]
+pub mod sum;
 
 verus! {
 
 global size_of usize == 8;
 
+#[cfg_attr(verus_keep_ghost, verifier::broadcast_use_by_default_when_this_crate_is_imported)]
+pub broadcast group group_axioms {
 }
+
+} // verus!

--- a/verify_proof/src/nonlinear.rs
+++ b/verify_proof/src/nonlinear.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Ziqiao Zhou <ziqiaozhou@microsoft.com>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Ziqiao Zhou <ziqiaozhou@microsoft.com>
+use vstd::prelude::*;
+verus! {
+
+pub proof fn lemma_modulus_product_divisibility(x: int, m: int, k: int)
+    requires
+        m != 0,
+        k != 0,
+        x % (k * m) == 0,
+    ensures
+        x % m == 0,
+{
+    let n = k * m;
+    let i = x / n;
+    assert(k * m != 0) by (nonlinear_arith)
+        requires
+            k != 0,
+            m != 0,
+    ;
+    assert(i * n == x) by (nonlinear_arith)
+        requires
+            i == x / n,
+            x % n == 0,
+            n != 0,
+    ;
+    assert((i * k) * m == i * (k * m)) by (nonlinear_arith);
+    assert(x % m == 0) by (nonlinear_arith)
+        requires
+            x == (i * k) * m,
+            m != 0,
+    ;
+}
+
+pub proof fn lemma_modulus_add_sub_m(x: int, m: int)
+    requires
+        m != 0,
+        x % m == 0,
+    ensures
+        x % (2 * m) != 0 ==> (((x - m) % (2 * m) == 0) && (x >= m || x <= -m)),
+        (x + m) % m == 0,
+        (x - m) % m == 0,
+{
+    let i = x / m;
+    let n = 2 * m;
+
+    assert((i + 1) * m == i * m + m) by (nonlinear_arith);
+    assert((i - 1) * m == i * m - m) by (nonlinear_arith);
+    assert(i * m == x) by (nonlinear_arith)
+        requires
+            x % m == 0,
+            m != 0,
+            i == x / m,
+    ;
+    assert((x + m) % m == 0) by (nonlinear_arith)
+        requires
+            (i + 1) * m == x + m,
+            m != 0,
+    ;
+
+    assert((x - m) % m == 0) by (nonlinear_arith)
+        requires
+            (i - 1) * m == x - m,
+            m != 0,
+    ;
+
+    let j = i / 2;
+    broadcast use vstd::arithmetic::mul::lemma_mul_is_commutative;
+
+    assert(i == j * 2 || i == j * 2 + 1);
+    if i == j * 2 {
+        assert(j * 2 * m == j * (2 * m)) by (nonlinear_arith);
+        assert(x % n == 0) by (nonlinear_arith)
+            requires
+                j * n == x,
+                n != 0,
+        ;
+    }
+    if x % n != 0 {
+        assert(i == j * 2 + 1);
+        assert(i >= 1 || i <= -1);
+        assert(x - m == (j * 2 + 1) * m - m);
+        assert((j * 2 + 1) * m - m == j * (2 * m)) by (nonlinear_arith);
+        assert((x - m) % n == 0) by (nonlinear_arith)
+            requires
+                x - m == j * n,
+                n != 0,
+        ;
+        assert(x >= m || x <= -m) by (nonlinear_arith)
+            requires
+                x == i * m,
+                i >= 1 || i <= -1,
+        ;
+    }
+}
+
+#[verifier(inline)]
+pub open spec fn align_down_ens(val: int, align: int, ret: int) -> bool {
+    &&& ret % align == 0
+    &&& ret <= val < ret + align
+}
+
+#[verifier(nonlinear)]
+proof fn lemma_is_aligned_down_iff(val: int, align: int, ret: int)
+    requires
+        align > 0,
+    ensures
+        align_down_ens(val, align, ret) <==> (ret == val - val % align),
+{
+}
+
+proof fn lemma_mod_bound(val: int, align: int)
+    requires
+        align > 0,
+    ensures
+        val >= 0 <==> (val - val % align) >= 0,
+        0 <= val % align < align,
+{
+    assert(val >= 0 <==> (val - val % align) >= 0) by (nonlinear_arith)
+        requires
+            align > 0,
+    ;
+    assert(0 <= val % align < align) by (nonlinear_arith)
+        requires
+            align > 0,
+    ;
+}
+
+pub proof fn lemma_align_down_properties(val: int, align: int, ret: int)
+    requires
+        align > 0,
+    ensures
+        align_down_ens(val, align, ret) <==> (ret == val - val % align),
+        val >= 0 <==> (val - val % align) >= 0,
+        0 <= val % align < align,
+{
+    lemma_is_aligned_down_iff(val, align, ret);
+    lemma_mod_bound(val, align);
+}
+
+pub proof fn lemma_align_up_properties(val: int, align: int, ret: int)
+    requires
+        align > 0,
+        val % align == 0 ==> val == ret,
+        val % align != 0 ==> ret == val + align - val % align,
+    ensures
+        val % align == 0 ==> val == ret,
+        val % align != 0 ==> ret / align == val / align + 1,
+        ret >= val,
+        val > 0 ==> ret >= align,
+        ret % align == 0,
+{
+    lemma_mod_bound(val, align);
+    assert((val + align - val % align) / align == val / align + 1) by (nonlinear_arith)
+        requires
+            align > 0,
+    ;
+    assert((val % align == 0 && val > 0) ==> val >= align) by (nonlinear_arith);
+
+    if val % align != 0 {
+        assert(ret % align == 0) by (nonlinear_arith)
+            requires
+                ret == val + align - val % align,
+                align > 0,
+        ;
+    }
+}
+
+} // verus!

--- a/verify_proof/src/set.rs
+++ b/verify_proof/src/set.rs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Ziqiao Zhou <ziqiaozhou@microsoft.com>
+use vstd::prelude::*;
+
+verus! {
+
+pub open spec fn set_usize_range(start: usize, end: int) -> Set<usize> {
+    Set::new(|i| start <= i < end)
+}
+
+pub broadcast proof fn lemma_set_usize_range(start: usize, end: int)
+    requires
+        start <= end,
+        end <= usize::MAX + 1,
+    ensures
+        (#[trigger] set_usize_range(start, end)).finite(),
+        set_usize_range(start, end).len() == end - start,
+    decreases end - start,
+{
+    if end > start {
+        let e2 = (end - 1) as usize;
+        let s1 = set_usize_range(start, end);
+        let s2 = set_usize_range(start, e2 as int);
+        lemma_set_usize_range(start, e2 as int);
+        assert(s1 =~= s2.insert(e2));
+    } else {
+        assert(set_usize_range(start, end) =~= Set::empty());
+    }
+}
+
+pub broadcast proof fn lemma_set_usize_finite(s: Set<usize>)
+    ensures
+        #[trigger] s.finite(),
+{
+    let maxset = set_usize_range(0, usize::MAX + 1);
+    lemma_set_usize_range(0, usize::MAX + 1);
+    assert(s.subset_of(maxset));
+}
+
+pub broadcast proof fn lemma_len_filter<A>(s: Set<A>, f: spec_fn(A) -> bool)
+    requires
+        s.finite(),
+    ensures
+        (#[trigger] s.filter(f)).finite(),
+        s.filter(f).len() <= s.len(),
+{
+    s.lemma_len_filter(f)
+}
+
+pub broadcast proof fn lemma_len_subset<A>(s1: Set<A>, s2: Set<A>)
+    requires
+        s2.finite(),
+        #[trigger] s1.subset_of(s2),
+    ensures
+        s1.len() <= s2.len(),
+        s1.finite(),
+{
+    vstd::set_lib::lemma_len_subset(s1, s2)
+}
+
+} // verus!

--- a/verify_proof/src/sum.rs
+++ b/verify_proof/src/sum.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Ziqiao Zhou <ziqiaozhou@microsoft.com>
+use vstd::multiset::Multiset;
+use vstd::prelude::*;
+
+verus! {
+
+pub trait CountTrait {
+    spec fn count(&self) -> nat;
+}
+
+pub open spec fn sum<T: CountTrait>(s: Multiset<T>) -> nat
+    decreases s.len(),
+{
+    if s.len() > 0 {
+        let e = s.choose();
+        e.count() + sum(s.remove(e))
+    } else {
+        0
+    }
+}
+
+pub proof fn lemma_sum_insert<T: CountTrait>(s: Multiset<T>, elem: T)
+    ensures
+        sum(s) + elem.count() == sum(s.insert(elem)),
+{
+    assert(s.insert(elem).remove(elem) =~= s);
+    lemma_sum_remove(s.insert(elem), elem);
+}
+
+pub proof fn lemma_sum_remove<T: CountTrait>(s: Multiset<T>, elem: T)
+    requires
+        s.contains(elem),
+    ensures
+        sum(s.remove(elem)) + elem.count() == sum(s),
+    decreases s.len(),
+{
+    let news = s.remove(elem);
+    if s.len() > 1 {
+        let e = s.choose();
+        if e != elem {
+            assert(sum(s.remove(e)) + e.count() == sum(s));
+            lemma_sum_remove(s.remove(e), elem);
+            lemma_sum_remove(s.remove(elem), e);
+            assert(s.remove(elem).remove(e) =~= s.remove(e).remove(elem));
+        } else {
+            assert(sum(s.remove(elem)) + elem.count() == sum(s));
+        }
+    } else {
+        Multiset::lemma_is_singleton(s);
+        let e = s.choose();
+        assert(s.contains(e));
+        assert(news.len() == 0);
+        assert(sum(news) == 0);
+        assert(e == elem);
+    }
+}
+
+} // verus!

--- a/verus_macro_stub/src/lib.rs
+++ b/verus_macro_stub/src/lib.rs
@@ -20,3 +20,13 @@ pub fn verus(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 pub fn proof(_input: TokenStream) -> TokenStream {
     TokenStream::new()
 }
+
+#[proc_macro]
+pub fn proof_decl(_input: TokenStream) -> TokenStream {
+    TokenStream::new()
+}
+
+#[proc_macro]
+pub fn proof_with(_input: TokenStream) -> TokenStream {
+    TokenStream::new()
+}


### PR DESCRIPTION
This is a large PR since it starts to introduce the ghost tracked permission to reason unsafe memory access using unforgeable tracked memory permissions.

## Description of the PR

This PR add verification codes for allocator. 

### A new proof-related data type (verify_proof/src/frac_xxx.rs)

I introduced an unforgeable tracked memory permissions FracTypedPerm<T> based on verus's default memory permission [PointsTo<T>](https://github.com/verus-lang/verus/blob/main/source/vstd/raw_ptr.rs) (As for how the memory permission token is used, you can also refer to [VeriSMo](https://www.usenix.org/system/files/osdi24-zhou.pdf) to know more usage and properties it can provide, if you are really interested in). This permission type allows us to define the ownership of data when dealing with raw memory where Rust's existing ownership does not work well, especially for memory allocator. Only when the code has &mut FracTypedPerm<T>  and its shared == total_share, the code can modify the memory protected by the permission; When the code has &FracTypedPerm<T> where share > 0, the code can read the memory. This is a critical property for some memory area inside memory allocator.  All ghost functions provided by the type are fully verified to satisfying the properties we defined using state machine reasoning.

Other proof helper functions in verify_proof/src are not tighly related to the semantic of SVSM code and are just math proofs we used in svsm's proofs.

### Ghost data types defined for allocator verification.

`MemoryRegionPerms`: stores all memory permissions managed by MemoryRegion
`MRFreePerms`: stores all free memory permissions managed by MemoryRegion
`PageInfoDb`: Stores memory permissions pointing to PageInfo in reserved memory used by MemoryRegion. Those permissoins could be shared as readonly via FracTypedPerm when a page is allocated.
`MemRegionMapping`: A memory permission pointing to the global state of the memory region to ensure allocated memory and the global mem region shares the same mapping and address provenance.

### Verification of allocator (alloc_perm.verus.rs, alloc_free.verus.rs, alloc.rs)

With the above ghost permissions, in memory allocator, we need to prove the correct use of raw memory pointer and some invariants we defined for the memory region permissions stored in the memory allocator. verus checks the correct use of those memory permissions since we defined the trusted pointer TCB in tcb_ptr.rs to require a proper memory permission to read/write a raw ptr.

Another way to think about the verification here is that you can treat ghost permissions as a real memory block stored in the allocator, and then the allocator will return a memory block when allocating an instance from itself and will take a memory block when freeing an instance. When merging or splitting pages, the allocator will merge two blocks into one or split one into two. The use of those "memory block" must follow the rust ownership. With the ghost permission token, we can do this without introducing real memory overhead.

At a high level, it guarantees that

1. The MemoryRegion never returns a page for more than once.
2. The returned page must be a page managed by the region.
3. The page info stored is correct. If the page is allocated out of the allocator, the allocator should not be able to update the page info for that page until the page is freed. And thus, checking the page info is valid to know the actual type of the page.
4. A memory page to be freed must be an allocated memory. For any unsafe/unsafe code that tries to dealloc a memory page via API, that code must has ownership of the page.
5. The page counting is correct.
6. The code cannot change the definition of memory region (start, end, mapping) when some pages are allocated out of the allocator.

Among them, 1,2,4,6 are implicitly implied through the permission mechanism at any time point. 3 is partially implied by the permission and verified as an invariant in MRFreePerms::ens_perm_valid. 
Property 5 is verified for all pub or API functions by ensuring MemoryRegion::wf_perms which cannot be an invariant since MemoryRegion has some intermediate states (via some private functions) that can violate that property.

In addition, the verification helps to avoid some potential panic (e.g., Rust may panic if underflow/overflow happens) and provides proofs for some unreachable state. For all verified code, we can guarantee it will never cause overflow and underflow problems.  (If unverified code violates the preconditions we defined, it may still cause the problem, but we will incrementally ensure that will not happen).

### Encode and decode properties for some data types in allocator (alloc_type.verus.rs).

The allocator code also has many decode/encode function pairs, and I have proved the correct encode/decode relationship in SpecDecoderProof::proof_encode_decode (If a variable x can be encoded, the encoded value must be able to be decoded back to x) See that in alloc_type.verus.rs. 

## New information about the verification

In this PR, you will find three new syntax:
1. Defines extra **ghost** arguments passed to a function. The arguments does not exist in final compiled code.
```rust
#[verus_spec(with Tracked(x): Tracked<XType>)]
fn xyz() {}
```

2. Pass ghost arguments to a function call.
```rust
proof_with!(Tracked(x))
let _ = xyz();
```

3. Prove while declaring ghost/tracked variable that could be used in other proof blocks inside the same function
```rust
proof_decl!{
   let ghost x = 1usize;
   let tracked y = Map::tracked_empty();
}
```

4. Prove the loop with invariant
```rust
#[verus_spec(invariant true)] 
loop {}
```

5. Allow panic!() by enabling "vpanic" feature in builtin_macros and vstd.

In verus, the default setting disallows any panic to ensure the verified code is panic-free. But `svsm` has used panic in many places, and so we need to enable "vpanic" feature to allow panic to be used and also need to check the parameters passed to panic macro. 

## Changes

As before, verification-only files are
* under `verify_proof/src/` and `verify_externals/src/` 
* `kernel/src/*.verus.rs` are only used by verification.

Added executable files:
* [kernel/src/utils/safe_ptr.rs](https://github.com/coconut-svsm/svsm/compare/main...MSRSSP:svsm:verus-alloc-main#diff-854db1c5e0ea3471d8ebeffa0017dcf07e364bab029b32ef062cc43abfc87254) adds new raw pointer read/write function with a safe tracked permission.
Modified executable files:
* [kernel/src/address.rs](https://github.com/coconut-svsm/svsm/compare/main...MSRSSP:svsm:verus-alloc-main#diff-4345e2aa126d200ea1f34e2ef0bcffce704adc159e175aa570b28591752dbd11)
* [kernel/src/mm/address_space.rs](https://github.com/coconut-svsm/svsm/compare/main...MSRSSP:svsm:verus-alloc-main#diff-b4e8f094354e7e8101561be3695b473c69bf35e2c27f8780ed63e739831e64d3)
* [kernel/src/mm/alloc.rs](https://github.com/coconut-svsm/svsm/compare/main...MSRSSP:svsm:verus-alloc-main#diff-7eace8c7386d76dc9aa61d4f5d6e28af507602e921daad687f4064bf109d45c1)

NOTE: Inline comments will be left on executable code changes for further context.

## Verification Results
verification result could be found here at https://github.com/MSRSSP/svsm/actions/runs/14611944129/job/40991530406
Each commit is verifiable without issue (see per-commit CI result here at https://github.com/MSRSSP/svsm/pull/8)

