### PR TITLE
kernel/sev/ghcb: Always supply RCX on GHCB CPUID NAE event

### DIFF
--- a/kernel/src/cpu/cpuid.rs
+++ b/kernel/src/cpu/cpuid.rs
@@ -127,8 +127,8 @@ pub fn cpuid_table_raw(eax: u32, ecx: u32, xcr0: u64, xss: u64) -> Option<CpuidR
     None
 }
 
-pub fn cpuid_table(eax: u32) -> Option<CpuidResult> {
-    cpuid_table_raw(eax, 0, 0, 0)
+pub fn cpuid_table(eax: u32, ecx: u32) -> Option<CpuidResult> {
+    cpuid_table_raw(eax, ecx, 0, 0)
 }
 
 pub fn dump_cpuid_table() {

--- a/kernel/src/cpu/features.rs
+++ b/kernel/src/cpu/features.rs
@@ -13,24 +13,24 @@ const X86_FEATURE_UMIP: u32 = 2;
 
 pub fn cpu_has_pge(platform: &dyn SvsmPlatform) -> bool {
     platform
-        .cpuid(0x0000_0001)
+        .cpuid(0x0000_0001, 0)
         .map_or_else(|| false, |c| (c.edx >> X86_FEATURE_PGE) & 1 == 1)
 }
 
 pub fn cpu_has_smep(platform: &dyn SvsmPlatform) -> bool {
     platform
-        .cpuid(0x0000_0007)
+        .cpuid(0x0000_0007, 0)
         .map_or_else(|| false, |c| (c.ebx >> X86_FEATURE_SMEP & 1) == 1)
 }
 
 pub fn cpu_has_smap(platform: &dyn SvsmPlatform) -> bool {
     platform
-        .cpuid(0x0000_0007)
+        .cpuid(0x0000_0007, 0)
         .map_or_else(|| false, |c| (c.ebx >> X86_FEATURE_SMAP & 1) == 1)
 }
 
 pub fn cpu_has_umip(platform: &dyn SvsmPlatform) -> bool {
     platform
-        .cpuid(0x0000_0007)
+        .cpuid(0x0000_0007, 0)
         .map_or_else(|| false, |c| (c.ecx >> X86_FEATURE_UMIP & 1) == 1)
 }

--- a/kernel/src/hyperv/hv.rs
+++ b/kernel/src/hyperv/hv.rs
@@ -272,7 +272,7 @@ pub static IS_HYPERV: ImmutAfterInitCell<bool> = ImmutAfterInitCell::uninit();
 
 fn is_hyperv_hypervisor() -> bool {
     // Get the hypervisor interface signature.
-    let result = SVSM_PLATFORM.cpuid(0x40000001);
+    let result = SVSM_PLATFORM.cpuid(0x40000001, 0);
     if let Some(cpuid_result) = result {
         cpuid_result.eax == 0x31237648
     } else {

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -139,7 +139,7 @@ pub trait SvsmPlatform: Sync {
     ) -> hyperv::HvHypercallOutput;
 
     /// Obtain CPUID using platform-specific tables.
-    fn cpuid(&self, eax: u32) -> Option<CpuidResult>;
+    fn cpuid(&self, eax: u32, ecx: u32) -> Option<CpuidResult>;
 
     /// Write a host-owned MSR.
     /// # Safety

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -121,8 +121,8 @@ impl SvsmPlatform for NativePlatform {
         unsafe { hyperv::execute_hypercall(input_control, hypercall_pages) }
     }
 
-    fn cpuid(&self, eax: u32) -> Option<CpuidResult> {
-        Some(CpuidResult::get(eax, 0))
+    fn cpuid(&self, eax: u32, ecx: u32) -> Option<CpuidResult> {
+        Some(CpuidResult::get(eax, ecx))
     }
 
     unsafe fn write_host_msr(&self, msr: u32, value: u64) {

--- a/kernel/src/platform/tdp.rs
+++ b/kernel/src/platform/tdp.rs
@@ -130,8 +130,8 @@ impl SvsmPlatform for TdpPlatform {
         })
     }
 
-    fn cpuid(&self, eax: u32) -> Option<CpuidResult> {
-        Some(CpuidResult::get(eax, 0))
+    fn cpuid(&self, eax: u32, ecx: u32) -> Option<CpuidResult> {
+        Some(CpuidResult::get(eax, ecx))
     }
 
     unsafe fn write_host_msr(&self, msr: u32, value: u64) {

--- a/kernel/src/sev/ghcb.rs
+++ b/kernel/src/sev/ghcb.rs
@@ -308,9 +308,10 @@ impl GHCB {
         Ok(())
     }
 
-    pub fn cpuid(&self, eax: u32) -> Result<CpuidResult, SvsmError> {
+    pub fn cpuid(&self, eax: u32, ecx: u32) -> Result<CpuidResult, SvsmError> {
         self.clear();
         self.set_rax_valid(eax as u64);
+        self.set_rcx_valid(ecx as u64);
         self.vmgexit(GHCBExitCode::CPUID, 0, 0)?;
         Ok(CpuidResult {
             eax: self.get_rax_valid()? as u32,
@@ -321,7 +322,7 @@ impl GHCB {
     }
 
     pub fn cpuid_regs(&self, regs: &mut X86GeneralRegs) -> Result<(), SvsmError> {
-        let result = self.cpuid(regs.rax as u32)?;
+        let result = self.cpuid(regs.rax as u32, regs.rcx as u32)?;
         regs.rax = result.eax as usize;
         regs.rbx = result.ebx as usize;
         regs.rcx = result.ecx as usize;


### PR DESCRIPTION
RCX must always be supplied when sending a GHCB CPUID NAE event to the hypervisor. When RCX is not supplied, the GHCB call will (or should) fail. The KVM hypervisor will log the following:

  kvm_amd: kvm [15381]: vcpu0, guest rIP: 0x0 vmgexit: exit code 0x72 input is not valid

Update the GHCB cpuid() function to supply RCX with a value of zero.