### PR TITLE
Work around build failures in release builds

### DIFF
--- a/kernel/src/boot_stage2.rs
+++ b/kernel/src/boot_stage2.rs
@@ -343,3 +343,18 @@ global_asm!(
     AP_STARTUP_RIP_ADDR = const AP_CTXT_ADDR + offset_of!(ApStartContext, initial_rip) as u32,
     options(att_syntax)
 );
+
+// Provide dummy symbols in stage2 which might be required by code shared
+// between SVSM and Stage2.
+global_asm!(
+    r#"
+        .globl entry_code_start
+        entry_code_start:
+        .globl entry_code_end
+        entry_code_end:
+        .globl bsp_stack
+        bsp_stack:
+        .globl bsp_stack_end
+        bsp_stack_end:
+        "#
+);

--- a/kernel/src/stage2.lds
+++ b/kernel/src/stage2.lds
@@ -18,6 +18,10 @@ SECTIONS
 		*(.text)
 		*(.text.*)
 		. = ALIGN(16);
+		early_exception_table_start = .;
+		KEEP(*(__early_exception_table))
+		early_exception_table_end = .;
+		. = ALIGN(16);
 		exception_table_start = .;
 		KEEP(*(__exception_table))
 		exception_table_end = .;


### PR DESCRIPTION
Apparently the Rust compiler decided to include some code into the stage2 binary which references symbols which are only present in the SVSM. This is not the first time this happened and currently it can be seen in release builds.

This PR works around this by providing some of the SVSM symbols as dummies in the stage2 binary as well. This fixes the linker issue and makes the build more robust for now.

The longer term solution still needs to be splitting out Stage2 into a separate Rust crate to better manage the code sharing between SVSM and Stage2.