### PR TITLE
toolchain, kernel, stage2: Bump rust version to 1.86.0

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -2,7 +2,7 @@
 name = "svsm"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.84.0"
+rust-version = "1.86.0"
 
 [[bin]]
 name = "stage2"

--- a/kernel/src/cpu/cpuset.rs
+++ b/kernel/src/cpu/cpuset.rs
@@ -12,7 +12,7 @@ pub const MAX_CPUS: usize = 1024;
 /// be represented.
 #[derive(Copy, Clone, Debug, Default)]
 pub struct CpuSet {
-    bitmask: [u64; (MAX_CPUS + 63) / 64],
+    bitmask: [u64; MAX_CPUS.div_ceil(64)],
 }
 
 impl CpuSet {
@@ -79,7 +79,7 @@ impl Iterator for CpuSetIterator<'_> {
 /// addition and removal.  A maximum of 1024 CPUs can be represented.
 #[derive(Debug, Default)]
 pub struct AtomicCpuSet {
-    bitmask: [AtomicU64; (MAX_CPUS + 63) / 64],
+    bitmask: [AtomicU64; MAX_CPUS.div_ceil(64)],
 }
 
 impl AtomicCpuSet {

--- a/kernel/src/cpu/tss.rs
+++ b/kernel/src/cpu/tss.rs
@@ -11,7 +11,7 @@ use core::num::NonZeroU8;
 use core::ptr::addr_of;
 
 // IST offsets
-pub const IST_DF: NonZeroU8 = unsafe { NonZeroU8::new_unchecked(1) };
+pub const IST_DF: NonZeroU8 = NonZeroU8::new(1).unwrap();
 
 #[derive(Debug, Default, Clone, Copy)]
 #[repr(C, packed(4))]

--- a/kernel/src/crypto/mod.rs
+++ b/kernel/src/crypto/mod.rs
@@ -31,7 +31,7 @@ pub mod aead {
         /// * `aad`: Additional authenticated data
         /// * `inbuf`: Cleartext buffer to be encrypted
         /// * `outbuf`: Buffer to store the encrypted data, it must be large enough to also
-        ///             hold the authenticated tag.
+        ///   hold the authenticated tag.
         ///
         /// # Returns
         ///

--- a/kernel/src/fs/filesystem.rs
+++ b/kernel/src/fs/filesystem.rs
@@ -216,7 +216,7 @@ impl FileHandle {
     ///  # Arguments
     ///
     ///  - `offset`: specifies the size in bytes to which the file
-    ///     git  is to be truncated.
+    ///    git  is to be truncated.
     ///
     ///  # Returns
     ///

--- a/kernel/src/greq/driver.rs
+++ b/kernel/src/greq/driver.rs
@@ -200,7 +200,7 @@ impl SnpGuestRequestDriver {
     /// * `req_class`: whether this is a regular or extended `SNP_GUEST_REQUEST` command
     /// * `msg_type`: type of the command stored in `buffer`, e.g. SNP_MSG_REPORT_REQ
     /// * `buffer`: buffer with the `SNP_GUEST_REQUEST` command to be sent.
-    ///             The same buffer will also be used to store the response.
+    ///   The same buffer will also be used to store the response.
     /// * `command_len`: Size (in bytes) of the command stored in `buffer`
     ///
     /// # Returns

--- a/kernel/src/greq/msg.rs
+++ b/kernel/src/greq/msg.rs
@@ -186,9 +186,9 @@ impl SnpGuestRequestMsg {
     ///
     /// * `msg_type`: Type of the command stored in the `command` buffer.
     /// * `msg_seqno`: VMPL0 sequence number to be used in the message. The PSP will reject
-    ///                subsequent messages when it detects that the sequence numbers are
-    ///                out of sync. The sequence number is also used as initialization
-    ///                vector (IV) in encryption.
+    ///   subsequent messages when it detects that the sequence numbers are
+    ///   out of sync. The sequence number is also used as initialization
+    ///   vector (IV) in encryption.
     /// * `vmpck0`: VMPCK0 key that will be used to encrypt the command.
     /// * `command`: command slice to be encrypted.
     ///

--- a/kernel/src/greq/services.rs
+++ b/kernel/src/greq/services.rs
@@ -63,14 +63,14 @@ fn get_report(buffer: &mut [u8], certs: Option<&mut [u8]>) -> Result<usize, Svsm
 /// # Arguments
 ///
 /// * `buffer`: Buffer with the [`MSG_REPORT_REQ`](SnpReportRequest) command that will be
-///             sent to the PSP. It must be large enough to hold the
-///             [`MSG_REPORT_RESP`](SnpReportResponse) received from the PSP.
+///   sent to the PSP. It must be large enough to hold the
+///   [`MSG_REPORT_RESP`](SnpReportResponse) received from the PSP.
 ///
 /// # Returns
 ///
 /// * Success
 ///     * `usize`: Number of bytes written to `buffer`. It should match the
-///        [`MSG_REPORT_RESP`](SnpReportResponse) size.
+///       [`MSG_REPORT_RESP`](SnpReportResponse) size.
 /// * Error
 ///     * [`SvsmReqError`]
 pub fn get_regular_report(buffer: &mut [u8]) -> Result<usize, SvsmReqError> {
@@ -89,15 +89,15 @@ pub fn get_regular_report(buffer: &mut [u8]) -> Result<usize, SvsmReqError> {
 /// # Arguments
 ///
 /// * `buffer`: Buffer with the [`MSG_REPORT_REQ`](SnpReportRequest) command that will be
-///             sent to the PSP. It must be large enough to hold the
-///             [`MSG_REPORT_RESP`](SnpReportResponse) received from the PSP.
+///   sent to the PSP. It must be large enough to hold the
+///   [`MSG_REPORT_RESP`](SnpReportResponse) received from the PSP.
 /// * `certs`:  Buffer to store the SEV-SNP certificates received from the hypervisor.
 ///
 /// # Return codes
 ///
 /// * Success
 ///     * `usize`: Number of bytes written to `buffer`. It should match
-///                the [`MSG_REPORT_RESP`](SnpReportResponse) size.
+///       the [`MSG_REPORT_RESP`](SnpReportResponse) size.
 /// * Error
 ///     * [`SvsmReqError`]
 ///     * `SvsmReqError::FatalError(SvsmError::Ghcb(GhcbError::VmgexitError(certs_buffer_size, psp_rc)))`:

--- a/kernel/src/mm/alloc.rs
+++ b/kernel/src/mm/alloc.rs
@@ -2154,7 +2154,7 @@ mod test {
     fn test_drop_pagebox_slice() {
         use core::num::NonZeroUsize;
 
-        const NUM_ITEMS: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(8192) };
+        const NUM_ITEMS: NonZeroUsize = NonZeroUsize::new(8192).unwrap();
         static DROPPED: AtomicUsize = AtomicUsize::new(0);
 
         #[derive(Clone)]

--- a/kernel/src/mm/vm/mapping/api.rs
+++ b/kernel/src/mm/vm/mapping/api.rs
@@ -77,8 +77,8 @@ pub trait VirtualMapping: core::fmt::Debug {
     /// # Arguments
     ///
     /// * 'offset' -> The offset in bytes into the `VirtualMapping`. The flags
-    ///               returned from this function relate to the page at the
-    ///               given offset
+    ///   returned from this function relate to the page at the
+    ///   given offset
     ///
     /// # Returns
     ///
@@ -118,14 +118,14 @@ pub trait VirtualMapping: core::fmt::Debug {
     /// # Arguments
     ///
     /// * 'vmr' - Virtual memory range that contains the mapping. This
-    ///           [`VirtualMapping`] can use this to insert/remove regions
-    ///           as necessary to handle the page fault.
+    ///   [`VirtualMapping`] can use this to insert/remove regions
+    ///   as necessary to handle the page fault.
     ///
     /// * `offset` - Offset into the virtual mapping that was the subject of
-    ///              the page fault.
+    ///   the page fault.
     ///
     /// * 'write' - `true` if the fault was due to a write to the memory
-    ///              location, or 'false' if the fault was due to a read.
+    ///   location, or 'false' if the fault was due to a read.
     fn handle_page_fault(
         &mut self,
         _vmr: &VMR,

--- a/kernel/src/mm/vm/mapping/file_mapping.rs
+++ b/kernel/src/mm/vm/mapping/file_mapping.rs
@@ -56,7 +56,7 @@ impl VMFileMapping {
     /// # Arguments
     ///
     /// * 'file' - The file to create the mapping for. This instance keeps a
-    ///            reference to the file until it is dropped.
+    ///   reference to the file until it is dropped.
     ///
     /// * 'offset' - The offset from the start of the file to map. This must be
     ///   align to PAGE_SIZE.

--- a/kernel/src/mm/vm/mapping/kernel_stack.rs
+++ b/kernel/src/mm/vm/mapping/kernel_stack.rs
@@ -31,7 +31,7 @@ impl VMKernelStack {
     /// # Arguments
     ///
     /// * `base` - Virtual base address this stack is mapped at (including
-    ///            guard pages).
+    ///   guard pages).
     ///
     /// # Returns
     ///
@@ -48,7 +48,7 @@ impl VMKernelStack {
     /// # Arguments
     ///
     /// * `base` - Virtual base address this stack is mapped at (including
-    ///            guard pages).
+    ///   guard pages).
     ///
     /// # Returns
     ///

--- a/kernel/src/mm/vm/mapping/rawalloc.rs
+++ b/kernel/src/mm/vm/mapping/rawalloc.rs
@@ -38,7 +38,7 @@ impl RawAllocMapping {
     /// New instance of RawAllocMapping. Still needs to call `alloc_pages()` on it before it can be used.
     pub fn new(size: usize) -> Self {
         let count = align_up(size, PAGE_SIZE) >> PAGE_SHIFT;
-        let pages: Vec<Option<PageRef>> = iter::repeat(None).take(count).collect();
+        let pages: Vec<Option<PageRef>> = iter::repeat_n(None, count).collect();
         RawAllocMapping { pages, count }
     }
 

--- a/kernel/src/mm/vm/range.rs
+++ b/kernel/src/mm/vm/range.rs
@@ -73,7 +73,7 @@ impl VMR {
     ///
     /// * `start` - Virtual start address for the memory region. Must be aligned to [`VMR_GRANULE`]
     /// * `end` - Virtual end address (non-inclusive) for the memory region.
-    ///           Must be bigger than `start` and aligned to [`VMR_GRANULE`].
+    ///   Must be bigger than `start` and aligned to [`VMR_GRANULE`].
     /// * `flags` - Global [`PTEntryFlags`] to use for this [`struct VMR`].
     ///
     /// # Returns
@@ -419,7 +419,7 @@ impl VMR {
     /// # Arguments
     ///
     /// * `addr` - The virtual address at which the search for a mapping area
-    ///            starts
+    ///   starts
     /// * `mapping` - `Arc` pointer to the VMM to insert
     ///
     /// # Returns

--- a/kernel/src/protocols/vtpm.rs
+++ b/kernel/src/protocols/vtpm.rs
@@ -189,12 +189,12 @@ fn vtpm_query_request(params: &mut RequestParams) -> Result<(), SvsmReqError> {
 /// # Arguments
 ///
 /// * `buffer`: Contains the TpmSendCommandRequest. It will also be
-///             used to store the TpmSendCommandResponse as a byte slice
+///   used to store the TpmSendCommandResponse as a byte slice
 ///
 /// # Returns
 ///
 /// * `u32`: Number of bytes written back to `buffer` as part of
-///          the TpmSendCommandResponse
+///   the TpmSendCommandResponse
 fn tpm_send_command_request(buffer: &mut [u8]) -> Result<u32, SvsmReqError> {
     let outbuf: Vec<u8> = {
         let request = TpmSendCommandRequest::try_from_as_ref(buffer)?;

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -11,10 +11,10 @@
 //! depends on the state of the task:
 //!
 //! * [`RUNNING`] A task in running state is owned by the [`RunQueue`] and either
-//!    stored in the `run_list` (when the task is not actively running) or in
-//!    `current_task` when it is scheduled on the CPU.
+//!   stored in the `run_list` (when the task is not actively running) or in
+//!   `current_task` when it is scheduled on the CPU.
 //! * [`BLOCKED`] A task in this state is waiting for an event to become runnable
-//!    again. It is owned by a wait object when in this state.
+//!   again. It is owned by a wait object when in this state.
 //! * [`TERMINATED`] The task is about to be destroyed and owned by the [`RunQueue`].
 //!
 //! The scheduler is cooperative. A task runs until it voluntarily calls the

--- a/kernel/src/utils/immut_after_init.rs
+++ b/kernel/src/utils/immut_after_init.rs
@@ -247,8 +247,8 @@ impl<'a, T: Copy> ImmutAfterInitRef<'a, T> {
     /// initialized instance.
     ///
     /// * `r` - Reference to the value to make the `ImmutAfterInitRef` to refer
-    ///         to. By convention, the referenced value must have been
-    ///         initialized already.
+    ///   to. By convention, the referenced value must have been
+    ///   initialized already.
     pub fn init_from_ref<'b>(&self, r: &'b T) -> ImmutAfterInitResult<()>
     where
         'b: 'a,
@@ -268,8 +268,8 @@ impl<'a, T: Copy> ImmutAfterInitRef<'a, T> {
     /// Must **not** get called on an already initialized `ImmutAfterInitRef` instance!
     ///
     /// * `cell` - The value to make the `ImmutAfterInitRef` to refer to. By
-    ///            convention, the referenced value must have been initialized
-    ///            already.
+    ///   convention, the referenced value must have been initialized
+    ///   already.
     pub fn init_from_cell<'b>(&self, cell: &'b ImmutAfterInitCell<T>) -> ImmutAfterInitResult<()>
     where
         'b: 'a,

--- a/kernel/src/vtpm/mod.rs
+++ b/kernel/src/vtpm/mod.rs
@@ -36,9 +36,9 @@ pub trait TcgTpmSimulatorInterface: VtpmProtocolInterface {
     /// # Arguments
     ///
     /// * `buffer`: Buffer with the command to be sent to the TPM. It has to be large enough
-    ///             to hold the response received from the TPM.
+    ///   to hold the response received from the TPM.
     /// * `length`: The length of the command stored in `buffer`. It will be updated with the
-    ///             size of the TPM response received from the TPM.
+    ///   size of the TPM response received from the TPM.
     /// * `locality`: TPM locality the TPM command will be executed
     fn send_tpm_command(
         &self,

--- a/kernel/src/vtpm/tcgtpm/tss.rs
+++ b/kernel/src/vtpm/tcgtpm/tss.rs
@@ -92,7 +92,7 @@ fn create_mtauth_ek_cmd(tpmt_public: &[u8]) -> Vec<u8> {
 /// * `vtpm`: An implementation of [`TcgTpmSimulatorInterface`] to send `cmd` to.
 /// * `cmd`: A command buffer large enough to receive the command response.
 /// * `set_len`: If true, sets the command length in the command header to `cmd.len()` before
-///              sending the command.
+///   sending the command.
 pub fn checked_send<T: TcgTpmSimulatorInterface>(
     vtpm: &T,
     cmd: &mut [u8],

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.84.1"
+channel = "1.86.0"
 targets = [ "x86_64-unknown-none" ]

--- a/stage1/Cargo.toml
+++ b/stage1/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stage1"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.82.0"
+rust-version = "1.86.0"
 
 [[bin]]
 name = "stage1"

--- a/user/lib/src/locking.rs
+++ b/user/lib/src/locking.rs
@@ -67,7 +67,7 @@ impl<'a, T> SpinLock<T> {
     /// # Arguments:
     ///
     /// * `data`: Data to be protected by the `SpinLock`. The data is moved into
-    ///    and from this point on owned by the SpinLock.
+    ///   and from this point on owned by the SpinLock.
     ///
     /// # Returns:
     ///


### PR DESCRIPTION
As discussed before, the attestation proxy in #528 will rely on [cocoon-tpm](https://github.com/nicstange/cocoon-tpm)'s crypto crate for generating EC keys required for attestation. This crate depends on the 1.86 toolchain. Bump the toolchain version to accommodate this.