### PR TITLE
add uefi variable store protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
 name = "bitfield-struct"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +207,17 @@ name = "bitfield-struct"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2be5a46ba01b60005ae2c51a36a29cfe134bcacae2dd5cedcd4615fbaad1494b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "bitfield-struct"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8769c4854c5ada2852ddf6fd09d15cf43d4c2aaeccb4de6432f5402f08a6003b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -552,8 +569,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "der_derive",
+ "flagset",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -682,6 +712,12 @@ name = "find-msvc-tools"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "form_urlencoded"
@@ -1520,6 +1556,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
+name = "ptr_meta"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "publicsuffix"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1920,6 +1976,7 @@ dependencies = [
  "verus_builtin",
  "verus_builtin_macros",
  "verus_stub",
+ "virtfw-varstore",
  "virtio-drivers",
  "vstd",
  "zerocopy",
@@ -2140,6 +2197,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "ucs2"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79298e11f316400c57ec268f3c2c29ac3c4d4777687955cd3d4f3a35ce7eba"
+dependencies = [
+ "bit_field",
+]
+
+[[package]]
+name = "uefi"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe9058b73ee2b6559524af9e33199c13b2485ddbf3ad1181b68051cdc50c17"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "log",
+ "ptr_meta",
+ "ucs2",
+ "uefi-macros",
+ "uefi-raw",
+ "uguid",
+]
+
+[[package]]
+name = "uefi-macros"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4687412b5ac74d245d5bfb1733ede50c31be19bf8a4b6a967a29b451bab49e67"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "uefi-raw"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f64fe59e11af447d12fd60a403c74106eb104309f34b4c6dbce6e927d97da9d"
+dependencies = [
+ "bitflags 2.10.0",
+ "uguid",
+]
+
+[[package]]
+name = "uguid"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8352f8c05e47892e7eaf13b34abd76a7f4aeaf817b716e88789381927f199c"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2292,6 +2401,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "virtfw-libefi"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfe5a2adf2b20c1cdb1f24614c3f07a94398995ab6c2c2562f97d1b2f0d9fb7"
+dependencies = [
+ "bitfield-struct 0.12.1",
+ "byteorder",
+ "der",
+ "log",
+ "uguid",
+ "x509-cert",
+ "zerocopy",
+]
+
+[[package]]
+name = "virtfw-varstore"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e006f827ff617f08e9cb01ab51e87e261153970359cd3365f5a39702812aaf6c"
+dependencies = [
+ "der",
+ "hex",
+ "log",
+ "uefi",
+ "uguid",
+ "virtfw-libefi",
+ "x509-cert",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2507,6 +2647,17 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid",
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "xbuild"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1976,6 +1976,7 @@ dependencies = [
  "verus_builtin",
  "verus_builtin_macros",
  "verus_stub",
+ "virtfw-libefi",
  "virtfw-varstore",
  "virtio-drivers",
  "vstd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
 name = "bitfield-struct"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +207,17 @@ name = "bitfield-struct"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2be5a46ba01b60005ae2c51a36a29cfe134bcacae2dd5cedcd4615fbaad1494b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "bitfield-struct"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8769c4854c5ada2852ddf6fd09d15cf43d4c2aaeccb4de6432f5402f08a6003b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -582,8 +599,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "der_derive",
+ "flagset",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -707,6 +737,12 @@ name = "find-msvc-tools"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "form_urlencoded"
@@ -1564,6 +1600,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
+name = "ptr_meta"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "publicsuffix"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1965,6 +2021,7 @@ dependencies = [
  "verus_builtin",
  "verus_builtin_macros",
  "verus_stub",
+ "virtfw-varstore",
  "virtio-drivers",
  "vstd",
  "zerocopy",
@@ -2185,6 +2242,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "ucs2"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79298e11f316400c57ec268f3c2c29ac3c4d4777687955cd3d4f3a35ce7eba"
+dependencies = [
+ "bit_field",
+]
+
+[[package]]
+name = "uefi"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe9058b73ee2b6559524af9e33199c13b2485ddbf3ad1181b68051cdc50c17"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "log",
+ "ptr_meta",
+ "ucs2",
+ "uefi-macros",
+ "uefi-raw",
+ "uguid",
+]
+
+[[package]]
+name = "uefi-macros"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4687412b5ac74d245d5bfb1733ede50c31be19bf8a4b6a967a29b451bab49e67"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "uefi-raw"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f64fe59e11af447d12fd60a403c74106eb104309f34b4c6dbce6e927d97da9d"
+dependencies = [
+ "bitflags",
+ "uguid",
+]
+
+[[package]]
+name = "uguid"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8352f8c05e47892e7eaf13b34abd76a7f4aeaf817b716e88789381927f199c"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2343,6 +2452,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "virtfw-libefi"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfe5a2adf2b20c1cdb1f24614c3f07a94398995ab6c2c2562f97d1b2f0d9fb7"
+dependencies = [
+ "bitfield-struct 0.12.1",
+ "byteorder",
+ "der",
+ "log",
+ "uguid",
+ "x509-cert",
+ "zerocopy",
+]
+
+[[package]]
+name = "virtfw-varstore"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e006f827ff617f08e9cb01ab51e87e261153970359cd3365f5a39702812aaf6c"
+dependencies = [
+ "der",
+ "hex",
+ "log",
+ "uefi",
+ "uguid",
+ "virtfw-libefi",
+ "x509-cert",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2569,6 +2709,17 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid",
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "xbuild"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2021,6 +2021,7 @@ dependencies = [
  "verus_builtin",
  "verus_builtin_macros",
  "verus_stub",
+ "virtfw-libefi",
  "virtfw-varstore",
  "virtio-drivers",
  "vstd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ serde = { version = "1.0.215", default-features = false }
 serde_json = { version = "1.0", default-features = false }
 sha2 = { version = "0.10.8", default-features = false }
 uuid = { version = "1.6.1", default-features = false }
+virtfw-varstore = { version = "0.6.1" }
 # Add the derive feature by default because all crates use it.
 zerocopy = { version = "0.8.2", features = ["derive"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ serde = { version = "1.0.215", default-features = false }
 serde_json = { version = "1.0", default-features = false }
 sha2 = { version = "0.10.8", default-features = false }
 uuid = { version = "1.6.1", default-features = false }
+virtfw-libefi = { version = "0.6" }
 virtfw-varstore = { version = "0.6.1" }
 # Add the derive feature by default because all crates use it.
 zerocopy = { version = "0.8.2", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ serde = { version = "1.0.215", default-features = false }
 serde_json = { version = "1.0", default-features = false }
 sha2 = { version = "0.10.8", default-features = false }
 uuid = { version = "1.6.1", default-features = false }
+virtfw-varstore = { version = "0.6.1" }
 # Add the derive feature by default because all crates use it.
 zerocopy = { version = "0.8.2", features = ["derive"] }
 embedded-io = { version = "0.6.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ serde = { version = "1.0.215", default-features = false }
 serde_json = { version = "1.0", default-features = false }
 sha2 = { version = "0.10.8", default-features = false }
 uuid = { version = "1.6.1", default-features = false }
+virtfw-libefi = { version = "0.6" }
 virtfw-varstore = { version = "0.6.1" }
 # Add the derive feature by default because all crates use it.
 zerocopy = { version = "0.8.2", features = ["derive"] }

--- a/Documentation/docs/protocols/uefivars.md
+++ b/Documentation/docs/protocols/uefivars.md
@@ -1,0 +1,69 @@
+
+## SVSM UEFI MM PROTOCOL
+
+Process MM communication requests from edk2 firmware.
+
+Usually this request serialization format is used by edk2 for
+communication between normal mode and management mode (MM for short).
+
+This SVSM protocol is a thin wrapper to allow edk2 firmware send those
+requests to the SVSM instead.  This allows the SVSM to provide services
+which are usually running in SMM mode on bare metal or
+non-confidential VMs, specifically an UEFI variable store.
+
+### protocol number
+
+```
+pub const SVSM_UEFI_MM_PROTOCOL: u32 = 4;
+```
+
+### protocol request
+
+```
+const SVSM_UEFI_MM_REQUEST: u32 = 1;
+```
+Parameters:
+ * RCX: buffer address (guest physical).  Must be page aligned.
+ * RDX: buffer size
+
+Request SVSM to process the communication buffer as a UEFI request.
+The response format is request-specific.
+
+### request format
+
+The request serialization format is specified by edk2, the short
+overview below is purely informational.
+
+The buffer starts with this header:
+
+```
+// EFI_MM_COMMUNICATE_HEADER
+#[repr(C, packed)]
+pub struct MmCoreHeader {
+    pub guid: [u8; 16],
+    pub size: u64,
+}
+```
+
+The `guid` specifies the receiver of the message (typically an efi
+protocol guid or an efi event guid), and therefore also the format of
+the request data following this header.  The `size` field specified
+the size of the request data (excluding the header).
+
+### uefi spec references
+
+ * UEFI Platform Initialization Specification, section IV-5.7 "MM
+   Communication Protocol" describes the EFI_MM_COMMUNICATE_HEADER
+   struct.
+
+### edk2 code references
+
+ * MdePkg/Include/Protocol/MmCommunication.h
+ * MdeModulePkg/Include/Guid/SmmVariableCommon.h
+ * MdeModulePkg/Include/Guid/VarCheckPolicyMmi.h
+
+### linux references
+
+The linux kernel has an efi variable driver implementation using this
+request format in `drivers/firmware/efi/stmm`.  It sends those
+requests to the edk2 MM code running in arm secure partition.

--- a/Documentation/mkdocs.yml
+++ b/Documentation/mkdocs.yml
@@ -32,4 +32,6 @@ nav:
     - Formal Verification: 'developer/VERIFICATION.md'
     - Attestation: 'developer/ATTESTATION.md'
     - GitHub Workflows: 'developer/GH_WORKFLOWS.md'
+  - SVSM Protocols:
+    - UEFI MM Protocol: 'protocols/uefivars.md'
   - 'COCONUT-SVSM Rustdoc': 'rustdoc/svsm'

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SVSM_ARGS += --features ${FEATURES}
 XBUILD_ARGS += -f ${FEATURES}
 endif
 
-FEATURES_TEST ?= vtpm,virtio-drivers,block,vsock
+FEATURES_TEST ?= vtpm,virtio-drivers,block,vsock,uefivars,secureboot
 SVSM_ARGS_TEST += --no-default-features
 ifneq ($(FEATURES_TEST),)
 SVSM_ARGS_TEST += --features ${FEATURES_TEST}

--- a/configs/qemu-target.json
+++ b/configs/qemu-target.json
@@ -14,7 +14,7 @@
     },
     "kernel": {
         "svsm": {
-            "features": "vtpm",
+            "features": "vtpm,uefivars",
             "binary": false
         },
         "stage2": {

--- a/configs/qemu-target.json
+++ b/configs/qemu-target.json
@@ -14,7 +14,7 @@
     },
     "kernel": {
         "svsm": {
-            "features": "vtpm,uefivars",
+            "features": "vtpm,uefivars,secureboot",
             "binary": false
         },
         "stage2": {

--- a/configs/qemu-target.json
+++ b/configs/qemu-target.json
@@ -14,7 +14,7 @@
     },
     "kernel": {
         "svsm": {
-            "features": "vtpm",
+            "features": "vtpm,uefivars",
             "binary": false
         },
         "bldr": {

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -86,6 +86,7 @@ noverify = []
 virtio-drivers = ["dep:virtio-drivers"]
 block = []
 uefivars = ["dep:virtfw-varstore"]
+secureboot = []
 
 [dev-dependencies]
 sha2 = { workspace = true, features = ["force-soft"] }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -60,6 +60,7 @@ release.workspace = true
 sha2 = { workspace = true, features = ["force-soft"] }
 uuid.workspace = true
 virtio-drivers = { workspace = true, optional = true }
+virtfw-varstore = { workspace = true, optional = true }
 
 verus_builtin = { workspace = true, optional = true }
 verus_builtin_macros = { workspace = true, optional = true }
@@ -84,6 +85,7 @@ verus = ["verus_all", "verify_proof/noverify", "verify_external/noverify"]
 noverify = []
 virtio-drivers = ["dep:virtio-drivers"]
 block = []
+uefivars = ["dep:virtfw-varstore"]
 
 [dev-dependencies]
 sha2 = { workspace = true, features = ["force-soft"] }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -60,6 +60,7 @@ release.workspace = true
 sha2 = { workspace = true, features = ["force-soft"] }
 uuid.workspace = true
 virtio-drivers = { workspace = true, optional = true }
+virtfw-libefi = { workspace = true, optional = true }
 virtfw-varstore = { workspace = true, optional = true }
 
 verus_builtin = { workspace = true, optional = true }
@@ -85,7 +86,7 @@ verus = ["verus_all", "verify_proof/noverify", "verify_external/noverify"]
 noverify = []
 virtio-drivers = ["dep:virtio-drivers"]
 block = []
-uefivars = ["dep:virtfw-varstore"]
+uefivars = ["dep:virtfw-varstore", "dep:virtfw-libefi"]
 secureboot = []
 
 [dev-dependencies]

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -55,6 +55,7 @@ release.workspace = true
 sha2 = { workspace = true, features = ["force-soft"] }
 uuid.workspace = true
 virtio-drivers = { workspace = true, optional = true }
+virtfw-libefi = { workspace = true, optional = true }
 virtfw-varstore = { workspace = true, optional = true }
 
 verus_builtin = { workspace = true, optional = true }
@@ -81,7 +82,7 @@ noverify = []
 virtio-drivers = ["dep:virtio-drivers"]
 block = []
 vsock = []
-uefivars = ["dep:virtfw-varstore"]
+uefivars = ["dep:virtfw-varstore", "dep:virtfw-libefi"]
 secureboot = ["uefivars"]
 
 [dev-dependencies]

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -82,6 +82,7 @@ virtio-drivers = ["dep:virtio-drivers"]
 block = []
 vsock = []
 uefivars = ["dep:virtfw-varstore"]
+secureboot = ["uefivars"]
 
 [dev-dependencies]
 sha2 = { workspace = true, features = ["force-soft"] }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -55,6 +55,7 @@ release.workspace = true
 sha2 = { workspace = true, features = ["force-soft"] }
 uuid.workspace = true
 virtio-drivers = { workspace = true, optional = true }
+virtfw-varstore = { workspace = true, optional = true }
 
 verus_builtin = { workspace = true, optional = true }
 verus_builtin_macros = { workspace = true, optional = true }
@@ -80,6 +81,7 @@ noverify = []
 virtio-drivers = ["dep:virtio-drivers"]
 block = []
 vsock = []
+uefivars = ["dep:virtfw-varstore"]
 
 [dev-dependencies]
 sha2 = { workspace = true, features = ["force-soft"] }

--- a/kernel/src/protocols/attest.rs
+++ b/kernel/src/protocols/attest.rs
@@ -17,6 +17,8 @@ use crate::greq::{
     services::get_regular_report,
 };
 use crate::mm::guestmem::{copy_slice_to_guest, read_bytes_from_guest, read_from_guest};
+#[cfg(all(feature = "uefivars", not(test)))]
+use crate::protocols::uefivars::uefi_mm_get_manifest;
 use crate::protocols::{RequestParams, errors::SvsmReqError};
 use crate::utils::MemoryRegion;
 #[cfg(all(feature = "vtpm", not(test)))]
@@ -38,6 +40,8 @@ const SVSM_ATTEST_SINGLE_SERVICE: u32 = 1;
 
 #[cfg(all(feature = "vtpm", not(test)))]
 const SVSM_ATTEST_VTPM_GUID: Uuid = uuid!("c476f1eb-0123-45a5-9641-b4e7dde5bfe3");
+#[cfg(all(feature = "uefivars", not(test)))]
+const SVSM_ATTEST_UEFI_MM_GUID: Uuid = uuid!("a4453a59-9e1b-4787-a033-1986d6adbe55");
 
 // According to
 // https://github.com/torvalds/linux/blob/155a3c003e555a7300d156a5252c004c392ec6b0/drivers/virt/coco/sev-guest/sev-guest.c#L370
@@ -545,6 +549,10 @@ fn attest_multiple_services(params: &mut RequestParams) -> Result<(), SvsmReqErr
 
     #[cfg(all(feature = "vtpm", not(test)))]
     services.push(SVSM_ATTEST_VTPM_GUID, vtpm_get_manifest()?);
+
+    #[cfg(all(feature = "uefivars", not(test)))]
+    services.push(SVSM_ATTEST_UEFI_MM_GUID, uefi_mm_get_manifest()?);
+
     let manifest = services.to_vec()?;
     let mut nonce_and_manifest = attest_op.get_nonce()?;
     nonce_and_manifest.extend_from_slice(manifest.as_slice());
@@ -569,12 +577,13 @@ fn attest_single_service_handler(params: &mut RequestParams) -> Result<(), SvsmR
 
     // Extract the GUID from the Attest Single Service Operation structure.
     // The GUID is used to determine the specific service to be attested.
-    // Currently, only the VTPM service with the GUID 0xebf176c4_2301a545_9641b4e7_dde5bfe3
-    // is supported, see 8.3.1 of the spec "Secure VM Service Module for SEV-SNP Guests
-    // 58019 Rev. 1.00" for more details.
     match attest_op.get_guid() {
         #[cfg(all(feature = "vtpm", not(test)))]
         SVSM_ATTEST_VTPM_GUID => attest_single_vtpm(params, &attest_op),
+        #[cfg(all(feature = "uefivars", not(test)))]
+        SVSM_ATTEST_UEFI_MM_GUID => {
+            attest_single_service(uefi_mm_get_manifest()?.as_slice(), params, &attest_op)
+        }
         _ => Err(SvsmReqError::unsupported_protocol()),
     }
 }

--- a/kernel/src/protocols/core.rs
+++ b/kernel/src/protocols/core.rs
@@ -12,9 +12,13 @@ use crate::locking::RWLock;
 use crate::mm::virtualrange::{VIRT_ALIGN_2M, VIRT_ALIGN_4K};
 use crate::mm::{GuestPtr, valid_phys_address, writable_phys_addr};
 use crate::mm::{PerCPUMapping, PerCPUPageMappingGuard};
+#[cfg(all(feature = "uefivars", not(test)))]
+use crate::protocols::SVSM_UEFI_MM_PROTOCOL;
 use crate::protocols::apic::{APIC_PROTOCOL_VERSION_MAX, APIC_PROTOCOL_VERSION_MIN};
 use crate::protocols::attest::{ATTEST_PROTOCOL_VERSION_MAX, ATTEST_PROTOCOL_VERSION_MIN};
 use crate::protocols::errors::SvsmReqError;
+#[cfg(all(feature = "uefivars", not(test)))]
+use crate::protocols::uefivars::{UEFI_MM_PROTOCOL_VERSION_MAX, UEFI_MM_PROTOCOL_VERSION_MIN};
 use crate::protocols::{
     RequestParams, SVSM_APIC_PROTOCOL, SVSM_ATTEST_PROTOCOL, SVSM_CORE_PROTOCOL,
 };
@@ -249,6 +253,12 @@ fn core_query_protocol(params: &mut RequestParams) -> Result<(), SvsmReqError> {
             version,
             ATTEST_PROTOCOL_VERSION_MIN,
             ATTEST_PROTOCOL_VERSION_MAX,
+        ),
+        #[cfg(all(feature = "uefivars", not(test)))]
+        SVSM_UEFI_MM_PROTOCOL => protocol_supported(
+            version,
+            UEFI_MM_PROTOCOL_VERSION_MIN,
+            UEFI_MM_PROTOCOL_VERSION_MAX,
         ),
         _ => 0,
     };

--- a/kernel/src/protocols/core.rs
+++ b/kernel/src/protocols/core.rs
@@ -12,9 +12,13 @@ use crate::locking::RWLock;
 use crate::mm::virtualrange::{VIRT_ALIGN_2M, VIRT_ALIGN_4K};
 use crate::mm::{GuestPtr, valid_phys_region, writable_phys_addr};
 use crate::mm::{PerCPUMapping, PerCPUPageMappingGuard};
+#[cfg(all(feature = "uefivars", not(test)))]
+use crate::protocols::SVSM_UEFI_MM_PROTOCOL;
 use crate::protocols::apic::{APIC_PROTOCOL_VERSION_MAX, APIC_PROTOCOL_VERSION_MIN};
 use crate::protocols::attest::{ATTEST_PROTOCOL_VERSION_MAX, ATTEST_PROTOCOL_VERSION_MIN};
 use crate::protocols::errors::SvsmReqError;
+#[cfg(all(feature = "uefivars", not(test)))]
+use crate::protocols::uefivars::{UEFI_MM_PROTOCOL_VERSION_MAX, UEFI_MM_PROTOCOL_VERSION_MIN};
 use crate::protocols::{
     RequestParams, SVSM_APIC_PROTOCOL, SVSM_ATTEST_PROTOCOL, SVSM_CORE_PROTOCOL,
 };
@@ -254,6 +258,12 @@ fn core_query_protocol(params: &mut RequestParams) -> Result<(), SvsmReqError> {
             version,
             ATTEST_PROTOCOL_VERSION_MIN,
             ATTEST_PROTOCOL_VERSION_MAX,
+        ),
+        #[cfg(all(feature = "uefivars", not(test)))]
+        SVSM_UEFI_MM_PROTOCOL => protocol_supported(
+            version,
+            UEFI_MM_PROTOCOL_VERSION_MIN,
+            UEFI_MM_PROTOCOL_VERSION_MAX,
         ),
         _ => 0,
     };

--- a/kernel/src/protocols/mod.rs
+++ b/kernel/src/protocols/mod.rs
@@ -8,6 +8,8 @@ pub mod apic;
 pub mod attest;
 pub mod core;
 pub mod errors;
+#[cfg(all(feature = "uefivars", not(test)))]
+pub mod uefivars;
 #[cfg(all(feature = "vtpm", not(test)))]
 pub mod vtpm;
 

--- a/kernel/src/protocols/uefivars.rs
+++ b/kernel/src/protocols/uefivars.rs
@@ -98,6 +98,15 @@ pub fn uefi_mm_protocol_init() -> Result<(), SvsmReqError> {
     let mut store = STORE.lock();
     store.reset();
 
+    #[cfg(all(feature = "secureboot", not(test)))]
+    {
+        // hard coded configuration for now.
+        store.enroll_pk_mgmt();
+        store.enroll_kek_microsoft();
+        store.enroll_db_microsoft_uefi();
+        store.enroll_dbx_native();
+    }
+
     // In case a TPM is present, shim's fallback.efi will setup efi
     // boot variables then reboot.  This is not going to work until we
     // have persistence support for the UEFI variable store.  So turn

--- a/kernel/src/protocols/uefivars.rs
+++ b/kernel/src/protocols/uefivars.rs
@@ -17,8 +17,13 @@
 //! is implemented by the virtfw_varstore crate.  The later implements
 //! the MM protocols needed to provide an UEFI variable store.
 
+extern crate alloc;
+use alloc::vec::Vec;
+use bitfield_struct::bitfield;
 use core::mem::size_of;
+use zerocopy::{Immutable, IntoBytes};
 
+use virtfw_libefi::efivar::ids::PK;
 use virtfw_varstore::mm::core::{MmCoreHeader, core_request_dispatch};
 use virtfw_varstore::store::EfiVarStore;
 
@@ -120,4 +125,42 @@ pub fn uefi_mm_protocol_init() -> Result<(), SvsmReqError> {
     store.quirk_disable_shim_reboot(true);
 
     Ok(())
+}
+
+#[bitfield(u32)]
+#[derive(IntoBytes, Immutable)]
+pub struct UefiMmManifestFlags {
+    // non-volatile uefi variables are written to persistent storage
+    pub persistent_nv_vars: bool,
+    // secure boot is enabled
+    pub secureboot_enabled: bool,
+    // secure boot databases ('db' + 'dbx') can be updated by the
+    // guest (assuming proper pkcs7 signature of course).
+    // This should only be set in case secure boot is enabled.
+    pub secureboot_db_update: bool,
+
+    #[bits(29)]
+    _reserved: u32,
+}
+
+#[allow(dead_code)]
+#[derive(IntoBytes, Immutable)]
+struct UefiMmManifest {
+    pub version: u32,
+    pub flags: UefiMmManifestFlags,
+}
+
+pub fn uefi_mm_get_manifest() -> Result<Vec<u8>, SvsmReqError> {
+    let store = STORE.lock();
+
+    let pk = store.get(&PK.into());
+    let sb = pk.is_ok();
+
+    let flags = UefiMmManifestFlags::new()
+        .with_persistent_nv_vars(false)
+        .with_secureboot_enabled(sb)
+        .with_secureboot_db_update(false);
+    let manifest = UefiMmManifest { version: 0, flags };
+
+    Ok(manifest.as_bytes().to_vec())
 }

--- a/kernel/src/protocols/uefivars.rs
+++ b/kernel/src/protocols/uefivars.rs
@@ -104,6 +104,15 @@ pub fn uefi_mm_protocol_init() -> Result<(), SvsmReqError> {
     let mut store = STORE.lock();
     store.reset();
 
+    #[cfg(all(feature = "secureboot", not(test)))]
+    {
+        // hard coded configuration for now.
+        store.enroll_pk_mgmt();
+        store.enroll_kek_microsoft();
+        store.enroll_db_microsoft_uefi();
+        store.enroll_dbx_native();
+    }
+
     // In case a TPM is present, shim's fallback.efi will setup efi
     // boot variables then reboot.  This is not going to work until we
     // have persistence support for the UEFI variable store.  So turn

--- a/kernel/src/protocols/uefivars.rs
+++ b/kernel/src/protocols/uefivars.rs
@@ -31,6 +31,9 @@ use crate::protocols::errors::SvsmReqError;
 
 const SVSM_UEFI_MM_REQUEST: u32 = 1;
 
+pub const UEFI_MM_PROTOCOL_VERSION_MIN: u32 = 1;
+pub const UEFI_MM_PROTOCOL_VERSION_MAX: u32 = 1;
+
 // current edk2 uses 64k
 pub const UEFI_MM_BUFFER_LIMIT: usize = 256 * 1024;
 

--- a/kernel/src/protocols/uefivars.rs
+++ b/kernel/src/protocols/uefivars.rs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (C) 2025 Red Hat, Inc.
+//
+// Author: Gerd Hoffmann <kraxel@redhat.com>
+
+//! UEFI MM protocol implementation
+//!
+//! Process MM communication requests from edk2 firmware.
+//!
+//! Usually this request serialization format is used by edk2 for
+//! communication between normal mode and management mode (MM for
+//! short).
+//!
+//! This SVSM protocol is a thin wrapper to allow edk2 firmware send
+//! those requests to the SVSM instead.  The actual request processing
+//! is implemented by the virtfw_varstore crate.  The later implements
+//! the MM protocols needed to provide an UEFI variable store.
+
+use core::mem::size_of;
+
+use virtfw_varstore::mm::core::{MmCoreHeader, core_request_dispatch};
+use virtfw_varstore::store::EfiVarStore;
+
+use crate::address::{Address, PhysAddr};
+use crate::locking::SpinLock;
+use crate::mm::guestmem::{copy_slice_to_guest, read_bytes_from_guest, read_from_guest};
+use crate::mm::valid_phys_address;
+use crate::protocols::RequestParams;
+use crate::protocols::errors::SvsmReqError;
+
+const SVSM_UEFI_MM_REQUEST: u32 = 1;
+
+// current edk2 uses 64k
+pub const UEFI_MM_BUFFER_LIMIT: usize = 256 * 1024;
+
+static STORE: SpinLock<EfiVarStore> = SpinLock::new(EfiVarStore::new());
+
+fn check_buffer(addr: u64, size: usize) -> Result<(), SvsmReqError> {
+    let paddr = PhysAddr::from(addr);
+    if paddr.is_null() {
+        return Err(SvsmReqError::invalid_parameter());
+    }
+    if !valid_phys_address(paddr) {
+        return Err(SvsmReqError::invalid_address());
+    }
+    if paddr.page_offset() != 0 {
+        return Err(SvsmReqError::invalid_address());
+    }
+    if size < size_of::<MmCoreHeader>() {
+        return Err(SvsmReqError::invalid_parameter());
+    }
+    if size > UEFI_MM_BUFFER_LIMIT {
+        return Err(SvsmReqError::invalid_parameter());
+    }
+    Ok(())
+}
+
+// process uefi mm request in passed buffer
+fn uefi_mm_request(params: &RequestParams) -> Result<(), SvsmReqError> {
+    let addr = params.rcx;
+    let size = params.rdx as usize;
+
+    let mut store = STORE.lock();
+
+    // check buffer parameters
+    check_buffer(addr, size)?;
+    log::debug!("uefi mm buffer: 0x{addr:x} +0x{size:x}");
+
+    let paddr = PhysAddr::from(addr);
+    let mmcore = read_from_guest::<MmCoreHeader>(paddr)?;
+    let boffset = size_of::<MmCoreHeader>();
+    let bsize = mmcore.size as usize;
+    if bsize > size - boffset {
+        return Err(SvsmReqError::invalid_parameter());
+    }
+
+    let req = read_bytes_from_guest(paddr + boffset, bsize)?;
+    let rsp = core_request_dispatch(&mut store, &mmcore.guid, &req);
+    if rsp.len() > bsize {
+        // should not happen (add SvsmReqError::internal_error() ?)
+        log::debug!("uefi mm: response buffer too big");
+        return Err(SvsmReqError::invalid_request());
+    }
+    copy_slice_to_guest(&rsp, paddr + boffset)?;
+
+    Ok(())
+}
+
+pub fn uefi_mm_protocol_request(
+    request: u32,
+    params: &mut RequestParams,
+) -> Result<(), SvsmReqError> {
+    match request {
+        SVSM_UEFI_MM_REQUEST => uefi_mm_request(params),
+        _ => Err(SvsmReqError::unsupported_call()),
+    }
+}
+
+pub fn uefi_mm_protocol_init() -> Result<(), SvsmReqError> {
+    let mut store = STORE.lock();
+    store.reset();
+
+    // In case a TPM is present, shim's fallback.efi will setup efi
+    // boot variables then reboot.  This is not going to work until we
+    // have persistence support for the UEFI variable store.  So turn
+    // off that behaviour for now (via EFI variable).
+    store.quirk_disable_shim_reboot(true);
+
+    Ok(())
+}

--- a/kernel/src/protocols/uefivars.rs
+++ b/kernel/src/protocols/uefivars.rs
@@ -17,8 +17,13 @@
 //! is implemented by the virtfw_varstore crate.  The latter implements
 //! the MM protocols needed to provide an UEFI variable store.
 
+extern crate alloc;
+use alloc::vec::Vec;
+use bitfield_struct::bitfield;
 use core::mem::size_of;
+use zerocopy::{Immutable, IntoBytes};
 
+use virtfw_libefi::efivar::ids::PK;
 use virtfw_varstore::mm::core::{MmCoreHeader, core_request_dispatch};
 use virtfw_varstore::store::EfiVarStore;
 
@@ -114,4 +119,42 @@ pub fn uefi_mm_protocol_init() -> Result<(), SvsmReqError> {
     store.quirk_disable_shim_reboot(true);
 
     Ok(())
+}
+
+#[bitfield(u32)]
+#[derive(IntoBytes, Immutable)]
+pub struct UefiMmManifestFlags {
+    // non-volatile uefi variables are written to persistent storage
+    pub persistent_nv_vars: bool,
+    // secure boot is enabled
+    pub secureboot_enabled: bool,
+    // secure boot databases ('db' + 'dbx') can be updated by the
+    // guest (assuming proper pkcs7 signature of course).
+    // This should only be set in case secure boot is enabled.
+    pub secureboot_db_update: bool,
+
+    #[bits(29)]
+    _reserved: u32,
+}
+
+#[derive(IntoBytes, Immutable)]
+#[repr(C, packed)]
+struct UefiMmManifest {
+    pub version: u32,
+    pub flags: UefiMmManifestFlags,
+}
+
+pub fn uefi_mm_get_manifest() -> Result<Vec<u8>, SvsmReqError> {
+    let store = STORE.lock();
+
+    let pk = store.get(&PK.into());
+    let sb = pk.is_ok();
+
+    let flags = UefiMmManifestFlags::new()
+        .with_persistent_nv_vars(false)
+        .with_secureboot_enabled(sb)
+        .with_secureboot_db_update(false);
+    let manifest = UefiMmManifest { version: 0, flags };
+
+    Ok(manifest.as_bytes().to_vec())
 }

--- a/kernel/src/protocols/uefivars.rs
+++ b/kernel/src/protocols/uefivars.rs
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (C) 2025 Red Hat, Inc.
+//
+// Author: Gerd Hoffmann <kraxel@redhat.com>
+
+//! UEFI MM protocol implementation
+//!
+//! Process MM communication requests from edk2 firmware.
+//!
+//! Usually this request serialization format is used by edk2 for
+//! communication between normal mode and management mode (MM for
+//! short).
+//!
+//! This SVSM protocol is a thin wrapper to allow edk2 firmware send
+//! those requests to the SVSM instead.  The actual request processing
+//! is implemented by the virtfw_varstore crate.  The latter implements
+//! the MM protocols needed to provide an UEFI variable store.
+
+use core::mem::size_of;
+
+use virtfw_varstore::mm::core::{MmCoreHeader, core_request_dispatch};
+use virtfw_varstore::store::EfiVarStore;
+
+use crate::address::{Address, PhysAddr};
+use crate::locking::SpinLock;
+use crate::mm::guestmem::{copy_slice_to_guest, read_bytes_from_guest, read_from_guest};
+use crate::mm::valid_phys_address;
+use crate::protocols::RequestParams;
+use crate::protocols::errors::SvsmReqError;
+
+const SVSM_UEFI_MM_REQUEST: u32 = 1;
+
+// current edk2 uses 64k
+const UEFI_MM_BUFFER_LIMIT: usize = 256 * 1024;
+
+static STORE: SpinLock<EfiVarStore> = SpinLock::new(EfiVarStore::new());
+
+fn check_buffer(addr: u64, size: usize) -> Result<(), SvsmReqError> {
+    let paddr = PhysAddr::from(addr);
+    if paddr.is_null() {
+        return Err(SvsmReqError::invalid_parameter());
+    }
+    if !valid_phys_address(paddr) {
+        return Err(SvsmReqError::invalid_address());
+    }
+    if paddr.page_offset() != 0 {
+        return Err(SvsmReqError::invalid_address());
+    }
+    if size < size_of::<MmCoreHeader>() {
+        return Err(SvsmReqError::invalid_parameter());
+    }
+    if size > UEFI_MM_BUFFER_LIMIT {
+        return Err(SvsmReqError::invalid_parameter());
+    }
+    Ok(())
+}
+
+// process uefi mm request in passed buffer
+fn uefi_mm_request(params: &RequestParams) -> Result<(), SvsmReqError> {
+    let addr = params.rcx;
+    let size = params.rdx as usize;
+
+    // check buffer parameters
+    check_buffer(addr, size)?;
+    log::debug!("uefi mm buffer: 0x{addr:x} +0x{size:x}");
+
+    let paddr = PhysAddr::from(addr);
+    let mmcore = read_from_guest::<MmCoreHeader>(paddr)?;
+    let boffset = size_of::<MmCoreHeader>();
+    let bsize = mmcore.size as usize;
+    if bsize > size - boffset {
+        return Err(SvsmReqError::invalid_parameter());
+    }
+
+    let req = read_bytes_from_guest(paddr + boffset, bsize)?;
+    let rsp = core_request_dispatch(&mut STORE.lock(), &mmcore.guid, &req);
+    assert!(rsp.len() <= bsize);
+    copy_slice_to_guest(&rsp, paddr + boffset)?;
+
+    Ok(())
+}
+
+pub fn uefi_mm_protocol_request(
+    request: u32,
+    params: &mut RequestParams,
+) -> Result<(), SvsmReqError> {
+    match request {
+        SVSM_UEFI_MM_REQUEST => uefi_mm_request(params),
+        _ => Err(SvsmReqError::unsupported_call()),
+    }
+}
+
+pub fn uefi_mm_protocol_init() -> Result<(), SvsmReqError> {
+    let mut store = STORE.lock();
+    store.reset();
+
+    // In case a TPM is present, shim's fallback.efi will setup efi
+    // boot variables then reboot.  This is not going to work until we
+    // have persistence support for the UEFI variable store.  So turn
+    // off that behaviour for now (via EFI variable).
+    store.quirk_disable_shim_reboot(true);
+
+    Ok(())
+}

--- a/kernel/src/protocols/uefivars.rs
+++ b/kernel/src/protocols/uefivars.rs
@@ -31,6 +31,9 @@ use crate::protocols::errors::SvsmReqError;
 
 const SVSM_UEFI_MM_REQUEST: u32 = 1;
 
+pub const UEFI_MM_PROTOCOL_VERSION_MIN: u32 = 1;
+pub const UEFI_MM_PROTOCOL_VERSION_MAX: u32 = 1;
+
 // current edk2 uses 64k
 const UEFI_MM_BUFFER_LIMIT: usize = 256 * 1024;
 

--- a/kernel/src/requests.rs
+++ b/kernel/src/requests.rs
@@ -18,6 +18,8 @@ use crate::protocols::attest::attest_protocol_request;
 use crate::protocols::{
     RequestParams, SVSM_APIC_PROTOCOL, SVSM_ATTEST_PROTOCOL, SVSM_CORE_PROTOCOL,
 };
+#[cfg(all(feature = "uefivars", not(test)))]
+use crate::protocols::{SVSM_UEFI_MM_PROTOCOL, uefivars::uefi_mm_protocol_request};
 #[cfg(all(feature = "vtpm", not(test)))]
 use crate::protocols::{SVSM_VTPM_PROTOCOL, vtpm::vtpm_protocol_request};
 
@@ -84,6 +86,8 @@ fn request_loop_once(
         #[cfg(all(feature = "vtpm", not(test)))]
         SVSM_VTPM_PROTOCOL => vtpm_protocol_request(request, params),
         SVSM_APIC_PROTOCOL => apic_protocol_request(request, params),
+        #[cfg(all(feature = "uefivars", not(test)))]
+        SVSM_UEFI_MM_PROTOCOL => uefi_mm_protocol_request(request, params),
         _ => Err(SvsmReqError::unsupported_protocol()),
     }
 }

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -61,6 +61,8 @@ use svsm::platform::SvsmPlatform;
 use svsm::platform::SvsmPlatformCell;
 use svsm::platform::init_capabilities;
 use svsm::platform::init_platform_type;
+#[cfg(all(feature = "uefivars", not(test)))]
+use svsm::protocols::uefivars::uefi_mm_protocol_init;
 use svsm::sev::secrets_page_mut;
 use svsm::svsm_paging::enumerate_early_boot_regions;
 use svsm::svsm_paging::invalidate_early_boot_memory;
@@ -481,6 +483,9 @@ fn svsm_init(launch_info: &KernelLaunchInfo) {
 
     #[cfg(all(feature = "vtpm", not(test)))]
     vtpm_init().expect("vTPM failed to initialize");
+
+    #[cfg(all(feature = "uefivars", not(test)))]
+    uefi_mm_protocol_init().expect("uefi mm protocol failed to initialize");
 
     virt_log_usage();
 

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -61,6 +61,8 @@ use svsm::platform::SvsmPlatform;
 use svsm::platform::SvsmPlatformCell;
 use svsm::platform::init_capabilities;
 use svsm::platform::init_platform_type;
+#[cfg(all(feature = "uefivars", not(test)))]
+use svsm::protocols::uefivars::uefi_mm_protocol_init;
 use svsm::sev::secrets_page_mut;
 use svsm::svsm_paging::enumerate_early_boot_regions;
 use svsm::svsm_paging::invalidate_early_boot_memory;
@@ -555,6 +557,9 @@ fn svsm_init(launch_info: &KernelLaunchInfo) {
 
     #[cfg(all(feature = "vtpm", not(test)))]
     vtpm_init().expect("vTPM failed to initialize");
+
+    #[cfg(all(feature = "uefivars", not(test)))]
+    uefi_mm_protocol_init().expect("uefi mm protocol failed to initialize");
 
     virt_log_usage();
 

--- a/uefivars.md
+++ b/uefivars.md
@@ -1,0 +1,70 @@
+
+## SVSM UEFI MM PROTOCOL
+
+Process MM communication requests from edk2 firmware.
+
+Usually this request serialization format is used by edk2 for
+communication between normal mode and management mode (MM for short).
+
+This SVSM protocol is a thin wrapper to allow edk2 firmware send those
+requests to the SVSM instead.  This allows the SVSM to provide services
+which are usually running in SMM mode on bare metal or
+non-confidential VMs, specifically an UEFI variable store.
+
+### protocol number
+
+```
+pub const SVSM_UEFI_MM_PROTOCOL: u32 = 4;
+```
+preliminary, not yet officially assigned
+
+### protocol request
+
+```
+const SVSM_UEFI_MM_REQUEST: u32 = 1;
+```
+Parameters:
+ * RCX: buffer address (guest physical).  Must be page aligned.
+ * RDX: buffer size
+
+Request SVSM to process the communication buffer as a UEFI request.
+The response format is request-specific.
+
+### request format
+
+The request serialization format is specified by edk2, the short
+overview below is purely informational.
+
+The buffer starts with this header:
+
+```
+// EFI_MM_COMMUNICATE_HEADER
+#[repr(C, packed)]
+pub struct MmCoreHeader {
+    pub guid: [u8; 16],
+    pub size: u64,
+}
+```
+
+The `guid` specifies the receiver of the message (typically an efi
+protocol guid or an efi event guid), and therefore also the format of
+the request data following this header.  The `size` field specified
+the size of the request data (excluding the header).
+
+### uefi spec references
+
+ * UEFI Platform Initialization Specification, section IV-5.7 "MM
+   Communication Protocol" describes the EFI_MM_COMMUNICATE_HEADER
+   struct.
+
+### edk2 code references
+
+ * MdePkg/Include/Protocol/MmCommunication.h
+ * MdeModulePkg/Include/Guid/SmmVariableCommon.h
+ * MdeModulePkg/Include/Guid/VarCheckPolicyMmi.h
+
+### linux references
+
+The linux kernel has an efi variable driver implementation using this
+request format in `drivers/firmware/efi/stmm`.  It sends those
+requests to the edk2 MM code running in arm secure partition.


### PR DESCRIPTION
Initial bits of a UEFI variable store protocol implementation.

https://gitlab.com/kraxel/virt-firmware-rs/-/tree/main/varstore is a uefi
variable store implementation in rust.  Its far from being complete, but
should be good enough to get a linux guest boot up to the login prompt
(without secure boot).

The design idea is to re-use serialization protocol edk2 uses to talk to
SMM mode code.  The only change on the edk2 side is that the buffers are
passed to SVSM instead of SMM.  The same approach is used by the qemu
uefi variable store (new in qemu 10.0), which also receives request
buffers from the firmware.

So SVSM needs a simple protocol to send request buffers.  This is the
purpose of this PR.  Protocol documentation is in the `uefivars.md` file
created by the first patch.

TODO: Once merged use coconfs storage support to make uefi variables
persistent (will be a separate PR).