### PR TITLE
CI: treat nightly failures as warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,6 +67,7 @@ jobs:
 
   nightly-check:
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Failures of the nightly toolchain provide useful information about keeping the build healthy, but those failures should not block PRs from merging.