### PR TITLE
github/workflows: install toolchain and components for the base branch

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -129,6 +129,12 @@ jobs:
           submodules: recursive
           ref: ${{ github.event.pull_request.base.sha }}
 
+      - name: Install specified rust toolchain for the base branch
+        run: rustup toolchain install --profile minimal
+
+      - name: Add rust components to the base branch toolchain
+        run: rustup component add clippy
+
       - name: Build base branch
         run: make FEATURES="default,enable-gdb" STAGE1_RUSTC_ARGS="--emit=obj -C linker=/usr/bin/true" stage1_elf_full stage1_elf_trampoline
 


### PR DESCRIPTION
In the `unsafe-check` pipeline we need to build both the current PR branch and the base branch to compare the number of unsafe blocks. If the PR changes the toolchain, the step where we run `clippy` on the base branch fails, because we haven`t installed it.

Install the toolchain and components for the base branch as well just after checkout to avoid this problem.