### PR TITLE
kernel: remove manual UUID implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,7 @@ dependencies = [
 name = "bootlib"
 version = "0.1.0"
 dependencies = [
+ "uuid",
  "zerocopy 0.8.10",
 ]
 

--- a/bootlib/Cargo.toml
+++ b/bootlib/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+uuid.workspace = true
 zerocopy.workspace = true
 
 [lints]

--- a/bootlib/src/firmware.rs
+++ b/bootlib/src/firmware.rs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Author: Carlos López <carlos.lopezr4096@gmail.com>
+
+use uuid::{uuid, Uuid};
+
+pub const OVMF_RESET_VECTOR_GUID: Uuid = uuid!("813d7b2c-9558-4d88-8b31-1427a85abe69");
+pub const OVMF_SEV_METADATA_GUID: Uuid = uuid!("dc886566-984a-4798-a75e-5585a7bf67cc");
+pub const OVMF_TABLE_FOOTER_GUID: Uuid = uuid!("96b582de-1fb2-45f7-baea-a366c55a082d");
+pub const SEV_INFO_BLOCK_GUID: Uuid = uuid!("00f771de-1a7e-4fcb-890e-68c77e2fb44e");
+pub const SVSM_INFO_GUID: Uuid = uuid!("a789a612-0597-4c4b-a49f-cbb1fe9d1ddd");
+
+pub const SEV_META_DESC_TYPE_MEM: u32 = 1;
+pub const SEV_META_DESC_TYPE_SECRETS: u32 = 2;
+pub const SEV_META_DESC_TYPE_CPUID: u32 = 3;
+pub const SEV_META_DESC_TYPE_CAA: u32 = 4;
+pub const SEV_META_DESC_TYPE_KERNEL_HASHES: u32 = 16;

--- a/bootlib/src/lib.rs
+++ b/bootlib/src/lib.rs
@@ -10,6 +10,7 @@
 
 #![no_std]
 
+pub mod firmware;
 pub mod igvm_params;
 pub mod kernel_launch;
 pub mod platform;

--- a/igvmbuilder/src/ovmf_firmware.rs
+++ b/igvmbuilder/src/ovmf_firmware.rs
@@ -9,24 +9,14 @@ use std::fs::File;
 use std::io::Read;
 use std::mem::size_of;
 
+use bootlib::firmware::*;
 use bootlib::igvm_params::{IgvmGuestContext, IgvmParamBlockFwInfo};
 use igvm::IgvmDirectiveHeader;
 use igvm_defs::{IgvmPageDataFlags, IgvmPageDataType, PAGE_SIZE_4K};
-use uuid::{uuid, Uuid};
+use uuid::Uuid;
 
 use crate::firmware::Firmware;
 use crate::igvm_builder::{NATIVE_COMPATIBILITY_MASK, SNP_COMPATIBILITY_MASK};
-
-const OVMF_TABLE_FOOTER_GUID: Uuid = uuid!("96b582de-1fb2-45f7-baea-a366c55a082d");
-const OVMF_SEV_METADATA_GUID: Uuid = uuid!("dc886566-984a-4798-a75e-5585a7bf67cc");
-const SEV_INFO_BLOCK_GUID: Uuid = uuid!("00f771de-1a7e-4fcb-890e-68c77e2fb44e");
-const OVMF_RESET_VECTOR_GUID: Uuid = uuid!("813d7b2c-9558-4d88-8b31-1427a85abe69");
-
-const SEV_META_DESC_TYPE_MEM: u32 = 1;
-const SEV_META_DESC_TYPE_SECRETS: u32 = 2;
-const SEV_META_DESC_TYPE_CPUID: u32 = 3;
-const SEV_META_DESC_TYPE_CAA: u32 = 4;
-const SEV_META_DESC_TYPE_KERNEL_HASHES: u32 = 16;
 
 // Offset from the end of the file where the OVMF table footer GUID should be.
 const FOOTER_OFFSET: usize = 32;

--- a/kernel/src/platform/snp_fw.rs
+++ b/kernel/src/platform/snp_fw.rs
@@ -18,7 +18,7 @@ use crate::types::{PageSize, GUEST_VMPL, PAGE_SIZE};
 use crate::utils::fw_meta::{find_table, RawMetaBuffer};
 use crate::utils::{zero_mem_region, MemoryRegion};
 use alloc::vec::Vec;
-use uuid::{uuid, Uuid};
+use bootlib::firmware::*;
 use zerocopy::{FromBytes, Immutable, KnownLayout};
 
 use core::mem::{size_of, size_of_val};
@@ -46,10 +46,6 @@ impl SevFWMetaData {
     }
 }
 
-const OVMF_TABLE_FOOTER_GUID: Uuid = uuid!("96b582de-1fb2-45f7-baea-a366c55a082d");
-const OVMF_SEV_META_DATA_GUID: Uuid = uuid!("dc886566-984a-4798-a75e-5585a7bf67cc");
-const SVSM_INFO_GUID: Uuid = uuid!("a789a612-0597-4c4b-a49f-cbb1fe9d1ddd");
-
 #[derive(Clone, Copy, Debug, FromBytes, KnownLayout, Immutable)]
 #[repr(C, packed)]
 struct SevMetaDataHeader {
@@ -66,11 +62,6 @@ struct SevMetaDataDesc {
     len: u32,
     t: u32,
 }
-
-const SEV_META_DESC_TYPE_MEM: u32 = 1;
-const SEV_META_DESC_TYPE_SECRETS: u32 = 2;
-const SEV_META_DESC_TYPE_CPUID: u32 = 3;
-const SEV_META_DESC_TYPE_CAA: u32 = 4;
 
 /// Parse the firmware metadata from the given slice.
 pub fn parse_fw_meta_data(mem: &[u8]) -> Result<SevFWMetaData, SvsmError> {
@@ -114,7 +105,7 @@ fn parse_sev_meta(
     raw_data: &[u8],
 ) -> Result<(), SvsmError> {
     // Find SEV metadata table
-    let Some(tbl) = find_table(&OVMF_SEV_META_DATA_GUID, raw_data) else {
+    let Some(tbl) = find_table(&OVMF_SEV_METADATA_GUID, raw_data) else {
         log::warn!("Could not find SEV metadata in firmware");
         return Ok(());
     };

--- a/kernel/src/utils/fw_meta.rs
+++ b/kernel/src/utils/fw_meta.rs
@@ -4,98 +4,11 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
-use crate::error::SvsmError;
 use crate::types::PAGE_SIZE;
+use uuid::Uuid;
 use zerocopy::{FromBytes, Immutable, KnownLayout};
 
-use core::fmt;
 use core::mem::{size_of, size_of_val};
-use core::str::FromStr;
-
-fn from_hex(c: char) -> Result<u8, SvsmError> {
-    match c.to_digit(16) {
-        Some(d) => Ok(d as u8),
-        None => Err(SvsmError::Firmware),
-    }
-}
-
-#[derive(Copy, Clone, Debug, Default)]
-pub struct Uuid {
-    data: [u8; 16],
-}
-
-impl Uuid {
-    pub const fn new() -> Self {
-        Uuid { data: [0; 16] }
-    }
-}
-
-impl TryFrom<&[u8]> for Uuid {
-    type Error = ();
-    fn try_from(mem: &[u8]) -> Result<Self, Self::Error> {
-        let arr: &[u8; 16] = mem.try_into().map_err(|_| ())?;
-        Ok(Self::from(arr))
-    }
-}
-
-impl From<&[u8; 16]> for Uuid {
-    fn from(mem: &[u8; 16]) -> Self {
-        Self {
-            data: [
-                mem[3], mem[2], mem[1], mem[0], mem[5], mem[4], mem[7], mem[6], mem[8], mem[9],
-                mem[10], mem[11], mem[12], mem[13], mem[14], mem[15],
-            ],
-        }
-    }
-}
-
-impl FromStr for Uuid {
-    type Err = SvsmError;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut uuid = Uuid::new();
-        let mut buf: u8 = 0;
-        let mut index = 0;
-
-        for c in s.chars() {
-            if !c.is_ascii_hexdigit() {
-                continue;
-            }
-
-            if (index % 2) == 0 {
-                buf = from_hex(c)? << 4;
-            } else {
-                buf |= from_hex(c)?;
-                let i = index / 2;
-                if i >= 16 {
-                    break;
-                }
-                uuid.data[i] = buf;
-            }
-
-            index += 1;
-        }
-
-        Ok(uuid)
-    }
-}
-
-impl PartialEq for Uuid {
-    fn eq(&self, other: &Self) -> bool {
-        self.data.iter().zip(&other.data).all(|(a, b)| a == b)
-    }
-}
-
-impl fmt::Display for Uuid {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for i in 0..16 {
-            write!(f, "{:02x}", self.data[i])?;
-            if i == 3 || i == 5 || i == 7 || i == 9 {
-                write!(f, "-")?;
-            }
-        }
-        Ok(())
-    }
-}
 
 #[derive(Debug, Clone, Copy, FromBytes, KnownLayout, Immutable)]
 #[repr(C, packed)]
@@ -105,8 +18,8 @@ pub struct RawMetaHeader {
 }
 
 impl RawMetaHeader {
-    pub fn uuid(&self) -> Uuid {
-        (&self.uuid).into()
+    pub const fn uuid(&self) -> Uuid {
+        Uuid::from_bytes_le(self.uuid)
     }
 
     pub fn data_len(&self) -> Option<usize> {
@@ -146,7 +59,7 @@ pub fn find_table<'a>(uuid: &Uuid, mem: &'a [u8]) -> Option<&'a [u8]> {
         idx = hdr_start.checked_sub(data_len)?;
 
         let raw_uuid = hdr.uuid;
-        let curr_uuid = Uuid::from(&raw_uuid);
+        let curr_uuid = Uuid::from_bytes_le(raw_uuid);
         if *uuid == curr_uuid {
             return Some(&mem[idx..idx + data_len]);
         }


### PR DESCRIPTION
Since the uuid crate is already being used in the SVSM kernel and other packages in the workspace, rely on it instead of the in-kernel implementation. While we are at it, centralize GUIDs into the bootlib crate, so that the kernel and igvmbuilder can access the same definitions.