### PR TITLE
Makefile: allow building with empty features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
 FEATURES ?= vtpm
+ifneq ($(FEATURES),)
 SVSM_ARGS += --features ${FEATURES}
+endif
 
 FEATURES_TEST ?= virtio-drivers
-SVSM_ARGS_TEST += --no-default-features --features ${FEATURES_TEST}
+SVSM_ARGS_TEST += --no-default-features
+ifneq ($(FEATURES_TEST),)
+SVSM_ARGS_TEST += --features ${FEATURES_TEST}
+endif
 
 ifdef RELEASE
 TARGET_PATH=release


### PR DESCRIPTION
Currently there is no easy way to build the SVSM from the command line with only the default features. The Makefile will build the SVSM with the `vtpm` feature unless `FEATURES` is overriden. However, overriding `FEATURES` to an empty value (to avoid building the `vtpm` feature) will result in passing the `--features` flag to cargo without any actual features. Thus, pass only this flag when there are features explicitly enabled. Also, do the equivalent for `FEATURES_TEST`.