### PR TITLE
mm/page_visibility: `SharedBox` improvements

### DIFF
--- a/kernel/src/greq/msg.rs
+++ b/kernel/src/greq/msg.rs
@@ -167,7 +167,7 @@ impl Default for SnpGuestRequestMsgHdr {
 
 /// `SNP_GUEST_REQUEST` message format
 #[repr(C, align(4096))]
-#[derive(Clone, Copy, Debug, FromBytes)]
+#[derive(Clone, Copy, Debug, FromBytes, IntoBytes, Immutable)]
 pub struct SnpGuestRequestMsg {
     hdr: SnpGuestRequestMsgHdr,
     pld: [u8; MSG_PAYLOAD_SIZE],

--- a/kernel/src/mm/page_visibility.rs
+++ b/kernel/src/mm/page_visibility.rs
@@ -36,7 +36,7 @@ use zerocopy::{FromBytes, FromZeros, Immutable, IntoBytes};
 /// Notably any objects at `vaddr` must tolerate unsynchronized writes of any
 /// bit pattern.  In addition, the caller must take responsibility for
 /// returning a page to the private state if it is ever freed.
-pub unsafe fn make_page_shared(vaddr: VirtAddr) -> Result<(), SvsmError> {
+unsafe fn make_page_shared(vaddr: VirtAddr) -> Result<(), SvsmError> {
     // Revoke page validation before changing page state.
     SVSM_PLATFORM.validate_virtual_page_range(
         MemoryRegion::new(vaddr, PAGE_SIZE),
@@ -75,7 +75,7 @@ pub unsafe fn make_page_shared(vaddr: VirtAddr) -> Result<(), SvsmError> {
 ///
 /// Converting the memory at `vaddr` must be safe within Rust's memory model.
 /// No outstanding references to the page may exist.
-pub unsafe fn make_page_private(vaddr: VirtAddr) -> Result<(), SvsmError> {
+unsafe fn make_page_private(vaddr: VirtAddr) -> Result<(), SvsmError> {
     // Update the page tables to map the page as private.
     this_cpu().get_pgtable().set_encrypted_4k(vaddr)?;
     flush_tlb_global_sync();

--- a/kernel/src/mm/page_visibility.rs
+++ b/kernel/src/mm/page_visibility.rs
@@ -114,8 +114,20 @@ impl<T: FromZeros> SharedBox<T> {
         let ptr = NonNull::from(PageBox::leak(page_box)).cast::<T>();
 
         for offset in (0..core::mem::size_of::<T>()).step_by(PAGE_SIZE) {
-            unsafe {
-                make_page_shared(vaddr + offset)?;
+            let r1 = unsafe { make_page_shared(vaddr + offset) };
+            if let Err(e1) = r1 {
+                for off in (0..offset).step_by(PAGE_SIZE) {
+                    // SAFETY: we previously marked this page as shared in this same function.
+                    let r2 = unsafe { make_page_private(vaddr + off) };
+                    if let Err(e2) = r2 {
+                        panic!(
+                            "Failed to restore page visibility ({e2:?}) after allocation failure"
+                        );
+                    }
+                }
+                // SAFETY: we previously allocated these pages in this same function
+                let _ = unsafe { PageBox::from_raw(ptr) };
+                return Err(e1);
             }
         }
 

--- a/kernel/src/sev/hv_doorbell.rs
+++ b/kernel/src/sev/hv_doorbell.rs
@@ -14,6 +14,7 @@ use bitfield_struct::bitfield;
 use core::arch::asm;
 use core::cell::UnsafeCell;
 use core::sync::atomic::{AtomicU32, AtomicU8, Ordering};
+use zerocopy::FromBytes;
 
 #[bitfield(u8)]
 pub struct HVDoorbellFlags {
@@ -42,7 +43,7 @@ pub struct HVExtIntStatus {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct HVExtIntInfo {
     pub status: AtomicU32,
     pub irr: [AtomicU32; 7],
@@ -68,7 +69,7 @@ pub fn allocate_hv_doorbell_page(ghcb: &GHCB) -> Result<&'static HVDoorbell, Svs
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct HVDoorbell {
     pub vector: AtomicU8,
     pub flags: AtomicU8,


### PR DESCRIPTION
* Fix `SharedBox` trait bounds so that methods are truly safe
* Attempt to restore page visibility on failure during `SharedBox::try_new_zeroed()`.
* Remove the last user of the low level `make_page_shared()` and `make_page_private()` functions, and then make them private to the `page_visibility` module.