### PR TITLE
Launcher improvements

### DIFF
--- a/scripts/launch_guest.sh
+++ b/scripts/launch_guest.sh
@@ -11,7 +11,13 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 : "${QEMU:=qemu-system-x86_64}"
 : "${IGVM:=$SCRIPT_DIR/../bin/coconut-qemu.igvm}"
 
-C_BIT_POS=$("$SCRIPT_DIR/../utils/cbit" || true)
+C_BIT_UTIL="$SCRIPT_DIR/../utils/cbit"
+if [ ! -x "$C_BIT_UTIL" ]; then
+  echo "C-Bit util not found. Trying to build it..."
+  make -C "$SCRIPT_DIR/.." utils/cbit || true
+fi
+
+C_BIT_POS=$("$C_BIT_UTIL" || true)
 COM1_SERIAL="-serial stdio" # console
 COM2_SERIAL="-serial null"  # debug
 COM3_SERIAL="-serial null"  # used by hyper-v


### PR DESCRIPTION
Here are some little convenience improvements for the QEMU launcher script.

1) Pass-through of arbitrary arguments to the QEMU call. This is convenient for
   debugging, for example.
2) Don't set the boot device explicitly. This allows booting from other devices
   for testing/experiments.
3) Automatically build the cbit util, if it does not exist.
   (Very handy, because I *always* forget to build it!)
