### PR TITLE
cpu: eliminate static IDT allocation

### DIFF
--- a/kernel/src/cpu/idt/mod.rs
+++ b/kernel/src/cpu/idt/mod.rs
@@ -8,4 +8,5 @@ pub mod common;
 pub mod stage2;
 pub mod svsm;
 
-pub use common::{idt, idt_mut};
+pub use common::{IdtEntry, EARLY_IDT_ENTRIES, IDT};
+pub use svsm::{load_static_idt, GLOBAL_IDT};

--- a/kernel/src/cpu/idt/stage2.rs
+++ b/kernel/src/cpu/idt/stage2.rs
@@ -4,22 +4,36 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
-use super::common::{idt_mut, DF_VECTOR, HV_VECTOR, VC_VECTOR};
+use super::common::{DF_VECTOR, HV_VECTOR, IDT, VC_VECTOR};
 use crate::cpu::control_regs::read_cr2;
 use crate::cpu::vc::{stage2_handle_vc_exception, stage2_handle_vc_exception_no_ghcb};
 use crate::cpu::X86ExceptionContext;
 use core::arch::global_asm;
 
-pub fn early_idt_init_no_ghcb() {
-    let mut idt = idt_mut();
+/// # Safety
+/// The caller must guarantee that the IDT object passed in does not go out of
+/// scope before the IDT is reloaded with a different object.
+pub unsafe fn early_idt_init_no_ghcb(idt: &mut IDT<'_>) {
     idt.init(&raw const stage2_idt_handler_array_no_ghcb, 32);
-    idt.load();
+
+    // SAFETY: the caller guarantees that the lifetime of the IDT object is
+    // appropriate for use here.
+    unsafe {
+        idt.load();
+    }
 }
 
-pub fn early_idt_init() {
-    let mut idt = idt_mut();
+/// # Safety
+/// The caller must guarantee that the IDT object passed in does not go out of
+/// scope before the IDT is reloaded with a different object.
+pub unsafe fn early_idt_init(idt: &mut IDT<'_>) {
     idt.init(&raw const stage2_idt_handler_array, 32);
-    idt.load();
+
+    // SAFETY: the caller guarantees that the lifetime of the IDT object is
+    // appropriate for use here.
+    unsafe {
+        idt.load();
+    }
 }
 
 #[no_mangle]

--- a/kernel/src/cpu/smp.rs
+++ b/kernel/src/cpu/smp.rs
@@ -4,10 +4,10 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
+use super::idt::load_static_idt;
 use crate::acpi::tables::ACPICPUInfo;
 use crate::address::{Address, VirtAddr};
 use crate::cpu::efer::EFERFlags;
-use crate::cpu::idt::idt;
 use crate::cpu::ipi::ipi_start_cpu;
 use crate::cpu::percpu::{
     cpu_idle_loop, this_cpu, this_cpu_shared, PerCpu, PerCpuShared, PERCPU_AREAS,
@@ -81,7 +81,7 @@ pub fn start_secondary_cpus(platform: &dyn SvsmPlatform, cpus: &[ACPICPUInfo]) {
 extern "C" fn start_ap_setup(top_of_stack: u64) {
     // Initialize the GDT, TSS, and IDT.
     this_cpu().load_gdt_tss(true);
-    idt().load();
+    load_static_idt();
     // Now the stack unwinder can be used
     this_cpu().set_current_stack(MemoryRegion::new(
         VirtAddr::from(top_of_stack)

--- a/kernel/src/cpu/vmsa.rs
+++ b/kernel/src/cpu/vmsa.rs
@@ -11,7 +11,7 @@ use crate::types::{GUEST_VMPL, SVSM_CS, SVSM_CS_ATTRIBUTES, SVSM_DS, SVSM_DS_ATT
 use cpuarch::vmsa::{VMSASegment, VMSA};
 
 use super::gdt::GLOBAL_GDT;
-use super::idt::common::idt;
+use super::idt::GLOBAL_IDT;
 
 pub fn svsm_code_segment() -> hyperv::HvSegmentRegister {
     hyperv::HvSegmentRegister {
@@ -41,7 +41,7 @@ pub fn svsm_gdt_segment() -> hyperv::HvTableRegister {
 }
 
 pub fn svsm_idt_segment() -> hyperv::HvTableRegister {
-    let (base, limit) = idt().base_limit();
+    let (base, limit) = GLOBAL_IDT.base_limit();
     hyperv::HvTableRegister {
         limit,
         base,


### PR DESCRIPTION
Split the IDT into an early-boot IDT (only large enough to contain exception vectors), which is allocated on the stack, and a global IDT (with full contents), which is allocated from persistent memory.  This makes it much easier to make the IDT read-only after it has been populated.