### PR TITLE
mm/page_visibility, hyperv: multiple safety & ergonomic improvements

### DIFF
--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -610,10 +610,7 @@ impl PerCpu {
         // to ensure that only a single reference can ever be taken at a time.
         let page_ref: RefMut<'_, Option<(HypercallPage, HypercallPage)>> =
             self.hypercall_pages.borrow_mut();
-        // SAFETY: the virtual addresses were allocated when the hypercall
-        // pages were configured, and the physical addresses were captured at
-        // that time.
-        unsafe { HypercallPagesGuard::new(RefMut::map(page_ref, |o| o.as_mut().unwrap())) }
+        HypercallPagesGuard::new(RefMut::map(page_ref, |o| o.as_mut().unwrap()))
     }
 
     pub fn hv_doorbell(&self) -> Option<&HVDoorbell> {

--- a/kernel/src/hyperv/mod.rs
+++ b/kernel/src/hyperv/mod.rs
@@ -11,8 +11,10 @@ pub use hv::*;
 pub use msr::*;
 
 use bitfield_struct::bitfield;
+use zerocopy::{Immutable, IntoBytes};
 
 #[bitfield(u8)]
+#[derive(IntoBytes, Immutable)]
 pub struct HvInputVtl {
     #[bits(4)]
     target_vtl: u8,
@@ -32,7 +34,7 @@ impl HvInputVtl {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, IntoBytes, Immutable)]
 pub struct HvSegmentRegister {
     pub base: u64,
     pub limit: u32,
@@ -41,7 +43,7 @@ pub struct HvSegmentRegister {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, IntoBytes, Immutable)]
 pub struct HvTableRegister {
     pub _rsvd: [u16; 3],
     pub limit: u16,
@@ -49,7 +51,7 @@ pub struct HvTableRegister {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, IntoBytes, Immutable)]
 pub struct HvInitialVpContext {
     pub rip: u64,
     pub rsp: u64,

--- a/kernel/src/mm/page_visibility.rs
+++ b/kernel/src/mm/page_visibility.rs
@@ -170,6 +170,14 @@ impl<T> SharedBox<T> {
         core::mem::forget(self);
         ptr
     }
+
+    // Gets the address of the inner pointer
+    pub fn ptr_ref(&self) -> *const *const T {
+        // We are casting a `*const NonNull<T>` to a `*const *const T`.
+        // The cast is valid because `NonNull<T>` is transparent over
+        // `*mut T`, and `*mut T` has the same layout as `*const T`.
+        (&raw const self.ptr).cast()
+    }
 }
 
 impl<T, const N: usize> SharedBox<[T; N]> {

--- a/kernel/src/mm/page_visibility.rs
+++ b/kernel/src/mm/page_visibility.rs
@@ -5,6 +5,7 @@
 // Author: Jon Lange (jlange@microsoft.com)
 
 use core::mem::MaybeUninit;
+use core::ops::Deref;
 use core::ptr::NonNull;
 
 use crate::address::VirtAddr;
@@ -204,6 +205,23 @@ impl<T, const N: usize> SharedBox<[T; N]> {
         }
 
         Ok(())
+    }
+}
+
+impl<T: FromBytes + Sync> Deref for SharedBox<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: ptr pointing to valid memory is part of this type's
+        // invariant. The target is Sync, so there cannot be any data
+        // races, and it is FromBytes, so it has no invalid
+        // representations.
+        unsafe { self.ptr.as_ref() }
+    }
+}
+
+impl<T: FromBytes + Sync> AsRef<T> for SharedBox<T> {
+    fn as_ref(&self) -> &T {
+        self
     }
 }
 


### PR DESCRIPTION
There are multiple uses of types behind a `SharedBox`, which have the particularity that reside on hypervisor-shared memory, which means that:
1. The contents may be updated at any time by the hypervisor without synchronization.
2. The contents may contain arbitrary data, including invalid type representations.

The first use case is the `HvDoorbell` page. Since this type is `Sync` (cannot suffer from data races) and `FromBytes` (has no invalid representations), it should be accessible from behind a `SharedBox` transparently. Thus, allow for types following these characteristics to be accessed through a `SharedBox` via `Deref` or `AsRef`.

The second case is the Hyper-V hypercall pages. In this case, keep the semantic information of memory being shared by not leaking the backing pages, and simply allow unsafely copying bytes from/to the shared memory inside the `HypercallInput` and `HypercallOutput` type methods. The aforementioned methods now have the proper `IntoBytes` / `FromBytes` requirements. While we are at it, remove clippy warning suppressions by properly giving out mutable borrows of the backing pages, ensuring only one piece of code is attempting to mutate them. Finally, remove some unsafe blocks thanks to the type safety we introduced.