### PR TITLE
unsafe blocks: add options to Makefile and new script to print stats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,11 @@ ifneq ($(FEATURES_TEST),)
 SVSM_ARGS_TEST += --features ${FEATURES_TEST}
 endif
 
+CLIPPY_ARGS ?= -D warnings
+ifdef UNSAFE_BLOCKS
+CLIPPY_ARGS += -W warnings -W clippy::undocumented_unsafe_blocks
+endif
+
 ifdef RELEASE
 TARGET_PATH=release
 CARGO_ARGS += --release
@@ -184,11 +189,11 @@ bin/svsm-test.bin: bin/svsm-test
 	objcopy -O binary $< $@
 
 clippy:
-	cargo clippy --all-features --workspace --exclude svsm --exclude stage1 --exclude svsm-fuzz -- -D warnings
-	RUSTFLAGS="--cfg fuzzing" cargo clippy --all-features --package svsm-fuzz -- -D warnings
-	cargo clippy --all-features --package svsm --target x86_64-unknown-none -- -D warnings
-	cargo clippy --all-features --package stage1 --target x86_64-unknown-none -- -D warnings ${STAGE1_RUSTC_ARGS}
-	cargo clippy --all-features --workspace --tests --exclude packit -- -D warnings
+	cargo clippy --all-features --workspace --exclude svsm --exclude stage1 --exclude svsm-fuzz -- ${CLIPPY_ARGS}
+	RUSTFLAGS="--cfg fuzzing" cargo clippy --all-features --package svsm-fuzz -- ${CLIPPY_ARGS}
+	cargo clippy --all-features --package svsm --target x86_64-unknown-none -- ${CLIPPY_ARGS}
+	cargo clippy --all-features --package stage1 --target x86_64-unknown-none -- ${CLIPPY_ARGS} ${STAGE1_RUSTC_ARGS}
+	cargo clippy --all-features --workspace --tests --exclude packit -- ${CLIPPY_ARGS}
 
 clean:
 	cargo clean

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ ifneq ($(FEATURES_TEST),)
 SVSM_ARGS_TEST += --features ${FEATURES_TEST}
 endif
 
+CLIPPY_OPTIONS ?=
 CLIPPY_ARGS ?= -D warnings
 ifdef UNSAFE_BLOCKS
 CLIPPY_ARGS += -W warnings -W clippy::undocumented_unsafe_blocks
@@ -189,11 +190,11 @@ bin/svsm-test.bin: bin/svsm-test
 	objcopy -O binary $< $@
 
 clippy:
-	cargo clippy --all-features --workspace --exclude svsm --exclude stage1 --exclude svsm-fuzz -- ${CLIPPY_ARGS}
-	RUSTFLAGS="--cfg fuzzing" cargo clippy --all-features --package svsm-fuzz -- ${CLIPPY_ARGS}
-	cargo clippy --all-features --package svsm --target x86_64-unknown-none -- ${CLIPPY_ARGS}
-	cargo clippy --all-features --package stage1 --target x86_64-unknown-none -- ${CLIPPY_ARGS} ${STAGE1_RUSTC_ARGS}
-	cargo clippy --all-features --workspace --tests --exclude packit -- ${CLIPPY_ARGS}
+	cargo clippy ${CLIPPY_OPTIONS} --all-features --workspace --exclude svsm --exclude stage1 --exclude svsm-fuzz -- ${CLIPPY_ARGS}
+	RUSTFLAGS="--cfg fuzzing" cargo clippy ${CLIPPY_OPTIONS} --all-features --package svsm-fuzz -- ${CLIPPY_ARGS}
+	cargo clippy ${CLIPPY_OPTIONS} --all-features --package svsm --target x86_64-unknown-none -- ${CLIPPY_ARGS}
+	cargo clippy ${CLIPPY_OPTIONS} --all-features --package stage1 --target x86_64-unknown-none -- ${CLIPPY_ARGS} ${STAGE1_RUSTC_ARGS}
+	cargo clippy ${CLIPPY_OPTIONS} --all-features --workspace --tests --exclude packit -- ${CLIPPY_ARGS}
 
 clean:
 	cargo clean

--- a/scripts/unsafe_blocks_report.sh
+++ b/scripts/unsafe_blocks_report.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+CLIPPY_SAFETY_MSG="missing a safety comment"
+
+CLIPPY_FILE=
+TMP_FILE=
+QUIET=0
+
+ALL=1
+MODULE=0
+TOTAL=0
+
+cleanup() {
+  if [ -n "${TMP_FILE}" ]; then
+    rm "${TMP_FILE}"
+  fi
+}
+trap cleanup EXIT
+
+function usage
+{
+    echo -e "usage: $0 [OPTION...]"
+    echo -e ""
+    echo -e "Print statistics about undocumented unsafe blocks"
+    echo -e ""
+    echo -e "Generic options:"
+    echo -e " -f, --file FILENAME  Use the specified file, instead of running clippy"
+    echo -e " -q, --quiet          Print just stats without log messages"
+    echo -e " -h, --help           Print this help"
+    echo -e ""
+    echo -e "By default all stats are printed; to select only some of them,"
+    echo -e "please use the following options:"
+    echo -e " -m, --module         Undocumented unsafe blocks per module"
+    echo -e " -t, --total          Total number of undocumented unsafe blocks"
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -f | --file)
+            CLIPPY_FILE="$2"
+            shift
+        ;;
+        -q | --quiet)
+            QUIET=1
+        ;;
+        -m | --module)
+            ALL=0
+            MODULE=1
+        ;;
+        -t | --total)
+            ALL=0
+            TOTAL=1
+        ;;
+        -h | --help)
+            usage
+            exit
+            ;;
+        -*|--*)
+            echo "Unknown option $1"
+            exit 1
+            ;;
+        *)
+            echo "Invalid parameter $1"
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+log() {
+  if [ "${QUIET}" == "0" ]; then
+    echo -e "$@"
+  fi
+}
+
+clippy_unsafe_blocks_per_module() {
+    grep -A 1 "${CLIPPY_SAFETY_MSG}" "$1" | grep "\-->" | awk '{print $2}' | \
+        sort | uniq | cut -d':' -f1 | \
+        awk -F'/' '{
+            module=$1;
+            print module;
+            for(i=2; i <= NF; i++) {
+                module=module "/" $i;
+                print module
+            }
+        }' | sort | uniq -c
+}
+
+clippy_unsafe_blocks_total() {
+    grep -A 1 "${CLIPPY_SAFETY_MSG}" "$1" | grep "\-->" | awk '{print $2}' | \
+        sort | uniq | wc -l
+}
+
+if [ -z "${CLIPPY_FILE}" ]; then
+    log "Running \`make clippy\`..."
+    TMP_FILE=$(mktemp)
+    make -C "${SCRIPT_DIR}/.." clippy CLIPPY_OPTIONS="--quiet --color=never" \
+        UNSAFE_BLOCKS=1 2>"${TMP_FILE}"
+    CLIPPY_FILE="${TMP_FILE}"
+    log ""
+fi
+
+if [[ "${ALL}" == "1" || "${MODULE}" == "1" ]]; then
+    log "Undocumented unsafe blocks per module\n"
+    clippy_unsafe_blocks_per_module "${CLIPPY_FILE}"
+    log ""
+fi
+
+if [[ "${ALL}" == "1" || "${TOTAL}" == "1" ]]; then
+    log "Total number of undocumented unsafe blocks\n"
+    clippy_unsafe_blocks_total "${CLIPPY_FILE}"
+    log ""
+fi


### PR DESCRIPTION
This PR adds `UNSAFE_BLOCKS` and `CLIPPY_OPTIONS` to the Makefile.
These are used by the new `unsafe_blocks_report.sh` also added by this PR to print stats about undocumented unsafe blocks in our base code.

I'll open a new PR when this is merged to use the script in the CI, since our pipeline requires to have the changes in the base branch