### PR TITLE
stage2: Add stacktrace support

### DIFF
--- a/bootlib/src/kernel_launch.rs
+++ b/bootlib/src/kernel_launch.rs
@@ -17,9 +17,10 @@ pub const LOWMEM_END: u32 = 0xA0000;
 pub const STAGE2_HEAP_START: u32 = 0x10000; // 64 KB
 pub const STAGE2_HEAP_END: u32 = LOWMEM_END; // 640 KB
 pub const STAGE2_BASE: u32 = 0x800000; // Start of stage2 area excluding heap
-pub const STAGE2_STACK_END: u32 = 0x805000;
+pub const STAGE2_STACK_END: u32 = STAGE2_BASE;
+pub const STAGE2_STACK_PAGE: u32 = 0x805000;
 pub const STAGE2_INFO_SZ: u32 = size_of::<Stage2LaunchInfo>() as u32;
-pub const STAGE2_STACK: u32 = STAGE2_STACK_END + 0x1000 - STAGE2_INFO_SZ;
+pub const STAGE2_STACK: u32 = STAGE2_STACK_PAGE + 0x1000 - STAGE2_INFO_SZ;
 pub const SECRETS_PAGE: u32 = 0x806000;
 pub const CPUID_PAGE: u32 = 0x807000;
 // Stage2 is loaded at 8 MB + 32 KB

--- a/igvmbuilder/src/gpa_map.rs
+++ b/igvmbuilder/src/gpa_map.rs
@@ -8,7 +8,7 @@ use std::error::Error;
 use std::fs::metadata;
 
 use bootlib::kernel_launch::{
-    CPUID_PAGE, SECRETS_PAGE, STAGE2_BASE, STAGE2_STACK_PAGE, STAGE2_START,
+    CPUID_PAGE, SECRETS_PAGE, STAGE2_BASE, STAGE2_MAXLEN, STAGE2_STACK_PAGE, STAGE2_START,
 };
 use igvm_defs::PAGE_SIZE_4K;
 
@@ -107,6 +107,13 @@ impl GpaMap {
 
         // Obtain the lengths of the binary files
         let stage2_len = Self::get_metadata(&options.stage2)?.len() as usize;
+        if stage2_len > STAGE2_MAXLEN as usize {
+            return Err(format!(
+                "Stage2 binary size ({stage2_len:#x}) exceeds limit: {STAGE2_MAXLEN:#x}"
+            )
+            .into());
+        }
+
         let kernel_elf_len = Self::get_metadata(&options.kernel)?.len() as usize;
         let kernel_fs_len = if let Some(fs) = &options.filesystem {
             metadata(fs)?.len() as usize

--- a/igvmbuilder/src/gpa_map.rs
+++ b/igvmbuilder/src/gpa_map.rs
@@ -8,7 +8,7 @@ use std::error::Error;
 use std::fs::metadata;
 
 use bootlib::kernel_launch::{
-    CPUID_PAGE, SECRETS_PAGE, STAGE2_BASE, STAGE2_STACK_END, STAGE2_START,
+    CPUID_PAGE, SECRETS_PAGE, STAGE2_BASE, STAGE2_STACK_PAGE, STAGE2_START,
 };
 use igvm_defs::PAGE_SIZE_4K;
 
@@ -168,7 +168,7 @@ impl GpaMap {
         let gpa_map = Self {
             base_addr: STAGE2_BASE.into(),
             stage1_image,
-            stage2_stack: GpaRange::new_page(STAGE2_STACK_END.into())?,
+            stage2_stack: GpaRange::new_page(STAGE2_STACK_PAGE.into())?,
             stage2_image,
             secrets_page: GpaRange::new_page(SECRETS_PAGE.into())?,
             cpuid_page: GpaRange::new_page(CPUID_PAGE.into())?,

--- a/igvmbuilder/src/igvm_builder.rs
+++ b/igvmbuilder/src/igvm_builder.rs
@@ -505,7 +505,8 @@ impl IgvmBuilder {
             )?;
         }
 
-        // Populate the empty region below the stage2 stack.
+        // Populate the empty region below the stage2 stack page.
+        // This region is used for stage2 stack at runtime.
         self.add_empty_pages(
             self.gpa_map.base_addr,
             self.gpa_map.stage2_stack.get_start() - self.gpa_map.base_addr,

--- a/kernel/src/boot_stage2.rs
+++ b/kernel/src/boot_stage2.rs
@@ -348,10 +348,6 @@ global_asm!(
 // between SVSM and Stage2.
 global_asm!(
     r#"
-        .globl entry_code_start
-        entry_code_start:
-        .globl entry_code_end
-        entry_code_end:
         .globl bsp_stack
         bsp_stack:
         .globl bsp_stack_end

--- a/kernel/src/boot_stage2.rs
+++ b/kernel/src/boot_stage2.rs
@@ -285,6 +285,10 @@ global_asm!(
          */
         movl %ebp, %edi
         andq $~0xf, %rsp
+
+        /* Mark the next stack frame as the bottom frame */
+        xor %rbp, %rbp
+
         call stage2_main
 
         .data

--- a/kernel/src/cpu/idt/stage2.rs
+++ b/kernel/src/cpu/idt/stage2.rs
@@ -4,7 +4,8 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
-use super::common::{idt_mut, DF_VECTOR, HV_VECTOR, VC_VECTOR};
+use super::super::extable::handle_exception_table_early;
+use super::common::{idt_mut, DF_VECTOR, HV_VECTOR, PF_VECTOR, VC_VECTOR};
 use crate::cpu::control_regs::read_cr2;
 use crate::cpu::vc::{stage2_handle_vc_exception, stage2_handle_vc_exception_no_ghcb};
 use crate::cpu::X86ExceptionContext;
@@ -53,21 +54,30 @@ pub extern "C" fn stage2_generic_idt_handler(ctx: &mut X86ExceptionContext, vect
 
 #[no_mangle]
 pub extern "C" fn stage2_generic_idt_handler_no_ghcb(ctx: &mut X86ExceptionContext, vector: usize) {
+    let rip = ctx.frame.rip;
+    let rsp = ctx.frame.rsp;
+    let err = ctx.error_code; // zero if no error code is given
+
     match vector {
         DF_VECTOR => {
             let cr2 = read_cr2();
-            let rip = ctx.frame.rip;
-            let rsp = ctx.frame.rsp;
             panic!(
                 "Double-Fault at RIP {:#018x} RSP: {:#018x} CR2: {:#018x}",
                 rip, rsp, cr2
             );
         }
+        PF_VECTOR => {
+            let cr2 = read_cr2();
+
+            if !handle_exception_table_early(ctx) {
+                panic!(
+                    "Unhandled Page-Fault at RIP {:#018x} CR2: {:#018x} error code: {:#018x}",
+                    rip, cr2, err
+                );
+            }
+        }
         VC_VECTOR => stage2_handle_vc_exception_no_ghcb(ctx).expect("Failed to handle #VC"),
         _ => {
-            let err = ctx.error_code;
-            let rip = ctx.frame.rip;
-
             panic!(
                 "Unhandled exception {} RIP {:#018x} error code: {:#018x}",
                 vector, rip, err

--- a/kernel/src/cpu/idt/stage2.rs
+++ b/kernel/src/cpu/idt/stage2.rs
@@ -107,6 +107,8 @@ global_asm!(
         addq    $8, %rsp /* Skip error code */
         iretq
 
+        .pushsection .entry.text, "ax"
+
          /* Early tage 2 handler array setup */
     push_regs_no_ghcb:
         pushq   %rbx
@@ -133,6 +135,8 @@ global_asm!(
         call    stage2_generic_idt_handler_no_ghcb
         jmp     generic_idt_handler_return
 
+        .popsection
+
         .align 32
         .globl stage2_idt_handler_array_no_ghcb
     stage2_idt_handler_array_no_ghcb:
@@ -146,7 +150,9 @@ global_asm!(
         jmp     push_regs_no_ghcb
         i = i + 1
         .endr
-        
+
+        .pushsection .entry.text, "ax"
+
         /* Stage 2 handler array setup */
     push_regs_stage2:
         pushq   %rbx
@@ -172,6 +178,8 @@ global_asm!(
         movq    %rsp, %rdi
         call    stage2_generic_idt_handler
         jmp     generic_idt_handler_return
+
+        .popsection
 
         .align 32
         .globl stage2_idt_handler_array

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -632,20 +632,20 @@ impl PerCpu {
             .unwrap_or(ptr::null())
     }
 
-    pub fn get_top_of_shadow_stack(&self) -> VirtAddr {
-        self.init_shadow_stack.get().unwrap()
+    pub fn get_top_of_shadow_stack(&self) -> Option<VirtAddr> {
+        self.init_shadow_stack.get()
     }
 
-    pub fn get_top_of_context_switch_stack(&self) -> VirtAddr {
-        self.context_switch_stack.get().unwrap()
+    pub fn get_top_of_context_switch_stack(&self) -> Option<VirtAddr> {
+        self.context_switch_stack.get()
     }
 
-    pub fn get_top_of_df_stack(&self) -> VirtAddr {
-        self.ist.double_fault_stack.get().unwrap()
+    pub fn get_top_of_df_stack(&self) -> Option<VirtAddr> {
+        self.ist.double_fault_stack.get()
     }
 
-    pub fn get_top_of_df_shadow_stack(&self) -> VirtAddr {
-        self.ist.double_fault_shadow_stack.get().unwrap()
+    pub fn get_top_of_df_shadow_stack(&self) -> Option<VirtAddr> {
+        self.ist.double_fault_shadow_stack.get()
     }
 
     pub fn get_current_stack(&self) -> MemoryRegion<VirtAddr> {
@@ -763,7 +763,7 @@ impl PerCpu {
     }
 
     fn setup_tss(&self) {
-        let double_fault_stack = self.get_top_of_df_stack();
+        let double_fault_stack = self.get_top_of_df_stack().unwrap();
         // SAFETY: the stck pointer is known to be correct.
         unsafe {
             self.tss.set_ist_stack(IST_DF, double_fault_stack);
@@ -771,7 +771,7 @@ impl PerCpu {
     }
 
     fn setup_isst(&self) {
-        let double_fault_shadow_stack = self.get_top_of_df_shadow_stack();
+        let double_fault_shadow_stack = self.get_top_of_df_shadow_stack().unwrap();
         let mut isst = self.isst.get();
         isst.set(IST_DF, double_fault_shadow_stack);
         self.isst.set(isst);
@@ -926,7 +926,7 @@ impl PerCpu {
             // page table because it resides in the PerCpu virtual range.
             //
             // See switch_to() for details.
-            rsp: self.get_top_of_context_switch_stack().into(),
+            rsp: self.get_top_of_context_switch_stack().unwrap().into(),
             rflags: 2,
 
             cs: svsm_code_segment(),

--- a/kernel/src/cpu/shadow_stack.rs
+++ b/kernel/src/cpu/shadow_stack.rs
@@ -51,7 +51,7 @@ macro_rules! enable_shadow_stacks {
     ($bsp_percpu:ident) => {{
         use core::arch::asm;
 
-        let token_addr = $bsp_percpu.get_top_of_shadow_stack();
+        let token_addr = $bsp_percpu.get_top_of_shadow_stack().unwrap();
 
         unsafe {
             asm!(

--- a/kernel/src/cpu/shadow_stack.rs
+++ b/kernel/src/cpu/shadow_stack.rs
@@ -1,4 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Coconut-SVSM authors
+//
+// Author: Tom Dohrmann <erbse.13@gmx.de>
 
 use crate::platform::SvsmPlatform;
 

--- a/kernel/src/stage2.lds
+++ b/kernel/src/stage2.lds
@@ -18,6 +18,10 @@ SECTIONS
 		*(.text)
 		*(.text.*)
 		. = ALIGN(16);
+		entry_code_start = .;
+		*(.entry.text)
+		entry_code_end = .;
+		. = ALIGN(16);
 		early_exception_table_start = .;
 		KEEP(*(__early_exception_table))
 		early_exception_table_end = .;

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -11,7 +11,7 @@ pub mod boot_stage2;
 
 use bootlib::kernel_launch::{
     KernelLaunchInfo, Stage2LaunchInfo, LOWMEM_END, STAGE2_HEAP_END, STAGE2_HEAP_START,
-    STAGE2_START,
+    STAGE2_STACK, STAGE2_STACK_END, STAGE2_START,
 };
 use bootlib::platform::SvsmPlatformType;
 use core::arch::asm;
@@ -64,6 +64,10 @@ fn init_percpu(platform: &mut dyn SvsmPlatform) -> Result<(), SvsmError> {
     // on multi-threaded access to the per-cpu areas.
     let percpu_shared = unsafe { PERCPU_AREAS.create_new(0) };
     let bsp_percpu = PerCpu::alloc(percpu_shared)?;
+    bsp_percpu.set_current_stack(MemoryRegion::from_addresses(
+        VirtAddr::from(STAGE2_STACK_END as u64),
+        VirtAddr::from(STAGE2_STACK as u64),
+    ));
     // SAFETY: pgtable is properly aligned and is never freed within the
     // lifetime of stage2. We go through a raw pointer to promote it to a
     // static mut. Only the BSP is able to get a reference to it so no

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -28,6 +28,7 @@ use svsm::cpu::flush_tlb_percpu;
 use svsm::cpu::gdt::GLOBAL_GDT;
 use svsm::cpu::idt::stage2::{early_idt_init, early_idt_init_no_ghcb};
 use svsm::cpu::percpu::{this_cpu, PerCpu, PERCPU_AREAS};
+use svsm::debug::stacktrace::print_stack;
 use svsm::error::SvsmError;
 use svsm::igvm_params::IgvmParams;
 use svsm::mm::alloc::{memory_info, print_memory_info, root_mem_init};
@@ -518,6 +519,9 @@ pub extern "C" fn stage2_main(launch_info: &Stage2LaunchInfo) -> ! {
 fn panic(info: &PanicInfo<'_>) -> ! {
     log::error!("Panic! COCONUT-SVSM Version: {}", COCONUT_VERSION);
     log::error!("Info: {}", info);
+
+    print_stack(3);
+
     loop {
         platform::halt();
     }

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -156,6 +156,7 @@ fn setup_env(
     init_percpu(platform).expect("Failed to initialize per-cpu area");
 
     // Init IDT again with handlers requiring GHCB (eg. #VC handler)
+    // Must be done after init_percpu() to catch early #PFs
     early_idt_init();
 
     // Complete initializtion of the platform.  After that point, the console
@@ -495,8 +496,8 @@ pub extern "C" fn stage2_main(launch_info: &Stage2LaunchInfo) -> ! {
 
     log::info!("Starting SVSM kernel...");
 
-    // Shut down the GHCB
     unsafe {
+        // Shut down the PerCpu instance
         shutdown_percpu();
 
         asm!("jmp *%rax",

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -409,7 +409,7 @@ unsafe fn switch_to(prev: *const Task, next: *const Task) {
         // in the new page tables. To protect against this, we switch to another
         // stack that's mapped into both the old and the new set of page tables.
         // That way we always have a valid stack to handle exceptions on.
-        let tos_cs: u64 = this_cpu().get_top_of_context_switch_stack().into();
+        let tos_cs: u64 = this_cpu().get_top_of_context_switch_stack().unwrap().into();
 
         // Switch to new task
         asm!(

--- a/kernel/src/utils/memory_region.rs
+++ b/kernel/src/utils/memory_region.rs
@@ -225,7 +225,7 @@ where
     /// assert!(!region.contains(VirtAddr::from(0xffffff1000u64)));
     /// ```
     pub fn contains(&self, addr: A) -> bool {
-        self.start() <= addr && addr < self.end()
+        (self.start()..self.end()).contains(&addr)
     }
 
     /// Check whether an address is within this region, treating `end` as part

--- a/kernel/src/utils/memory_region.rs
+++ b/kernel/src/utils/memory_region.rs
@@ -66,7 +66,8 @@ where
     }
 
     /// Create a memory region from two raw addresses.
-    pub const fn from_addresses(start: A, end: A) -> Self {
+    pub fn from_addresses(start: A, end: A) -> Self {
+        assert!(start <= end);
         Self { start, end }
     }
 


### PR DESCRIPTION
This PR enables stacktrace support in Stage2. Early #PFs are handled by evaluating the early exception table to ensure try_this_cpu() works before the PerCpu structure is available.