### PR TITLE
kernel/task: make `current_task_terminated()` safe

### DIFF
--- a/kernel/src/syscall/class0.rs
+++ b/kernel/src/syscall/class0.rs
@@ -18,9 +18,7 @@ pub fn sys_exit(exit_code: u32) -> ! {
         "Terminating task {}, exit_code {exit_code}",
         current_task().get_task_name()
     );
-    unsafe {
-        current_task_terminated();
-    }
+    current_task_terminated();
     schedule();
     unreachable!("schedule() returned in sys_exit()");
 }

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -329,10 +329,10 @@ pub fn is_current_task(id: u32) -> bool {
 
 /// Terminates the current task.
 ///
-/// # Safety
+/// # Panic
 ///
 /// This function must only be called after scheduling is initialized, otherwise it will panic.
-pub unsafe fn current_task_terminated() {
+pub fn current_task_terminated() {
     let cpu = this_cpu();
     let mut rq = cpu.runqueue().lock_write();
     let task_node = rq
@@ -343,10 +343,7 @@ pub unsafe fn current_task_terminated() {
 }
 
 pub fn terminate() {
-    // TODO: re-evaluate whether current_task_terminated() needs to be unsafe
-    unsafe {
-        current_task_terminated();
-    }
+    current_task_terminated();
     schedule();
 }
 

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -840,9 +840,7 @@ extern "C" fn run_kernel_task(entry: extern "C" fn(usize), xsa_addr: u64, start_
 }
 
 extern "C" fn task_exit() {
-    unsafe {
-        current_task_terminated();
-    }
+    current_task_terminated();
     schedule();
 }
 


### PR DESCRIPTION
In commit 051e2844 ("kernel/syscall: Implement two testing syscalls") we marked `current_task_terminated()` unsafe because it can panic, but this should not be related to memory safety.