### PR TITLE
kernel/fs: add safety comment

### DIFF
--- a/kernel/src/fs/init.rs
+++ b/kernel/src/fs/init.rs
@@ -44,6 +44,7 @@ pub fn populate_ram_fs(kernel_fs_start: u64, kernel_fs_end: u64) -> Result<(), S
     let guard = PerCPUPageMappingGuard::create(pstart.page_align(), pend.page_align_up(), 0)?;
     let vstart = guard.virt_addr() + pstart.page_offset();
 
+    // SAFETY: `vstart` is just mapped and the mapping covers the entire `size`
     let data: &[u8] = unsafe { slice::from_raw_parts(vstart.as_ptr(), size) };
     let archive = PackItArchiveDecoder::load(data)?;
 


### PR DESCRIPTION
`slice::from_raw_parts` missed the safety comment.