### PR TITLE
fuzz: add safety comments

### DIFF
--- a/fuzz/fuzz_targets/acpi.rs
+++ b/fuzz/fuzz_targets/acpi.rs
@@ -38,6 +38,8 @@ impl IOPort for FuzzIo<'_> {
 
     fn inb(&self, _port: u16) -> u8 {
         let pos = self.pos.load(Ordering::Relaxed);
+        // SAFETY: we always keep `pos` within bounds by using the
+        // modulo operation before updating it.
         let val = unsafe { *self.data.get_unchecked(pos) };
         self.pos.store((pos + 1) % self.len, Ordering::Relaxed);
         val

--- a/fuzz/fuzz_targets/fs.rs
+++ b/fuzz/fuzz_targets/fs.rs
@@ -47,6 +47,7 @@ fn get_idx<T>(v: &[T], idx: usize) -> Option<usize> {
 
 fn get_item<T>(v: &[T], idx: usize) -> Option<&T> {
     let idx = get_idx(v, idx)?;
+    // SAFETY: we modulo the index to be within bounds
     Some(unsafe { v.get_unchecked(idx) })
 }
 


### PR DESCRIPTION
Document all uses of unsafe in the fuzzing harnesses.

Closes #734 