### PR TITLE
kernel/debug: add missing safety comments

### DIFF
--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -172,13 +172,19 @@ pub fn idt_init() -> Result<(), SvsmError> {
 // Debug handler
 #[no_mangle]
 extern "C" fn ex_handler_debug(ctx: &mut X86ExceptionContext) {
-    handle_debug_exception(ctx, DB_VECTOR);
+    // SAFETY: gdbstub could compromise memory safety, but this function is
+    // a nop if `enable-gdb` feature is disabled. `enable-gdb` can't be
+    // enabled on release builds.
+    unsafe { handle_debug_exception(ctx, DB_VECTOR) };
 }
 
 // Breakpoint handler
 #[no_mangle]
 extern "C" fn ex_handler_breakpoint(ctx: &mut X86ExceptionContext) {
-    handle_debug_exception(ctx, BP_VECTOR);
+    // SAFETY: gdbstub could compromise memory safety, but this function is
+    // a nop if `enable-gdb` feature is disabled. `enable-gdb` can't be
+    // enabled on release builds.
+    unsafe { handle_debug_exception(ctx, BP_VECTOR) };
 }
 
 // Doube-Fault handler
@@ -269,7 +275,10 @@ extern "C" fn ex_handler_page_fault(ctxt: &mut X86ExceptionContext, vector: usiz
         .is_err()
         && !handle_exception_table(ctxt)
     {
-        handle_debug_exception(ctxt, vector);
+        // SAFETY: gdbstub could compromise memory safety, but this function is
+        // a nop if `enable-gdb` feature is disabled. `enable-gdb` can't be
+        // enabled on release builds.
+        unsafe { handle_debug_exception(ctxt, vector) };
         panic!(
             "Unhandled Page-Fault at RIP {:#018x} CR2: {:#018x} error code: {:#018x}",
             rip, cr2, err

--- a/kernel/src/cpu/vc.rs
+++ b/kernel/src/cpu/vc.rs
@@ -165,7 +165,10 @@ pub fn handle_vc_exception(ctx: &mut X86ExceptionContext, vector: usize) -> Resu
         // will cause either an exception via DB_VECTOR if the DEBUG_SWAP sev_feature is
         // clear, or a VC exception with an error code of X86_TRAP if set.
         (X86_TRAP, _) => {
-            handle_debug_exception(ctx, vector);
+            // SAFETY: gdbstub could compromise memory safety, but this function is
+            // a nop if `enable-gdb` feature is disabled. `enable-gdb` can't be
+            // enabled on release builds.
+            unsafe { handle_debug_exception(ctx, vector) };
             Ok(())
         }
         (SVM_EXIT_CPUID, Some(DecodedInsn::Cpuid)) => handle_cpuid(ctx),

--- a/kernel/src/debug/gdbstub.rs
+++ b/kernel/src/debug/gdbstub.rs
@@ -11,6 +11,11 @@
 //
 #[cfg(feature = "enable-gdb")]
 pub mod svsm_gdbstub {
+    // Comment the following 2 lines if you really want to enable gdbstub in
+    // release build because memory safety is not guaranteed.
+    #[cfg(not(debug_assertions))]
+    compile_error!("This module must not be built in release mode!");
+
     use crate::address::{Address, VirtAddr};
     use crate::cpu::control_regs::read_cr3;
     use crate::cpu::idt::common::{X86ExceptionContext, BP_VECTOR, DB_VECTOR, VC_VECTOR};

--- a/kernel/src/debug/gdbstub.rs
+++ b/kernel/src/debug/gdbstub.rs
@@ -4,6 +4,12 @@
 //
 // Author: Roy Hopkins <rhopkins@suse.de>
 
+// Some unsafe blocks can really compromise memory safety, so we are unable to
+// provide appropriate SAFETY comments. However, this is acceptable since
+// all public functions are a nop if `enable-gdb` feature is disabled.
+// `enable-gdb` can't be enabled on release builds.
+#![allow(clippy::undocumented_unsafe_blocks)]
+
 //
 // For release builds this module should not be compiled into the
 // binary. See the bottom of this file for placeholders that are

--- a/kernel/src/debug/gdbstub.rs
+++ b/kernel/src/debug/gdbstub.rs
@@ -53,6 +53,10 @@ pub mod svsm_gdbstub {
     ///
     /// Starting the gdbstub is not multi-thread safe, so the caller must
     /// ensure to call this function on a single processor.
+    ///
+    /// Some gdbstub operations are very dangerous and could compromise memory
+    /// safety, but these are not avoidable for now, so the caller must be sure
+    /// to use gdbstub carefully (and only in debug mode).
     // The static mutable reference to the stack is protected by the GDB_STATE lock.
     #[allow(static_mut_refs)]
     pub unsafe fn gdbstub_start(platform: &'static dyn SvsmPlatform) -> Result<(), u64> {
@@ -92,7 +96,12 @@ pub mod svsm_gdbstub {
         }
     }
 
-    pub fn handle_debug_exception(ctx: &mut X86ExceptionContext, exception: usize) {
+    /// # Safety
+    ///
+    /// Some gdbstub operations are very dangerous and could compromise memory
+    /// safety, but these are not avoidable for now, so the caller must be sure
+    /// to use gdbstub carefully (and only in debug mode).
+    pub unsafe fn handle_debug_exception(ctx: &mut X86ExceptionContext, exception: usize) {
         let exception_type = ExceptionType::from(exception);
         let id = this_cpu().runqueue().lock_read().current_task_id();
         let mut task_ctx = TaskContext {
@@ -175,7 +184,12 @@ pub mod svsm_gdbstub {
         }
     }
 
-    pub fn debug_break() {
+    /// # Safety
+    ///
+    /// Some gdbstub operations are very dangerous and could compromise memory
+    /// safety, but these are not avoidable for now, so the caller must be sure
+    /// to use gdbstub carefully (and only in debug mode).
+    pub unsafe fn debug_break() {
         if GDB_INITIALISED.load(Ordering::Acquire) {
             log::info!("***********************************");
             log::info!("* Waiting for connection from GDB *");
@@ -779,11 +793,25 @@ pub mod svsm_gdbstub {
     ///
     /// Starting the gdbstub is not multi-thread safe, so the caller must
     /// ensure to call this function on a single processor.
+    ///
+    /// Some gdbstub operations are very dangerous and could compromise memory
+    /// safety, but these are not avoidable for now, so the caller must be sure
+    /// to use gdbstub carefully (and only in debug mode).
     pub unsafe fn gdbstub_start(_platform: &'static dyn SvsmPlatform) -> Result<(), u64> {
         Ok(())
     }
 
-    pub fn handle_debug_exception(_ctx: &mut X86ExceptionContext, _exception: usize) {}
+    /// # Safety
+    ///
+    /// Some gdbstub operations are very dangerous and could compromise memory
+    /// safety, but these are not avoidable for now, so the caller must be sure
+    /// to use gdbstub carefully (and only in debug mode).
+    pub unsafe fn handle_debug_exception(_ctx: &mut X86ExceptionContext, _exception: usize) {}
 
-    pub fn debug_break() {}
+    /// # Safety
+    ///
+    /// Some gdbstub operations are very dangerous and could compromise memory
+    /// safety, but these are not avoidable for now, so the caller must be sure
+    /// to use gdbstub carefully (and only in debug mode).
+    pub unsafe fn debug_break() {}
 }

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -301,9 +301,12 @@ extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) -> ! {
 pub extern "C" fn svsm_main(cpu_index: usize) {
     debug_assert_eq!(cpu_index, 0);
 
-    // If required, the GDB stub can be started earlier, just after the console
-    // is initialised in svsm_start() above.
-    gdbstub_start(&**SVSM_PLATFORM).expect("Could not start GDB stub");
+    // SAFETY: We are calling this only on CPU 0, since it is not multi-thread safe
+    unsafe {
+        // If required, the GDB stub can be started earlier, just after the console
+        // is initialised in svsm_start() above.
+        gdbstub_start(&**SVSM_PLATFORM).expect("Could not start GDB stub");
+    }
     // Uncomment the line below if you want to wait for
     // a remote GDB connection
     //debug_break();

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -301,7 +301,10 @@ extern "C" fn svsm_start(li: &KernelLaunchInfo, vb_addr: usize) -> ! {
 pub extern "C" fn svsm_main(cpu_index: usize) {
     debug_assert_eq!(cpu_index, 0);
 
-    // SAFETY: We are calling this only on CPU 0, since it is not multi-thread safe
+    // SAFETY: We are calling this only on CPU 0, since it is not multi-thread safe.
+    // gdbstub could compromise memory safety, but this function is
+    // a nop if `enable-gdb` feature is disabled. `enable-gdb` can't be
+    // enabled on release builds.
     unsafe {
         // If required, the GDB stub can be started earlier, just after the console
         // is initialised in svsm_start() above.
@@ -396,7 +399,10 @@ fn panic(info: &PanicInfo<'_>) -> ! {
     print_stack(3);
 
     loop {
-        debug_break();
+        // SAFETY: gdbstub could compromise memory safety, but this function is
+        // a nop if `enable-gdb` feature is disabled. `enable-gdb` can't be
+        // enabled on release builds.
+        unsafe { debug_break() };
         platform::halt();
     }
 }


### PR DESCRIPTION
Add safety comments around `unsafe` blocks and mark some functions `unsafe` if the safety is demanded to the caller.
Add a FIXME in place where unsafe could be very dangerous and silence `clippy::undocumented_unsafe_blocks` lint in gdbstub.rs
Mark all 'gdbstub' public functions unsafe.
Add a compilation error if gdbstub is enabled in release (we already had a comment on discourage that)
   
