### PR TITLE
Migration

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -29,6 +29,7 @@ pub mod io;
 pub mod kernel_region;
 pub mod locking;
 pub mod mm;
+pub mod migration;
 pub mod platform;
 pub mod protocols;
 pub mod requests;

--- a/kernel/src/migration/guest_valid_bitmap.rs
+++ b/kernel/src/migration/guest_valid_bitmap.rs
@@ -1,0 +1,104 @@
+use crate::mm::PageBox;
+use crate::error::SvsmError;
+use crate::address::PhysAddr;
+use crate::utils::memory_region::MemoryRegion;
+
+use crate::locking::SpinLock;
+use crate::utils::valid_bitmap::{ValidBitmap,bitmap_elems};
+
+// FIXME: Defines number of continuous regions, that can be tracked. In future,
+// the number of regions should be decided dynamically at runtime.
+const REGIONS_COUNT: usize = 2;
+
+#[derive(Debug)]
+pub struct GuestValidBitmap {
+    bitmap: [SpinLock<Option<ValidBitmap>>;REGIONS_COUNT]
+}
+
+
+impl GuestValidBitmap {
+    pub const fn new() -> Self{
+        GuestValidBitmap {
+            bitmap: [const {SpinLock::new(None)}; REGIONS_COUNT]
+        }
+    }
+
+    pub fn add_region(&self, region: MemoryRegion<PhysAddr>) -> Result<(), SvsmError> {
+        log::info!("Region: {:x?}", region);
+        for (i, map) in self.bitmap.iter().enumerate() {
+            if map.lock().is_none() {
+                log::info!("Allocating to bitmap position {}", i);
+                let len = bitmap_elems(region);
+                let bitmap = PageBox::try_new_slice(0u64, len)?;
+                *map.lock() = Some(ValidBitmap::new(region, bitmap));
+                break
+            }
+        }
+        Ok(())
+    }
+    pub fn set_valid_4k(&self, paddr: PhysAddr) -> bool {
+        for map in self.bitmap.iter() {
+            if let Some(bm) = map.lock().as_mut() {
+                if bm.check_addr(paddr) {
+                    if !bm.is_valid_4k(paddr) {
+                        // Only validate if invalid
+                        bm.set_valid_4k(paddr);
+                        return true
+                    }
+                }
+            }
+        }
+        false
+    }
+    pub fn set_valid_2m(&self, paddr: PhysAddr) -> bool {
+        for map in self.bitmap.iter() {
+            if let Some(bm) = map.lock().as_mut() {
+                if bm.check_addr(paddr) {
+                    //if !bm.is_valid_2m(paddr) {
+                        // Only validate if invalid
+                        bm.set_valid_2m(paddr);
+                        return true
+                    //}
+                }
+            }
+        }
+        false
+    }
+
+    pub fn clear_valid_4k(&self, paddr: PhysAddr) {
+        for map in self.bitmap.iter() {
+            if let Some(bm) = map.lock().as_mut() {
+                if bm.check_addr(paddr) {
+                    if bm.is_valid_4k(paddr) {
+                        // Only invalidate if valid
+                        bm.clear_valid_4k(paddr);
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn clear_valid_2m(&self, paddr: PhysAddr) {
+        for map in self.bitmap.iter() {
+            if let Some(bm) = map.lock().as_mut() {
+                if bm.check_addr(paddr) {
+                    //if bm.is_valid_2m(paddr) {
+                        // Only invalidate if valid
+                        bm.clear_valid_2m(paddr);
+                    //}
+                }
+            }
+        }
+    }
+
+    pub fn is_valid_4k(&self, paddr: PhysAddr) -> bool {
+        for map in self.bitmap.iter() {
+            if let Some(bm) = map.lock().as_mut() {
+                if bm.check_addr(paddr) {
+                    return bm.is_valid_4k(paddr);
+                }
+            }
+        }
+        false
+    }
+}

--- a/kernel/src/migration/migration.rs
+++ b/kernel/src/migration/migration.rs
@@ -1,0 +1,174 @@
+use crate::address::PhysAddr;
+use crate::cpu::flush_tlb_global_sync;
+use crate::cpu::percpu::this_cpu;
+use crate::error::SvsmError;
+use crate::migration::guest_valid_bitmap::GuestValidBitmap;
+use crate::mm::{virt_to_phys,PageBox};
+use crate::mm::guestmem::copy_slice_from_guest;
+use crate::mm::memory::MEMORY_MAP;
+use crate::sev::{pvalidate,PvalidateOp};
+use crate::sev::msr_protocol::invalidate_page_msr;
+use crate::task::set_affinity;
+use crate::task::schedule;
+use crate::types::PageSize;
+use crate::utils::memory_region::MemoryRegion;
+
+use igvm_defs::PAGE_SIZE_4K;
+use sha2::{Sha256,Digest};
+use zerocopy::FromZeros;
+
+pub static VALIDATED_PAGES: GuestValidBitmap = GuestValidBitmap::new();
+
+// Used in communication with QEMU
+const SNP_MIGRATION_STATUS_INCOMING: u8 = 0x1;
+const SNP_MIGRATION_STATUS_RUNNING: u8 = 0x2;
+const SNP_MIGRATION_STATUS_COMPLETED: u8 = 0x3;
+
+const SNP_MIGRATION_DATA_READY: u8 = 0x4;
+const SNP_MIGRATION_DATA_READ: u8 = 0x5;
+
+const DATA_BUFFER_SIZE: usize = 0x800;
+// DATA_BUFFER_SIZE must divide the PAGE_SIZE_4K
+const _: () = assert!(PAGE_SIZE_4K as usize % DATA_BUFFER_SIZE == 0);
+
+pub fn define_region_bitmap(region: MemoryRegion<PhysAddr>) -> Result<(), SvsmError> {
+    VALIDATED_PAGES.add_region(region)?;
+    Ok(())
+}
+
+pub fn count_pvalidate(paddr: PhysAddr, page_size: PageSize, op: PvalidateOp) {
+    match op {
+        PvalidateOp::Valid => {
+            if page_size == PageSize::Huge{
+                VALIDATED_PAGES.set_valid_2m(paddr);
+            } else {
+                VALIDATED_PAGES.set_valid_4k(paddr);
+            }
+        }
+        PvalidateOp::Invalid => {
+            if page_size == PageSize::Huge{
+                VALIDATED_PAGES.clear_valid_2m(paddr);
+            } else {
+                VALIDATED_PAGES.clear_valid_4k(paddr);
+            }
+        }
+    }
+}
+
+
+fn start_migration(context : &mut MigrationPage){
+    log::info!("Migration Started");
+    let mut hash = Sha256::new();
+    let mut block_count = 0;
+    let mut read_page_count = 0;
+    let mut unread_page_count = 0;
+
+    let mut buffer = [0; DATA_BUFFER_SIZE];
+
+    for region in MEMORY_MAP.lock_read().iter() {
+        for page in region.iter_pages(PageSize::Regular) {
+            if VALIDATED_PAGES.is_valid_4k(page) {
+                for offset in (0..PAGE_SIZE_4K as usize).step_by(DATA_BUFFER_SIZE) {
+                    if block_count % 100_000 == 0 {
+                        log::info!("Blocks sent {}", block_count);
+                    }
+                    let _ = copy_slice_from_guest(page + offset, &mut buffer);
+                    hash.update(&buffer);
+                    block_count += 1;
+                    context.write_new_page(&buffer);
+                }
+                read_page_count += 1;
+            } else {
+                unread_page_count +=1;
+            }
+        }
+    }
+    context.0.status_reg = SNP_MIGRATION_STATUS_COMPLETED;
+    log::info!("Blocks send {:?}", block_count);
+    log::info!("Data hash: {:?}", hash.finalize());
+    log::info!("Total read_page_count: {}", read_page_count);
+    log::info!("Total unread_page_count: {}", unread_page_count);
+}
+
+fn start_migration_incoming(context : &mut MigrationPage){
+    log::info!("Incoming migration started");
+    let mut hash = Sha256::new();
+    let mut block_count = 0;
+
+    loop {
+        if context.0.data_reg == SNP_MIGRATION_DATA_READY {
+            hash.update(&context.0.buffer);
+            context.0.data_reg = SNP_MIGRATION_DATA_READ;
+            block_count += 1;
+            if block_count % 100_000 == 0 {
+                log::info!("Blocks received {}", block_count);
+            }
+        }
+        // FIXME: Only for debugging. It should be this thread that ends the migration not
+        // hypervisor.
+        if context.0.status_reg == SNP_MIGRATION_STATUS_COMPLETED &&
+           context.0.data_reg == SNP_MIGRATION_DATA_READ {
+            break;
+        }
+    }
+    log::info!("Received blocks: {:?}", block_count);
+    log::info!("Data hash: {:?}", hash.finalize());
+    log::info!("Incoming migration finished");
+}
+
+pub extern "C" fn migration_agent(cpu_index: usize) {
+    set_affinity(cpu_index);
+    log::info!("Started migration thread.");
+
+    let mut mig_page = MigrationPage::new().expect("Cannot create migration page");
+    let mig_page_pa = virt_to_phys(mig_page.0.vaddr());
+    log::info!("Migration page is at address: {:x?}", mig_page_pa);
+
+    let mut status;
+    loop {
+        status = mig_page.0.status_reg;
+        if status == SNP_MIGRATION_STATUS_RUNNING {
+            start_migration(&mut mig_page);
+        }
+        if status == SNP_MIGRATION_STATUS_INCOMING {
+            start_migration_incoming(&mut mig_page);
+        }
+        schedule();
+    }
+}
+#[repr(C)]
+#[derive(Debug, FromZeros)]
+pub struct MigrationContext {
+    status_reg: u8,
+    data_reg: u8,
+    reserved: [u8; 0x800 - 2],
+    buffer: [u8; DATA_BUFFER_SIZE],
+}
+
+#[derive(Debug)]
+pub struct MigrationPage(PageBox<MigrationContext>);
+
+impl MigrationPage {
+    pub fn new() -> Result<Self, SvsmError> {
+        let page = PageBox::<MigrationContext>::try_new_zeroed()?;
+        let vaddr = page.vaddr();
+        let paddr = virt_to_phys(vaddr);
+
+        pvalidate(vaddr, PageSize::Regular, PvalidateOp::Invalid)?;
+
+        unsafe {
+            invalidate_page_msr(paddr)?;
+        }
+        this_cpu().get_pgtable().set_shared_4k(vaddr)?;
+        flush_tlb_global_sync();
+
+        Ok(Self(page))
+    }
+
+    fn write_new_page(&mut self, buffer: &[u8; DATA_BUFFER_SIZE]) {
+        // Wait for the until the previous block is process by hypervisor
+        while self.0.data_reg != SNP_MIGRATION_DATA_READ {}
+        self.0.buffer = *buffer;
+        self.0.data_reg = SNP_MIGRATION_DATA_READY;
+    }
+}

--- a/kernel/src/migration/mod.rs
+++ b/kernel/src/migration/mod.rs
@@ -1,0 +1,2 @@
+pub mod migration;
+pub mod guest_valid_bitmap;

--- a/kernel/src/mm/alloc.rs
+++ b/kernel/src/mm/alloc.rs
@@ -44,8 +44,8 @@ impl From<AllocError> for SvsmError {
     }
 }
 
-/// Maximum order of page allocations (up to 128kb)
-pub const MAX_ORDER: usize = 6;
+/// Maximum order of page allocations (up to 512kb)
+pub const MAX_ORDER: usize = 8;
 
 /// Calculates the order of a given size for page allocation.
 ///

--- a/kernel/src/mm/validate.rs
+++ b/kernel/src/mm/validate.rs
@@ -4,27 +4,16 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
-use crate::address::{Address, PhysAddr};
+use crate::address::PhysAddr;
 use crate::error::SvsmError;
 use crate::locking::SpinLock;
-use crate::mm::{virt_to_phys, PageBox};
-use crate::types::{PAGE_SIZE, PAGE_SIZE_2M};
+use crate::mm::PageBox;
 use crate::utils::MemoryRegion;
-use core::mem::MaybeUninit;
-use core::num::NonZeroUsize;
+use crate::utils::valid_bitmap::{ValidBitmap,bitmap_elems};
 use core::ptr::NonNull;
 
-static VALID_BITMAP: SpinLock<Option<ValidBitmap>> = SpinLock::new(None);
 
-fn bitmap_elems(region: MemoryRegion<PhysAddr>) -> NonZeroUsize {
-    NonZeroUsize::new(
-        region
-            .len()
-            .div_ceil(PAGE_SIZE)
-            .div_ceil(u64::BITS as usize),
-    )
-    .unwrap()
-}
+static VALID_BITMAP: SpinLock<Option<ValidBitmap>> = SpinLock::new(None);
 
 /// # Safety
 ///
@@ -45,8 +34,7 @@ pub fn init_valid_bitmap_alloc(region: MemoryRegion<PhysAddr>) -> Result<(), Svs
 }
 
 pub fn migrate_valid_bitmap() -> Result<(), SvsmError> {
-    let region = VALID_BITMAP.lock().as_ref().unwrap().region;
-    let len = bitmap_elems(region);
+    let len = VALID_BITMAP.lock().as_ref().unwrap().region_len();
     let bitmap = PageBox::try_new_uninit_slice(len)?;
 
     // lock again here because allocator path also takes VALID_BITMAP.lock()
@@ -108,127 +96,4 @@ pub fn valid_bitmap_valid_addr(paddr: PhysAddr) -> bool {
         .as_ref()
         .map(|vb| vb.check_addr(paddr))
         .unwrap_or(false)
-}
-
-#[derive(Debug)]
-struct ValidBitmap {
-    region: MemoryRegion<PhysAddr>,
-    bitmap: PageBox<[u64]>,
-}
-
-impl ValidBitmap {
-    const fn new(region: MemoryRegion<PhysAddr>, bitmap: PageBox<[u64]>) -> Self {
-        Self { region, bitmap }
-    }
-
-    fn check_addr(&self, paddr: PhysAddr) -> bool {
-        self.region.contains(paddr)
-    }
-
-    fn bitmap_addr(&self) -> PhysAddr {
-        virt_to_phys(self.bitmap.vaddr())
-    }
-
-    #[inline(always)]
-    fn index(&self, paddr: PhysAddr) -> (usize, usize) {
-        let page_offset = (paddr - self.region.start()) / PAGE_SIZE;
-        let index = page_offset / 64;
-        let bit = page_offset % 64;
-
-        (index, bit)
-    }
-
-    fn migrate(&mut self, mut new: PageBox<[MaybeUninit<u64>]>) {
-        for (dst, src) in new
-            .iter_mut()
-            .zip(self.bitmap.iter().copied().chain(core::iter::repeat(0)))
-        {
-            dst.write(src);
-        }
-        // SAFETY: we initialized the contents of the whole slice
-        self.bitmap = unsafe { new.assume_init_slice() };
-    }
-
-    fn set_valid_4k(&mut self, paddr: PhysAddr) {
-        let (index, bit) = self.index(paddr);
-
-        assert!(paddr.is_page_aligned());
-        assert!(self.check_addr(paddr));
-
-        self.bitmap[index] |= 1u64 << bit;
-    }
-
-    fn clear_valid_4k(&mut self, paddr: PhysAddr) {
-        let (index, bit) = self.index(paddr);
-
-        assert!(paddr.is_page_aligned());
-        assert!(self.check_addr(paddr));
-
-        self.bitmap[index] &= !(1u64 << bit);
-    }
-
-    fn set_2m(&mut self, paddr: PhysAddr, val: u64) {
-        const NR_INDEX: usize = PAGE_SIZE_2M / (PAGE_SIZE * 64);
-        let (index, _) = self.index(paddr);
-
-        assert!(paddr.is_aligned(PAGE_SIZE_2M));
-        assert!(self.check_addr(paddr));
-
-        self.bitmap[index..index + NR_INDEX].fill(val);
-    }
-
-    fn set_valid_2m(&mut self, paddr: PhysAddr) {
-        self.set_2m(paddr, !0u64);
-    }
-
-    fn clear_valid_2m(&mut self, paddr: PhysAddr) {
-        self.set_2m(paddr, 0u64);
-    }
-
-    fn modify_bitmap_word(&mut self, index: usize, mask: u64, new_val: u64) {
-        let val = &mut self.bitmap[index];
-        *val = (*val & !mask) | (new_val & mask);
-    }
-
-    fn set_range(&mut self, paddr_begin: PhysAddr, paddr_end: PhysAddr, new_val: bool) {
-        // All ones.
-        let mask = !0u64;
-        // All ones if val == true, zero otherwise.
-        let new_val = 0u64.wrapping_sub(new_val as u64);
-
-        let (index_head, bit_head_begin) = self.index(paddr_begin);
-        let (index_tail, bit_tail_end) = self.index(paddr_end);
-        if index_head != index_tail {
-            let mask_head = mask >> bit_head_begin << bit_head_begin;
-            self.modify_bitmap_word(index_head, mask_head, new_val);
-
-            self.bitmap[index_head + 1..index_tail].fill(new_val);
-
-            if bit_tail_end != 0 {
-                let mask_tail = mask << (64 - bit_tail_end) >> (64 - bit_tail_end);
-                self.modify_bitmap_word(index_tail, mask_tail, new_val);
-            }
-        } else {
-            let mask = mask >> bit_head_begin << bit_head_begin;
-            let mask = mask << (64 - bit_tail_end) >> (64 - bit_tail_end);
-            self.modify_bitmap_word(index_head, mask, new_val);
-        }
-    }
-
-    fn set_valid_range(&mut self, paddr_begin: PhysAddr, paddr_end: PhysAddr) {
-        self.set_range(paddr_begin, paddr_end, true);
-    }
-
-    fn clear_valid_range(&mut self, paddr_begin: PhysAddr, paddr_end: PhysAddr) {
-        self.set_range(paddr_begin, paddr_end, false);
-    }
-
-    fn is_valid_4k(&self, paddr: PhysAddr) -> bool {
-        let (index, bit) = self.index(paddr);
-
-        assert!(self.check_addr(paddr));
-
-        let mask: u64 = 1u64 << bit;
-        self.bitmap[index] & mask == mask
-    }
 }

--- a/kernel/src/requests.rs
+++ b/kernel/src/requests.rs
@@ -8,6 +8,7 @@ extern crate alloc;
 
 use crate::cpu::ipi::wait_for_ipi_block;
 use crate::cpu::percpu::{this_cpu, PERCPU_AREAS};
+use crate::migration::migration::migration_agent;
 use crate::protocols::apic::apic_protocol_request;
 use crate::protocols::core::core_protocol_request;
 use crate::protocols::errors::{SvsmReqError, SvsmResultCode};
@@ -101,7 +102,12 @@ pub extern "C" fn request_loop_main(cpu_index: usize) {
         for task_index in 1..cpu_count {
             let loop_name = format!("request-loop on CPU {}", task_index);
             start_kernel_task(request_loop_main, task_index, loop_name)
-                .expect("Failed to launch request loop task");
+                    .expect("Failed to launch request loop task");
+            if task_index == 3 {
+                let loop_name = format!("Migration agent on CPU {}", task_index);
+                start_kernel_task(migration_agent, task_index, loop_name)
+                    .expect("Failed to launch migration agent");
+            }
         }
     }
 

--- a/kernel/src/sev/utils.rs
+++ b/kernel/src/sev/utils.rs
@@ -6,11 +6,14 @@
 
 use crate::address::{Address, VirtAddr};
 use crate::error::SvsmError;
+use crate::migration::migration::count_pvalidate;
 use crate::mm::virt_to_frame;
+use crate::mm::address_space::virt_to_phys;
 use crate::types::{PageSize, GUEST_VMPL, PAGE_SIZE, PAGE_SIZE_2M};
 use crate::utils::MemoryRegion;
 use core::arch::asm;
 use core::fmt;
+
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[expect(non_camel_case_types)]
@@ -109,6 +112,9 @@ pub fn pvalidate(vaddr: VirtAddr, size: PageSize, valid: PvalidateOp) -> Result<
     let rdx = valid as u64;
     let ret: u64;
     let cf: u64;
+
+    let paddr = virt_to_phys(vaddr);
+    count_pvalidate(paddr, size, valid);
 
     unsafe {
         asm!("xorq %r8, %r8",

--- a/kernel/src/utils/mod.rs
+++ b/kernel/src/utils/mod.rs
@@ -10,6 +10,7 @@ pub mod immut_after_init;
 pub mod memory_region;
 pub mod scoped;
 pub mod util;
+pub mod valid_bitmap;
 
 pub use memory_region::MemoryRegion;
 pub use scoped::{ScopedMut, ScopedRef};

--- a/kernel/src/utils/valid_bitmap.rs
+++ b/kernel/src/utils/valid_bitmap.rs
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2022-2023 SUSE LLC
+//
+// Author: Joerg Roedel <jroedel@suse.de>
+
+use crate::address::{Address, PhysAddr};
+use crate::mm::{virt_to_phys, PageBox};
+use crate::types::{PAGE_SIZE, PAGE_SIZE_2M};
+use crate::utils::MemoryRegion;
+use core::mem::MaybeUninit;
+use core::num::NonZeroUsize;
+
+pub fn bitmap_elems(region: MemoryRegion<PhysAddr>) -> NonZeroUsize {
+    NonZeroUsize::new(
+        region
+            .len()
+            .div_ceil(PAGE_SIZE)
+            .div_ceil(u64::BITS as usize),
+    )
+    .unwrap()
+}
+
+#[derive(Debug)]
+pub struct ValidBitmap {
+    region: MemoryRegion<PhysAddr>,
+    bitmap: PageBox<[u64]>,
+}
+
+impl ValidBitmap {
+    pub const fn new(region: MemoryRegion<PhysAddr>, bitmap: PageBox<[u64]>) -> Self {
+        Self { region, bitmap }
+    }
+    
+    pub fn region_len(&self) -> NonZeroUsize {
+        return bitmap_elems(self.region);
+    }
+
+    pub fn check_addr(&self, paddr: PhysAddr) -> bool {
+        self.region.contains(paddr)
+    }
+
+    pub fn bitmap_addr(&self) -> PhysAddr {
+        virt_to_phys(self.bitmap.vaddr())
+    }
+
+    #[inline(always)]
+    fn index(&self, paddr: PhysAddr) -> (usize, usize) {
+        let page_offset = (paddr - self.region.start()) / PAGE_SIZE;
+        let index = page_offset / 64;
+        let bit = page_offset % 64;
+
+        (index, bit)
+    }
+
+    pub fn migrate(&mut self, mut new: PageBox<[MaybeUninit<u64>]>) {
+        for (dst, src) in new
+            .iter_mut()
+            .zip(self.bitmap.iter().copied().chain(core::iter::repeat(0)))
+        {
+            dst.write(src);
+        }
+        // SAFETY: we initialized the contents of the whole slice
+        self.bitmap = unsafe { new.assume_init_slice() };
+    }
+
+    pub fn set_valid_4k(&mut self, paddr: PhysAddr) {
+        let (index, bit) = self.index(paddr);
+
+        assert!(paddr.is_page_aligned());
+        assert!(self.check_addr(paddr));
+
+        self.bitmap[index] |= 1u64 << bit;
+    }
+
+    pub fn clear_valid_4k(&mut self, paddr: PhysAddr) {
+        let (index, bit) = self.index(paddr);
+
+        assert!(paddr.is_page_aligned());
+        assert!(self.check_addr(paddr));
+
+        self.bitmap[index] &= !(1u64 << bit);
+    }
+
+    fn set_2m(&mut self, paddr: PhysAddr, val: u64) {
+        const NR_INDEX: usize = PAGE_SIZE_2M / (PAGE_SIZE * 64);
+        let (index, _) = self.index(paddr);
+
+        assert!(paddr.is_aligned(PAGE_SIZE_2M));
+        assert!(self.check_addr(paddr));
+
+        self.bitmap[index..index + NR_INDEX].fill(val);
+    }
+
+    pub fn set_valid_2m(&mut self, paddr: PhysAddr) {
+        self.set_2m(paddr, !0u64);
+    }
+
+    pub fn clear_valid_2m(&mut self, paddr: PhysAddr) {
+        self.set_2m(paddr, 0u64);
+    }
+
+    fn modify_bitmap_word(&mut self, index: usize, mask: u64, new_val: u64) {
+        let val = &mut self.bitmap[index];
+        *val = (*val & !mask) | (new_val & mask);
+    }
+
+    fn set_range(&mut self, paddr_begin: PhysAddr, paddr_end: PhysAddr, new_val: bool) {
+        // All ones.
+        let mask = !0u64;
+        // All ones if val == true, zero otherwise.
+        let new_val = 0u64.wrapping_sub(new_val as u64);
+
+        let (index_head, bit_head_begin) = self.index(paddr_begin);
+        let (index_tail, bit_tail_end) = self.index(paddr_end);
+        if index_head != index_tail {
+            let mask_head = mask >> bit_head_begin << bit_head_begin;
+            self.modify_bitmap_word(index_head, mask_head, new_val);
+
+            self.bitmap[index_head + 1..index_tail].fill(new_val);
+
+            if bit_tail_end != 0 {
+                let mask_tail = mask << (64 - bit_tail_end) >> (64 - bit_tail_end);
+                self.modify_bitmap_word(index_tail, mask_tail, new_val);
+            }
+        } else {
+            let mask = mask >> bit_head_begin << bit_head_begin;
+            let mask = mask << (64 - bit_tail_end) >> (64 - bit_tail_end);
+            self.modify_bitmap_word(index_head, mask, new_val);
+        }
+    }
+
+    pub fn set_valid_range(&mut self, paddr_begin: PhysAddr, paddr_end: PhysAddr) {
+        self.set_range(paddr_begin, paddr_end, true);
+    }
+
+    pub fn clear_valid_range(&mut self, paddr_begin: PhysAddr, paddr_end: PhysAddr) {
+        self.set_range(paddr_begin, paddr_end, false);
+    }
+
+    pub fn is_valid_4k(&self, paddr: PhysAddr) -> bool {
+        let (index, bit) = self.index(paddr);
+
+        assert!(self.check_addr(paddr));
+
+        let mask: u64 = 1u64 << bit;
+        self.bitmap[index] & mask == mask
+    }
+}


### PR DESCRIPTION
All validated guest pages can be transferred from the source SVSM to the target SVSM. Currently, no packaging (no confidentiality) is performed, but a hash of all transferred/received blocks is computed that can be compared to verify that the channel is working correctly. Also, the main migration function of the source and destination SVSM is busy waiting for a signal from QEMU to start outbound or incoming migration.

A single shared page called MigrationPage is used for data transfer and communication with QEMU. The migration page contains two registers and a buffer: a status register, a data register, and a data buffer. The status register is used to signal a change in status (e.g., migration starts, migration is complete). The data register is used to signal that a new page has been prepared in the data buffer by the provider or processed by the consumer. The roles of provider and consumer are switched between SVSM and QEMU on the source and destination machines.

The QEMU implementation of this communication is implemented in a patch[1]. A hack in edkII [2] is required to successfully start the guest. Further patches are required on my machine. Since they are also needed in case migration changes are not implemented, I have them in a separate development branch [3]. I provide it so that one can check it in case the machine does not start or crashes.

[1] https://github.com/coconut-svsm/qemu/pull/23
[2] https://github.com/ruzickajakub/edk2/commit/7209a4ac8a4bc4ee34a2a91e28763ad419298f3f
[3] https://github.com/ruzickajakub/coconut-svsm/tree/migration-dev