### PR TITLE
Document unsafe blocks in memory management code

### DIFF
--- a/kernel/src/debug/gdbstub.rs
+++ b/kernel/src/debug/gdbstub.rs
@@ -531,7 +531,8 @@ pub mod svsm_gdbstub {
             let _task_context = GdbTaskContext::switch_to_task(tid.get() as u32);
             let start_addr = VirtAddr::from(start_addr);
             for (off, dst) in data.iter_mut().enumerate() {
-                let Ok(val) = read_u8(start_addr + off) else {
+                // SAFETY: Unsafe but ok since this is a debug access
+                let Ok(val) = (unsafe { read_u8(start_addr + off) }) else {
                     return Err(TargetError::NonFatal);
                 };
                 *dst = val;
@@ -691,7 +692,8 @@ pub mod svsm_gdbstub {
             // The breakpoint works by taking the opcode at the bp address, storing
             // it and replacing it with an INT3 instruction
             let vaddr = VirtAddr::from(addr);
-            let Ok(inst) = read_u8(vaddr) else {
+            // SAFETY: Unsafe but ok since this is a debug access
+            let Ok(inst) = (unsafe { read_u8(vaddr) }) else {
                 return Ok(false);
             };
             let Ok(_) = GdbStubTarget::write_bp_address(vaddr, INT3_INSTR) else {

--- a/kernel/src/mm/validate.rs
+++ b/kernel/src/mm/validate.rs
@@ -32,6 +32,9 @@ fn bitmap_elems(region: MemoryRegion<PhysAddr>) -> NonZeroUsize {
 pub unsafe fn init_valid_bitmap_ptr(region: MemoryRegion<PhysAddr>, raw: NonNull<u64>) {
     let len = bitmap_elems(region);
     let ptr = NonNull::slice_from_raw_parts(raw, len.get());
+    // SAFETY: Valid bitmap pointers are allocated via
+    // init_valid_bitmap_alloc(), which uses a PageBox for allocation. So
+    // converting the pointer back to PageBox is safe.
     let bitmap = unsafe { PageBox::from_raw(ptr) };
     *VALID_BITMAP.lock() = Some(ValidBitmap::new(region, bitmap));
 }


### PR DESCRIPTION
This PR documents all not-yet documented unsafe blocks in the memory management code.