### PR TITLE
cpu/ipi: improve safety

### DIFF
--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -6,6 +6,7 @@
 
 use super::super::control_regs::read_cr2;
 use super::super::extable::{handle_exception_table, handle_exception_table_early};
+use super::super::ipi::handle_ipi_interrupt;
 use super::super::percpu::{current_task, this_cpu};
 use super::super::tss::IST_DF;
 use super::super::vc::handle_vc_exception;
@@ -454,7 +455,7 @@ pub fn common_isr_handler(vector: usize) {
 
     // Process the requested interrupt vector.
     match vector {
-        IPI_VECTOR => this_cpu().handle_ipi_interrupt(),
+        IPI_VECTOR => handle_ipi_interrupt(),
         _ => {
             // Ignore all unrecognized interrupt vectors and treat them as
             // spurious interrupts.


### PR DESCRIPTION
This change improves safety of the IPI mechanism by encapsulating all of the IPI functionality in the IPI module without any reliance on functions in `PerCpu` or `PerCpuShared` other than a single unsafe function that cannot be abused elsewhere.

Now that all of the IPI logic is together, and synchronization guarantees can be ensured, the IPI state associated with a CPU can be marked `Sync`, since the rules can be upheld in one place.