### PR TITLE
libtcgtpm/libcrt: Halt execution if stub is called

### DIFF
--- a/libtcgtpm/deps/libcrt/src/stub.c
+++ b/libtcgtpm/deps/libcrt/src/stub.c
@@ -2,7 +2,12 @@
 
 #include <libcrt.h>
 
-#define NOT_IMPLEMENTED printf("WARNING: %s not implemented\n", __func__)
+#define NOT_IMPLEMENTED                                                        \
+  do {                                                                         \
+    printf("ERROR: libcrt: %s not implemented\n", __func__);                   \
+    abort();                                                                   \
+  } while (0)
+
 
 // errno.h
 


### PR DESCRIPTION
If a subbed function in the C library is called, stop the execution
using abort().
Also elevate the warning message to an error.

These stubs should never be called. Simply printing a warning is not
enough, since it can easily be missed.

I use the `about()` function that we already present in the libcrt,
which calls `sev::msr_protocol::request_termination_msr()` in the Rust part.
