### PR TITLE
testing: initialize HAS_TEST_IOREQUESTS variable

### DIFF
--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -356,6 +356,9 @@ pub extern "C" fn svsm_main(cpu_index: usize) {
         if config.has_qemu_testdev() {
             crate::testutils::set_has_qemu_testdev();
         }
+        if config.has_test_iorequests() {
+            crate::testutils::set_has_test_iorequests();
+        }
         crate::test_main();
     }
 


### PR DESCRIPTION
Commit 56c43b2 introduced the variable `HAS_TEST_IOREQUESTS`, but it was never set. This caused all the tests calling `has_test_iorequests()` to never run.

Initialize it according to the IGVM parameter.

Fixes: 56c43b2 ("testing: Split qemu_test_env into 2 booleans")