### PR TITLE
hyperv: fix hypercall pages addresses

### DIFF
--- a/kernel/src/mm/address_space.rs
+++ b/kernel/src/mm/address_space.rs
@@ -73,6 +73,16 @@ pub fn virt_to_phys(vaddr: VirtAddr) -> PhysAddr {
     }
 }
 
+#[cfg(target_os = "none")]
+pub fn virt_to_page_frame(vaddr: VirtAddr) -> PhysAddr {
+    match PageTable::virt_to_frame(vaddr) {
+        Some(paddr) => paddr.page_frame(),
+        None => {
+            panic!("Invalid virtual address {:#018x}", vaddr);
+        }
+    }
+}
+
 pub fn virt_to_frame(vaddr: VirtAddr) -> PageFrame {
     match PageTable::virt_to_frame(vaddr) {
         Some(paddr) => paddr,
@@ -97,9 +107,14 @@ pub fn phys_to_virt(paddr: PhysAddr) -> VirtAddr {
 }
 
 #[cfg(not(target_os = "none"))]
-pub fn virt_to_phys(vaddr: VirtAddr) -> PhysAddr {
+pub fn virt_to_page_frame(vaddr: VirtAddr) -> PhysAddr {
     use crate::address::Address;
     PhysAddr::from(vaddr.bits())
+}
+
+#[cfg(not(target_os = "none"))]
+pub fn virt_to_phys(vaddr: VirtAddr) -> PhysAddr {
+    virt_to_page_frame(vaddr)
 }
 
 #[cfg(not(target_os = "none"))]

--- a/kernel/src/mm/pagetable.rs
+++ b/kernel/src/mm/pagetable.rs
@@ -120,7 +120,11 @@ fn make_private_address(paddr: PhysAddr) -> PhysAddr {
 }
 
 fn strip_confidentiality_bits(paddr: PhysAddr) -> PhysAddr {
-    PhysAddr::from(paddr.bits() & !(shared_pte_mask() | private_pte_mask()))
+    PhysAddr::from(paddr.bits() & !private_pte_mask())
+}
+
+fn strip_shared_address_bits(paddr: PhysAddr) -> PhysAddr {
+    PhysAddr::from(paddr.bits() & !shared_pte_mask())
 }
 
 bitflags! {
@@ -350,10 +354,15 @@ impl PTEntry {
         self.0 = PhysAddr::from(addr | supported_flags(flags).bits());
     }
 
-    /// Get the address from the page table entry, excluding the C bit.
-    pub fn address(&self) -> PhysAddr {
+    /// Get the address from the page table entry, including the shared bit.
+    pub fn page_frame(&self) -> PhysAddr {
         let addr = PhysAddr::from(self.0.bits() & 0x000f_ffff_ffff_f000);
         strip_confidentiality_bits(addr)
+    }
+
+    /// Get the address from the page table entry, excluding the C/shared bit.
+    pub fn address(&self) -> PhysAddr {
+        strip_shared_address_bits(self.page_frame())
     }
 
     /// Read a page table entry from the specified virtual address.
@@ -460,12 +469,17 @@ pub enum PageFrame {
 }
 
 impl PageFrame {
-    pub fn address(&self) -> PhysAddr {
-        match *self {
+    pub fn page_frame(&self) -> PhysAddr {
+        let paddr = match *self {
             Self::Size4K(pa) => pa,
             Self::Size2M(pa) => pa,
             Self::Size1G(pa) => pa,
-        }
+        };
+        strip_confidentiality_bits(paddr)
+    }
+
+    pub fn address(&self) -> PhysAddr {
+        strip_shared_address_bits(self.page_frame())
     }
 
     pub fn size(&self) -> usize {
@@ -687,7 +701,7 @@ impl PageTable {
             return None;
         }
         if pdpe.huge() {
-            let pa = pdpe.address() + (usize::from(vaddr) & 0x3FFF_FFFF);
+            let pa = pdpe.page_frame() + (usize::from(vaddr) & 0x3FFF_FFFF);
             return Some(PageFrame::Size1G(pa));
         }
 
@@ -698,7 +712,7 @@ impl PageTable {
             return None;
         }
         if pde.huge() {
-            let pa = pde.address() + (usize::from(vaddr) & 0x001F_FFFF);
+            let pa = pde.page_frame() + (usize::from(vaddr) & 0x001F_FFFF);
             return Some(PageFrame::Size2M(pa));
         }
 
@@ -706,7 +720,7 @@ impl PageTable {
         // page. So the PTE exists and can be read safely.
         let pte = unsafe { PTEntry::read_pte(pte_addr) };
         if pte.present() {
-            let pa = pte.address() + (usize::from(vaddr) & 0xFFF);
+            let pa = pte.page_frame() + (usize::from(vaddr) & 0xFFF);
             Some(PageFrame::Size4K(pa))
         } else {
             None


### PR DESCRIPTION
Hyper-V expects hypercall page addresses to be passed with the correct shared GPA bits.  However, the virtual-to-physical translation layer always strips both confidentiality and shared bits during address translation.  A new translation method must be defined to preserve those bits.