### PR TITLE
Documentation and RamFS Fixes

### DIFF
--- a/Documentation/mkdocs.yml
+++ b/Documentation/mkdocs.yml
@@ -15,4 +15,5 @@ nav:
     - Rustdoc Guidelines: 'developer/RUSTDOC-GUIDELINES.md'
     - Fuzzing: 'developer/FUZZING.md'
     - Contributing to COCONUT-SVSM: 'developer/CONTRIBUTING.md'
+    - Formal Verification: 'developer/VERIFICATION.md'
   - 'COCONUT-SVSM Rustdoc': 'rustdoc/svsm'

--- a/kernel/src/fs/ramfs.rs
+++ b/kernel/src/fs/ramfs.rs
@@ -95,12 +95,17 @@ impl RawRamFile {
         let page_offset = page_offset(file_offset);
         let page_index = file_offset / PAGE_SIZE;
 
+        // Make sure the page exists before trying to read from it.
+        let Some(page) = self.pages.get(page_index) else {
+            return Ok(0);
+        };
+
         // Minimum of space bytes-to-read on the page and remaining space in buffer
         let buffer_min = min(buffer.size() - buffer_offset, PAGE_SIZE - page_offset);
         // Make sure to not read beyond EOF
         let size = min(self.size.checked_sub(file_offset).unwrap(), buffer_min);
 
-        self.pages[page_index].copy_to_buffer(buffer, buffer_offset, page_offset, size)
+        page.copy_to_buffer(buffer, buffer_offset, page_offset, size)
     }
 
     /// Write data from [`Buffer`] object to a file page.


### PR DESCRIPTION
This PR fixes two problems:

1. The documentation on how to run the Verus verifier is not linked in the documentation.
2. An out-of-bounds `Vec` access in RamFS code.