### PR TITLE
Fix `test_make_ro_after_init()`

### DIFF
--- a/kernel/src/mm/ro_after_init.rs
+++ b/kernel/src/mm/ro_after_init.rs
@@ -72,13 +72,13 @@ mod tests {
 
         // SAFETY: writing to ro_after_init_start is supposed to fail preventing memory safety break.
         let res_w1 = unsafe {
-            GuestPtr::<u8>::new(VirtAddr::from(&raw const ro_after_init_start)).write(0x41)
+            GuestPtr::<u8>::new(VirtAddr::from(&raw const ro_after_init_start)).write(0x41u8)
         };
         assert!(res_w1.is_err());
 
         // SAFETY: writing to ro_after_init_end is supposed to fail preventing memory safety break.
         let res_w2 = unsafe {
-            GuestPtr::<u8>::new(VirtAddr::from(&raw const ro_after_init_end)).write(0x41)
+            GuestPtr::<u8>::new(VirtAddr::from(&raw const ro_after_init_end)).write(0x41u8)
         };
         assert!(res_w2.is_err());
     }

--- a/kernel/src/mm/ro_after_init.rs
+++ b/kernel/src/mm/ro_after_init.rs
@@ -76,9 +76,10 @@ mod tests {
         };
         assert!(res_w1.is_err());
 
-        // SAFETY: writing to ro_after_init_end is supposed to fail preventing memory safety break.
+        // SAFETY: writing up to ro_after_init_end is supposed to fail preventing memory safety break.
         let res_w2 = unsafe {
-            GuestPtr::<u8>::new(VirtAddr::from(&raw const ro_after_init_end)).write(0x41u8)
+            GuestPtr::<u8>::new(VirtAddr::from(&raw const ro_after_init_end).const_sub(1))
+                .write(0x41u8)
         };
         assert!(res_w2.is_err());
     }


### PR DESCRIPTION
The test fails because it expects a write right after the read-only section to fail. Fix the test so that it only expects failures when writing to the actual read-only section.