### PR TITLE
Documentation: use `alloc` fuzzer in the example

### DIFF
--- a/Documentation/docs/developer/FUZZING.md
+++ b/Documentation/docs/developer/FUZZING.md
@@ -42,11 +42,11 @@ RUSTFLAGS="-Clinker=clang -Clink-arg=-fuse-ld=lld" cargo +nightly fuzz build --s
 
 As mentioned before, you may run a specific harness, building it if
 needed, by using the `run` subcommand and specifying its name. The
-following will run the `fw_meta` fuzzer:
+following will run the `alloc` fuzzer:
 
 
 ```bash
-RUSTFLAGS="-Clinker=clang -Clink-arg=-fuse-ld=lld" cargo +nightly fuzz run fw_meta --strip-dead-code
+RUSTFLAGS="-Clinker=clang -Clink-arg=-fuse-ld=lld" cargo +nightly fuzz run alloc --strip-dead-code
 ```
 
 The generated test cases, as well as any found crashes, will be placed


### PR DESCRIPTION
`fw_meta` fuzzer was removed by commit 4ae85dfa ("firmware: remove dead code") since we don't use it anymore.

Replace `fw_meta` with `alloc` fuzzer in the example of our fuzzing documentation.