### PR TITLE
kernel/platform: Add mmio support for native platform

### DIFF
--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -217,19 +217,19 @@ pub trait SvsmPlatform: Sync {
     ///
     /// # Safety
     ///
-    /// Caller must ensure that `pa` points to a properly aligned memory location and the
+    /// Caller must ensure that `vaddr` points to a properly aligned memory location and the
     /// memory accessed is part of a valid MMIO range.
-    unsafe fn mmio_write(&self, _paddr: PhysAddr, _data: &[u8]) -> Result<(), SvsmError>;
+    unsafe fn mmio_write(&self, vaddr: VirtAddr, data: &[u8]) -> Result<(), SvsmError>;
 
     /// Perfrom a read from a memory-mapped IO area
     ///
     /// # Safety
     ///
-    /// Caller must ensure that `paddr` points to a properly aligned memory location and the
+    /// Caller must ensure that `vaddr` points to a properly aligned memory location and the
     /// memory accessed is part of a valid MMIO range.
     unsafe fn mmio_read(
         &self,
-        paddr: PhysAddr,
+        vaddr: VirtAddr,
         data: &mut [MaybeUninit<u8>],
     ) -> Result<(), SvsmError>;
 }

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -233,13 +233,13 @@ impl SvsmPlatform for NativePlatform {
         Ok(())
     }
 
-    unsafe fn mmio_write(&self, _paddr: PhysAddr, _data: &[u8]) -> Result<(), SvsmError> {
+    unsafe fn mmio_write(&self, _vaddr: VirtAddr, _data: &[u8]) -> Result<(), SvsmError> {
         unimplemented!()
     }
 
     unsafe fn mmio_read(
         &self,
-        _paddr: PhysAddr,
+        _vaddr: VirtAddr,
         _data: &mut [MaybeUninit<u8>],
     ) -> Result<(), SvsmError> {
         unimplemented!()

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -233,15 +233,123 @@ impl SvsmPlatform for NativePlatform {
         Ok(())
     }
 
-    unsafe fn mmio_write(&self, _vaddr: VirtAddr, _data: &[u8]) -> Result<(), SvsmError> {
-        unimplemented!()
+    /// Perform a write to a memory-mapped IO area
+    ///
+    /// This function expects data to be 1, 2, 4 or 8 bytes long.
+    ///
+    /// It is not possible to loop and write one byte at a time because mmio devices (e.g., those emulated by QEMU)
+    /// expect certain registers to be written with a single operation. Using a generic on SvsmPlatform is
+    /// not possible because it uses the dyn trait.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure that `vaddr` points to a properly aligned memory location and the
+    /// memory accessed is part of a valid MMIO range.
+    unsafe fn mmio_write(&self, vaddr: VirtAddr, data: &[u8]) -> Result<(), SvsmError> {
+        match data.len() {
+            1 => {
+                // SAFETY: We are trusting the caller to ensure validity of `vaddr`.
+                unsafe {
+                    mmio_write_type::<u8>(vaddr, data);
+                }
+            }
+            2 => {
+                // SAFETY: We are trusting the caller to ensure validity of `vaddr`.
+                unsafe {
+                    mmio_write_type::<u16>(vaddr, data);
+                }
+            }
+            4 => {
+                // SAFETY: We are trusting the caller to ensure validity of `vaddr`.
+                unsafe {
+                    mmio_write_type::<u32>(vaddr, data);
+                }
+            }
+            8 => {
+                // SAFETY: We are trusting the caller to ensure validity of `vaddr`.
+                unsafe {
+                    mmio_write_type::<u64>(vaddr, data);
+                }
+            }
+            _ => return Err(SvsmError::InvalidBytes),
+        };
+
+        Ok(())
     }
 
+    /// Perform a read from a memory-mapped IO area
+    ///
+    /// This function expects reads to be 1, 2, 4 or 8 bytes long.
+    ///
+    /// It is not possible to loop and read one byte at a time because mmio devices (e.g., those emulated by QEMU)
+    /// expect certain registers to be read with a single operation. Using a generic on SvsmPlatform is
+    /// not possible because it uses the dyn trait.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure that `vaddr` points to a properly aligned memory location and the
+    /// memory accessed is part of a valid MMIO range.
     unsafe fn mmio_read(
         &self,
-        _vaddr: VirtAddr,
-        _data: &mut [MaybeUninit<u8>],
+        vaddr: VirtAddr,
+        data: &mut [MaybeUninit<u8>],
     ) -> Result<(), SvsmError> {
-        unimplemented!()
+        match data.len() {
+            1 => {
+                // SAFETY: We are trusting the caller to ensure validity of `vaddr`.
+                unsafe {
+                    mmio_read_type::<u8>(vaddr, data);
+                }
+            }
+            2 => {
+                // SAFETY: We are trusting the caller to ensure validity of `vaddr`.
+                unsafe {
+                    mmio_read_type::<u16>(vaddr, data);
+                }
+            }
+            4 => {
+                // SAFETY: We are trusting the caller to ensure validity of `vaddr`.
+                unsafe {
+                    mmio_read_type::<u32>(vaddr, data);
+                }
+            }
+            8 => {
+                // SAFETY: We are trusting the caller to ensure validity of `vaddr`.
+                unsafe {
+                    mmio_read_type::<u64>(vaddr, data);
+                }
+            }
+            _ => return Err(SvsmError::InvalidBytes),
+        };
+
+        Ok(())
     }
+}
+
+unsafe fn mmio_write_type<T: Copy>(vaddr: VirtAddr, data: &[u8]) {
+    let data_ptr = data.as_ptr().cast::<T>();
+    let ptr = vaddr.as_mut_ptr::<T>();
+
+    // SAFETY: We are trusting the caller to ensure validity of `vaddr`.
+    unsafe {
+        if data_ptr.is_aligned() {
+            ptr.write_volatile(data_ptr.read());
+        } else {
+            ptr.write_volatile(data_ptr.read_unaligned());
+        }
+    };
+}
+
+unsafe fn mmio_read_type<T>(vaddr: VirtAddr, data: &mut [MaybeUninit<u8>]) {
+    let data_ptr = data.as_mut_ptr().cast::<T>();
+    let ptr = vaddr.as_mut_ptr::<T>();
+
+    // SAFETY: We are trusting the caller to ensure validity of `vaddr`.
+    unsafe {
+        if data_ptr.is_aligned() {
+            data_ptr.write(ptr.read_volatile());
+        } else {
+            data_ptr.write_unaligned(ptr.read_volatile());
+        }
+    };
 }

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -381,9 +381,11 @@ impl SvsmPlatform for SnpPlatform {
     ///
     /// # Safety
     ///
-    /// Caller must ensure that `paddr` points to a properly aligned memory location and the
+    /// Caller must ensure that `vaddr` points to a properly aligned memory location and the
     /// memory accessed is part of a valid MMIO range.
-    unsafe fn mmio_write(&self, paddr: PhysAddr, data: &[u8]) -> Result<(), SvsmError> {
+    unsafe fn mmio_write(&self, vaddr: VirtAddr, data: &[u8]) -> Result<(), SvsmError> {
+        let paddr = this_cpu().get_pgtable().phys_addr(vaddr)?;
+
         // SAFETY: We are trusting the caller to ensure validity of `paddr` and alignment of data.
         unsafe { crate::cpu::percpu::current_ghcb().mmio_write(paddr, data) }
     }
@@ -392,13 +394,14 @@ impl SvsmPlatform for SnpPlatform {
     ///
     /// # Safety
     ///
-    /// Caller must ensure that `paddr` points to a properly aligned memory location and the
+    /// Caller must ensure that `vaddr` points to a properly aligned memory location and the
     /// memory accessed is part of a valid MMIO range.
     unsafe fn mmio_read(
         &self,
-        paddr: PhysAddr,
+        vaddr: VirtAddr,
         data: &mut [MaybeUninit<u8>],
     ) -> Result<(), SvsmError> {
+        let paddr = this_cpu().get_pgtable().phys_addr(vaddr)?;
         // SAFETY: We are trusting the caller to ensure validity of `paddr` and alignment of data.
         unsafe { crate::cpu::percpu::current_ghcb().mmio_read(paddr, data) }
     }

--- a/kernel/src/platform/tdp.rs
+++ b/kernel/src/platform/tdp.rs
@@ -280,13 +280,13 @@ impl SvsmPlatform for TdpPlatform {
         Ok(())
     }
 
-    unsafe fn mmio_write(&self, _paddr: PhysAddr, _data: &[u8]) -> Result<(), SvsmError> {
+    unsafe fn mmio_write(&self, _vaddr: VirtAddr, _data: &[u8]) -> Result<(), SvsmError> {
         unimplemented!()
     }
 
     unsafe fn mmio_read(
         &self,
-        _paddr: PhysAddr,
+        _vaddr: VirtAddr,
         _data: &mut [MaybeUninit<u8>],
     ) -> Result<(), SvsmError> {
         unimplemented!()


### PR DESCRIPTION
Currently native platform does not support mmio operations. This can be useful when developing or testing drivers that rely on MMIO, like virtio-vsock or virtio-block.

Tested on top of my RFC #766 that introduces Vsock support, using `make test-in-svsm`