### PR TITLE
kernel/virtio: avoid zeroing and extra copying the destination buffer

### DIFF
--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -20,6 +20,7 @@ use tdp::TdpPlatform;
 
 use core::arch::asm;
 use core::fmt::Debug;
+use core::mem::MaybeUninit;
 
 use crate::address::{PhysAddr, VirtAddr};
 use crate::config::SvsmConfig;
@@ -224,9 +225,13 @@ pub trait SvsmPlatform: Sync {
     ///
     /// # Safety
     ///
-    /// Caller must ensure that `pa` points to a properly aligned memory location and the
+    /// Caller must ensure that `paddr` points to a properly aligned memory location and the
     /// memory accessed is part of a valid MMIO range.
-    unsafe fn mmio_read(&self, _paddr: PhysAddr, _data: &mut [u8]) -> Result<(), SvsmError>;
+    unsafe fn mmio_read(
+        &self,
+        paddr: PhysAddr,
+        data: &mut [MaybeUninit<u8>],
+    ) -> Result<(), SvsmError>;
 }
 
 //FIXME - remove Copy trait

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -237,7 +237,11 @@ impl SvsmPlatform for NativePlatform {
         unimplemented!()
     }
 
-    unsafe fn mmio_read(&self, _paddr: PhysAddr, _data: &mut [u8]) -> Result<(), SvsmError> {
+    unsafe fn mmio_read(
+        &self,
+        _paddr: PhysAddr,
+        _data: &mut [MaybeUninit<u8>],
+    ) -> Result<(), SvsmError> {
         unimplemented!()
     }
 }

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -38,6 +38,7 @@ use crate::utils::immut_after_init::ImmutAfterInitCell;
 use crate::utils::MemoryRegion;
 use syscall::GlobalFeatureFlags;
 
+use core::mem::MaybeUninit;
 use core::sync::atomic::{AtomicU32, Ordering};
 
 #[cfg(test)]
@@ -393,7 +394,11 @@ impl SvsmPlatform for SnpPlatform {
     ///
     /// Caller must ensure that `paddr` points to a properly aligned memory location and the
     /// memory accessed is part of a valid MMIO range.
-    unsafe fn mmio_read(&self, paddr: PhysAddr, data: &mut [u8]) -> Result<(), SvsmError> {
+    unsafe fn mmio_read(
+        &self,
+        paddr: PhysAddr,
+        data: &mut [MaybeUninit<u8>],
+    ) -> Result<(), SvsmError> {
         // SAFETY: We are trusting the caller to ensure validity of `paddr` and alignment of data.
         unsafe { crate::cpu::percpu::current_ghcb().mmio_read(paddr, data) }
     }

--- a/kernel/src/platform/tdp.rs
+++ b/kernel/src/platform/tdp.rs
@@ -284,7 +284,11 @@ impl SvsmPlatform for TdpPlatform {
         unimplemented!()
     }
 
-    unsafe fn mmio_read(&self, _paddr: PhysAddr, _data: &mut [u8]) -> Result<(), SvsmError> {
+    unsafe fn mmio_read(
+        &self,
+        _paddr: PhysAddr,
+        _data: &mut [MaybeUninit<u8>],
+    ) -> Result<(), SvsmError> {
         unimplemented!()
     }
 }


### PR DESCRIPTION
While reviewing #775 I figured out that `SvsmHal::mmio_read()` could be improved a bit.

`SvsmHal::mmio_read()` currently allocates the destination buffer, zeros it, and then copies its value. Avoid all this by allocating `MaybeUninit::<T>` on the stack and passing a pointer to `SVSM_PLATFORM.mmio_read()`.

Cascade the changes to the functions to use a pointer, since the destination buffer may be uninitialized.