### PR TITLE
Fix handle_icr_write

### DIFF
--- a/kernel/src/cpu/apic.rs
+++ b/kernel/src/cpu/apic.rs
@@ -620,10 +620,7 @@ impl LocalApic {
 
         // Verify that this message type is supported.
         let valid_type = match icr.message_type() {
-            IcrMessageType::Fixed => {
-                // Only asserted edge-triggered interrupts can be handled.
-                !icr.trigger_mode() && icr.assert()
-            }
+            IcrMessageType::Fixed => true,
             IcrMessageType::Nmi => true,
             _ => false,
         };


### PR DESCRIPTION
SVSM has been checking bits of trigger mode and assert in ICR message for IPI, however the Hardware ignores those bits and this is how Linux has been doing it since forever.

Fix handle_icr_write() to ignore those bits just like real hardware does.