### PR TITLE
cpu/apic: Fix handle_icr_write

### DIFF
--- a/kernel/src/cpu/apic.rs
+++ b/kernel/src/cpu/apic.rs
@@ -618,15 +618,10 @@ impl LocalApic {
     fn handle_icr_write(&mut self, value: u64) -> Result<(), SvsmError> {
         let icr = ApicIcr::from(value);
 
-        // Verify that this message type is supported.
-        let valid_type = match icr.message_type() {
-            IcrMessageType::Fixed => {
-                // Only asserted edge-triggered interrupts can be handled.
-                !icr.trigger_mode() && icr.assert()
-            }
-            IcrMessageType::Nmi => true,
-            _ => false,
-        };
+        let valid_type = matches!(
+            icr.message_type(),
+            IcrMessageType::Fixed | IcrMessageType::Nmi
+        );
 
         if !valid_type {
             return Err(SvsmError::Apic(Emulation));


### PR DESCRIPTION
SVSM has been checking bits of trigger mode and assert in ICR message for IPI, however the Hardware ignores those bits and this is how Linux has been doing it since forever.

Fix handle_icr_write() to ignore those bits just like real hardware does.