### PR TITLE
configs: build SVSM as package

### DIFF
--- a/configs/all-targets.json
+++ b/configs/all-targets.json
@@ -36,7 +36,7 @@
     "kernel": {
         "svsm": {
             "features": "vtpm,enable-gdb",
-            "binary": true
+            "binary": false
         },
         "stage2": {
             "manifest": "kernel/Cargo.toml",

--- a/configs/hyperv-target.json
+++ b/configs/hyperv-target.json
@@ -15,7 +15,7 @@
     "kernel": {
         "svsm": {
             "features": "vtpm",
-            "binary": true
+            "binary": false
         },
         "stage2": {
             "manifest": "kernel/Cargo.toml",

--- a/configs/qemu-target.json
+++ b/configs/qemu-target.json
@@ -15,7 +15,7 @@
     "kernel": {
         "svsm": {
             "features": "vtpm",
-            "binary": true
+            "binary": false
         },
         "stage2": {
             "manifest": "kernel/Cargo.toml",

--- a/configs/vanadium-target.json
+++ b/configs/vanadium-target.json
@@ -15,7 +15,7 @@
     "kernel": {
         "svsm": {
             "features": "vtpm",
-            "binary": true
+            "binary": false
         },
         "stage2": {
             "manifest": "kernel/Cargo.toml",


### PR DESCRIPTION
Do not build the SVSM kernel as a binary (`--bin`) but as a package instead (`--package`) when invoking cargo. This needs to be done because building as a binary uses different dependency resolution logic in cargo, which in the end may end up building dependencies for a std target, causing breakage in builds.

Fixes: #779