### PR TITLE
Bump igvm and igvm_defs version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "bitfield-struct"
-version = "0.7.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2ce686adbebce0ee484a502c440b4657739adbad65eadf06d64f5816ee9765"
+checksum = "2be5a46ba01b60005ae2c51a36a29cfe134bcacae2dd5cedcd4615fbaad1494b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1078,31 +1078,32 @@ dependencies = [
 
 [[package]]
 name = "igvm"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4ae8479aa3163c8a0fa716aa6ef08a6553e1097f8a89544f46fee695b5a162"
+checksum = "67578b05ebcdfa1aa0fe13f77a13bdd7d87036128898a327f1bf8e7356cf09cd"
 dependencies = [
- "bitfield-struct 0.7.0",
+ "bitfield-struct 0.10.1",
  "crc32fast",
  "hex",
  "igvm_defs",
  "open-enum",
  "range_map_vec",
- "thiserror 1.0.69",
+ "static_assertions",
+ "thiserror",
  "tracing",
- "zerocopy 0.7.35",
+ "zerocopy 0.8.26",
 ]
 
 [[package]]
 name = "igvm_defs"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4f70c18b574e5c7fa6222c1f0ebd8bfe2e14b762573b799faf8697c044b0e2a"
+checksum = "eedd8c64460676101062f9f2ecdeb52d8f43e622da6a6c5bf5158f4ef08b0906"
 dependencies = [
- "bitfield-struct 0.7.0",
+ "bitfield-struct 0.10.1",
  "open-enum",
  "static_assertions",
- "zerocopy 0.7.35",
+ "zerocopy 0.8.26",
 ]
 
 [[package]]
@@ -1114,7 +1115,6 @@ dependencies = [
  "igvm",
  "igvm_defs",
  "uuid",
- "zerocopy 0.7.35",
  "zerocopy 0.8.26",
 ]
 
@@ -1127,7 +1127,6 @@ dependencies = [
  "igvm_defs",
  "p384",
  "sha2",
- "zerocopy 0.7.35",
  "zerocopy 0.8.26",
 ]
 
@@ -1236,7 +1235,7 @@ dependencies = [
  "base64",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror",
 ]
 
 [[package]]
@@ -2020,31 +2019,11 @@ version = "0.1.0"
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.12",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,8 +69,8 @@ cocoon-tpm-tpm2-interface = { version = "0.1.0", default-features = false }
 cocoon-tpm-utils-common = { version = "0.1.0", default-features = false }
 gdbstub = { version = "0.6.6", default-features = false }
 gdbstub_arch = { version = "0.2.4" }
-igvm = { version = "0.3.4", default-features = false }
-igvm_defs = { version = "0.3.4", default-features = false }
+igvm = { version = "0.4.0", default-features = false }
+igvm_defs = { version = "0.4.0", default-features = false }
 intrusive-collections = "0.9.6"
 kbs-types = { version = "0.10.0", default-features = false }
 libfuzzer-sys = "0.4"

--- a/igvmbuilder/Cargo.toml
+++ b/igvmbuilder/Cargo.toml
@@ -13,7 +13,6 @@ igvm_defs.workspace = true
 igvm.workspace = true
 uuid.workspace = true
 zerocopy.workspace = true
-zerocopy07 = { package = "zerocopy", version = "0.7" }
 
 [lints]
 workspace = true

--- a/igvmbuilder/src/vmsa.rs
+++ b/igvmbuilder/src/vmsa.rs
@@ -8,7 +8,7 @@ use igvm::registers::{SegmentRegister, X86Register};
 use igvm::snp_defs::{SevFeatures, SevSelector, SevVmsa};
 use igvm::IgvmDirectiveHeader;
 use igvm_defs::IgvmNativeVpContextX64;
-use zerocopy07::FromZeroes;
+use zerocopy::FromZeros;
 
 use crate::cmd_options::{Hypervisor, SevExtraFeatures};
 
@@ -66,7 +66,8 @@ pub fn construct_native_start_context(
     regs: &[X86Register],
     compatibility_mask: u32,
 ) -> IgvmDirectiveHeader {
-    let mut context_box = IgvmNativeVpContextX64::new_box_zeroed();
+    let mut context_box =
+        IgvmNativeVpContextX64::new_box_zeroed().expect("Failed to allocate memory for context");
     let context = context_box.as_mut();
 
     // Copy values from the register list.
@@ -186,7 +187,7 @@ pub fn construct_vmsa(
     extra_features: &Vec<SevExtraFeatures>,
     hypervisor: Hypervisor,
 ) -> IgvmDirectiveHeader {
-    let mut vmsa_box = SevVmsa::new_box_zeroed();
+    let mut vmsa_box = SevVmsa::new_box_zeroed().expect("Failed to allocate memory for VMSA");
     let vmsa = vmsa_box.as_mut();
 
     // Copy values from the register list.

--- a/igvmmeasure/Cargo.toml
+++ b/igvmmeasure/Cargo.toml
@@ -12,8 +12,6 @@ igvm.workspace = true
 igvm_defs.workspace = true
 p384.workspace = true
 zerocopy.workspace = true
-# igvm_defs still uses 0.7, so we need to import the zerocopy 0.7 traits to use them.
-zerocopy07 = { package = "zerocopy", version = "0.7" }
 
 [lints]
 workspace = true

--- a/igvmmeasure/src/id_block.rs
+++ b/igvmmeasure/src/id_block.rs
@@ -15,8 +15,7 @@ use p384::ecdsa::signature::Signer;
 use p384::ecdsa::{Signature, SigningKey};
 use p384::elliptic_curve::bigint::ArrayEncoding;
 use p384::{EncodedPoint, SecretKey};
-use zerocopy::{Immutable, IntoBytes};
-use zerocopy07::FromZeroes;
+use zerocopy::{FromZeros, Immutable, IntoBytes};
 
 use crate::igvm_measure::IgvmMeasure;
 use crate::utils::{get_compatibility_mask, get_policy};

--- a/igvmmeasure/src/igvm_measure.rs
+++ b/igvmmeasure/src/igvm_measure.rs
@@ -10,7 +10,7 @@ use igvm::snp_defs::SevVmsa;
 use igvm::{IgvmDirectiveHeader, IgvmFile};
 use igvm_defs::{IgvmPageDataFlags, IgvmPageDataType, IgvmPlatformType, PAGE_SIZE_4K};
 use sha2::{Digest, Sha256};
-use zerocopy07::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::page_info::PageInfo;
 


### PR DESCRIPTION
`igvm` and `igvm_defs` crates have been updated to version 0.4.0. This allows us to drop the dependency on "zerocopy07" as `igvm_defs` is using the same version of zerocopy as svsm.

Fixes: #797