### PR TITLE
virtio: fix typo in safety comments

### DIFF
--- a/kernel/src/virtio/hal.rs
+++ b/kernel/src/virtio/hal.rs
@@ -196,7 +196,7 @@ unsafe impl virtio_drivers::Hal for SvsmHal {
     ///
     /// # Safety
     ///
-    /// `src` must be properly alinged and reside at a readable memory address.
+    /// `src` must be properly aligned and reside at a readable memory address.
     unsafe fn mmio_read<T: FromBytes + Immutable>(src: &T) -> T {
         let paddr = this_cpu()
             .get_pgtable()
@@ -227,7 +227,7 @@ unsafe impl virtio_drivers::Hal for SvsmHal {
     ///
     /// # Safety
     ///
-    /// `dst` must be properly alinged and reside at a writable memory address.
+    /// `dst` must be properly aligned and reside at a writable memory address.
     unsafe fn mmio_write<T: IntoBytes + Immutable>(dst: &mut T, v: T) {
         let paddr = this_cpu()
             .get_pgtable()

--- a/virtio-drivers/src/hal.rs
+++ b/virtio-drivers/src/hal.rs
@@ -151,12 +151,12 @@ pub unsafe trait Hal {
     ///
     /// # Safety
     ///
-    /// `src` must be properly alinged and reside at a readable memory address.
+    /// `src` must be properly aligned and reside at a readable memory address.
     unsafe fn mmio_read<T>(src: &T) -> T
     where
         T: FromBytes + Immutable,
     {
-        // SAFETY: `src` is assumed to be properly aligned and within readale memory
+        // SAFETY: `src` is assumed to be properly aligned and within readable memory
         unsafe { (src as *const T).read_volatile() }
     }
 
@@ -167,12 +167,12 @@ pub unsafe trait Hal {
     ///
     /// # Safety
     ///
-    /// `dst` must be properly alinged and reside at a writable memory address.
+    /// `dst` must be properly aligned and reside at a writable memory address.
     unsafe fn mmio_write<T>(dst: &mut T, value: T)
     where
         T: IntoBytes + Immutable,
     {
-        // SAFETY: dst is assumed to be properly alinged and within writeble memory
+        // SAFETY: dst is assumed to be properly aligned and within writable memory
         unsafe {
             (dst as *mut T).write_volatile(value);
         }


### PR DESCRIPTION
Replace `alinged` with `aligned`, `writeble` with `writable`, and `readale` with `readable`.