### PR TITLE
CocoonFs based persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,12 +462,26 @@ dependencies = [
  "cocoon-tpm-utils-common",
  "crypto-common 0.1.7",
  "digest",
+ "ecb",
  "generic-array 1.4.3",
  "hmac",
  "ofb",
  "sha2",
  "sm4",
  "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "cocoon-tpm-storage"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4557cee7aa93353f56d63bcacb0673c6b0ef296668b436d8d2e7b9f690ef9b0"
+dependencies = [
+ "cocoon-tpm-crypto",
+ "cocoon-tpm-tpm2-interface",
+ "cocoon-tpm-utils-async",
+ "cocoon-tpm-utils-common",
  "zeroize",
 ]
 
@@ -728,6 +742,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
+]
+
+[[package]]
+name = "ecb"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
+dependencies = [
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -2092,6 +2115,7 @@ dependencies = [
  "bootdefs",
  "bootimg",
  "cocoon-tpm-crypto",
+ "cocoon-tpm-storage",
  "cocoon-tpm-tpm2-interface",
  "cocoon-tpm-utils-async",
  "cocoon-tpm-utils-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,6 +478,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f524208dcc8aa8c63f8d0a1a64f458beeb6eff7d7d64deec515be639a57811ea"
 
 [[package]]
+name = "cocoon-tpm-utils-async"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff56a8746df3ead93d408761fed1e39974e4395fcab63084272fd7b8b33d8391"
+dependencies = [
+ "cocoon-tpm-utils-common",
+]
+
+[[package]]
 name = "cocoon-tpm-utils-common"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2084,6 +2093,7 @@ dependencies = [
  "bootimg",
  "cocoon-tpm-crypto",
  "cocoon-tpm-tpm2-interface",
+ "cocoon-tpm-utils-async",
  "cocoon-tpm-utils-common",
  "concat-kdf",
  "cpuarch",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,18 +439,18 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "cmpa"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be785eeeffa3c5f99e7f71775051590c14b68b7f07fdf85641648d89dc9bf16"
+checksum = "360388c699cb87bbff6ad171727548056ccf43cc8fa442a745ad0676ab23b888"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "cocoon-tpm-crypto"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b7633b7e5996b4b5d15929736d10910c087713a9bdf9b7a05c1f16d192ae413"
+checksum = "a3df5637dcf02eb5defb21bb108c0f3796bda0db2c7c7e3804759447b10e781c"
 dependencies = [
  "aes 0.8.4",
  "camellia",
@@ -462,7 +462,7 @@ dependencies = [
  "cocoon-tpm-utils-common",
  "crypto-common 0.1.7",
  "digest",
- "generic-array 1.3.5",
+ "generic-array 1.4.3",
  "hmac",
  "ofb",
  "sha2",
@@ -473,15 +473,15 @@ dependencies = [
 
 [[package]]
 name = "cocoon-tpm-tpm2-interface"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd87d8fabcfd5949ef574c04814c6c783858310bdcc58d807003fc8da56eac23"
+checksum = "f524208dcc8aa8c63f8d0a1a64f458beeb6eff7d7d64deec515be639a57811ea"
 
 [[package]]
 name = "cocoon-tpm-utils-common"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19fa8730c221b252c85b70e895101b9022cd5777d8c8d3c35e9f92d1a27d1b45"
+checksum = "6ba97316b8f3f4ab72ee646c222285a8c2480130e30ba3a7e38596ef36812598"
 dependencies = [
  "cmpa",
  "zeroize",
@@ -904,9 +904,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "1.3.5"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf57c49a95fd1fe24b90b3033bee6dc7e8f1288d51494cb44e627c295e38542"
+checksum = "c2e55f16dcf0e9c00efbe2e655ffe45fc98e7066b52bc92f8a79e64060a79351"
 dependencies = [
  "rustversion",
  "typenum",
@@ -1385,9 +1385,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1668,9 +1668,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -1713,9 +1713,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -1843,9 +1843,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -2132,9 +2132,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2397,9 +2397,9 @@ checksum = "0c8352f8c05e47892e7eaf13b34abd76a7f4aeaf817b716e88789381927f199c"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-xid"
@@ -2904,18 +2904,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ bitflags = "2.6"
 clap = { version = "4.4.14", default-features = false }
 cocoon-tpm-crypto = { version = "0.1.4", default-features = false }
 cocoon-tpm-tpm2-interface = { version = "0.1.1", default-features = false }
+cocoon-tpm-utils-async = { version = "0.1.3", default-features = false }
 cocoon-tpm-utils-common = { version = "0.1.3", default-features = false }
 concat-kdf = "0.1.0"
 gdbstub = { version = "0.7.10", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ bitfield-struct = "0.6.2"
 bitflags = "2.6"
 clap = { version = "4.4.14", default-features = false }
 cocoon-tpm-crypto = { version = "0.1.4", default-features = false }
+cocoon-tpm-storage = { version = "0.1.4", default-features = false }
 cocoon-tpm-tpm2-interface = { version = "0.1.1", default-features = false }
 cocoon-tpm-utils-async = { version = "0.1.3", default-features = false }
 cocoon-tpm-utils-common = { version = "0.1.3", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,9 +78,9 @@ bindgen = { version = "0.71.0", default-features = false }
 bitfield-struct = "0.6.2"
 bitflags = "2.6"
 clap = { version = "4.4.14", default-features = false }
-cocoon-tpm-crypto = { version = "0.1.0", default-features = false }
-cocoon-tpm-tpm2-interface = { version = "0.1.0", default-features = false }
-cocoon-tpm-utils-common = { version = "0.1.0", default-features = false }
+cocoon-tpm-crypto = { version = "0.1.4", default-features = false }
+cocoon-tpm-tpm2-interface = { version = "0.1.1", default-features = false }
+cocoon-tpm-utils-common = { version = "0.1.3", default-features = false }
 concat-kdf = "0.1.0"
 gdbstub = { version = "0.7.10", default-features = false }
 gdbstub_arch = { version = "0.3.3" }

--- a/Documentation/docs/developer/PERSISTENCE.md
+++ b/Documentation/docs/developer/PERSISTENCE.md
@@ -1,0 +1,100 @@
+Persistence
+===========
+
+The persistence subsystem enables the SVSM to securely preserve sensitive state
+across reboots, such as, but not limited to, the vTPM NV state or UEFI
+variables.
+
+
+Overview
+--------
+When persisting sensitive state to external, non-volatile storage from a TEE or
+the SVSM in particular, special security considerations apply: the untrusted
+virtualization host not only has full access to the external storage volume's
+contents, but is even capable of spoofing and altering IO requests over time,
+potentially enabling certain attacks on traditional block-level FDE schemes.
+
+The
+[CocoonFs](https://coconut-svsm.github.io/cocoon-tpm/cocoonfs/cocoonfs-format.html)
+filesystem format has been designed specifically with a TEE's security
+requirements in mind, and is currently the only filesystem supported by the
+SVSM. Support for other formats might perhaps get added in the future if
+there's a demand.
+
+The persistence storage is protected by a symmetric key received at startup from
+a KBS as the result of a successful remote attestation, therefore the
+persistence functionality requires a working [attestation
+setup](ATTESTATION.md).
+
+There are two alternative ways to initially provision a CocoonFs filesystem
+image with the [`cocoonfs-cli`](https://crates.io/crates/cocoonfs-cli) utility:
+without or with access to the key. If created without a key, a mere "filesystem
+creation header" would get written, the actual formatting would then
+subsequently take place on the first attempt to open the image from the SVSM,
+with the key obtained from attestation procedure. If created with a key, the
+filesystem will get formatted right away at `cocoonfs-cli` invocation time.
+
+At startup, the SVSM would iterate over all block devices attached to it and use
+the first one that can be opened successfully with the key provided from
+attestation for all its persistence needs. In particular:
+
+* At most one CocoonFs volume will actively be used from a given SVSM boot instance.
+* If a block device has a CocoonFs image formatted onto it, but its
+  authentication with the key obtained from attestation failed, it would get
+  skipped.
+* If no working CocoonFs image had been found yet, and the next block device has
+  a "CocoonFs creation header" on it, the filesystem would get formatted with
+  whatever key had been obtained from attestation and henceforth be used for the
+  persistence needs, irrespective of whether there's perhaps another CocoonFs
+  block device formatted with that same key later in the iteration list or not.
+
+Current development state and caveats
+-------------------------------------
+The persistence functionality is under development, the core subsystem itself
+has been implemented, but none of the components which could potentially make
+use of it have been adapted yet to actually do so.
+
+Furthermore, the exact details on how the symmetric key material used for
+securing the externally stored data is to get derived from the secret received
+from the KBS have not been finalized yet, so do not expect at this point that
+persistence volume images accessible from the SVSM at some code version will
+continue to work with past or future releases.
+
+Currently, the secret key material received from the KBS is not authenticated in
+any way, making the persistence subsystem prone to MITM attacks. The details on
+how to resolve this have not been settled yet, for reference and further details
+c.f. [this mail thread](https://lore.kernel.org/r/877bwxyiqv.fsf@).
+
+Setup/Testing
+-------------
+1. Enable the `persistence` Cargo feature. This will pull in the virtio-drivers feature.
+2. Setup attestation -- it's currently the only way to get a secret into the SVSM.
+3. Prepare a CocoonFs filesystem image using [`cocoonfs-cli`](https://crates.io/crates/cocoonfs-cli)
+   ```
+   cocoonfs -i cocoonfs.img -f write-mkfs-info-header -H sha2 -C aes -t 128 -I 'ddeeff' -s 8M
+   ```
+   Note that this merely writes a CocoonFs "filesystem creation info header",
+   which doesn't require access to the key. The actual filesystem formatting
+   will get done when the SVSM first attempts to open the filesystem.
+4. Attach the filesystem image to the SVSM via the qemu command line (taken from
+   `scripts/launch_guest.sh`): append `,x-svsm-virtio-mmio=on` to the `-machine`
+   spec and add
+   ```
+   -global virtio-mmio.force-legacy=false
+   -drive file=<path>/cocoonfs.img,format=raw,if=none,id=svsm_storage,cache=none
+   -device virtio-blk-device,drive=svsm_storage
+   ```
+
+If everything goes well, you should see the following message at the first boot:
+```
+[SVSM] persistent CocoonFs storage opened successfully
+[SVSM] persistence demo: no boot counter found yet
+[SVSM] persistence demo: successfully wrote updated boot counter
+```
+and e.g.
+```
+[SVSM] persistent CocoonFs storage opened successfully
+[SVSM] persistence demo: boot counter read back is 1
+[SVSM] persistence demo: successfully wrote updated boot counter
+```
+etc. in subsequent ones.

--- a/Documentation/mkdocs.yml
+++ b/Documentation/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
     - Contributing to COCONUT-SVSM: 'developer/CONTRIBUTING.md'
     - Formal Verification: 'developer/VERIFICATION.md'
     - Attestation: 'developer/ATTESTATION.md'
+    - Persistence: 'developer/PERSISTENCE.md'
     - GitHub Workflows: 'developer/GH_WORKFLOWS.md'
     - 'developer/AI-AGENTS.md'
     - Design Documentation:

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -46,6 +46,7 @@ cocoon-tpm-crypto = { workspace = true, features = [
     "ecc_nist_p521",
 ]}
 cocoon-tpm-tpm2-interface = { workspace = true }
+cocoon-tpm-utils-async = { workspace = true }
 cocoon-tpm-utils-common = { workspace = true }
 concat-kdf = { workspace = true, optional = true }
 gdbstub = { workspace = true, optional = true }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -95,7 +95,7 @@ attest = [
 attest-serial = ["attest"]
 
 default = []
-persistence = ["dep:cocoon-tpm-storage", "block", "virtio-drivers"]
+persistence = ["dep:cocoon-tpm-storage", "block", "virtio-drivers", "attest"]
 enable-gdb = ["dep:gdbstub", "dep:gdbstub_arch"]
 vtpm = ["dep:libtcgtpm"]
 nosmep = []

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -44,9 +44,9 @@ cocoon-tpm-crypto = { workspace = true, features = [
     "ecc_nist_p256",
     "ecc_nist_p384",
     "ecc_nist_p521",
-], optional = true }
-cocoon-tpm-tpm2-interface = { workspace = true, optional = true }
-cocoon-tpm-utils-common = { workspace = true, optional = true }
+]}
+cocoon-tpm-tpm2-interface = { workspace = true }
+cocoon-tpm-utils-common = { workspace = true }
 concat-kdf = { workspace = true, optional = true }
 gdbstub = { workspace = true, optional = true }
 gdbstub_arch = { workspace = true, optional = true }
@@ -84,9 +84,6 @@ test.workspace = true
 attest = [
     "vsock",
     "dep:aes-kw",
-    "dep:cocoon-tpm-crypto",
-    "dep:cocoon-tpm-tpm2-interface",
-    "dep:cocoon-tpm-utils-common",
     "dep:concat-kdf",
     "dep:kbs-types",
     "dep:libaproxy",

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -45,6 +45,7 @@ cocoon-tpm-crypto = { workspace = true, features = [
     "ecc_nist_p384",
     "ecc_nist_p521",
 ]}
+cocoon-tpm-storage = { workspace = true, features = ["zeroize"], optional = true }
 cocoon-tpm-tpm2-interface = { workspace = true }
 cocoon-tpm-utils-async = { workspace = true }
 cocoon-tpm-utils-common = { workspace = true }
@@ -94,6 +95,7 @@ attest = [
 attest-serial = ["attest"]
 
 default = []
+persistence = ["dep:cocoon-tpm-storage", "block", "virtio-drivers"]
 enable-gdb = ["dep:gdbstub", "dep:gdbstub_arch"]
 vtpm = ["dep:libtcgtpm"]
 nosmep = []

--- a/kernel/src/async.rs
+++ b/kernel/src/async.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright 2025 SUSE LLC
+// Author: Nicolai Stange <nstange@suse.de>
+
+//! Implementation of Rust `async` [`Future`] related functionality.
+
+use cocoon_tpm_utils_async as utils_async;
+
+use utils_async::sync_types;
+
+use crate::locking::{LockGuard, RWLock, ReadLockGuard, SpinLock, WriteLockGuard};
+
+impl<T: Send> sync_types::Lock<T> for SpinLock<T> {
+    type Guard<'a>
+        = LockGuard<'a, T>
+    where
+        T: 'a;
+
+    fn lock(&self) -> Self::Guard<'_> {
+        SpinLock::lock(self)
+    }
+}
+
+impl<T: Send> sync_types::ConstructibleLock<T> for SpinLock<T> {
+    fn get_mut(&mut self) -> &mut T {
+        SpinLock::get_mut(self)
+    }
+}
+
+impl<T: Send + Sync> sync_types::RwLock<T> for RWLock<T> {
+    type ReadGuard<'a>
+        = ReadLockGuard<'a, T>
+    where
+        T: 'a;
+    type WriteGuard<'a>
+        = WriteLockGuard<'a, T>
+    where
+        T: 'a;
+
+    fn read(&self) -> Self::ReadGuard<'_> {
+        RWLock::lock_read(self)
+    }
+
+    fn write(&self) -> Self::WriteGuard<'_> {
+        RWLock::lock_write(self)
+    }
+
+    fn get_mut(&mut self) -> &mut T {
+        RWLock::get_mut(self)
+    }
+}
+
+/// Implementation of the `cocoon-tpm-utils-async` crate's [`SyncTypes`](sync_types::SyncTypes)
+/// trait suitable for the SVSM kernel execution environment.
+#[derive(Debug)]
+pub struct SvsmSyncTypes;
+
+impl sync_types::SyncTypes for SvsmSyncTypes {
+    type Lock<T: Send> = SpinLock<T>;
+    type RwLock<T: Send + Sync> = RWLock<T>;
+    type SyncRcPtrFactory = sync_types::GenericArcFactory;
+}

--- a/kernel/src/async.rs
+++ b/kernel/src/async.rs
@@ -6,6 +6,7 @@
 
 use cocoon_tpm_utils_async as utils_async;
 
+use core::task;
 use utils_async::sync_types;
 
 use crate::locking::{LockGuard, RWLock, ReadLockGuard, SpinLock, WriteLockGuard};
@@ -59,4 +60,24 @@ impl sync_types::SyncTypes for SvsmSyncTypes {
     type Lock<T: Send> = SpinLock<T>;
     type RwLock<T: Send + Sync> = RWLock<T>;
     type SyncRcPtrFactory = sync_types::GenericArcFactory;
+}
+
+/// Busypoll an asynchronous task to completion.
+///
+/// The task to poll on is represented as a closure, `task`. Note that this scheme enables
+/// convenient polling on standard Rust [`Future`]s, as well as on `Future`-like types taking
+/// additional arguments for their `poll()`.
+///
+/// # Arguments:
+///
+/// * `task` -> The task to poll to completion.
+pub fn task_busypoll_to_completion<O, T: FnMut(&mut task::Context<'_>) -> task::Poll<O>>(
+    mut task: T,
+) -> O {
+    let mut ctx = task::Context::from_waker(task::Waker::noop());
+    loop {
+        if let task::Poll::Ready(result) = task(&mut ctx) {
+            return result;
+        }
+    }
 }

--- a/kernel/src/attest.rs
+++ b/kernel/src/attest.rs
@@ -8,7 +8,7 @@
 extern crate alloc;
 
 use crate::{
-    crypto::SecretSlice,
+    crypto::{SecretSlice, get_svsm_rng},
     error::SvsmError,
     greq::{pld_report::*, services::get_regular_report},
     io::{Read, Write},
@@ -21,15 +21,10 @@ use aes_gcm::{AeadInPlace, Aes256Gcm, KeyInit, Nonce, aead::generic_array::Gener
 use aes_kw::{KeyInit as _, KwAes256};
 use alloc::{string::ToString, vec::Vec};
 use cocoon_tpm_crypto::{
-    CryptoError, EmptyCryptoIoSlices,
+    CryptoError,
     ecc::{EccKey, curve::Curve, ecdh::ecdh_c_1_1_cdh_compute_z},
-    rng::{self, HashDrbg, RngCore as _, X86RdSeedRng},
 };
-use cocoon_tpm_tpm2_interface::{self as tpm2_interface, TpmEccCurve, TpmiAlgHash, TpmsEccPoint};
-use cocoon_tpm_utils_common::{
-    alloc::try_alloc_zeroizing_vec,
-    io_slices::{self, IoSlicesIterCommon as _},
-};
+use cocoon_tpm_tpm2_interface::{TpmEccCurve, TpmsEccPoint};
 use kbs_types::Tee;
 use libaproxy::*;
 use serde::Serialize;
@@ -332,27 +327,8 @@ impl From<AttestationError> for SvsmError {
 /// Generate a key used to establish a secure channel between the confidential guest and
 /// attestation server.
 fn sc_key_generate(curve: &Curve) -> Result<EccKey, CryptoError> {
-    let mut rng = {
-        let mut rdseed = X86RdSeedRng::instantiate().map_err(|_| CryptoError::RngFailure)?;
-        let mut hash_drbg_entropy =
-            try_alloc_zeroizing_vec(HashDrbg::min_seed_entropy_len(TpmiAlgHash::Sha256))?;
-
-        rdseed.generate::<_, EmptyCryptoIoSlices>(
-            io_slices::SingletonIoSliceMut::new(hash_drbg_entropy.as_mut_slice())
-                .map_infallible_err(),
-            None,
-        )?;
-
-        rng::HashDrbg::instantiate(
-            tpm2_interface::TpmiAlgHash::Sha256,
-            &hash_drbg_entropy,
-            None,
-            Some(b"SVSM attestation RNG"),
-        )
-    }?;
-
+    let mut rng = get_svsm_rng()?;
     let curve_ops = curve.curve_ops()?;
-
     EccKey::generate(&curve_ops, &mut rng, None)
 }
 

--- a/kernel/src/crypto/mod.rs
+++ b/kernel/src/crypto/mod.rs
@@ -154,6 +154,9 @@ pub mod digest {
 
 pub mod rustcrypto;
 
+mod rng;
+pub use rng::{SvsmRng, get_svsm_rng};
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/kernel/src/crypto/rng.rs
+++ b/kernel/src/crypto/rng.rs
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright 2025 SUSE LLC
+// Author: Nicolai Stange <nstange@suse.de>
+
+//! SVSM Random Number Generator (RNG) management.
+//!
+//! Whenever users need an cryptographically secure RNG, they should invoke [`get_svsm_rng()`] to
+//! obtain an exclusively owned [`SvsmRng`] instance.
+
+extern crate alloc;
+use alloc::boxed::Box;
+
+use crate::locking::SpinLock;
+
+use core::sync::atomic;
+
+use cocoon_tpm_crypto::{
+    CryptoError, EmptyCryptoIoSlices,
+    hash::hash_alg_digest_len,
+    rng::{self, HashDrbg, RngCore, X86RdSeedRng},
+};
+use cocoon_tpm_tpm2_interface::TpmiAlgHash;
+use cocoon_tpm_utils_common::{
+    alloc::box_try_new,
+    fixed_vec::{FixedVec, FixedVecMemoryAllocationFailure},
+    io_slices::{self, IoSlicesIterCommon as _},
+    zeroize,
+};
+
+/// Hash algorithm to be used for all NIST HashDrbg instantiations.
+// C.f. NIST SP 800-90A Rev. 1: the HashDrbg's security strength is equal to the underlying hash
+// algorithm's pre-image resistance. That is, SHA256 gives a security strength of 256 bits.
+const SVSM_RNG_DRBG_HASH_ALG: TpmiAlgHash = TpmiAlgHash::Sha256;
+
+/// Number of [`SVSM_RNG_POOL`] slots.
+const SVSM_RNG_POOL_SIZE: usize = 4;
+
+/// RNG instance pool
+///
+/// [`SvsmRng::drop()`] returns instances back into some free slot, if any. [`get_svsm_rng()`] tries
+/// to take a currently unused instance from the pool before attempting to instantiate one.
+#[allow(clippy::type_complexity)]
+static SVSM_RNG_POOL: SpinLock<
+    [Option<Box<rng::ChainedRng<rng::X86RdSeedRng, rng::HashDrbg>>>; SVSM_RNG_POOL_SIZE],
+> = SpinLock::new([None, None, None, None]);
+
+/// Counter used for the RNG instance's personalization.
+static SVSM_RNG_INSTANTIATION_ID: atomic::AtomicU64 = atomic::AtomicU64::new(0);
+
+/// Opaque type implementing [`RngCore`] as suitable for the SVSM environment and build
+/// configuration.
+///
+/// Instances of `SvsmRng` are to be obtained through [`get_svsm_rng()`].
+///
+/// No assumptions must be made about `SvsmRng`, other than instances thereof are small, typically
+/// of pointer size, and that it implements [`RngCore`].
+#[allow(missing_debug_implementations)]
+pub struct SvsmRng {
+    // Is never None while self is alive, the rng needs to get stored in an Option<> so that it can
+    // get returned back to the pool when dropped.
+    rng: Option<Box<rng::ChainedRng<X86RdSeedRng, rng::HashDrbg>>>,
+}
+
+impl SvsmRng {
+    fn instantiate() -> Result<Self, CryptoError> {
+        // The FixedVec internal representation is optimized for the case of power-of-two lengths,
+        // relative to a specified compile-time "base" value. In practice, the HashDrbg seed length
+        // is equal to the digest length for all known hashes, so use that for the FixedVec base. If
+        // not a power of two (e.g. SHA-1), the optimization wouldn't be possible anyway, so the
+        // value is irrelevant then.
+        const DRBG_HASH_ALG_DIGEST_LEN_LOG2: u32 =
+            hash_alg_digest_len(SVSM_RNG_DRBG_HASH_ALG).ilog2();
+        let mut hash_drbg_entropy = zeroize::Zeroizing::new(
+            FixedVec::<u8, DRBG_HASH_ALG_DIGEST_LEN_LOG2>::new_with_default(
+                HashDrbg::min_seed_entropy_len(SVSM_RNG_DRBG_HASH_ALG),
+            )
+            .map_err(|e| match e {
+                FixedVecMemoryAllocationFailure => CryptoError::MemoryAllocationFailure,
+            })?,
+        );
+
+        let mut rdseed_rng = X86RdSeedRng::instantiate().map_err(|_| CryptoError::RngFailure)?;
+        rdseed_rng.generate::<_, EmptyCryptoIoSlices>(
+            io_slices::SingletonIoSliceMut::new(hash_drbg_entropy.as_mut_slice())
+                .map_infallible_err(),
+            None,
+        )?;
+
+        let mut personalization = [0u8; 16];
+        personalization[..8].copy_from_slice(b"SVSM-RNG");
+        personalization[8..].copy_from_slice(
+            &SVSM_RNG_INSTANTIATION_ID
+                .fetch_add(1, atomic::Ordering::Relaxed)
+                .to_ne_bytes(),
+        );
+
+        let hash_drbg_rng = rng::HashDrbg::instantiate(
+            SVSM_RNG_DRBG_HASH_ALG,
+            &hash_drbg_entropy,
+            None,
+            Some(&personalization),
+        )?;
+
+        let chained_rng = rng::ChainedRng::chain(rdseed_rng, hash_drbg_rng);
+
+        Ok(Self {
+            rng: Some(box_try_new(chained_rng).map_err(|_| CryptoError::MemoryAllocationFailure)?),
+        })
+    }
+}
+
+impl rng::RngCore for SvsmRng {
+    fn generate<
+        'a,
+        'b,
+        OI: cocoon_tpm_crypto::CryptoWalkableIoSlicesMutIter<'a>,
+        AII: cocoon_tpm_crypto::CryptoPeekableIoSlicesIter<'b>,
+    >(
+        &mut self,
+        output: OI,
+        additional_input: Option<AII>,
+    ) -> Result<(), rng::RngGenerateError> {
+        let rng = match self.rng.as_mut() {
+            Some(rng) => rng,
+            None => {
+                return Err(rng::RngGenerateError::CryptoError(CryptoError::Internal));
+            }
+        };
+        rng.generate(output, additional_input)
+    }
+}
+
+impl Drop for SvsmRng {
+    fn drop(&mut self) {
+        if let Some(rng) = self.rng.take() {
+            // Return the rng instance in some free pool slot, if any.
+            let mut pool = SVSM_RNG_POOL.lock();
+            for pool_slot in pool.iter_mut() {
+                if pool_slot.is_none() {
+                    *pool_slot = Some(rng);
+                    break;
+                }
+            }
+        }
+    }
+}
+
+/// Obtain an exclusively owned [`SvsmRng`] instance.
+pub fn get_svsm_rng() -> Result<SvsmRng, CryptoError> {
+    let mut pool = SVSM_RNG_POOL.lock();
+    for pool_slot in pool.iter_mut() {
+        if let Some(rng) = pool_slot.take() {
+            return Ok(SvsmRng { rng: Some(rng) });
+        }
+    }
+
+    SvsmRng::instantiate()
+}

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -42,6 +42,8 @@ pub mod kernel_region;
 pub mod locking;
 pub mod log_buffer;
 pub mod mm;
+#[cfg(feature = "persistence")]
+pub mod persistence;
 pub mod platform;
 pub mod protocols;
 pub mod requests;

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -21,6 +21,7 @@
 
 pub mod acpi;
 pub mod address;
+pub mod r#async;
 #[cfg(feature = "attest")]
 pub mod attest;
 #[cfg(feature = "block")]

--- a/kernel/src/locking/rwlock.rs
+++ b/kernel/src/locking/rwlock.rs
@@ -499,6 +499,17 @@ impl<T: Send, I: IrqLocking> RawRWLock<T, I> {
     pub fn write_noblock(&self) -> RawWriteLockGuard<'_, T, I> {
         self.try_lock_write().expect("Detected potential deadlock")
     }
+
+    /// Returns a mutable reference to the underlying data.
+    ///
+    /// Since this call borrows the `RawRWLock` mutably, no actual locking needs to take place --
+    /// the mutable borrow statically guarantees no new locks can be acquired while this reference
+    /// exists.
+    pub fn get_mut(&mut self) -> &mut T {
+        // SAFETY: the returned reference carries an exclusive borrow on self,
+        // thereby establishing exclusive access.
+        unsafe { &mut *self.data.get() }
+    }
 }
 
 /// A lock can only be acquired for read access if its inner type implements

--- a/kernel/src/locking/rwlock.rs
+++ b/kernel/src/locking/rwlock.rs
@@ -582,6 +582,12 @@ impl<T: Send + Sync, I: IrqLocking> RawRWLock<T, I> {
     }
 }
 
+impl<T: Send, I: IrqLocking> From<T> for RawRWLock<T, I> {
+    fn from(value: T) -> Self {
+        Self::new(value)
+    }
+}
+
 pub type RWLock<T> = RawRWLock<T, IrqUnsafeLocking>;
 pub type RWLockIrqSafe<T> = RawRWLock<T, IrqGuardLocking>;
 pub type RWLockAnyTpr<T, const TPR: usize> = RawRWLock<T, TprGuardLocking<TPR>>;

--- a/kernel/src/locking/spinlock.rs
+++ b/kernel/src/locking/spinlock.rs
@@ -225,6 +225,17 @@ impl<T: Send, I: IrqLocking> RawSpinLock<T, I> {
 
         None
     }
+
+    /// Returns a mutable reference to the underlying data.
+    ///
+    /// Since this call borrows the `RawSpinLock` mutably, no actual locking needs to take place --
+    /// the mutable borrow statically guarantees no new locks can be acquired while this reference
+    /// exists.
+    pub fn get_mut(&mut self) -> &mut T {
+        // SAFETY: the returned reference carries an exclusive borrow on self,
+        // thereby establishing exclusive access.
+        unsafe { &mut *self.data.get() }
+    }
 }
 
 pub type SpinLock<T> = RawSpinLock<T, IrqUnsafeLocking>;

--- a/kernel/src/locking/spinlock.rs
+++ b/kernel/src/locking/spinlock.rs
@@ -238,6 +238,12 @@ impl<T: Send, I: IrqLocking> RawSpinLock<T, I> {
     }
 }
 
+impl<T: Send, I: IrqLocking> From<T> for RawSpinLock<T, I> {
+    fn from(value: T) -> Self {
+        Self::new(value)
+    }
+}
+
 pub type SpinLock<T> = RawSpinLock<T, IrqUnsafeLocking>;
 pub type SpinLockIrqSafe<T> = RawSpinLock<T, IrqGuardLocking>;
 pub type SpinLockAnyTpr<T, const TPR: usize> = RawSpinLock<T, TprGuardLocking<TPR>>;

--- a/kernel/src/persistence.rs
+++ b/kernel/src/persistence.rs
@@ -14,7 +14,7 @@ use cocoon_tpm_storage::{
         NvBlkDev, NvBlkDevFuture, NvBlkDevIoError, NvBlkDevReadRequest, NvBlkDevWriteRequest,
     },
     fs::{
-        NvFsError, NvFsIoError,
+        NvFs, NvFsError, NvFsFuture, NvFsIoError, TransactionCommitError,
         cocoonfs::{self, CocoonFs},
     },
     nvblkdev_err_internal,
@@ -30,6 +30,7 @@ use crate::r#async::{SvsmSyncTypes, task_busypoll_to_completion};
 use crate::block::{BLOCK_DEVICE, BlockDeviceError, api::BlockDriver};
 use crate::crypto::get_svsm_rng;
 use crate::error::SvsmError;
+use crate::fs::FsError;
 use crate::mm::alloc::AllocError;
 use crate::types::PAGE_SHIFT;
 use crate::utils::immut_after_init::ImmutAfterInitCell;
@@ -638,6 +639,8 @@ type SvsmCocoonFsType = CocoonFs<SvsmSyncTypes, SvsmNvBlkDev<&'static dyn BlockD
 type SvsmCocoonFsSyncRcPtrType =
     <<SvsmSyncTypes as sync_types::SyncTypes>::SyncRcPtrFactory as sync_types::SyncRcPtrFactory>
     ::SyncRcPtr<SvsmCocoonFsType>;
+type SvsmCocoonFsSyncRcPtrRefType<'a> =
+    <SvsmCocoonFsSyncRcPtrType as sync_types::SyncRcPtr<SvsmCocoonFsType>>::SyncRcPtrRef<'a>;
 
 static SVSM_COCOONFS_INSTANCE: ImmutAfterInitCell<pin::Pin<SvsmCocoonFsSyncRcPtrType>> =
     ImmutAfterInitCell::uninit();
@@ -816,4 +819,258 @@ pub fn persistence_init(
 /// in which case it would report `false`.
 pub fn persistence_available() -> bool {
     SVSM_COCOONFS_INSTANCE.try_get_inner().is_ok()
+}
+
+/// Instantiate a [`CocoonFs::StartTransactionFut`].
+///
+/// The [`CocoonFs::StartTransactionFut`] is not exactly small -- by instantiating it in an
+/// `inline(never)` function and `Box`ing it right after, the stack allocations required for the
+/// moves are hopefully getting freed up quickly again.
+#[inline(never)]
+fn instantiate_cocoonfs_start_transaction_fut(
+    fs_instance: &pin::Pin<SvsmCocoonFsSyncRcPtrRefType<'_>>,
+) -> Result<Box<<SvsmCocoonFsType as NvFs>::StartTransactionFut>, NvFsError> {
+    let start_transaction_fut = SvsmCocoonFsType::start_transaction(fs_instance, None);
+    box_try_new(start_transaction_fut).map_err(NvFsError::from)
+}
+
+/// Instantiate a [`CocoonFs::CommitTransactionFut`].
+///
+/// The [`CocoonFs::CommitTransactionFut`] is not exactly small -- by instantiating it in an
+/// `inline(never)` function and `Box`ing it right after, the stack allocations required for the
+/// moves are hopefully getting freed up quickly again.
+#[inline(never)]
+fn instantiate_cocoonfs_commit_transaction_fut(
+    fs_instance: &pin::Pin<SvsmCocoonFsSyncRcPtrRefType<'_>>,
+    transaction: <SvsmCocoonFsType as NvFs>::Transaction,
+    issue_sync: bool,
+) -> Result<Box<<SvsmCocoonFsType as NvFs>::CommitTransactionFut>, NvFsError> {
+    let commit_transaction_fut =
+        SvsmCocoonFsType::commit_transaction(fs_instance, transaction, None, None, issue_sync);
+    box_try_new(commit_transaction_fut).map_err(NvFsError::from)
+}
+
+/// Instantiate a [`CocoonFs::WriteInodeFut`].
+///
+/// The [`CocoonFs::WriteInodeFut`] is not exactly small -- by instantiating it in an
+/// `inline(never)` function and `Box`ing it right after, the stack allocations required for the
+/// moves are hopefully getting freed up quickly again.
+#[inline(never)]
+fn instantiate_cocoonfs_write_inode_fut(
+    fs_instance: &pin::Pin<SvsmCocoonFsSyncRcPtrRefType<'_>>,
+    transaction: <SvsmCocoonFsType as NvFs>::Transaction,
+    inode: u64,
+    data: Zeroizing<Vec<u8>>,
+) -> Result<Box<<SvsmCocoonFsType as NvFs>::WriteInodeFut>, NvFsError> {
+    let write_inode_fut =
+        SvsmCocoonFsType::write_inode(fs_instance, transaction, inode, 0, 0, data);
+    box_try_new(write_inode_fut).map_err(NvFsError::from)
+}
+
+/// Instantiate a [`CocoonFs::ReadInodeFut`].
+///
+/// The [`CocoonFs::ReadInodeFut`] is not exactly small -- by instantiating it in an
+/// `inline(never)` function and `Box`ing it right after, the stack allocations required for the
+/// moves are hopefully getting freed up quickly again.
+#[inline(never)]
+fn instantiate_cocoonfs_read_inode_fut(
+    fs_instance: &pin::Pin<SvsmCocoonFsSyncRcPtrRefType<'_>>,
+    inode: u64,
+) -> Result<Box<<SvsmCocoonFsType as NvFs>::ReadInodeFut>, NvFsError> {
+    let read_inode_fut = SvsmCocoonFsType::read_inode(fs_instance, None, inode);
+    box_try_new(read_inode_fut).map_err(NvFsError::from)
+}
+
+/// Synchronously write data to an inode on persistent storage.
+///
+/// If the `inode` does not exist yet, it will get created. All of the inode's contents will get
+/// replaced with `data`.
+///
+/// The inode data writes are all-or-nothing and atomic: on successful completion, all of the
+/// `inode`'s data has been replaced with the new `data`, whereas on error its original contents are
+/// retained. Furthermore, there is a total order among all (successful) writes ever issued to the
+/// backing persistent storage volume, possibly to different target inodes even.
+///
+/// `persistence_write_inode_sync()` assumes ownership of the `data` buffer for the duration of the
+/// operation. It gets returned back unmodified to the caller on success.
+///
+/// Any error propagated back to the caller indicates an actual problem -- in particular requests to
+/// retry received from the backing filesystem implementation are handled transparently within
+/// `persistence_write_inode_sync()` itself.
+///
+/// # Arguments:
+///
+/// * `inode` - Number of the inode to update.
+/// * `data` - The data to write to `inode`.
+/// * `issue_sync` - Whether or not to issue a sync request to the underlying storage after the
+///   write has completed. That's best effort though and relies on the host to behave well.
+#[allow(unused)]
+pub fn persistence_write_inode_sync(
+    inode: u64,
+    mut data: Zeroizing<Vec<u8>>,
+    issue_sync: bool,
+) -> Result<Zeroizing<Vec<u8>>, SvsmError> {
+    let fs_instance = match SVSM_COCOONFS_INSTANCE.try_get_inner().ok() {
+        Some(fs_instance) => <pin::Pin<SvsmCocoonFsSyncRcPtrType> as sync_types::SyncRcPtr<
+            SvsmCocoonFsType,
+        >>::as_ref(fs_instance),
+        None => {
+            return Err(SvsmError::FileSystem(FsError::NotSupported));
+        }
+    };
+
+    let mut rng = match get_svsm_rng() {
+        Ok(rng) => rng,
+        Err(e) => {
+            log::error!("persistence write: failed to get rng instance: {e:?}");
+            return Err(nvfs_error_to_svsm_error(NvFsError::from(e)));
+        }
+    };
+
+    loop {
+        let mut transaction = match instantiate_cocoonfs_start_transaction_fut(&fs_instance)
+            .and_then(|mut start_transaction_fut| {
+                task_busypoll_to_completion(|cx| {
+                    NvFsFuture::poll(
+                        pin::Pin::new(&mut *start_transaction_fut),
+                        &fs_instance,
+                        &mut rng,
+                        cx,
+                    )
+                })
+            }) {
+            Ok(transaction) => transaction,
+            Err(NvFsError::Retry) => continue,
+            Err(e) => {
+                log::error!("persistence write: failed to start transaction: {e:?}");
+                return Err(nvfs_error_to_svsm_error(e));
+            }
+        };
+
+        // The Future instantiation step can fail only due to memory allocation
+        // failures. NvFsError::Retry is potentially getting returned only by the actual polling, in
+        // which case 'data' needs to get restored for the retry.
+        {
+            let mut write_inode_fut = match instantiate_cocoonfs_write_inode_fut(
+                &fs_instance,
+                transaction,
+                inode,
+                data,
+            ) {
+                Ok(write_inode_fut) => write_inode_fut,
+                Err(e) => {
+                    log::error!(
+                        "persistence write: failed to stage inode write at transaction: {e:?}"
+                    );
+                    return Err(nvfs_error_to_svsm_error(e));
+                }
+            };
+            (transaction, data) = match task_busypoll_to_completion(|cx| {
+                NvFsFuture::poll(
+                    pin::Pin::new(&mut *write_inode_fut),
+                    &fs_instance,
+                    &mut rng,
+                    cx,
+                )
+            }) {
+                (returned_data, Ok((transaction, Ok(())))) => (transaction, returned_data),
+                (returned_data, Ok((_, Err(NvFsError::Retry))) | Err(NvFsError::Retry)) => {
+                    data = returned_data;
+                    continue;
+                }
+                (_, Ok((_, Err(e))) | Err(e)) => {
+                    log::error!(
+                        "persistence write: failed to stage inode write at transaction: {e:?}"
+                    );
+                    return Err(nvfs_error_to_svsm_error(e));
+                }
+            };
+        }
+
+        if let Err(e) =
+            instantiate_cocoonfs_commit_transaction_fut(&fs_instance, transaction, issue_sync)
+                .and_then(|mut commit_transaction_fut| {
+                    task_busypoll_to_completion(|cx| {
+                        NvFsFuture::poll(
+                            pin::Pin::new(&mut *commit_transaction_fut),
+                            &fs_instance,
+                            &mut rng,
+                            cx,
+                        )
+                    })
+                    .map_err(|e| match e {
+                        TransactionCommitError::LogStateClean { reason } => reason,
+                        TransactionCommitError::LogStateIndeterminate { reason } => reason,
+                    })
+                })
+        {
+            if e == NvFsError::Retry {
+                continue;
+            }
+
+            log::error!("persistence write: failed to commit transaction: {e:?}");
+            return Err(nvfs_error_to_svsm_error(e));
+        }
+
+        break;
+    }
+
+    Ok(data)
+}
+
+/// Synchronously read data from an inode on persistent storage.
+///
+/// In case the `inode` does not exist, `None` is returned, otherwise all of the inode's data
+/// is returned wrapped in `Some`. Note that a non-existing inode and an existing one with
+/// empty data are considered different.
+///
+/// Any error propagated back to the caller indicates an actual problem -- in particular requests to
+/// retry received from the backing filesystem implementation are handled transparently within
+/// `persistence_read_inode_sync()` itself.
+///
+/// # Arguments:
+///
+/// * `inode` - Number of the inode whose data to read.
+#[allow(unused)]
+pub fn persistence_read_inode_sync(inode: u64) -> Result<Option<Zeroizing<Vec<u8>>>, SvsmError> {
+    let fs_instance = match SVSM_COCOONFS_INSTANCE.try_get_inner().ok() {
+        Some(fs_instance) => <pin::Pin<SvsmCocoonFsSyncRcPtrType> as sync_types::SyncRcPtr<
+            SvsmCocoonFsType,
+        >>::as_ref(fs_instance),
+        None => {
+            return Err(SvsmError::FileSystem(FsError::NotSupported));
+        }
+    };
+
+    let mut rng = match get_svsm_rng() {
+        Ok(rng) => rng,
+        Err(e) => {
+            log::error!("persistence read: failed to get rng instance: {e:?}");
+            return Err(nvfs_error_to_svsm_error(NvFsError::from(e)));
+        }
+    };
+
+    loop {
+        match instantiate_cocoonfs_read_inode_fut(&fs_instance, inode).and_then(
+            |mut read_inode_fut| {
+                task_busypoll_to_completion(|cx| {
+                    NvFsFuture::poll(
+                        pin::Pin::new(&mut *read_inode_fut),
+                        &fs_instance,
+                        &mut rng,
+                        cx,
+                    )
+                })
+            },
+        ) {
+            Ok((_read_context, Ok(result))) => {
+                break Ok(result.map(|read_result| read_result.1));
+            }
+            Ok((_, Err(NvFsError::Retry))) | Err(NvFsError::Retry) => (),
+            Ok((_, Err(e))) | Err(e) => {
+                log::error!("persistence read: failed to read inode data: {e:?}");
+                break Err(nvfs_error_to_svsm_error(e));
+            }
+        }
+    }
 }

--- a/kernel/src/persistence.rs
+++ b/kernel/src/persistence.rs
@@ -1074,3 +1074,49 @@ pub fn persistence_read_inode_sync(inode: u64) -> Result<Option<Zeroizing<Vec<u8
         }
     }
 }
+
+/// Persistence inode numbers allocated statically for specific SVSM uses.
+///
+/// Usable inode numbers start at `6`.
+#[derive(Debug)]
+#[repr(u64)]
+pub enum SvsmPersistenceStaticInode {
+    Demo = 16u64,
+}
+
+pub fn persistence_demo() {
+    if !persistence_available() {
+        return;
+    }
+
+    let data = match persistence_read_inode_sync(SvsmPersistenceStaticInode::Demo as u64) {
+        Ok(data) => data,
+        Err(_) => {
+            log::error!("persistence demo: failed to read inode data");
+            return;
+        }
+    };
+    let mut boot_counter = match data {
+        Some(data) => {
+            let mut boot_counter = [0u8; 4];
+            let l = data.len().min(4);
+            boot_counter[..l].copy_from_slice(&data[..l]);
+            let boot_counter = u32::from_le_bytes(boot_counter);
+            log::info!("persistence demo: boot counter read back is {boot_counter}");
+            boot_counter
+        }
+        None => {
+            log::info!("persistence demo: no boot counter found yet");
+            0
+        }
+    };
+
+    boot_counter = boot_counter.wrapping_add(1);
+
+    // This splats on allocation failure, but it's only a demo.
+    let data = Zeroizing::new(boot_counter.to_le_bytes().to_vec());
+    match persistence_write_inode_sync(SvsmPersistenceStaticInode::Demo as u64, data, true) {
+        Ok(_) => log::info!("persistence demo: successfully wrote updated boot counter"),
+        Err(e) => log::error!("persistence demo: boot counter updating write failed: {e:?}"),
+    };
+}

--- a/kernel/src/persistence.rs
+++ b/kernel/src/persistence.rs
@@ -1,0 +1,613 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright 2025 SUSE LLC
+// Author: Nicolai Stange <nstange@suse.de>
+
+//! Functionality related to persistent SVSM storage.
+
+use core::{fmt::Debug, ops, pin, task};
+
+use cocoon_tpm_storage::{
+    blkdev::{
+        NvBlkDev, NvBlkDevFuture, NvBlkDevIoError, NvBlkDevReadRequest, NvBlkDevWriteRequest,
+    },
+    nvblkdev_err_internal,
+};
+use cocoon_tpm_utils_common::fixed_vec::FixedVec;
+
+use crate::block::{BlockDeviceError, api::BlockDriver};
+use crate::error::SvsmError;
+use crate::mm::alloc::AllocError;
+use crate::types::PAGE_SHIFT;
+
+/// Wrapper around [`BlockDriver`] implementors, itself implementing the `cocoon-tpm-storage`
+/// crate's [`NvBlkDev`] block device abstraction.
+struct SvsmNvBlkDev<D: 'static + ops::Deref<Target: BlockDriver> + Send + Sync + Unpin> {
+    driver: D,
+    io_block_size_128b_log2: u32,
+}
+
+impl<D: ops::Deref<Target: BlockDriver> + Send + Sync + Unpin> SvsmNvBlkDev<D> {
+    #[allow(dead_code)]
+    fn new(driver: D) -> Self {
+        // We got to store the block size in order to avoid TOCTOU issues, c.f. the
+        // NvBlkDev::io_block_size_128b_log2() docs.
+        let io_block_size_log2 = driver.block_size_log2() as u32;
+        let io_block_size_128b_log2 = io_block_size_log2.saturating_sub(7);
+        Self {
+            driver,
+            io_block_size_128b_log2,
+        }
+    }
+}
+
+impl<D: 'static + ops::Deref<Target: BlockDriver> + Send + Sync + Unpin> NvBlkDev
+    for SvsmNvBlkDev<D>
+{
+    fn io_block_size_128b_log2(&self) -> u32 {
+        self.io_block_size_128b_log2
+    }
+
+    fn io_blocks(&self) -> u64 {
+        ((self.driver.size() as u64) >> self.io_block_size_128b_log2) >> 7
+    }
+
+    fn preferred_io_blocks_bulk_log2(&self) -> u32 {
+        (PAGE_SHIFT as u32)
+            .saturating_sub(self.io_block_size_128b_log2)
+            .saturating_sub(7)
+    }
+
+    type ResizeFuture = SvsmNvBlkDevResizeFuture;
+
+    fn resize(&self, _io_blocks_count: u64) -> Result<Self::ResizeFuture, NvBlkDevIoError> {
+        Ok(SvsmNvBlkDevResizeFuture)
+    }
+
+    type ReadFuture<R: NvBlkDevReadRequest> = SvsmNvBlkDevReadFuture<R>;
+
+    fn read<R: NvBlkDevReadRequest>(
+        &self,
+        request: R,
+    ) -> Result<Result<Self::ReadFuture<R>, (R, NvBlkDevIoError)>, NvBlkDevIoError> {
+        Ok(Ok(SvsmNvBlkDevReadFuture {
+            request: Some(request),
+            bounce_buffer: FixedVec::new_empty(),
+        }))
+    }
+
+    type WriteFuture<R: NvBlkDevWriteRequest> = SvsmNvBlkDevWriteFuture<R>;
+
+    fn write<R: NvBlkDevWriteRequest>(
+        &self,
+        request: R,
+    ) -> Result<Result<Self::WriteFuture<R>, (R, NvBlkDevIoError)>, NvBlkDevIoError> {
+        Ok(Ok(SvsmNvBlkDevWriteFuture {
+            request: Some(request),
+            bounce_buffer: FixedVec::new_empty(),
+        }))
+    }
+
+    type FlushQueuedWritesFuture = SvsmNvBlkDevFlushQueuedWritesFuture;
+
+    fn flush_queued_writes(&self) -> Result<Self::FlushQueuedWritesFuture, NvBlkDevIoError> {
+        Ok(SvsmNvBlkDevFlushQueuedWritesFuture)
+    }
+
+    type WriteBarrierFuture = SvsmNvBlkDevWriteSyncFuture;
+
+    fn write_barrier(&self) -> Result<Self::WriteBarrierFuture, NvBlkDevIoError> {
+        Ok(SvsmNvBlkDevWriteSyncFuture)
+    }
+
+    type WriteSyncFuture = SvsmNvBlkDevWriteSyncFuture;
+
+    fn write_sync(&self) -> Result<Self::WriteSyncFuture, NvBlkDevIoError> {
+        Ok(SvsmNvBlkDevWriteSyncFuture)
+    }
+
+    type TrimFuture = SvsmNvBlkDevTrimFuture;
+
+    fn trim(
+        &self,
+        io_block_index: u64,
+        io_blocks_count: u64,
+    ) -> Result<Self::TrimFuture, NvBlkDevIoError> {
+        Ok(SvsmNvBlkDevTrimFuture {
+            io_block_index,
+            io_blocks_count,
+            zeroes_buffer: FixedVec::new_empty(),
+        })
+    }
+}
+
+impl<D: 'static + ops::Deref<Target: BlockDriver> + Send + Sync + Unpin> Debug for SvsmNvBlkDev<D> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SvsmNvBlkDev").finish()
+    }
+}
+
+/// Convert a [`SvsmError`] to a [`NvBlkDevIoError`].
+fn svsm_error_to_nvblkdev_io_error(e: SvsmError) -> NvBlkDevIoError {
+    match e {
+        SvsmError::Block(BlockDeviceError::Failed) => NvBlkDevIoError::IoFailure,
+        SvsmError::Alloc(AllocError::OutOfMemory) => NvBlkDevIoError::MemoryAllocationFailure,
+        _ => NvBlkDevIoError::IoFailure,
+    }
+}
+
+/// [`NvBlkDev::ResizeFuture`] implementation for [`SvsmNvBlkDev`].
+#[derive(Debug)]
+struct SvsmNvBlkDevResizeFuture;
+
+impl<D: 'static + ops::Deref<Target: BlockDriver> + Send + Sync + Unpin>
+    NvBlkDevFuture<SvsmNvBlkDev<D>> for SvsmNvBlkDevResizeFuture
+{
+    type Output = Result<(), NvBlkDevIoError>;
+
+    fn poll(
+        self: pin::Pin<&mut Self>,
+        _dev: &SvsmNvBlkDev<D>,
+        _cx: &mut core::task::Context<'_>,
+    ) -> task::Poll<Self::Output> {
+        task::Poll::Ready(Err(NvBlkDevIoError::OperationNotSupported))
+    }
+}
+
+/// [`NvBlkDev::ReadFuture`] implementation for [`SvsmNvBlkDev`].
+#[derive(Debug)]
+struct SvsmNvBlkDevReadFuture<R: NvBlkDevReadRequest> {
+    request: Option<R>,
+    bounce_buffer: FixedVec<u8, 7>,
+}
+
+impl<D: 'static + ops::Deref<Target: BlockDriver> + Send + Sync + Unpin, R: NvBlkDevReadRequest>
+    NvBlkDevFuture<SvsmNvBlkDev<D>> for SvsmNvBlkDevReadFuture<R>
+{
+    type Output = Result<(R, Result<(), NvBlkDevIoError>), NvBlkDevIoError>;
+
+    fn poll(
+        self: pin::Pin<&mut Self>,
+        dev: &SvsmNvBlkDev<D>,
+        _cx: &mut task::Context<'_>,
+    ) -> task::Poll<Self::Output> {
+        let dev_io_block_size_128b_log2 = dev.io_block_size_128b_log2();
+        let preferred_dev_io_blocks_bulk_log2 = dev.preferred_io_blocks_bulk_log2();
+        let dev_io_blocks = dev.io_blocks();
+
+        let this = pin::Pin::into_inner(self);
+        let mut request = match this.request.take() {
+            Some(request) => request,
+            None => return task::Poll::Ready(Err(nvblkdev_err_internal!())),
+        };
+
+        let region = request.region().clone();
+        if region.chunk_size_128b_log2() >= dev_io_block_size_128b_log2 {
+            // The buffers are all larger than (by a fixed power of two multiple of) the device
+            // block size. No bounce buffer needed.
+            let block_size_128b_log2 = if region.is_aligned(region.chunk_size_128b_log2()) {
+                region.chunk_size_128b_log2()
+            } else if region.chunk_size_128b_log2()
+                >= preferred_dev_io_blocks_bulk_log2 + dev_io_block_size_128b_log2
+                && region
+                    .is_aligned(preferred_dev_io_blocks_bulk_log2 + dev_io_block_size_128b_log2)
+            {
+                preferred_dev_io_blocks_bulk_log2 + dev_io_block_size_128b_log2
+            } else {
+                debug_assert!(region.is_aligned(dev_io_block_size_128b_log2));
+                dev_io_block_size_128b_log2
+            };
+            let blocks_iter = match region.aligned_blocks_iter(block_size_128b_log2) {
+                Ok(blocks_iter) => blocks_iter,
+                Err(_) => return task::Poll::Ready(Ok((request, Err(nvblkdev_err_internal!())))),
+            };
+            for (physical_block_index, block_chunks) in blocks_iter {
+                let block_begin_128b = physical_block_index << block_size_128b_log2;
+                if block_begin_128b >= dev_io_blocks << dev_io_block_size_128b_log2
+                    || ((dev_io_blocks << dev_io_block_size_128b_log2) - block_begin_128b)
+                        >> block_size_128b_log2
+                        == 0
+                {
+                    return task::Poll::Ready(Ok((
+                        request,
+                        Err(NvBlkDevIoError::IoBlockOutOfRange),
+                    )));
+                }
+
+                for (offset_in_block_128b, chunk_range) in block_chunks {
+                    // The buffer size is >= the iteration block size.
+                    debug_assert_eq!(offset_in_block_128b, 0);
+                    let buf = match request.get_destination_buffer(&chunk_range) {
+                        Ok(buf) => buf,
+                        Err(e) => return task::Poll::Ready(Ok((request, Err(e)))),
+                    };
+                    let buf = match buf {
+                        Some(buf) => buf,
+                        None => {
+                            continue;
+                        }
+                    };
+
+                    let dev_block_id =
+                        (block_begin_128b + offset_in_block_128b) >> dev_io_block_size_128b_log2;
+                    let dev_block_id = match usize::try_from(dev_block_id) {
+                        Ok(dev_block_id) => dev_block_id,
+                        Err(_) => {
+                            // The dev_io_blocks has been derived from BlockDriver::size(), which is
+                            // an usize.
+                            return task::Poll::Ready(Ok((request, Err(nvblkdev_err_internal!()))));
+                        }
+                    };
+                    if let Err(e) = dev.driver.read_blocks(dev_block_id, buf) {
+                        log::error!(
+                            "block device read failed: error={e:?}, position={}, size={}",
+                            (block_begin_128b + offset_in_block_128b) << 7,
+                            1u64 << (block_size_128b_log2 + 7)
+                        );
+                        return task::Poll::Ready(Ok((
+                            request,
+                            Err(svsm_error_to_nvblkdev_io_error(e)),
+                        )));
+                    }
+                }
+            }
+        } else {
+            // The buffers are smaller than the volume block size, going through the bounce buffer
+            // is necessary.
+            let block_size_128b_log2 = dev_io_block_size_128b_log2;
+
+            if this.bounce_buffer.is_empty() {
+                this.bounce_buffer =
+                    match FixedVec::new_with_default(1usize << (block_size_128b_log2 + 7)) {
+                        Ok(bounce_buffer) => bounce_buffer,
+                        Err(_) => {
+                            return task::Poll::Ready(Ok((
+                                request,
+                                Err(NvBlkDevIoError::MemoryAllocationFailure),
+                            )));
+                        }
+                    };
+            }
+
+            let blocks_iter = match region.aligned_blocks_iter(block_size_128b_log2) {
+                Ok(blocks_iter) => blocks_iter,
+                Err(_) => return task::Poll::Ready(Ok((request, Err(nvblkdev_err_internal!())))),
+            };
+            for (physical_block_index, block_chunks) in blocks_iter {
+                let block_begin_128b = physical_block_index << block_size_128b_log2;
+                if block_begin_128b >= dev_io_blocks << dev_io_block_size_128b_log2
+                    || ((dev_io_blocks << dev_io_block_size_128b_log2) - block_begin_128b)
+                        >> block_size_128b_log2
+                        == 0
+                {
+                    return task::Poll::Ready(Ok((
+                        request,
+                        Err(NvBlkDevIoError::IoBlockOutOfRange),
+                    )));
+                }
+
+                let dev_block_id = block_begin_128b >> dev_io_block_size_128b_log2;
+                let dev_block_id = match usize::try_from(dev_block_id) {
+                    Ok(dev_block_id) => dev_block_id,
+                    Err(_) => {
+                        // The dev_io_blocks has been derived from BlockDriver::size(), which is an
+                        // usize.
+                        return task::Poll::Ready(Ok((request, Err(nvblkdev_err_internal!()))));
+                    }
+                };
+                if let Err(e) = dev
+                    .driver
+                    .read_blocks(dev_block_id, &mut this.bounce_buffer)
+                {
+                    log::error!(
+                        "block device read failed: error={e:?}, position={}, size={}",
+                        block_begin_128b << 7,
+                        1u64 << (block_size_128b_log2 + 7)
+                    );
+                    return task::Poll::Ready(Ok((
+                        request,
+                        Err(svsm_error_to_nvblkdev_io_error(e)),
+                    )));
+                }
+
+                for (offset_in_block_128b, chunk_range) in block_chunks {
+                    let buf = match request.get_destination_buffer(&chunk_range) {
+                        Ok(buf) => buf,
+                        Err(e) => return task::Poll::Ready(Ok((request, Err(e)))),
+                    };
+                    let buf = match buf {
+                        Some(buf) => buf,
+                        None => continue,
+                    };
+
+                    let buf_len = buf.len();
+                    debug_assert_eq!(buf_len, 1usize << (region.chunk_size_128b_log2() + 7));
+                    let offset_in_block = (offset_in_block_128b << 7) as usize;
+                    buf.copy_from_slice(
+                        &this.bounce_buffer[offset_in_block..offset_in_block + buf_len],
+                    );
+                }
+            }
+        }
+
+        task::Poll::Ready(Ok((request, Ok(()))))
+    }
+}
+
+/// [`NvBlkDev::WriteFuture`] implementation for [`SvsmNvBlkDev`].
+#[derive(Debug)]
+struct SvsmNvBlkDevWriteFuture<R: NvBlkDevWriteRequest> {
+    request: Option<R>,
+    bounce_buffer: FixedVec<u8, 7>,
+}
+
+impl<D: 'static + ops::Deref<Target: BlockDriver> + Send + Sync + Unpin, R: NvBlkDevWriteRequest>
+    NvBlkDevFuture<SvsmNvBlkDev<D>> for SvsmNvBlkDevWriteFuture<R>
+{
+    type Output = Result<(R, Result<(), NvBlkDevIoError>), NvBlkDevIoError>;
+
+    fn poll(
+        self: pin::Pin<&mut Self>,
+        dev: &SvsmNvBlkDev<D>,
+        _cx: &mut task::Context<'_>,
+    ) -> task::Poll<Self::Output> {
+        let dev_io_block_size_128b_log2 = dev.io_block_size_128b_log2();
+        let preferred_dev_io_blocks_bulk_log2 = dev.preferred_io_blocks_bulk_log2();
+        let dev_io_blocks = dev.io_blocks();
+
+        let this = pin::Pin::into_inner(self);
+        let request = match this.request.take() {
+            Some(request) => request,
+            None => return task::Poll::Ready(Err(nvblkdev_err_internal!())),
+        };
+
+        let region = request.region().clone();
+        if region.chunk_size_128b_log2() >= dev_io_block_size_128b_log2 {
+            // The buffers are all larger than (by a fixed power of two multiple of) the volume
+            // block size. No bounce buffer needed.
+            let block_size_128b_log2 = if region.is_aligned(region.chunk_size_128b_log2()) {
+                region.chunk_size_128b_log2()
+            } else if region.chunk_size_128b_log2()
+                >= preferred_dev_io_blocks_bulk_log2 + dev_io_block_size_128b_log2
+                && region
+                    .is_aligned(preferred_dev_io_blocks_bulk_log2 + dev_io_block_size_128b_log2)
+            {
+                preferred_dev_io_blocks_bulk_log2 + dev_io_block_size_128b_log2
+            } else {
+                debug_assert!(region.is_aligned(dev_io_block_size_128b_log2));
+                dev_io_block_size_128b_log2
+            };
+            let blocks_iter = match region.aligned_blocks_iter(block_size_128b_log2) {
+                Ok(blocks_iter) => blocks_iter,
+                Err(_) => return task::Poll::Ready(Ok((request, Err(nvblkdev_err_internal!())))),
+            };
+            for (physical_block_index, block_chunks) in blocks_iter {
+                let block_begin_128b = physical_block_index << block_size_128b_log2;
+                if block_begin_128b >= dev_io_blocks << dev_io_block_size_128b_log2
+                    || ((dev_io_blocks << dev_io_block_size_128b_log2) - block_begin_128b)
+                        >> block_size_128b_log2
+                        == 0
+                {
+                    return task::Poll::Ready(Ok((
+                        request,
+                        Err(NvBlkDevIoError::IoBlockOutOfRange),
+                    )));
+                }
+
+                for (offset_in_block_128b, chunk_range) in block_chunks {
+                    // The buffer size is >= the iteration block size.
+                    debug_assert_eq!(offset_in_block_128b, 0);
+                    let buf = match request.get_source_buffer(&chunk_range) {
+                        Ok(buf) => buf,
+                        Err(e) => return task::Poll::Ready(Ok((request, Err(e)))),
+                    };
+
+                    let dev_block_id =
+                        (block_begin_128b + offset_in_block_128b) >> dev_io_block_size_128b_log2;
+                    let dev_block_id = match usize::try_from(dev_block_id) {
+                        Ok(dev_block_id) => dev_block_id,
+                        Err(_) => {
+                            // The dev_io_blocks has been derived from BlockDriver::size(), which is
+                            // an usize.
+                            return task::Poll::Ready(Ok((request, Err(nvblkdev_err_internal!()))));
+                        }
+                    };
+                    if let Err(e) = dev.driver.write_blocks(dev_block_id, buf) {
+                        log::error!(
+                            "block device write failed: error={e:?}, position={}, size={}",
+                            (block_begin_128b + offset_in_block_128b) << 7,
+                            1u64 << (block_size_128b_log2 + 7)
+                        );
+                        return task::Poll::Ready(Ok((
+                            request,
+                            Err(svsm_error_to_nvblkdev_io_error(e)),
+                        )));
+                    }
+                }
+            }
+        } else {
+            // The buffers are smaller than the volume block size, going through the bounce buffer
+            // is necessary.
+            let block_size_128b_log2 = dev_io_block_size_128b_log2;
+
+            if this.bounce_buffer.is_empty() {
+                this.bounce_buffer =
+                    match FixedVec::new_with_default(1usize << (block_size_128b_log2 + 7)) {
+                        Ok(bounce_buffer) => bounce_buffer,
+                        Err(_) => {
+                            return task::Poll::Ready(Ok((
+                                request,
+                                Err(NvBlkDevIoError::MemoryAllocationFailure),
+                            )));
+                        }
+                    };
+            }
+
+            let blocks_iter = match region.aligned_blocks_iter(block_size_128b_log2) {
+                Ok(blocks_iter) => blocks_iter,
+                Err(_) => return task::Poll::Ready(Ok((request, Err(nvblkdev_err_internal!())))),
+            };
+            for (physical_block_index, block_chunks) in blocks_iter {
+                let block_begin_128b = physical_block_index << block_size_128b_log2;
+                if block_begin_128b >= dev_io_blocks << dev_io_block_size_128b_log2
+                    || ((dev_io_blocks << dev_io_block_size_128b_log2) - block_begin_128b)
+                        >> block_size_128b_log2
+                        == 0
+                {
+                    return task::Poll::Ready(Ok((
+                        request,
+                        Err(NvBlkDevIoError::IoBlockOutOfRange),
+                    )));
+                }
+
+                for (offset_in_block_128b, chunk_range) in block_chunks {
+                    let buf = match request.get_source_buffer(&chunk_range) {
+                        Ok(buf) => buf,
+                        Err(e) => return task::Poll::Ready(Ok((request, Err(e)))),
+                    };
+
+                    let buf_len = buf.len();
+                    debug_assert_eq!(buf_len, 1usize << (region.chunk_size_128b_log2() + 7));
+                    let offset_in_block = (offset_in_block_128b << 7) as usize;
+                    this.bounce_buffer[offset_in_block..offset_in_block + buf_len]
+                        .copy_from_slice(buf);
+                }
+
+                let dev_block_id = block_begin_128b >> dev_io_block_size_128b_log2;
+                let dev_block_id = match usize::try_from(dev_block_id) {
+                    Ok(dev_block_id) => dev_block_id,
+                    Err(_) => {
+                        // The dev_io_blocks has been derived from BlockDriver::size(), which is an
+                        // usize.
+                        return task::Poll::Ready(Ok((request, Err(nvblkdev_err_internal!()))));
+                    }
+                };
+                if let Err(e) = dev.driver.write_blocks(dev_block_id, &this.bounce_buffer) {
+                    log::error!(
+                        "block device write failed: error={e:?}, position={}, size={}",
+                        block_begin_128b << 7,
+                        1u64 << (block_size_128b_log2 + 7)
+                    );
+                    return task::Poll::Ready(Ok((
+                        request,
+                        Err(svsm_error_to_nvblkdev_io_error(e)),
+                    )));
+                }
+            }
+        }
+
+        task::Poll::Ready(Ok((request, Ok(()))))
+    }
+}
+
+/// [`NvBlkDev::FlushQueuedWritesFuture`] implementation for [`SvsmNvBlkDev`].
+#[derive(Debug)]
+struct SvsmNvBlkDevFlushQueuedWritesFuture;
+
+impl<D: 'static + ops::Deref<Target: BlockDriver> + Send + Sync + Unpin>
+    NvBlkDevFuture<SvsmNvBlkDev<D>> for SvsmNvBlkDevFlushQueuedWritesFuture
+{
+    type Output = Result<(), NvBlkDevIoError>;
+
+    fn poll(
+        self: pin::Pin<&mut Self>,
+        _dev: &SvsmNvBlkDev<D>,
+        _cx: &mut task::Context<'_>,
+    ) -> task::Poll<Self::Output> {
+        // Any pending write operations need to get "completed with unspecified" result here.  This
+        // can only manifest itself in how subsequently issued writes to overlapping storage regions
+        // are possibly getting ordered relative to the flushed/cancelled ones. One would hope that
+        // there is no moving of older request to after newer conflicting ones happening anywhere in
+        // the stack. So avoid issuing yet another write barrier here.
+        task::Poll::Ready(Ok(()))
+    }
+}
+
+/// [`NvBlkDev::WriteSyncFuture`] implementation for [`SvsmNvBlkDev`].
+///
+/// Also used for the [`NvBlkDev::WriteBarrierFuture`].
+#[derive(Debug)]
+struct SvsmNvBlkDevWriteSyncFuture;
+
+impl<D: 'static + ops::Deref<Target: BlockDriver> + Send + Sync + Unpin>
+    NvBlkDevFuture<SvsmNvBlkDev<D>> for SvsmNvBlkDevWriteSyncFuture
+{
+    type Output = Result<(), NvBlkDevIoError>;
+
+    fn poll(
+        self: pin::Pin<&mut Self>,
+        dev: &SvsmNvBlkDev<D>,
+        _cx: &mut core::task::Context<'_>,
+    ) -> core::task::Poll<Self::Output> {
+        if let Err(e) = dev.driver.flush() {
+            log::error!("block device flush request failed: error={e:?}");
+            return task::Poll::Ready(Err(svsm_error_to_nvblkdev_io_error(e)));
+        }
+
+        task::Poll::Ready(Ok(()))
+    }
+}
+
+/// [`NvBlkDev::TrimFuture`] implementation for [`SvsmNvBlkDev`].
+#[derive(Debug)]
+struct SvsmNvBlkDevTrimFuture {
+    io_block_index: u64,
+    io_blocks_count: u64,
+    zeroes_buffer: FixedVec<u8, 7>,
+}
+
+impl<D: 'static + ops::Deref<Target: BlockDriver> + Send + Sync + Unpin>
+    NvBlkDevFuture<SvsmNvBlkDev<D>> for SvsmNvBlkDevTrimFuture
+{
+    type Output = Result<(), NvBlkDevIoError>;
+
+    fn poll(
+        self: pin::Pin<&mut Self>,
+        dev: &SvsmNvBlkDev<D>,
+        _cx: &mut core::task::Context<'_>,
+    ) -> core::task::Poll<Self::Output> {
+        // The BlockDriver trait, and ultimately the VirtIOBlk, don't seem to provide DISCARD
+        // functionality. Write zeroes so that the host can still apply compression (if trimming is
+        // even enabled for the filesystem instance).
+        let dev_io_block_size_128b_log2 = dev.io_block_size_128b_log2();
+        let dev_io_blocks = dev.io_blocks();
+        if self.io_blocks_count == 0 {
+            return task::Poll::Ready(Ok(()));
+        } else if self.io_block_index > dev_io_blocks
+            || dev_io_blocks - self.io_block_index < self.io_blocks_count
+        {
+            return task::Poll::Ready(Err(NvBlkDevIoError::IoBlockOutOfRange));
+        }
+
+        let this = pin::Pin::into_inner(self);
+        if this.zeroes_buffer.is_empty() {
+            this.zeroes_buffer =
+                match FixedVec::new_with_default(1usize << (dev_io_block_size_128b_log2 + 7)) {
+                    Ok(zeroes_buffer) => zeroes_buffer,
+                    Err(_) => {
+                        return task::Poll::Ready(Err(NvBlkDevIoError::MemoryAllocationFailure));
+                    }
+                };
+        }
+
+        for i in 0..this.io_blocks_count {
+            let dev_block_id = match usize::try_from(this.io_block_index + i) {
+                Ok(dev_block_id) => dev_block_id,
+                Err(_) => {
+                    // The dev_io_blocks has been derived from BlockDriver::size(), which is an
+                    // usize.
+                    return task::Poll::Ready(Err(nvblkdev_err_internal!()));
+                }
+            };
+            if let Err(e) = dev.driver.write_blocks(dev_block_id, &this.zeroes_buffer) {
+                log::error!(
+                    "block device zeroization write failed: error={e:?}, position={}, size={}",
+                    (dev_block_id as u64) << (dev_io_block_size_128b_log2 + 7),
+                    1u64 << (dev_io_block_size_128b_log2 + 7)
+                );
+                return task::Poll::Ready(Err(svsm_error_to_nvblkdev_io_error(e)));
+            }
+        }
+
+        task::Poll::Ready(Ok(()))
+    }
+}

--- a/kernel/src/persistence.rs
+++ b/kernel/src/persistence.rs
@@ -1,23 +1,38 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-// Copyright 2025 SUSE LLC
+// Copyright 2025-2026 SUSE LLC
 // Author: Nicolai Stange <nstange@suse.de>
 
 //! Functionality related to persistent SVSM storage.
 
-use core::{fmt::Debug, ops, pin, task};
+extern crate alloc;
+use alloc::{boxed::Box, vec::Vec};
+
+use core::{fmt::Debug, future::Future, ops, pin, task};
 
 use cocoon_tpm_storage::{
     blkdev::{
         NvBlkDev, NvBlkDevFuture, NvBlkDevIoError, NvBlkDevReadRequest, NvBlkDevWriteRequest,
     },
+    fs::{
+        NvFsError, NvFsIoError,
+        cocoonfs::{self, CocoonFs},
+    },
     nvblkdev_err_internal,
 };
-use cocoon_tpm_utils_common::fixed_vec::FixedVec;
+use cocoon_tpm_utils_async::sync_types;
+use cocoon_tpm_utils_common::{
+    alloc::{box_try_new, try_alloc_zeroizing_vec},
+    fixed_vec::FixedVec,
+    zeroize::Zeroizing,
+};
 
-use crate::block::{BlockDeviceError, api::BlockDriver};
+use crate::r#async::{SvsmSyncTypes, task_busypoll_to_completion};
+use crate::block::{BLOCK_DEVICE, BlockDeviceError, api::BlockDriver};
+use crate::crypto::get_svsm_rng;
 use crate::error::SvsmError;
 use crate::mm::alloc::AllocError;
 use crate::types::PAGE_SHIFT;
+use crate::utils::immut_after_init::ImmutAfterInitCell;
 
 /// Wrapper around [`BlockDriver`] implementors, itself implementing the `cocoon-tpm-storage`
 /// crate's [`NvBlkDev`] block device abstraction.
@@ -27,7 +42,6 @@ struct SvsmNvBlkDev<D: 'static + ops::Deref<Target: BlockDriver> + Send + Sync +
 }
 
 impl<D: ops::Deref<Target: BlockDriver> + Send + Sync + Unpin> SvsmNvBlkDev<D> {
-    #[allow(dead_code)]
     fn new(driver: D) -> Self {
         // We got to store the block size in order to avoid TOCTOU issues, c.f. the
         // NvBlkDev::io_block_size_128b_log2() docs.
@@ -610,4 +624,196 @@ impl<D: 'static + ops::Deref<Target: BlockDriver> + Send + Sync + Unpin>
 
         task::Poll::Ready(Ok(()))
     }
+}
+
+fn nvfs_error_to_svsm_error(e: NvFsError) -> SvsmError {
+    match e {
+        NvFsError::MemoryAllocationFailure => SvsmError::Alloc(AllocError::OutOfMemory),
+        NvFsError::IoError(NvFsIoError::IoFailure) => SvsmError::Block(BlockDeviceError::Failed),
+        _ => SvsmError::Block(BlockDeviceError::Failed),
+    }
+}
+
+type SvsmCocoonFsType = CocoonFs<SvsmSyncTypes, SvsmNvBlkDev<&'static dyn BlockDriver>>;
+type SvsmCocoonFsSyncRcPtrType =
+    <<SvsmSyncTypes as sync_types::SyncTypes>::SyncRcPtrFactory as sync_types::SyncRcPtrFactory>
+    ::SyncRcPtr<SvsmCocoonFsType>;
+
+static SVSM_COCOONFS_INSTANCE: ImmutAfterInitCell<pin::Pin<SvsmCocoonFsSyncRcPtrType>> =
+    ImmutAfterInitCell::uninit();
+
+/// Instantiate a [`cocoonfs::ReadFsMetadataFuture`].
+///
+/// The `cocoonfs::ReadFsMetadataFuture` is huge, and by instantiating it in an `inline(never)`
+/// function and `Box`ing it right after, the stack allocations required for the moves are hopefully
+/// getting freed up quickly again.
+#[inline(never)]
+fn instantiate_cocoonfs_read_fs_metadata_fut(
+    blkdev: SvsmNvBlkDev<&'static dyn BlockDriver>,
+) -> Result<Box<cocoonfs::ReadFsMetadataFuture<SvsmNvBlkDev<&'static dyn BlockDriver>>>, NvFsError>
+{
+    let read_fs_metadata_fut =
+        cocoonfs::ReadFsMetadataFuture::new(blkdev).map_err(|(_blkdev, e)| e)?;
+    box_try_new(read_fs_metadata_fut).map_err(NvFsError::from)
+}
+
+/// Instantiate a [`cocoonfs::OpenFsFuture`].
+///
+/// The `cocoonfs::OpenFsFuture` is huge, and by instantiating it in an `inline(never)` function and
+/// `Box`ing it right after, the stack allocations required for the moves are hopefully getting
+/// freed up quickly again.
+#[allow(clippy::type_complexity)]
+#[inline(never)]
+fn instantiate_cocoonfs_open_fut(
+    blkdev: SvsmNvBlkDev<&'static dyn BlockDriver>,
+    fs_metadata: cocoonfs::FsMetadata,
+    key: Zeroizing<Vec<u8>>,
+) -> Result<
+    Box<cocoonfs::OpenFsFuture<SvsmSyncTypes, SvsmNvBlkDev<&'static dyn BlockDriver>>>,
+    NvFsError,
+> {
+    let rng = box_try_new(get_svsm_rng().map_err(NvFsError::from)?).map_err(NvFsError::from)?;
+    let cocoonfs_open_fut = cocoonfs::OpenFsFuture::new(blkdev, Some(fs_metadata), key, false, rng)
+        .map_err(|(_blkdev, _key, _rng, e)| e)?;
+    box_try_new(cocoonfs_open_fut).map_err(NvFsError::from)
+}
+
+/// Persistence metadata info returned by [`persistence_discover()`].
+///
+/// `PersistenceBootstrapInfo` gets returned by [`persistence_discover()`], is supposed to serve as
+/// input to the attestation, and, once the key has been obtained, to eventually get passed to
+/// [`persistence_init()`] for the unlocking.
+#[allow(missing_debug_implementations)]
+pub struct PersistenceBootstrapInfo {
+    blkdev: SvsmNvBlkDev<&'static dyn BlockDriver>,
+    fs_metadata: cocoonfs::FsMetadata,
+}
+
+impl PersistenceBootstrapInfo {
+    /// Access the metadata.
+    pub fn get_fs_metadata(&self) -> &cocoonfs::FsMetadata {
+        &self.fs_metadata
+    }
+}
+
+/// Obtain persistence bootstrap info from block devices, if any.
+///
+/// Persistence initialization is a split operation. In a first step, the metadata is read from any
+/// block devices via `persistence_discover()`, if any. That metadata is then served as input to the
+/// attestation procedure in order to obtain a key. Eventually, the bootstrap info and the key get
+/// passed to `persistence_init()` for the unlocking.
+///
+/// # See also:
+///
+/// * [`persistence_init()`]
+pub fn persistence_discover() -> Result<Option<PersistenceBootstrapInfo>, SvsmError> {
+    // Inspect the global BLOCK_DEVICE and see if there's a CocoonFs on it, either already formatted
+    // or one with a mkfsinfo header, which will get formatted transparently at first filesystem
+    // opening time.
+    log::debug!("attempting to find persistent CocoonFs storage...");
+    let blkdev = match BLOCK_DEVICE.try_get_inner().ok() {
+        Some(blkdev) => SvsmNvBlkDev::new(&**blkdev),
+        None => {
+            log::debug!("no block device found");
+            return Ok(None);
+        }
+    };
+
+    let mut read_fs_metadata_fut =
+        instantiate_cocoonfs_read_fs_metadata_fut(blkdev).map_err(nvfs_error_to_svsm_error)?;
+    match task_busypoll_to_completion(|cx| {
+        Future::poll(pin::Pin::new(&mut read_fs_metadata_fut), cx)
+    }) {
+        Ok((blkdev, Ok(fs_metadata))) => {
+            // Found one, return it.
+            log::debug!("found persistent CocoonFs storage");
+            Ok(Some(PersistenceBootstrapInfo {
+                blkdev,
+                fs_metadata,
+            }))
+        }
+        Ok((_blkdev, Err(e))) => {
+            if e == NvFsError::from(cocoonfs::FormatError::InvalidImageHeader) {
+                log::debug!("skipping over block device with no CocoonFs header");
+            } else {
+                log::error!("failed to read CocoonFs metadata from block device: {e:?}");
+            }
+            // No CocoonFs block device available.
+            log::info!("no persistent CocoonFs storage found");
+            Ok(None)
+        }
+        Err(e) => {
+            // If not even the blkdev is getting returned back, it's likely an internal error of
+            // the implementation.
+            log::error!("failed to read CocoonFs metadata from block device: {e:?}");
+            Err(nvfs_error_to_svsm_error(e))
+        }
+    }
+}
+
+/// Finalize the initialization of the persistence subsystem.
+///
+/// Must get invoked at most once at startup, any subsequent reinitialization attempt will result in
+/// a panic.
+///
+/// The successfully opened CocoonFs instance, if any, will henceforth be used to serve all
+/// the SVSM's persistence related needs.
+///
+/// # Arguments:
+///
+/// * `bootstrap_info` - The bootstrap info previously obtained from [`persistence_discover()`] and
+///   provided to the attestation in order to obtain the `key`.
+/// * `key` - The CocoonFs root key used (indirectly) for authentication and encryption.
+///
+/// # See also:
+///
+/// * [`persistence_discover()`]
+pub fn persistence_init(
+    bootstrap_info: PersistenceBootstrapInfo,
+    key: &[u8],
+) -> Result<(), SvsmError> {
+    let PersistenceBootstrapInfo {
+        blkdev,
+        fs_metadata,
+    } = bootstrap_info;
+
+    // Make a copy for the OpenFsFuture.
+    let mut owned_key = try_alloc_zeroizing_vec(key.len())
+        .map_err(|_| SvsmError::Alloc(AllocError::OutOfMemory))?;
+    owned_key.copy_from_slice(key);
+
+    let mut cocoonfs_open_fut = match instantiate_cocoonfs_open_fut(blkdev, fs_metadata, owned_key)
+    {
+        Ok(cocoonfs_open_fut) => cocoonfs_open_fut,
+        Err(e) => {
+            log::error!("failed to initiate CocoonFs opening operation: {e:?}");
+            return Err(nvfs_error_to_svsm_error(e));
+        }
+    };
+
+    match task_busypoll_to_completion(|cx| Future::poll(pin::Pin::new(&mut cocoonfs_open_fut), cx))
+    {
+        Ok((_rng, Ok(cocoonfs_instance))) => {
+            SVSM_COCOONFS_INSTANCE
+                .init(cocoonfs_instance)
+                .expect("SVSM CocoonFs instance already initialized");
+            log::info!("persistent CocoonFs storage opened successfully");
+            Ok(())
+        }
+        Ok((_, Err((_, _, e)))) | Err(e) => {
+            log::error!("failed to open CocoonFs block device: {e:?}");
+            Err(nvfs_error_to_svsm_error(e))
+        }
+    }
+}
+
+/// Test whether persistence functionality is available.
+///
+/// Persistence functionality is available only if a block device with a valid CocoonFs instance on
+/// it could get opened successfully from [`persistence_init()`].
+///
+/// `persistence_available()` may get invoked even if [`persistence_init()`] has not been run at all,
+/// in which case it would report `false`.
+pub fn persistence_available() -> bool {
+    SVSM_COCOONFS_INSTANCE.try_get_inner().is_ok()
 }

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -52,6 +52,8 @@ use svsm::mm::pagetable::paging_init;
 use svsm::mm::ro_after_init::make_ro_after_init;
 use svsm::mm::validate::init_valid_bitmap;
 use svsm::mm::virtualrange::virt_log_usage;
+#[cfg(feature = "persistence")]
+use svsm::persistence::{persistence_discover, persistence_init};
 use svsm::platform::PageValidateOp;
 use svsm::platform::PlatformPageType;
 use svsm::platform::SVSM_PLATFORM;
@@ -551,11 +553,21 @@ fn svsm_init(launch_info: &KernelLaunchInfo) {
 
     #[cfg(feature = "attest")]
     {
-        let mut proxy = AttestationDriver::try_from(Tee::Snp).unwrap();
-        let _data = proxy.attest().unwrap();
+        // Obtain the persistence metadata first. It's not the case yet,
+        // but it likely will be needed as input to the attestation.
+        #[cfg(feature = "persistence")]
+        let persistence_bootstrap_info = persistence_discover().unwrap();
 
-        // Nothing to do with data at the moment, simply print a success message.
+        let mut proxy = AttestationDriver::try_from(Tee::Snp).unwrap();
+        let secret = proxy.attest().unwrap();
         log::info!("attestation successful");
+
+        #[cfg(not(feature = "persistence"))]
+        let _ = secret;
+        #[cfg(feature = "persistence")]
+        if let Some(persistence_bootstrap_info) = persistence_bootstrap_info {
+            persistence_init(persistence_bootstrap_info, &secret).unwrap();
+        }
     }
 
     #[cfg(all(feature = "vtpm", not(test)))]

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -53,7 +53,7 @@ use svsm::mm::ro_after_init::make_ro_after_init;
 use svsm::mm::validate::init_valid_bitmap;
 use svsm::mm::virtualrange::virt_log_usage;
 #[cfg(feature = "persistence")]
-use svsm::persistence::{persistence_discover, persistence_init};
+use svsm::persistence::{persistence_demo, persistence_discover, persistence_init};
 use svsm::platform::PageValidateOp;
 use svsm::platform::PlatformPageType;
 use svsm::platform::SVSM_PLATFORM;
@@ -567,6 +567,8 @@ fn svsm_init(launch_info: &KernelLaunchInfo) {
         #[cfg(feature = "persistence")]
         if let Some(persistence_bootstrap_info) = persistence_bootstrap_info {
             persistence_init(persistence_bootstrap_info, &secret).unwrap();
+            // TODO: remove once we have real persistence users.
+            persistence_demo();
         }
     }
 


### PR DESCRIPTION
This PR integrates CocoonFs for SVSM persistence.

I presented about CocoonFs in one of our devel meetings, see the [minutes from 2025-07-23](https://github.com/coconut-svsm/governance/blob/main/Meetings/devel-call-2025-07-23.md). To recap, it's been designed specifically with the persistence needs of TEEs in mind, the main features distinguishing it from existing solutions are
- Authentication of the FS state as a whole with a single, global Merkle tree -- other FSes implementing that are typically read-only.
- Fresh and random IVs at file granularity generated for every new write.
- Robustness against service disruptions by means of a journal.
For more details, see [the cocoonfs-cli README](https://github.com/coconut-svsm/cocoon-tpm/tree/main/cocoonfs-cli), which provides some further pointers to e.g. the spec.

One remark ahead: I believe it is well understood, but better to make it explicit anyway: as the secret key is obtained from the attestation subsystem, and that secret is not authenticated in any way yet, the overall scheme in its current state is prone to MITM attacks and **totally insecure**.

This PR implements the bare persistence functionality only, which culminates in providing `persistence_write_inode_sync()` and `persistence_read_inode_sync()` for use from the other SVSM code parts. I opted against wiring up the vtpm in this PR, because
- It's big enough by itself already.
- There are some security implications which need to be understood and documented, mainly due to the vtpm's identity not necessarily being unique anymore. We might end up implementing rollback protection at some point, but that would require talking to the outside and we don't have that yet. Until then, we might perhaps enforce `TPM_SU_CLEAR` for `TPM2_Shutdown()` for ensuring that the null hierarchy gets wiped at least.
- Lastly, @osteffenrh and @stefano-garzarella  have some patches for implementing vtpm persistence, c.f. [Oliver's kvm-forum-2025 branch](https://github.com/osteffenrh/coconut-svsm/commits/kvm-forum-2025/). It should be straight-forward to port these to the `persistence_{read,write}_inode_sync()` interface introduced here, and can help with that after coordinating with them.

As there are no persistence users yet, I added a small demo reading and incrementing a "boot counter" at startup. That can be found in the last commit, and is supposed to get reverted one way or the other at some point.

## Testing
- Setup attestation -- it's currently the only way to get a secret into the SVSM. Refer to `Documentation/docs/developer/ATTESTATION.md` in the sources.
- Enable the `cocoonfs` Cargo feature. This will pull in the `virtio-drivers` feature.
- Prepare a CocoonFs filesystem image using `cocoonfs-cli` (find it at the link provided above, or simply at crates.io):
  ```cocoonfs -i cocoonfs.img -f write-mkfs-info-header -H sha2 -C aes -t 128 -I 'ddeeff' -s 8M```
  Note that this merely writes a CocoonFs "filesystem creation info header", which doesn't require access to the key. The actual filesystem formatting will get done when the SVSM first attempts to open the filesystem.
- Attach the filesystem to the SVSM via the qemu command line (taken from `scripts/launch_guest.sh` in the sources):
  - append `,x-svsm-virtio-mmio=on` to the `-machine` spec and add
  - `-global virtio-mmio.force-legacy=false`
  - `-drive file=<path>/cocoonfs.img,format=raw,if=none,id=svsm_storage,cache=none`
  - `-device virtio-blk-device,drive=svsm_storage`

If everything goes well, you should see the following message at the first boot:
```
[SVSM] persistent CocoonFs storage opened successfully
[SVSM] persistence demo: no boot counter found yet
[SVSM] persistence demo: successfully wrote updated boot counter
```
and e.g.
```
[SVSM] persistent CocoonFs storage opened successfully
[SVSM] persistence demo: boot counter read back is 1
[SVSM] persistence demo: successfully wrote updated boot counter
```
etc. in subsequent ones.