### PR TITLE
qemu: add -vga none for guest launch

### DIFF
--- a/Documentation/docs/installation/INSTALL.md
+++ b/Documentation/docs/installation/INSTALL.md
@@ -309,10 +309,13 @@ $ sudo $HOME/bin/qemu-svsm/bin/qemu-system-x86_64 \
   -drive file=/path/to/guest/image.qcow2,if=none,id=disk0,format=qcow2,snapshot=off \
   -device virtio-scsi-pci,id=scsi0,disable-legacy=on,iommu_platform=on \
   -device scsi-hd,drive=disk0,bootindex=0 \
-  -vga std \
+  -vga none \
   -serial stdio \
   -serial pty
 ```
+Note: With QEMU 10.1 (which includes IGVM support), guests may fail to boot
+during VGA initialization. The `-vga none` option is added temporarily to
+disable VGA init until this issue is resolved.
 
 If everything works, initialization messages of the SVSM should appear
 in the terminal:

--- a/scripts/launch_guest.sh
+++ b/scripts/launch_guest.sh
@@ -172,6 +172,7 @@ if [ -t 0 ]; then
   stty intr ^]
 fi
 
+# Temporarily use -vga none to avoid IGVM VGA init failure in QEMU 10.1
 $SUDO_CMD \
   $QEMU \
     -cpu $CPU \
@@ -184,6 +185,7 @@ $SUDO_CMD \
     -netdev user,id=vmnic -device e1000,netdev=vmnic,romfile= \
     $IMAGE_DISK \
     -nographic \
+    -vga none \
     -monitor none \
     $COM1_SERIAL \
     $COM2_SERIAL \


### PR DESCRIPTION
With newer QEMU version(10.1), the upstream IGVM patches fail during VGA initialization. Add `-vga none `in the docs and launch script to disable VGA init until the upstream issue is resolved.

Related qemu PR is [here](https://github.com/coconut-svsm/qemu/pull/25).

cc @osteffenrh 