### PR TITLE
Update slab to 0.4.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1822,9 +1822,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "sm4"


### PR DESCRIPTION
`cargo audit` reports a security advisor about our `slab` version:

Crate:     slab
Version:   0.4.10
Title:     Out-of-bounds access in `get_disjoint_mut` due to incorrect bounds check
Date:      2025-08-12
ID:        RUSTSEC-2025-0047
URL:       https://rustsec.org/advisories/RUSTSEC-2025-0047
Solution:  Upgrade to >=0.4.11
Dependency tree:
slab 0.4.10
├── tokio 1.46.1
│   ├── tower 0.5.2
│   │   ├── tower-http 0.6.6
│   │   │   └── reqwest 0.12.22
│   │   │       └── aproxy 0.1.0
│   │   └── reqwest 0.12.22
│   ├── reqwest 0.12.22
│   ├── hyper-util 0.1.15
│   │   └── reqwest 0.12.22
│   └── hyper 1.6.0
│       ├── reqwest 0.12.22
│       └── hyper-util 0.1.15
└── futures-util 0.3.31
    ├── tower-http 0.6.6
    ├── tower 0.5.2
    ├── reqwest 0.12.22
    ├── hyper-util 0.1.15
    └── hyper 1.6.0