### PR TITLE
Increase opt-level to 1 for profile.dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,9 @@ panic = 'abort'
 
 [profile.dev]
 panic = 'abort'
+# Without any optimization whatsoever, stackframes can easily get too
+# large and result in unusable builds.
+opt-level = 1
 
 [workspace.lints.rust]
 future_incompatible = { level = "deny", priority = 127 }


### PR DESCRIPTION
Top `show-stack-sizes.sh` offenders w/o the patch:

```
 2280     svsm_start
 2456     elf::header::Elf64Hdr::read::he4dbcb190d9ed396
 2808     svsm::task::tasks::Task::create_common::h31236b6c8b389867
 2936     svsm::task::exec::exec_user::h5af32c9bdff9eb44
 4120     _$LT$svsm..mm..pagetable..PageTable$u20$as$u20$core..default..Default$GT$::default::hb5dd5f3760627e37
 4120     _$LT$svsm..mm..pagetable..RawPageTablePart$u20$as$u20$core..default..Default$GT$::default::h800ec5e5885f3e4e
 4136     svsm::sev::secrets_page::SecretsPage::copy_from::ha0efc555d365a5cb
 4152     _$LT$svsm..mm..pagetable..PTPage$u20$as$u20$core..default..Default$GT$::default::hdbf3038e4b41f1cb
 4152     svsm::sev::secrets_page::SecretsPage::copy_to::he32b9fc4979e69d1
 4168     _$LT$alloc..boxed..Box$LT$T$GT$$u20$as$u20$core..default..Default$GT$::default::h3739f530336d041e
 4184     svsm::sev::secrets_page::SecretsPage::copy_for_vmpl::hc00016f4e12387d2
 4280     svsm::mm::pagetable::PTPage::alloc::hc3811f66673c27b7
 4296     svsm::mm::pagebox::PageBox$LT$T$GT$::try_new::h472d833c0ddf2173
 4296     svsm::mm::pagebox::PageBox$LT$T$GT$::try_new::ha7bbb10736ff2dff
 4312     svsm::mm::pagetable::PageTable::allocate_new::he861cfeffc07b5e6
13880     sha2::sha512::soft::sha512_digest_block_u64::h632e752b20644016
```

And with the patch applied:
```
  616     svsm::protocols::attest::attest_protocol_request::h451f1178aaacfae1
  648     _$LT$svsm..platform..tdp..TdpPlatform$u20$as$u20$svsm..platform..SvsmPlatform$GT$::start_cpu::h7bc48fcd2fcbf0a6
  760     svsm::syscall::class1::sys_readdir::h9ed831d086fca833
  760     svsm::task::tasks::Task::create_common::ha1dd82ac117db4e7 (.llvm.17191934643532452602)
  840     core::slice::sort::unstable::quicksort::quicksort::h828a978d7e1b2e8c
  856     svsm::crypto::rustcrypto::_$LT$impl$u20$svsm..crypto..digest..Algorithm$u20$for$u20$svsm..crypto..digest..Sha512$GT$::digest::ha9331f32ad687f00
 1032     aes::soft::fixslice::aes256_key_schedule::h4352bd77db0a1a9b
 1080     svsm::task::exec::exec_user::h315707190817e239
 1144     _$LT$aes_gcm..AesGcm$LT$Aes$C$NonceSize$C$TagSize$GT$$u20$as$u20$crypto_common..KeyInit$GT$::new::h20fb5cff04c90770
 1208     svsm::crypto::rustcrypto::aes_gcm_do::h24ecda8f85d281ce
 1240     svsm_start
 1304     svsm::cpu::percpu::PerCpu::alloc::h5f445a531b228bcf
```