### PR TITLE
kernel/task: fix `start_kernel_task` parameters

### DIFF
--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -955,7 +955,7 @@ fn task_exit() {
 #[cfg(all(test, test_in_svsm))]
 mod tests {
     extern crate alloc;
-    use crate::task::start_kernel_task;
+    use crate::task::{start_kernel_task, KernelThreadStartInfo};
     use alloc::string::String;
     use core::arch::asm;
     use core::arch::global_asm;
@@ -1047,7 +1047,7 @@ mod tests {
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn test_fpu_context_switch() {
-        start_kernel_task(task1, 1, String::from("task1"))
+        start_kernel_task(KernelThreadStartInfo::new(task1, 1), String::from("task1"))
             .expect("Failed to launch request processing task");
     }
 
@@ -1059,7 +1059,7 @@ mod tests {
             asm!("call test_fpu", options(att_syntax));
         }
 
-        start_kernel_task(task2, 2, String::from("task2"))
+        start_kernel_task(KernelThreadStartInfo::new(task2, 2), String::from("task2"))
             .expect("Failed to launch request processing task");
 
         unsafe {


### PR DESCRIPTION
Commit fd2152881e8c ("task: encapsulate thread start information for safety") modified the parameters for `start_kernel_task`. Two calls were not updated accordingly, breaking `test-in-svsm`.

Update them using `KernelThreadStartInfo`.