### PR TITLE
mm/pagetable: reduce stack consumption

### DIFF
--- a/kernel/src/address.rs
+++ b/kernel/src/address.rs
@@ -14,6 +14,8 @@ use core::slice;
 
 use verus_stub::*;
 
+use zerocopy::FromZeros;
+
 #[cfg(verus_keep_ghost)]
 include!("address.verus.rs");
 
@@ -188,7 +190,7 @@ pub trait Address: Copy + From<InnerAddr> + Into<InnerAddr> + Ord {
 }
 
 #[verus_verify]
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, FromZeros)]
 #[repr(transparent)]
 pub struct PhysAddr(InnerAddr);
 

--- a/kernel/src/mm/pagetable.rs
+++ b/kernel/src/mm/pagetable.rs
@@ -24,6 +24,7 @@ use bitflags::bitflags;
 use core::cmp;
 use core::ops::{Index, IndexMut};
 use core::ptr::NonNull;
+use zerocopy::FromZeros;
 
 /// Number of entries in a page table (4KB/8B).
 const ENTRY_COUNT: usize = 512;
@@ -208,7 +209,7 @@ impl PagingMode {
 
 /// Represents a page table entry.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug, FromZeros)]
 pub struct PTEntry(PhysAddr);
 
 impl PTEntry {
@@ -388,7 +389,7 @@ impl PTEntry {
 
 /// A pagetable page with multiple entries.
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromZeros)]
 pub struct PTPage {
     entries: [PTEntry; ENTRY_COUNT],
 }
@@ -401,7 +402,7 @@ impl PTPage {
     ///
     /// Returns [`SvsmError`] if the page cannot be allocated.
     fn alloc() -> Result<(&'static mut Self, PhysAddr), SvsmError> {
-        let page = PageBox::try_new(PTPage::default())?;
+        let page: PageBox<Self> = PageBox::try_new_zeroed()?;
         let paddr = virt_to_phys(page.vaddr());
         Ok((PageBox::leak(page), paddr))
     }
@@ -432,13 +433,6 @@ impl PTPage {
         // SAFETY: Every PTEntry points to a previously allocated page-table
         // page, so this pointer dereference is safe.
         Some(unsafe { &mut *address.as_mut_ptr::<PTPage>() })
-    }
-}
-
-impl Default for PTPage {
-    fn default() -> Self {
-        let entries = [PTEntry::default(); ENTRY_COUNT];
-        PTPage { entries }
     }
 }
 
@@ -511,7 +505,7 @@ impl PageFrame {
 
 /// Page table structure containing a root page with multiple entries.
 #[repr(C)]
-#[derive(Default, Debug)]
+#[derive(Debug, FromZeros)]
 pub struct PageTable {
     root: PTPage,
 }
@@ -541,7 +535,7 @@ impl PageTable {
     /// # Errors
     /// Returns [`SvsmError`] if the page cannot be allocated.
     pub fn allocate_new() -> Result<PageBox<Self>, SvsmError> {
-        let mut pgtable = PageBox::try_new(PageTable::default())?;
+        let mut pgtable: PageBox<Self> = PageBox::try_new_zeroed()?;
         let paddr = virt_to_phys(pgtable.vaddr());
 
         // Set the self-map entry.
@@ -1274,7 +1268,7 @@ impl PageTable {
 }
 
 /// Represents a sub-tree of a page-table which can be mapped at a top-level index
-#[derive(Default, Debug)]
+#[derive(Debug, FromZeros)]
 struct RawPageTablePart {
     page: PTPage,
 }
@@ -1543,8 +1537,7 @@ impl PageTablePart {
 
     fn get_or_init_mut(&mut self) -> &mut RawPageTablePart {
         self.raw.get_or_insert_with(|| {
-            PageBox::try_new(RawPageTablePart::default())
-                .expect("Failed to allocate page table page")
+            PageBox::try_new_zeroed().expect("Failed to allocate page table page")
         })
     }
 


### PR DESCRIPTION
The use of `Default` for initial page table construction requires the creation of page-sized stack locals for templates during the allocation of page table pages.  Since a default empty page table is all zeroes, it is more efficient to use `FromZeros` to enable zero-filled allocations instead of requiring the creation of stack-based templates.