### PR TITLE
mm: Allow RO regions to start on HugePage boundary

### DIFF
--- a/kernel/src/mm/pagetable.rs
+++ b/kernel/src/mm/pagetable.rs
@@ -1241,10 +1241,6 @@ impl PageTable {
         &mut self,
         region: MemoryRegion<VirtAddr>,
     ) -> Result<(), SvsmError> {
-        // Since 4k alignment is explicitly mentioned in the safety requirements,
-        // let's use a debug assert here.
-        debug_assert!(!region.start().is_aligned(usize::from(PageSize::Huge)));
-
         for page in region.iter_pages(PageSize::Regular) {
             match self.walk_addr(page) {
                 Mapping::Level0(entry) => {


### PR DESCRIPTION
Remove an assert that forbids memory regions starting on a HugePage
boundary to be marked as read-only.

This restriction does not make sense and also does not match the comment
above it.

I am hitting this assert because, as it seems, the svsm binary size is reaching a critical size for me.

Adding one line of code (`log::info!()`) causes this:
```
[SVSM] CPU 2 is online
[SVSM] Launching AP 3 with APIC-ID 3
[SVSM] CPU 3 is online
[SVSM] ERROR: Panic on CPU[0]! COCONUT-SVSM Version: 2025.09-devel-14-ga6045d82+
[SVSM] ERROR: Info: panicked at kernel/src/mm/pagetable.rs:1246:9:
assertion failed: !region.start().is_aligned(usize::from(PageSize::Huge))
[SVSM] ---BACKTRACE---:
[SVSM]   [ffffff80000725be]
[SVSM]   [ffffff80000902cb]
[SVSM]   [ffffff8000090448]
[SVSM]   [ffffff800003ea5e]
[SVSM]   [ffffff8000060520]
[SVSM] ---END---
```
Taking away another call somewhere makes it work again.

`region.start()` = 0xffffff80003ff000 works, this one (1 page larger) not: 0xffffff8000400000