### PR TITLE
Documentation: Add link to ATTESTATION.md

### DIFF
--- a/Documentation/mkdocs.yml
+++ b/Documentation/mkdocs.yml
@@ -16,4 +16,5 @@ nav:
     - Fuzzing: 'developer/FUZZING.md'
     - Contributing to COCONUT-SVSM: 'developer/CONTRIBUTING.md'
     - Formal Verification: 'developer/VERIFICATION.md'
+    - Attestation: 'developer/ATTESTATION.md'
   - 'COCONUT-SVSM Rustdoc': 'rustdoc/svsm'


### PR DESCRIPTION
Add a link in the documentation menu to the attestation guide.