### PR TITLE
kernel: refactor request processing loop

### DIFF
--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -48,8 +48,7 @@ use svsm::platform;
 use svsm::platform::{init_capabilities, init_platform_type, SvsmPlatformCell, SVSM_PLATFORM};
 use svsm::sev::secrets_page_mut;
 use svsm::svsm_paging::{init_page_table, invalidate_early_boot_memory};
-use svsm::task::schedule_init;
-use svsm::task::{start_kernel_task, KernelThreadStartInfo};
+use svsm::task::{schedule_init, start_kernel_task, KernelThreadStartInfo};
 use svsm::types::PAGE_SIZE;
 use svsm::utils::{immut_after_init::ImmutAfterInitCell, zero_mem_region, MemoryRegion};
 #[cfg(all(feature = "vtpm", not(test)))]
@@ -394,7 +393,7 @@ fn svsm_init() {
     #[cfg(not(test))]
     {
         use svsm::fs::opendir;
-        use svsm::requests::request_loop_main;
+        use svsm::requests::request_loop_start;
         use svsm::task::exec_user;
 
         match exec_user("/init", opendir("/").expect("Failed to find FS root")) {
@@ -405,7 +404,7 @@ fn svsm_init() {
         // Start request processing on this CPU if required.
         if SVSM_PLATFORM.start_svsm_request_loop() {
             start_kernel_task(
-                KernelThreadStartInfo::new(request_loop_main, 0),
+                KernelThreadStartInfo::new(request_loop_start, 0),
                 String::from("request-loop on CPU 0"),
             )
             .expect("Failed to launch request loop task");


### PR DESCRIPTION
Start guest processing using a dedicated startup routine rather than having the per-CPU start routine (per-thread) also be the initial task start routine.