### PR TITLE
stage2: remove an incorrect TODO comment

### DIFF
--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -343,9 +343,8 @@ fn load_kernel_elf(
             let Some(reloc) = reloc? else {
                 continue;
             };
-            // TODO: ensure that the ELF package rejects illegal relocations
-            // the point outside the image.
-            // SAFETY: the relocation address is known to be correct.
+            // SAFETY: the relocation address is known to be correct. The ELF loader rejects
+            // relocations that point outside a PT_LOAD segment.
             let dst = unsafe { slice::from_raw_parts_mut(reloc.dst as *mut u8, reloc.value_len) };
             let src = &reloc.value[..reloc.value_len];
             dst.copy_from_slice(src)


### PR DESCRIPTION
The ELF loader currently checks that relocations fall into one of the ELF's `PT_LOAD` segments within `Elf64AppliedRelaIterator::next()`, returning a `ElfError::InvalidRelocationOffset` if that is not the case. Thus, remove a TODO comment stating that we should check this condition.

The code performing the check is the following:
https://github.com/coconut-svsm/svsm/blob/e7ea13af558511e8d5286211b97a48cb6ba623ff/elf/src/relocation.rs#L355-L373