### PR TITLE
Documentation: Enable copy button on code blocks

### DIFF
--- a/Documentation/mkdocs.yml
+++ b/Documentation/mkdocs.yml
@@ -1,6 +1,8 @@
 site_name: COCONUT-SVSM
 theme:
   name: material
+  features:
+    - content.code.copy
 
 nav:
   - Documentation Home: 'index.md'


### PR DESCRIPTION
Enable the copy-button feature for code blocks of
the mkdocs material theme.
