### PR TITLE
QEMU launcher: add --snapshot [on|off]

### DIFF
--- a/scripts/launch_guest.sh
+++ b/scripts/launch_guest.sh
@@ -98,11 +98,11 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Split the QEMU version number so we can specify the correct parameters
-QEMU_VERSION=`$QEMU --version | grep -Po '(?<=version )[^ ]+'`
+QEMU_VERSION=$($QEMU --version | grep -Po '(?<=version )[^ ]+')
 QEMU_MAJOR=${QEMU_VERSION%%.*}
 QEMU_BUILD=${QEMU_VERSION##*.}
-QEMU_MINOR=${QEMU_VERSION##$QEMU_MAJOR.}
-QEMU_MINOR=${QEMU_MINOR%%.$QEMU_BUILD}
+QEMU_MINOR=${QEMU_VERSION##"$QEMU_MAJOR".}
+QEMU_MINOR=${QEMU_MINOR%%."$QEMU_BUILD"}
 
 if (( QEMU_MAJOR < 9)) && [ "$CGS" = "nocc" ]; then
   echo "Error: --nocc requires Qemu 9 or newer (with patches)." >&2
@@ -139,7 +139,7 @@ else
 fi
 
 # Setup a disk if an image has been specified
-if [ ! -z $IMAGE ]; then
+if [ ! -z "$IMAGE" ]; then
   IMAGE_DISK="-drive file=$IMAGE,if=none,id=disk0,format=qcow2,snapshot=$SNAPSHOT \
     -device virtio-scsi-pci,id=scsi0,disable-legacy=on,iommu_platform=on \
     -device scsi-hd,drive=disk0"
@@ -175,7 +175,7 @@ fi
 
 # Temporarily use -vga none to avoid IGVM VGA init failure in QEMU 10.1
 $SUDO_CMD \
-  $QEMU \
+  "$QEMU" \
     -cpu $CPU \
     -machine $MACHINE,$STATE_ENABLE \
     -object $MEMORY \


### PR DESCRIPTION
Add a new command line option to the QEMU launcher:
`--snapshot [on|off]` to enable/disable writes to the disk image.

This can be useful to install missing packages or change configs
in the image, while launching it with the same machine configuration.
