### PR TITLE
Introduce vsock support for attestation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "vsock",
 ]
 
 [[package]]
@@ -317,6 +318,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cipher"
@@ -1311,6 +1318,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2280,6 +2300,16 @@ dependencies = [
  "embedded-io",
  "log",
  "zerocopy",
+]
+
+[[package]]
+name = "vsock"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e8b4d00e672f147fc86a09738fadb1445bd1c0a40542378dfb82909deeee688"
+dependencies = [
+ "libc",
+ "nix",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,11 +119,13 @@ dependencies = [
  "anyhow",
  "base64",
  "clap",
+ "const_format",
  "kbs-types",
  "libaproxy",
  "reqwest",
  "serde",
  "serde_json",
+ "vsock",
 ]
 
 [[package]]
@@ -319,6 +321,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,6 +458,27 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "cookie"
@@ -1202,6 +1231,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
 name = "libaproxy"
 version = "0.1.0"
 dependencies = [
@@ -1308,6 +1352,19 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -2124,6 +2181,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2280,6 +2343,16 @@ dependencies = [
  "embedded-io",
  "log",
  "zerocopy",
+]
+
+[[package]]
+name = "vsock"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e8b4d00e672f147fc86a09738fadb1445bd1c0a40542378dfb82909deeee688"
+dependencies = [
+ "libc",
+ "nix",
 ]
 
 [[package]]

--- a/Documentation/docs/developer/ATTESTATION.md
+++ b/Documentation/docs/developer/ATTESTATION.md
@@ -10,6 +10,7 @@
     - [Frontend](#frontend)
     - [Backend](#backend)
     - [Host Proxy Diagram](#host-proxy-diagram)
+  - [Transport Methods](#transport-methods)
   - [Try for yourself](#try-for-yourself)
 <!--toc:end-->
 
@@ -242,6 +243,15 @@ launching the proxy. The supported backend attestation protocols include:
                              protocol)
 ```
 
+## Transport Methods
+
+SVSM communicates with the attestation proxy using one of two transport methods:
+
+- **vsock**: When the `vsock` feature is enabled, SVSM will first try to use vsock for communication with the host proxy
+  using port `1995`. If it fails, SVSM will try again using the serial port.
+
+- **Serial port**: If vsock is not available, SVSM uses the COM3 serial port for communication with the attestation proxy.
+
 ## Try for yourself
 
 Please keep in mind that the attestation services in SVSM are **experimental**
@@ -270,11 +280,33 @@ SEV-SNP machine with an SVSM-enabled kernel.
     ```shell
     git clone https://github.com/coconut-svsm/svsm.git
     # ... build OVMF, qemu, SVSM IGVM, etc...
-    FW_FILE=... make FEATURES=attest
+    FW_FILE=... make FEATURES=attest                       # serial transport
+    FW_FILE=... make FEATURES=attest,vsock,virtio-drivers  # vsock transport (with serial fallback)
     ```
 
 3. Run the proxy on the host
 
+    The proxy configuration depends on the transport mechanism:
+
+    Common parameters:
+
+    * `--url http://0.0.0.0:8080`: The attestation server is running at `http://0.0.0.0:8080`.
+    * `--protocol kbs`: The attestation server communicates via the KBS
+        protocol, configure the backend to use the KBS protocol.
+
+    **vsock parameters**
+    ```shell
+    cd svsm
+    make aproxy
+    bin/aproxy --protocol kbs \
+               --url http://0.0.0.0:8080 \
+               --vsock
+    ```
+
+    * `--vsock`: Listen for messages from SVSM on a vsock port (default: `1995`), which is
+      the port used by SVSM for attestation.
+
+    **Serial Port parameters**
     ```shell
     cd svsm
     make aproxy
@@ -283,28 +315,33 @@ SEV-SNP machine with an SVSM-enabled kernel.
                --unix /tmp/svsm-proxy.sock \
                --force
     ```
-    This runs the proxy with the following specified in the arguments:
 
-     * `--url http://0.0.0.0:8080`: The attestation server is running at
-       `http://0.0.0.0:8080`.
-     * `--protocol kbs`: The attestation server communicates via the KBS
-       protocol, configure the backend to use the KBS protocol.
-     * `--unix /tmp/svsm-proxy.sock`: Listen for messages from SVSM on a socket
-       created in file `/tmp/svsm-proxy-sock`.
-     * `--force`: Remove the `/tmp/svsm-proxy.sock` file (if it already exists)
-       before creating the socket.
+    * `--unix /tmp/svsm-proxy.sock`: Listen for messages from SVSM on a socket
+      created in file `/tmp/svsm-proxy-sock`.
+    * `--force`: Remove the `/tmp/svsm-proxy.sock` file (if it already exists)
+      before creating the socket.
 
 4. Run a guest with SVSM
 
-    Initially, SVSM communicates over the COM3 serial port. The attestation proxy
-    socket will need to be available in the correct `-serial` argument position to
-    ensure it communicates with the right socket.
+    SVSM will use vsock for communication if the feature is enabled, otherwise it
+    falls back to the COM3 serial port (see [Transport Methods](#transport-methods)).
+    The attestation proxy will need to be configured correctly to ensure proper communication
+    according to the transport used.
 
-    ```shell
-    ./scripts/launch_guest.sh --qemu $QEMU \
-                              --image $QCOW2 \
-                              --aproxy /tmp/svsm-proxy.sock
-    ```
+    * **vsock**
+      ```shell
+      ./scripts/launch_guest.sh --qemu $QEMU \
+                                --image $QCOW2 \
+                                --vsock 3
+      ```
+
+    * **Serial Port**
+      ```shell
+      ./scripts/launch_guest.sh --qemu $QEMU \
+                                --image $QCOW2 \
+                                --aproxy /tmp/svsm-proxy.sock
+      ```
+
     If successful, you should be able to find a message indicating a successful
     attestation within the SVSM boot logs.
 

--- a/Documentation/docs/developer/ATTESTATION.md
+++ b/Documentation/docs/developer/ATTESTATION.md
@@ -287,7 +287,7 @@ SEV-SNP machine with an SVSM-enabled kernel.
 
      * `--url http://0.0.0.0:8080`: The attestation server is running at
        `http://0.0.0.0:8080`.
-     * `--protocol kbs-test`: The attestation server communicates via the KBS
+     * `--protocol kbs`: The attestation server communicates via the KBS
        protocol, configure the backend to use the KBS protocol.
      * `--unix /tmp/svsm-proxy.sock`: Listen for messages from SVSM on a socket
        created in file `/tmp/svsm-proxy-sock`.

--- a/Documentation/docs/developer/ATTESTATION.md
+++ b/Documentation/docs/developer/ATTESTATION.md
@@ -10,6 +10,7 @@
     - [Frontend](#frontend)
     - [Backend](#backend)
     - [Host Proxy Diagram](#host-proxy-diagram)
+  - [Transport Methods](#transport-methods)
   - [Try for yourself](#try-for-yourself)
 <!--toc:end-->
 
@@ -242,6 +243,15 @@ launching the proxy. The supported backend attestation protocols include:
                              protocol)
 ```
 
+## Transport Methods
+
+SVSM communicates with the attestation proxy using one of two transport methods:
+
+- **vsock**: When the `vsock` feature is enabled, SVSM will first try to use vsock for communication with the host proxy
+  using port `1995`. If it fails, SVSM will try again using the serial port.
+
+- **Serial port**: If vsock is not available, SVSM uses the COM3 serial port for communication with the attestation proxy.
+
 ## Try for yourself
 
 Please keep in mind that the attestation services in SVSM are **experimental**
@@ -270,11 +280,33 @@ SEV-SNP machine with an SVSM-enabled kernel.
     ```shell
     git clone https://github.com/coconut-svsm/svsm.git
     # ... build OVMF, qemu, SVSM IGVM, etc...
-    FW_FILE=... make FEATURES=attest
+    FW_FILE=... make FEATURES=attest                       # serial transport
+    FW_FILE=... make FEATURES=attest,vsock,virtio-drivers  # vsock transport (with serial fallback)
     ```
 
 3. Run the proxy on the host
 
+    The proxy configuration depends on the transport mechanism:
+
+    Common parameters:
+
+    * `--url http://0.0.0.0:8080`: The attestation server is running at `http://0.0.0.0:8080`.
+    * `--protocol kbs`: The attestation server communicates via the KBS
+        protocol, configure the backend to use the KBS protocol.
+
+    **vsock parameters**
+    ```shell
+    cd svsm
+    make aproxy
+    bin/aproxy --protocol kbs \
+               --url http://0.0.0.0:8080 \
+               --vsock
+    ```
+
+    * `--vsock`: Listen for messages from SVSM on a vsock port (default: `1995`), which is
+      the port used by SVSM for attestation.
+
+    **Serial Port parameters**
     ```shell
     cd svsm
     make aproxy
@@ -283,28 +315,33 @@ SEV-SNP machine with an SVSM-enabled kernel.
                --unix /tmp/svsm-proxy.sock \
                --force
     ```
-    This runs the proxy with the following specified in the arguments:
 
-     * `--url http://0.0.0.0:8080`: The attestation server is running at
-       `http://0.0.0.0:8080`.
-     * `--protocol kbs`: The attestation server communicates via the KBS
-       protocol, configure the backend to use the KBS protocol.
-     * `--unix /tmp/svsm-proxy.sock`: Listen for messages from SVSM on a socket
-       created in file `/tmp/svsm-proxy.sock`.
-     * `--force`: Remove the `/tmp/svsm-proxy.sock` file (if it already exists)
-       before creating the socket.
+    * `--unix /tmp/svsm-proxy.sock`: Listen for messages from SVSM on a socket
+      created in file `/tmp/svsm-proxy.sock`.
+    * `--force`: Remove the `/tmp/svsm-proxy.sock` file (if it already exists)
+      before creating the socket.
 
 4. Run a guest with SVSM
 
-    Initially, SVSM communicates over the COM3 serial port. The attestation proxy
-    socket will need to be available in the correct `-serial` argument position to
-    ensure it communicates with the right socket.
+    SVSM will use vsock for communication if the feature is enabled, otherwise it
+    falls back to the COM3 serial port (see [Transport Methods](#transport-methods)).
+    The attestation proxy will need to be configured correctly to ensure proper communication
+    according to the transport used.
 
-    ```shell
-    ./scripts/launch_guest.sh --qemu $QEMU \
-                              --image $QCOW2 \
-                              --aproxy /tmp/svsm-proxy.sock
-    ```
+    * **vsock**
+      ```shell
+      ./scripts/launch_guest.sh --qemu $QEMU \
+                                --image $QCOW2 \
+                                --vsock 3
+      ```
+
+    * **Serial Port**
+      ```shell
+      ./scripts/launch_guest.sh --qemu $QEMU \
+                                --image $QCOW2 \
+                                --aproxy /tmp/svsm-proxy.sock
+      ```
+
     If successful, you should be able to find a message indicating a successful
     attestation within the SVSM boot logs.
 

--- a/kernel/src/attest.rs
+++ b/kernel/src/attest.rs
@@ -33,11 +33,35 @@ use serde::Serialize;
 use sha2::{Digest, Sha512};
 use zerocopy::{FromBytes, IntoBytes};
 
+enum Transport<'a> {
+    Serial(SerialPort<'a>),
+}
+
+impl Read for Transport<'_> {
+    type Err = SvsmError;
+
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Err> {
+        match self {
+            Transport::Serial(serial) => serial.read(buf),
+        }
+    }
+}
+
+impl Write for Transport<'_> {
+    type Err = SvsmError;
+
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Err> {
+        match self {
+            Transport::Serial(serial) => serial.write(buf),
+        }
+    }
+}
+
 /// The attestation driver that communicates with the proxy via some communication channel (serial
 /// port, virtio-vsock, etc...).
 #[allow(missing_debug_implementations)]
 pub struct AttestationDriver<'a> {
-    sp: SerialPort<'a>,
+    transport: Transport<'a>,
     tee: Tee,
     ecc: EccKey,
 }
@@ -59,7 +83,12 @@ impl TryFrom<Tee> for AttestationDriver<'_> {
         let curve = Curve::new(TpmEccCurve::NistP521).map_err(AttestationError::Crypto)?;
         let ecc = sc_key_generate(&curve).map_err(AttestationError::Crypto)?;
 
-        Ok(Self { sp, tee, ecc })
+        let transport = Transport::Serial(sp);
+        Ok(Self {
+            transport,
+            tee,
+            ecc,
+        })
     }
 }
 
@@ -184,7 +213,7 @@ impl AttestationDriver<'_> {
     fn read(&mut self) -> Result<Vec<u8>, AttestationError> {
         let len = {
             let mut bytes = [0u8; 8];
-            self.sp
+            self.transport
                 .read(&mut bytes)
                 .or(Err(AttestationError::ProxyRead))?;
 
@@ -193,7 +222,7 @@ impl AttestationDriver<'_> {
 
         let mut buf: Vec<u8> = vec_sized(len).or(Err(AttestationError::VecAlloc))?;
 
-        self.sp
+        self.transport
             .read(&mut buf)
             .or(Err(AttestationError::ProxyRead))?;
 
@@ -206,10 +235,10 @@ impl AttestationDriver<'_> {
 
         // The receiving party is unaware of how many bytes to read from the port. Write an 8-byte
         // header indicating the length of the buffer before writing the buffer itself.
-        self.sp
+        self.transport
             .write(&bytes.len().to_ne_bytes())
             .or(Err(AttestationError::ProxyWrite))?;
-        self.sp
+        self.transport
             .write(&bytes)
             .or(Err(AttestationError::ProxyWrite))?;
 

--- a/kernel/src/attest.rs
+++ b/kernel/src/attest.rs
@@ -14,6 +14,8 @@ use crate::{
     serial::SerialPort,
     utils::vec::{try_to_vec, vec_sized},
 };
+#[cfg(feature = "vsock")]
+use crate::{vsock::VMADDR_CID_HOST, vsock::stream::VsockStream};
 use aes_gcm::{AeadInPlace, Aes256Gcm, KeyInit, Nonce, aead::generic_array::GenericArray};
 use aes_kw::{Kek, KekAes256};
 use alloc::{string::ToString, vec::Vec};
@@ -33,7 +35,13 @@ use serde::Serialize;
 use sha2::{Digest, Sha512};
 use zerocopy::{FromBytes, IntoBytes};
 
+#[cfg(feature = "vsock")]
+const ATTEST_DEFAULT_VSOCK_PORT: u32 = 1995;
+const ATTEST_DEFAULT_SERIAL_IO_ADDR: u16 = 0x3e8; // COM3
+
 enum Transport<'a> {
+    #[cfg(feature = "vsock")]
+    Vsock(VsockStream),
     Serial(SerialPort<'a>),
 }
 
@@ -42,6 +50,8 @@ impl Read for Transport<'_> {
 
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Err> {
         match self {
+            #[cfg(feature = "vsock")]
+            Transport::Vsock(vsock) => vsock.read(buf),
             Transport::Serial(serial) => serial.read(buf),
         }
     }
@@ -52,9 +62,39 @@ impl Write for Transport<'_> {
 
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Err> {
         match self {
+            #[cfg(feature = "vsock")]
+            Transport::Vsock(vsock) => vsock.write(buf),
             Transport::Serial(serial) => serial.write(buf),
         }
     }
+}
+
+impl Transport<'_> {
+    #[cfg(feature = "vsock")]
+    fn new() -> Self {
+        match VsockStream::connect(ATTEST_DEFAULT_VSOCK_PORT, VMADDR_CID_HOST) {
+            Ok(value) => Transport::Vsock(value),
+            Err(e) => {
+                log::warn!(
+                    "Failed to connect to attestation proxy on vsock port \
+                     {ATTEST_DEFAULT_VSOCK_PORT}: {e:?}. \
+                     Attempting to start again using the serial port.",
+                );
+                create_serial_transport()
+            }
+        }
+    }
+
+    #[cfg(not(feature = "vsock"))]
+    fn new() -> Self {
+        create_serial_transport()
+    }
+}
+
+fn create_serial_transport<'a>() -> Transport<'a> {
+    let sp = SerialPort::new(&DEFAULT_IO_DRIVER, ATTEST_DEFAULT_SERIAL_IO_ADDR);
+    sp.init();
+    Transport::Serial(sp)
 }
 
 /// The attestation driver that communicates with the proxy via some communication channel (serial
@@ -70,11 +110,6 @@ impl TryFrom<Tee> for AttestationDriver<'_> {
     type Error = SvsmError;
 
     fn try_from(tee: Tee) -> Result<Self, Self::Error> {
-        // TODO: Make the IO port configurable/discoverable for other transport mechanisms such as
-        // virtio-vsock.
-        let sp = SerialPort::new(&DEFAULT_IO_DRIVER, 0x3e8); // COM3
-        sp.init();
-
         match tee {
             Tee::Snp => (),
             _ => return Err(AttestationError::UnsupportedTee.into()),
@@ -83,7 +118,7 @@ impl TryFrom<Tee> for AttestationDriver<'_> {
         let curve = Curve::new(TpmEccCurve::NistP521).map_err(AttestationError::Crypto)?;
         let ecc = sc_key_generate(&curve).map_err(AttestationError::Crypto)?;
 
-        let transport = Transport::Serial(sp);
+        let transport = Transport::new();
         Ok(Self {
             transport,
             tee,
@@ -209,7 +244,7 @@ impl AttestationDriver<'_> {
         Ok(())
     }
 
-    /// Read attestation data from the serial port.
+    /// Read attestation data from the transport channel.
     fn read(&mut self) -> Result<Vec<u8>, AttestationError> {
         let len = {
             let mut bytes = [0u8; 8];
@@ -229,7 +264,7 @@ impl AttestationDriver<'_> {
         Ok(buf)
     }
 
-    /// Write attestation data over the serial port.
+    /// Write attestation data over the transport channel.
     fn write(&mut self, param: impl Serialize) -> Result<(), AttestationError> {
         let bytes = serde_json::to_vec(&param).or(Err(AttestationError::NegotiationSerialize))?;
 

--- a/kernel/src/attest.rs
+++ b/kernel/src/attest.rs
@@ -214,7 +214,7 @@ impl AttestationDriver<'_> {
         let len = {
             let mut bytes = [0u8; 8];
             self.transport
-                .read(&mut bytes)
+                .read_exact(&mut bytes)
                 .or(Err(AttestationError::ProxyRead))?;
 
             usize::from_ne_bytes(bytes)
@@ -223,7 +223,7 @@ impl AttestationDriver<'_> {
         let mut buf: Vec<u8> = vec_sized(len).or(Err(AttestationError::VecAlloc))?;
 
         self.transport
-            .read(&mut buf)
+            .read_exact(&mut buf)
             .or(Err(AttestationError::ProxyRead))?;
 
         Ok(buf)
@@ -236,10 +236,10 @@ impl AttestationDriver<'_> {
         // The receiving party is unaware of how many bytes to read from the port. Write an 8-byte
         // header indicating the length of the buffer before writing the buffer itself.
         self.transport
-            .write(&bytes.len().to_ne_bytes())
+            .write_all(&bytes.len().to_ne_bytes())
             .or(Err(AttestationError::ProxyWrite))?;
         self.transport
-            .write(&bytes)
+            .write_all(&bytes)
             .or(Err(AttestationError::ProxyWrite))?;
 
         Ok(())

--- a/kernel/src/attest.rs
+++ b/kernel/src/attest.rs
@@ -14,6 +14,8 @@ use crate::{
     serial::SerialPort,
     utils::vec::{try_to_vec, vec_sized},
 };
+#[cfg(feature = "vsock")]
+use crate::{vsock::VMADDR_CID_HOST, vsock::stream::VsockStream};
 use aes_gcm::{AeadInPlace, Aes256Gcm, KeyInit, Nonce, aead::generic_array::GenericArray};
 use aes_kw::{Kek, KekAes256};
 use alloc::{string::ToString, vec::Vec};
@@ -33,7 +35,12 @@ use serde::Serialize;
 use sha2::{Digest, Sha512};
 use zerocopy::{FromBytes, IntoBytes};
 
+// TODO: Make the IO port configurable/discoverable or drop the support entirely.
+const ATTEST_DEFAULT_SERIAL_IO_ADDR: u16 = 0x3e8; // COM3
+
 enum Transport<'a> {
+    #[cfg(feature = "vsock")]
+    Vsock(VsockStream),
     Serial(SerialPort<'a>),
 }
 
@@ -42,6 +49,8 @@ impl Read for Transport<'_> {
 
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Err> {
         match self {
+            #[cfg(feature = "vsock")]
+            Transport::Vsock(vsock) => vsock.read(buf),
             Transport::Serial(serial) => serial.read(buf),
         }
     }
@@ -52,9 +61,39 @@ impl Write for Transport<'_> {
 
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Err> {
         match self {
+            #[cfg(feature = "vsock")]
+            Transport::Vsock(vsock) => vsock.write(buf),
             Transport::Serial(serial) => serial.write(buf),
         }
     }
+}
+
+impl Transport<'_> {
+    #[cfg(feature = "vsock")]
+    fn new() -> Self {
+        match VsockStream::connect(ATTEST_DEFAULT_VSOCK_PORT, VMADDR_CID_HOST) {
+            Ok(value) => Transport::Vsock(value),
+            Err(e) => {
+                log::warn!(
+                    "Failed to connect to attestation proxy on vsock port \
+                     {ATTEST_DEFAULT_VSOCK_PORT}: {e:?}. \
+                     Falling back to serial port transport.",
+                );
+                create_serial_transport()
+            }
+        }
+    }
+
+    #[cfg(not(feature = "vsock"))]
+    fn new() -> Self {
+        create_serial_transport()
+    }
+}
+
+fn create_serial_transport<'a>() -> Transport<'a> {
+    let sp = SerialPort::new(&DEFAULT_IO_DRIVER, ATTEST_DEFAULT_SERIAL_IO_ADDR);
+    sp.init();
+    Transport::Serial(sp)
 }
 
 /// The attestation driver that communicates with the proxy via some communication channel (serial
@@ -70,11 +109,6 @@ impl TryFrom<Tee> for AttestationDriver<'_> {
     type Error = SvsmError;
 
     fn try_from(tee: Tee) -> Result<Self, Self::Error> {
-        // TODO: Make the IO port configurable/discoverable for other transport mechanisms such as
-        // virtio-vsock.
-        let sp = SerialPort::new(&DEFAULT_IO_DRIVER, 0x3e8); // COM3
-        sp.init();
-
         match tee {
             Tee::Snp => (),
             _ => return Err(AttestationError::UnsupportedTee.into()),
@@ -83,7 +117,7 @@ impl TryFrom<Tee> for AttestationDriver<'_> {
         let curve = Curve::new(TpmEccCurve::NistP521).map_err(AttestationError::Crypto)?;
         let ecc = sc_key_generate(&curve).map_err(AttestationError::Crypto)?;
 
-        let transport = Transport::Serial(sp);
+        let transport = Transport::new();
         Ok(Self {
             transport,
             tee,
@@ -209,7 +243,7 @@ impl AttestationDriver<'_> {
         Ok(())
     }
 
-    /// Read attestation data from the serial port.
+    /// Read attestation data from the transport channel.
     fn read(&mut self) -> Result<Vec<u8>, AttestationError> {
         let len = {
             let mut bytes = [0u8; 8];
@@ -229,7 +263,7 @@ impl AttestationDriver<'_> {
         Ok(buf)
     }
 
-    /// Write attestation data over the serial port.
+    /// Write attestation data over the transport channel.
     fn write(&mut self, param: impl Serialize) -> Result<(), AttestationError> {
         let bytes = serde_json::to_vec(&param).or(Err(AttestationError::NegotiationSerialize))?;
 

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -40,6 +40,13 @@ use crate::vsock::VsockError;
 use elf::ElfError;
 use syscall::SysCallError;
 
+/// Errors related to I/O operations.
+#[derive(Clone, Copy, Debug)]
+pub enum IoError {
+    /// Unexpected end of file.
+    UnexpectedEof,
+}
+
 /// Errors related to APIC handling.  These may originate from multiple
 /// layers in the system.
 #[derive(Clone, Copy, Debug)]
@@ -148,6 +155,14 @@ pub enum SvsmError {
     /// Errors related to vsock.
     #[cfg(feature = "vsock")]
     Vsock(VsockError),
+    /// Errors related to I/O operations.
+    Io(IoError),
+}
+
+impl From<IoError> for SvsmError {
+    fn from(err: IoError) -> Self {
+        Self::Io(err)
+    }
 }
 
 impl From<ElfError> for SvsmError {

--- a/kernel/src/io.rs
+++ b/kernel/src/io.rs
@@ -4,7 +4,7 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
-use crate::error::SvsmError;
+use crate::error::{IoError, SvsmError};
 use core::arch::asm;
 use core::fmt::Debug;
 
@@ -67,14 +67,38 @@ pub static DEFAULT_IO_DRIVER: DefaultIOPort = DefaultIOPort {};
 
 /// Generic Read trait to be implemented over any transport channel when reading multiple bytes.
 pub trait Read {
-    type Err: Into<SvsmError>;
+    type Err: Into<SvsmError> + From<SvsmError>;
 
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Err>;
+
+    fn read_exact(&mut self, buf: &mut [u8]) -> Result<(), Self::Err> {
+        let mut total = 0;
+        while total < buf.len() {
+            let n = self.read(&mut buf[total..])?;
+            if n == 0 {
+                return Err(SvsmError::Io(IoError::UnexpectedEof).into());
+            }
+            total += n;
+        }
+        Ok(())
+    }
 }
 
 /// Generic Write trait to be implemented over any transport channel when writing multiple bytes.
 pub trait Write {
-    type Err: Into<SvsmError>;
+    type Err: Into<SvsmError> + From<SvsmError>;
 
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Err>;
+
+    fn write_all(&mut self, buf: &[u8]) -> Result<(), Self::Err> {
+        let mut total = 0;
+        while total < buf.len() {
+            let n = self.write(&buf[total..])?;
+            if n == 0 {
+                return Err(SvsmError::Io(IoError::UnexpectedEof).into());
+            }
+            total += n;
+        }
+        Ok(())
+    }
 }

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -543,6 +543,9 @@ fn svsm_init(launch_info: &KernelLaunchInfo) {
         panic!("Failed to prepare guest FW: {e:#?}");
     }
 
+    #[cfg(feature = "virtio-drivers")]
+    initialize_virtio_mmio(&boot_params).expect("Failed to initialize virtio-mmio drivers");
+
     #[cfg(feature = "attest")]
     {
         let mut proxy = AttestationDriver::try_from(Tee::Snp).unwrap();
@@ -556,9 +559,6 @@ fn svsm_init(launch_info: &KernelLaunchInfo) {
     vtpm_init().expect("vTPM failed to initialize");
 
     virt_log_usage();
-
-    #[cfg(feature = "virtio-drivers")]
-    initialize_virtio_mmio(&boot_params).expect("Failed to initialize virtio-mmio drivers");
 
     if let Err(e) = SVSM_PLATFORM.launch_fw(&boot_params) {
         panic!("Failed to launch FW: {e:?}");

--- a/libaproxy/src/attestation.rs
+++ b/libaproxy/src/attestation.rs
@@ -19,6 +19,9 @@ use serde::{Deserialize, Serialize};
 
 type Result<T> = core::result::Result<T, Error>;
 
+/// Default vsock port used for communicating with the proxy
+pub const ATTEST_DEFAULT_VSOCK_PORT: u32 = 1995;
+
 /// The format of the public key that is used to encrypt secrets sent to SVSM upon successful
 /// attestation.
 ///

--- a/tools/aproxy/Cargo.toml
+++ b/tools/aproxy/Cargo.toml
@@ -14,6 +14,7 @@ clap = { version = "4.5", features = ["derive"] }
 libaproxy.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+vsock = "0.5.1"
 
 [lints]
 workspace = true

--- a/tools/aproxy/Cargo.toml
+++ b/tools/aproxy/Cargo.toml
@@ -11,9 +11,11 @@ kbs-types.workspace = true
 anyhow = "1.0.93"
 base64 = { workspace = true, features = ["std"] }
 clap = { version = "4.5", features = ["derive"] }
+const_format = "0.2"
 libaproxy.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+vsock = "0.5.1"
 
 [lints]
 workspace = true

--- a/tools/aproxy/src/attest.rs
+++ b/tools/aproxy/src/attest.rs
@@ -9,13 +9,13 @@ use crate::backend;
 use anyhow::Context;
 use libaproxy::*;
 use serde::Serialize;
-use std::{
-    io::{Read, Write},
-    os::unix::net::UnixStream,
-};
+use std::io::{Read, Write};
 
 /// Attest an SVSM client session.
-pub fn attest(stream: &mut UnixStream, http: &mut backend::HttpClient) -> anyhow::Result<()> {
+pub fn attest(
+    stream: &mut (impl Read + Write),
+    http: &mut backend::HttpClient,
+) -> anyhow::Result<()> {
     negotiation(stream, http)?;
     attestation(stream, http)?;
 
@@ -30,7 +30,10 @@ pub fn attest(stream: &mut UnixStream, http: &mut backend::HttpClient) -> anyhow
 /// server and gather all data required (i.e. a nonce) that should be hashed into the attestation
 /// evidence. The proxy will also reply with the type of hash algorithm to use for the negotiation
 /// parameters.
-fn negotiation(stream: &mut UnixStream, http: &mut backend::HttpClient) -> anyhow::Result<()> {
+fn negotiation(
+    stream: &mut (impl Read + Write),
+    http: &mut backend::HttpClient,
+) -> anyhow::Result<()> {
     // Read the negotiation parameters from SVSM.
     let request: NegotiationRequest = {
         let payload = proxy_read(stream)?;
@@ -51,7 +54,10 @@ fn negotiation(stream: &mut UnixStream, http: &mut backend::HttpClient) -> anyho
 /// Attestation phase of SVSM attestation. SVSM will send an attestation request containing the TEE
 /// evidence. Proxy will respond with an attestation response containing the status
 /// (success/failure) and an optional secret upon successful attestation.
-fn attestation(stream: &mut UnixStream, http: &mut backend::HttpClient) -> anyhow::Result<()> {
+fn attestation(
+    stream: &mut (impl Read + Write),
+    http: &mut backend::HttpClient,
+) -> anyhow::Result<()> {
     let request: AttestationRequest = {
         let payload = proxy_read(stream)?;
         serde_json::from_slice(&payload)
@@ -67,9 +73,9 @@ fn attestation(stream: &mut UnixStream, http: &mut backend::HttpClient) -> anyho
     Ok(())
 }
 
-/// Read bytes from the UNIX socket connected to SVSM. With each write, SVSM first writes an 8-byte
+/// Read bytes from the stream connected to SVSM. With each write, SVSM first writes an 8-byte
 /// header indicating the length of the buffer. Once the length is read, the buffer can be read.
-fn proxy_read(stream: &mut UnixStream) -> anyhow::Result<Vec<u8>> {
+fn proxy_read(stream: &mut impl Read) -> anyhow::Result<Vec<u8>> {
     let len = {
         let mut bytes = [0u8; 8];
 
@@ -89,9 +95,9 @@ fn proxy_read(stream: &mut UnixStream) -> anyhow::Result<Vec<u8>> {
     Ok(bytes)
 }
 
-/// Write bytes to the UNIX socket connected to SVSM. With each write, an 8-byte header indicating
+/// Write bytes to the stream connected to SVSM. With each write, an 8-byte header indicating
 /// the length of the buffer is written. Once the length is written, the buffer is written.
-fn proxy_write(stream: &mut UnixStream, buf: impl Serialize) -> anyhow::Result<()> {
+fn proxy_write(stream: &mut impl Write, buf: impl Serialize) -> anyhow::Result<()> {
     let bytes = serde_json::to_vec(&buf).context("unable to convert buffer to JSON bytes")?;
     let len = bytes.len().to_ne_bytes();
 

--- a/tools/aproxy/src/main.rs
+++ b/tools/aproxy/src/main.rs
@@ -11,9 +11,11 @@ mod backend;
 use anyhow::Context;
 use clap::{Parser, ValueEnum};
 use std::{fs, os::unix::net::UnixListener};
+use vsock::{VMADDR_CID_ANY, VsockAddr, VsockListener};
 
 #[derive(Parser, Debug)]
 #[clap(version, about, long_about = None)]
+#[clap(group(clap::ArgGroup::new("transport").required(true)))]
 struct Args {
     /// HTTP url to KBS (e.g. http://server:4242)
     #[clap(long)]
@@ -24,11 +26,15 @@ struct Args {
     backend: ArgsBackend,
 
     /// UNIX domain socket path to the SVSM serial port
-    #[clap(long)]
-    unix: String,
+    #[clap(long, group = "transport")]
+    unix: Option<String>,
+
+    /// vsock listening port where SVSM will connect [default: 1995]
+    #[clap(long, group = "transport", num_args = 0..=1, default_missing_value = "1995")]
+    vsock: Option<u32>,
 
     /// Force Unix domain socket removal before bind
-    #[clap(long, short, default_value_t = false)]
+    #[clap(long, short, conflicts_with = "vsock", default_value_t = false)]
     force: bool,
 }
 
@@ -40,26 +46,30 @@ enum ArgsBackend {
     Kbs,
 }
 
+macro_rules! accept_loop {
+    ($listener:expr, $url:expr, $backend:expr) => {
+        for stream in $listener.incoming() {
+            let mut stream = stream.context("Failed to accept connection")?;
+            let mut http_client = backend::HttpClient::new($url.clone(), $backend.into())?;
+            attest::attest(&mut stream, &mut http_client)?;
+        }
+    };
+}
+
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
-    if args.force {
-        let _ = fs::remove_file(args.unix.clone());
-    }
-
-    let listener = UnixListener::bind(args.unix).context("unable to bind to UNIX socket")?;
-
-    for stream in listener.incoming() {
-        match stream {
-            Ok(mut stream) => {
-                let mut http_client =
-                    backend::HttpClient::new(args.url.clone(), args.backend.into())?;
-                attest::attest(&mut stream, &mut http_client)?;
-            }
-            Err(_) => {
-                panic!("error");
-            }
+    if let Some(port) = args.vsock {
+        let listener = VsockListener::bind(&VsockAddr::new(VMADDR_CID_ANY, port))
+            .context("bind and listen failed")?;
+        accept_loop!(listener, args.url, args.backend);
+    } else if let Some(unix) = args.unix {
+        if args.force {
+            let _ = fs::remove_file(&unix);
         }
+
+        let listener = UnixListener::bind(unix).context("unable to bind to UNIX socket")?;
+        accept_loop!(listener, args.url, args.backend);
     }
 
     Ok(())

--- a/tools/aproxy/src/main.rs
+++ b/tools/aproxy/src/main.rs
@@ -10,7 +10,11 @@ mod backend;
 
 use anyhow::Context;
 use clap::{Parser, ValueEnum};
-use std::{fs, os::unix::net::UnixListener};
+use std::{
+    fs,
+    io::{Read, Write},
+    os::unix::net::UnixListener,
+};
 
 #[derive(Parser, Debug)]
 #[clap(version, about, long_about = None)]
@@ -40,6 +44,19 @@ enum ArgsBackend {
     Kbs,
 }
 
+fn accept_loop<S: Read + Write>(
+    incoming: impl Iterator<Item = std::io::Result<S>>,
+    url: &str,
+    backend: ArgsBackend,
+) -> anyhow::Result<()> {
+    for stream in incoming {
+        let mut stream = stream.context("Failed to accept connection")?;
+        let mut http_client = backend::HttpClient::new(url.to_string(), backend.into())?;
+        attest::attest(&mut stream, &mut http_client)?;
+    }
+    Ok(())
+}
+
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
@@ -48,19 +65,7 @@ fn main() -> anyhow::Result<()> {
     }
 
     let listener = UnixListener::bind(args.unix).context("unable to bind to UNIX socket")?;
-
-    for stream in listener.incoming() {
-        match stream {
-            Ok(mut stream) => {
-                let mut http_client =
-                    backend::HttpClient::new(args.url.clone(), args.backend.into())?;
-                attest::attest(&mut stream, &mut http_client)?;
-            }
-            Err(_) => {
-                panic!("error");
-            }
-        }
-    }
+    accept_loop(listener.incoming(), &args.url, args.backend)?;
 
     Ok(())
 }

--- a/tools/aproxy/src/main.rs
+++ b/tools/aproxy/src/main.rs
@@ -10,14 +10,18 @@ mod backend;
 
 use anyhow::Context;
 use clap::{Parser, ValueEnum};
+use const_format::formatcp;
+use libaproxy::ATTEST_DEFAULT_VSOCK_PORT;
 use std::{
     fs,
     io::{Read, Write},
     os::unix::net::UnixListener,
 };
+use vsock::{VMADDR_CID_ANY, VsockAddr, VsockListener};
 
 #[derive(Parser, Debug)]
 #[clap(version, about, long_about = None)]
+#[clap(group(clap::ArgGroup::new("transport").required(true)))]
 struct Args {
     /// HTTP url to KBS (e.g. http://server:4242)
     #[clap(long)]
@@ -28,11 +32,15 @@ struct Args {
     backend: ArgsBackend,
 
     /// UNIX domain socket path to the SVSM serial port
-    #[clap(long)]
-    unix: String,
+    #[clap(long, group = "transport")]
+    unix: Option<String>,
+
+    /// vsock listening port where SVSM will connect [default: 1995]
+    #[clap(long, group = "transport", num_args = 0..=1, default_missing_value = formatcp!("{}", ATTEST_DEFAULT_VSOCK_PORT))]
+    vsock: Option<u32>,
 
     /// Force Unix domain socket removal before bind
-    #[clap(long, short, default_value_t = false)]
+    #[clap(long, short, conflicts_with = "vsock", default_value_t = false)]
     force: bool,
 }
 
@@ -60,12 +68,18 @@ fn accept_loop<S: Read + Write>(
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
-    if args.force {
-        let _ = fs::remove_file(args.unix.clone());
-    }
+    if let Some(port) = args.vsock {
+        let listener = VsockListener::bind(&VsockAddr::new(VMADDR_CID_ANY, port))
+            .context("bind and listen failed")?;
+        accept_loop(listener.incoming(), &args.url, args.backend)?;
+    } else if let Some(unix) = args.unix {
+        if args.force {
+            let _ = fs::remove_file(&unix);
+        }
 
-    let listener = UnixListener::bind(args.unix).context("unable to bind to UNIX socket")?;
-    accept_loop(listener.incoming(), &args.url, args.backend)?;
+        let listener = UnixListener::bind(unix).context("unable to bind to UNIX socket")?;
+        accept_loop(listener.incoming(), &args.url, args.backend)?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
This PR introduces the vsock transport for the attestation.

Vsock is more flexible than the serial port as it has the concept of port, and we can reuse vsock for anything else.

With this PR SVSM tries to perform attestation first with vsock, if it fails it falls back using the serial port.
No change intended to the attestation's logic, I am just adding a new transport type.

Default vsock port for attestation is `1995`. 

To compile it you need to enable the feature `attest` and  `vsock`.  To run it follow the instructions available in the Documentation.