### PR TITLE
cpu: Make sure interrupts do not disappear

### DIFF
--- a/cpuarch/src/vmsa.rs
+++ b/cpuarch/src/vmsa.rs
@@ -78,7 +78,7 @@ pub struct VIntrCtrl {
     pub v_intr_vector: u8,
     #[bits(23)]
     _rsvd_62_40: u32,
-    busy: bool,
+    pub busy: bool,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -1060,6 +1060,27 @@ impl PerCpu {
         }
     }
 
+    pub fn ai_handle_intercepts(&self, vmsa: &mut VMSA) {
+        let use_alternate_injection = SVSM_PLATFORM.query_apic_registration_state();
+        let g_eii = vmsa.guest_exitintinfo;
+
+        if !use_alternate_injection {
+            return;
+        }
+
+        // Re-inject events when intercept happens
+        if g_eii.valid() {
+            vmsa.event_inj = g_eii;
+        }
+
+        // Clear busy bit
+        let mut vintr_ctrl = vmsa.vintr_ctrl;
+        if vintr_ctrl.busy() {
+            vintr_ctrl.set_busy(false);
+            vmsa.vintr_ctrl = vintr_ctrl;
+        }
+    }
+
     pub fn use_apic_emulation(&self) -> bool {
         self.guest_apic().is_some()
     }

--- a/kernel/src/vmm/execloop.rs
+++ b/kernel/src/vmm/execloop.rs
@@ -139,6 +139,8 @@ pub fn enter_guest(mut regs: &[GuestRegister]) -> GuestExitMessage {
             // Clear EFER.SVME in guest VMSA.
             vmsa.disable();
 
+            cpu.ai_handle_intercepts(vmsa);
+
             if let Some(msg) = get_svsm_request_message(vmsa_ref.deref_mut()) {
                 return msg;
             }


### PR DESCRIPTION
When the guest is processing an interrupt, an intercept can happen which will stop the injection and set EXITINTINFO.V = 1.

That then means that the interrupt needs to be reinjected. Usually, when the hypervisor sees the valid bit, it will re-inject the interrupt.

However, with Alternate Injection, the hypervisor can not re-inject the interrupt into the guest directly but the SVSM needs to do that.

At the same time, the busy bit gets set so clear it too.