### PR TITLE
fs: ignore tests with inline assembly under Miri

### DIFF
--- a/kernel/src/fs/filesystem.rs
+++ b/kernel/src/fs/filesystem.rs
@@ -1087,6 +1087,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "inline assembly")]
     fn test_multiple_file_handles() {
         let _test_mem = TestRootMem::setup(DEFAULT_TEST_MEMORY_SIZE);
         let _test_fs = TestFileSystemGuard::setup();

--- a/kernel/src/fs/ramfs.rs
+++ b/kernel/src/fs/ramfs.rs
@@ -467,6 +467,7 @@ mod tests {
     use crate::mm::alloc::{TestRootMem, DEFAULT_TEST_MEMORY_SIZE};
 
     #[test]
+    #[cfg_attr(miri, ignore = "inline assembly")]
     fn test_ramfs_file_read_write() {
         let _test_mem = TestRootMem::setup(DEFAULT_TEST_MEMORY_SIZE);
 


### PR DESCRIPTION
Ignore tests that use inline assembly at some point down the call chain when running under Miri, as it cannot handle them, generating errors.