### PR TITLE
stage2: fix undefined behavior during IGVM param initialization

### DIFF
--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -430,14 +430,15 @@ fn load_igvm_params(
 
     // Copy the contents over
     let src_addr = VirtAddr::from(launch_info.igvm_params as u64);
-    // SAFETY: the source address specified in the launch info was mapped
-    // by the loader, which promises to supply a correctly formed IGRM
-    // parameter block
-    let igvm_src = unsafe { slice::from_raw_parts(src_addr.as_ptr::<u8>(), params_size) };
     // SAFETY: the destination address came from the heap allocation above and
-    // can be used safely.
-    let igvm_dst = unsafe { slice::from_raw_parts_mut(vaddr.as_mut_ptr::<u8>(), params_size) };
-    igvm_dst.copy_from_slice(igvm_src);
+    // can be used safely. The source address specified in the launch info was
+    // mapped by the loader, which promises to supply a correctly formed IGVM
+    // parameter block.
+    unsafe {
+        vaddr
+            .as_mut_ptr::<u8>()
+            .copy_from_nonoverlapping(src_addr.as_ptr::<u8>(), params_size)
+    };
 
     Ok(vaddr)
 }


### PR DESCRIPTION
Creating a reference (in this case a slice) to uninitialized data is always undefined behavior in Rust. Instead of creating a slice to uninitialized data to write into it, simply copy into a raw pointer.

Fixes: 6803f04b6383 ("Map IGVM params in stage 2 for use by the kernel")