### PR TITLE
kernel/mm/alloc: Fix pfn checks with NO_PAGE instead of 0 in allocate…

### DIFF
--- a/kernel/src/mm/alloc.rs
+++ b/kernel/src/mm/alloc.rs
@@ -1253,7 +1253,7 @@ impl HeapMemoryRegion {
             }
             proof_with!(Tracked(&current_perm));
             let current_pfn = self.next_free_pfn(old_pfn, order);
-            if current_pfn == 0 {
+            if current_pfn == NO_PAGE {
                 return Err(AllocError::OutOfMemory);
             }
 


### PR DESCRIPTION
This is to fix the incomplete change in #882

Without this fix, we cannot correctly verify the allocate_pfn function.