### PR TITLE
locking/rwlock: fix Send/Sync on reader/writer locks

### DIFF
--- a/kernel/src/locking/rwlock.rs
+++ b/kernel/src/locking/rwlock.rs
@@ -100,10 +100,16 @@ pub struct RawRWLock<T, I> {
     phantom: PhantomData<fn(I)>,
 }
 
-// SAFETY: All well-formed locks are `Send`.
-unsafe impl<T, I> Send for RawRWLock<T, I> {}
-// SAFETY: All well-formed locks are `Sync`.
-unsafe impl<T, I> Sync for RawRWLock<T, I> {}
+// SAFETY: All well-formed locks are `Send` when the inner type is Send.
+// This constraint is required because multiple readers can exist on a single
+// lock, and if the underlying type is not Send, then the multiple readers
+// do not satisfy Send semantics.
+unsafe impl<T, I> Send for RawRWLock<T, I> where T: Send {}
+// SAFETY: All well-formed locks are `Sync` when the inner type is Sync.
+// This constraint is required because multiple readers can exist on a single
+// lock, and if the underlying type is not Sync, then the multiple readers
+// do not satisfy Sync semantics.
+unsafe impl<T, I> Sync for RawRWLock<T, I> where T: Sync {}
 
 /// Splits a 64-bit value into two parts: readers (low 32 bits) and
 /// writers (high 32 bits).


### PR DESCRIPTION
Fix `RWLock<T>` to be `Sync` only when `T` is `Sync`, and to be `Send` only when `T` is `Send`.  These constraints are required because reader/writer locks permit multiple shared accesses to the inner type.  Consider, for example, a lock `lock: RWLock<Cell<T>>`.  `Cell<T>` is inherently not `Sync`, and if the lock were to blindly implement `Sync`, then it would be possible for multiple threads to have access to `lock` and to call `lock.lock_read().set()` simultaneously to modify the contents of the cell, which would result in a clear conflict.  Because of this, the lock itself can only be `Sync` if its inner type is `Sync`.  The same holds true for `Send`.