### PR TITLE
aproxy: use empty enum to represent available backends

### DIFF
--- a/tools/aproxy/src/backend/mod.rs
+++ b/tools/aproxy/src/backend/mod.rs
@@ -7,11 +7,12 @@
 
 mod kbs;
 
+use crate::ArgsBackend;
 use anyhow::{anyhow, Context};
 use kbs::KbsProtocol;
 use libaproxy::*;
 use reqwest::{blocking::Client, cookie::Jar};
-use std::{str::FromStr, sync::Arc};
+use std::sync::Arc;
 
 /// HTTP client and protocol identifier.
 #[derive(Clone, Debug)]
@@ -52,13 +53,10 @@ pub enum Protocol {
     Kbs(KbsProtocol),
 }
 
-impl FromStr for Protocol {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match &s.to_lowercase()[..] {
-            "kbs" => Ok(Self::Kbs(KbsProtocol)),
-            _ => Err(anyhow!("invalid backend attestation protocol selected")),
+impl From<ArgsBackend> for Protocol {
+    fn from(value: ArgsBackend) -> Self {
+        match value {
+            ArgsBackend::Kbs => Self::Kbs(KbsProtocol),
         }
     }
 }


### PR DESCRIPTION
The clap crate has an easy way to represent a list of possible values with the `ValueEnum` macro. This has the advantage of showing the possible values in the CLI when --help is used or when an invalid value is passed. However, this macro can only be used for empty enums.

Introduce an empty enum that can be trivially converted to the `BackendEnum` so that the CLI is more helpful and self-documenting.

Before:

```
$ ./bin/aproxy -h
      (...)
      --protocol <BACKEND>  Backend attestation protocol that the server implements
```

After:

```
$ ./bin/aproxy -h
      (...)
      --protocol <BACKEND>  Backend attestation protocol that the server implements [possible values: kbs]
```

This also allows removing the `FromStr` implementation for `Protocol`, since the value is now parsed by Clap for us.