### PR TITLE
locking/rwlock: add guard mapping methods

### DIFF
--- a/kernel/src/locking/rwlock.rs
+++ b/kernel/src/locking/rwlock.rs
@@ -384,6 +384,11 @@ impl<T: Send, I: IrqLocking> RawRWLock<T, I> {
         }
     }
 
+    /// Returns a pointer into the underlying data.
+    pub const fn as_ptr(&self) -> *mut T {
+        self.data.get()
+    }
+
     /// This function is used to wait until all writers have finished their
     /// operations and retrieve the current state of the [`RWLock`].
     ///


### PR DESCRIPTION
~~Fully harden the PerCpu structure against undefined behavior when used in a reentrant manner. Our approach before was not correct, since `Cell` and `RefCell` do not guarantee atomicity when keeping track of reads and writes, meaning that a preempted context may observe an inconsistent state, leading to undefined behavior.~~

~~The approach taken is to replace the aforementioned interior mutability types with read-write locks. Thus, whenever an invalid borrow is attempted (e.g. a mutable borrow while an immutable borrow is alive), it can be detected by the same mechanism that is used to prevent the same problem with threads. To avoid deadlocks, we introduce non-blocking methods to `RWLock`, and specific, panicking shorthands to avoid introducing too many calls to `unwrap()`.~~

Add methods to manipulate read and write locking guards, similar to those available for `RefCell`-related guards. This will help in a future change where `RefCells` are replaced by `RWLocks` to keep users mostly unbothered.

This PR does the following:
* Add non-blocking methods to `RWLock`.
* Add `map()`, `map_split()` and `filter_map()` methods to locking guards, similar to those for `Ref` and `RefMut`.
~~* Cleanup some access patterns into `PerCpu` fields.~~
~~* Replace remaining `Cell`s and `RefCell`s in the `PerCpu` with `RWLock`.~~
~~* Cleanup trait bounds on several `PerCpu` fields.~~
~~* Assert at compile time that `PerCpu` is `Sync`.~~