### PR TITLE
kernel/mm/alloc:  Remove dead code allowance

### DIFF
--- a/kernel/src/mm/alloc.rs
+++ b/kernel/src/mm/alloc.rs
@@ -2376,7 +2376,7 @@ unsafe impl GlobalAlloc for SvsmAllocator {
     }
 }
 
-#[cfg_attr(any(target_os = "none"), global_allocator)]
+#[cfg_attr(target_os = "none", global_allocator)]
 #[allow(dead_code)]
 static ALLOCATOR: SvsmAllocator = SvsmAllocator::new();
 

--- a/kernel/src/mm/alloc.rs
+++ b/kernel/src/mm/alloc.rs
@@ -2376,8 +2376,8 @@ unsafe impl GlobalAlloc for SvsmAllocator {
     }
 }
 
+#[cfg(any(target_os = "none", test, fuzzing))]
 #[cfg_attr(target_os = "none", global_allocator)]
-#[allow(dead_code)]
 static ALLOCATOR: SvsmAllocator = SvsmAllocator::new();
 
 /// Initializes the root memory region with the specified physical start


### PR DESCRIPTION
This PR introduces some cleanup and a configuration to enable SVSM ALLOCATOR only when needed, avoiding the need to use `#[allow(dead_code)]`.

When running unit tests outside of SVSM (e.g., `make test`), the crate is compiled twice (this can be seen with verbose mode): once with the test flag for running tests, and once without it for rustdoc. In both cases, the target is the host machine. In the second compilation, ALLOCATOR is never used, triggering an unused warning.

The fix conditionally compiles ALLOCATOR only when needed.