### PR TITLE
Add tylerfanelli as codeowner for attesation subsystem

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,3 +5,9 @@
 * joerg.roedel@amd.com jlange@microsoft.com peter.fang@intel.com sgarzare@redhat.com
 
 # Subsystem Maintainers
+
+# Attestation subsystem
+# Tyler Fanelli
+/libaproxy/* tfanelli@redhat.com
+/tools/aproxy/* tfanelli@redhat.com
+/kernel/src/attest.rs tfanelli@redhat.com


### PR DESCRIPTION
Add myself to CODEOWNERS for visibility of changes to the attestation subsystem.