### PR TITLE
svsm: Implement KASLR

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,6 +4,7 @@
 rustflags = [
 	"-C", "force-frame-pointers",
 	"-C", "linker-flavor=ld",
+	"-C", "relocation-model=pie",
 	"--cfg", "aes_force_soft",
 	"--cfg", "polyval_force_soft",
 ]

--- a/elf/src/header.rs
+++ b/elf/src/header.rs
@@ -65,6 +65,7 @@ impl Elf64Hdr {
     const ELFOSABI_GNU: Elf64char = 3;
 
     const ET_EXEC: Elf64Half = 2;
+    const ET_DYN: Elf64Half = 3;
 
     const EM_X86_64: Elf64Half = 62;
 
@@ -136,7 +137,7 @@ impl Elf64Hdr {
         let e_shnum = Elf64Half::from_le_bytes(buf[60..62].try_into().unwrap()) as Elf64Word;
         let e_shstrndx = Elf64Half::from_le_bytes(buf[62..64].try_into().unwrap()) as Elf64Word;
 
-        if e_type != Self::ET_EXEC {
+        if e_type != Self::ET_EXEC && e_type != Self::ET_DYN {
             return Err(ElfError::UnsupportedType);
         }
         if e_machine != Self::EM_X86_64 {

--- a/kernel/build.rs
+++ b/kernel/build.rs
@@ -23,7 +23,7 @@ fn main() {
     println!("cargo:rustc-link-arg-bin=svsm=--build-id=none");
     println!("cargo:rustc-link-arg-bin=svsm=--no-relax");
     println!("cargo:rustc-link-arg-bin=svsm=-Tkernel/src/svsm.lds");
-    println!("cargo:rustc-link-arg-bin=svsm=-no-pie");
+    println!("cargo:rustc-link-arg-bin=svsm=-pie");
 
     // Extra linker args for tests.
     println!("cargo:rerun-if-env-changed=LINK_TEST");

--- a/kernel/src/mm/address_space.rs
+++ b/kernel/src/mm/address_space.rs
@@ -174,6 +174,7 @@ pub const PGTABLE_LVL3_IDX_SHARED: usize = 511;
 
 /// Base Address of shared memory region
 pub const SVSM_GLOBAL_BASE: VirtAddr = virt_from_idx(PGTABLE_LVL3_IDX_SHARED);
+pub const SVSM_GLOBAL_END: VirtAddr = SVSM_GLOBAL_BASE.const_add(256 * SIZE_1G);
 
 /// Shared mappings region start
 pub const SVSM_GLOBAL_MAPPING_BASE: VirtAddr = SVSM_GLOBAL_BASE.const_add(256 * SIZE_1G);

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -32,6 +32,7 @@ use svsm::cpu::percpu::{this_cpu, PerCpu, PERCPU_AREAS};
 use svsm::debug::stacktrace::print_stack;
 use svsm::error::SvsmError;
 use svsm::igvm_params::IgvmParams;
+use svsm::mm::address_space::SVSM_GLOBAL_BASE;
 use svsm::mm::alloc::{memory_info, print_memory_info, root_mem_init, AllocError};
 use svsm::mm::pagetable::{paging_init, PTEntryFlags, PageTable};
 use svsm::mm::validate::{
@@ -358,8 +359,7 @@ fn load_kernel_elf(
     let bytes = unsafe { slice::from_raw_parts(elf_start.bits() as *const u8, elf_len) };
     let elf = elf::Elf64File::read(bytes)?;
 
-    let vaddr_alloc_info = elf.image_load_vaddr_alloc_info();
-    let vaddr_alloc_base = vaddr_alloc_info.range.vaddr_begin;
+    let vaddr_alloc_base = SVSM_GLOBAL_BASE.as_usize() as u64;
 
     // Map, validate and populate the SVSM kernel ELF's PT_LOAD segments. The
     // segments' virtual address range might not necessarily be contiguous,

--- a/kernel/src/svsm.lds
+++ b/kernel/src/svsm.lds
@@ -2,7 +2,7 @@ OUTPUT_ARCH(i386:x86-64)
 
 SECTIONS
 {
-	. = 0xffffff8000000000;
+	. = SIZEOF_HEADERS;
 	.text : {
 		*(.startup.*)
 		*(.text)


### PR DESCRIPTION
This PR implement **KASLR** for the svsm (feature mentioned in #448).

With those changes, `stage2` loads the kernel ELF with a random offset after `SVSM_GLOBAL_BASE`  within a range that does not overlap with other regions in the virtual address space.

With the code as-is, we randomize at most 26 bits [1].  A reorganization of the address space layout would be required if higher randomization needs to be pursued

The last missing piece is to check hardware support for `rdrandr`. Before proceeding further, I am opening this Draft PR to ensure that the maintainers agree the implementation is heading in the right direction.

---
- [1] There are 256GB (2<sup>38</sup>) between `SVSM_GLOBAL_BASE` and `SVSM_GLOBAL_END`, but the code needs to be 4KB aligned, which eats 12bits. Hence 2<sup>26</sup>.