### PR TITLE
sev/vmsa: fix `VMSA::set_tpr()`

### DIFF
--- a/kernel/src/sev/vmsa.rs
+++ b/kernel/src/sev/vmsa.rs
@@ -129,8 +129,8 @@ impl GuestCpuState for VMSA {
     }
 
     fn set_tpr(&mut self, tpr: u8) {
-        let mut vintr_ctrl = self.vintr_ctrl;
-        vintr_ctrl.set_v_tpr(tpr >> 4)
+        let vintr_ctrl = self.vintr_ctrl;
+        self.vintr_ctrl = vintr_ctrl.with_v_tpr(tpr >> 4);
     }
 
     fn request_nmi(&mut self) {


### PR DESCRIPTION
The method was making a copy of the field and updating the copy, but it never copied the updated value back into the structure, rendering the method a no-op.