### PR TITLE
userspace: Introduce test in svsm and Allocator

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,14 +31,20 @@ jobs:
       - name: Install TPM 2.0 Reference Implementation build dependencies
         run: sudo apt install -y build-essential cmake pkg-config
 
-      - name: Build debug image
-        run: cargo xbuild ./configs/*
+      - name: Build (non-test) debug images
+        run: |
+          shopt -s extglob
+          cargo xbuild ./configs/!(*-test-*.json)
 
-      - name: Build debug image with all features
-        run: cargo xbuild --all-features ./configs/*
+      - name: Build (non-test) debug images with all features
+        run: |
+          shopt -s extglob
+          cargo xbuild --all-features ./configs/!(*-test-*.json)
 
-      - name: Build release image
-        run: cargo xbuild --release ./configs/*
+      - name: Build (non-test) release images
+        run: |
+          shopt -s extglob
+          cargo xbuild --release ./configs/!(*-test-*.json)
 
       - name: Run tests
         run: make test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,6 +388,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "coconut-alloc"
+version = "0.1.0"
+source = "git+https://github.com/n-ramacciotti/coconut-alloc.git?branch=user_alloc#1bbeca5761e34cad0610023cdfd5d0dd4eb2227d"
+
+[[package]]
 name = "cocoon-tpm-crypto"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2152,6 +2157,7 @@ dependencies = [
 name = "userinit"
 version = "0.1.0"
 dependencies = [
+ "test",
  "userlib",
 ]
 
@@ -2159,7 +2165,9 @@ dependencies = [
 name = "userlib"
 version = "0.1.0"
 dependencies = [
+ "coconut-alloc",
  "syscall",
+ "test",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,8 @@ userlib = { path = "user/lib" }
 userinit = { path = "user/init" }
 release = { path = "release" }
 virtio-drivers = { path = "virtio-drivers" }
+# TODO: switch coconut-alloc to upstream when user_alloc branch is merged
+coconut-alloc = { git = "https://github.com/n-ramacciotti/coconut-alloc.git" , branch= "user_alloc" }
 
 # crates.io
 aes-gcm = { version = "0.10.3", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,11 @@ bin/test-kernel.elf: bin
 		--target=x86_64-unknown-none \
 		--config 'target.x86_64-unknown-none.runner=["sh", "-c", "cp $$0 ../$@"]'
 
+bin/test-userinit.elf: bin
+	RUSTDOC=true LINK_TEST=1 cargo +nightly test --package userinit ${CARGO_ARGS} \
+        --target=x86_64-unknown-none \
+		--config 'target.x86_64-unknown-none.runner=["sh", "-c", "cp $$0 ../../$@"]'
+
 ${FS_BIN}: bin
 ifneq ($(FS_FILE), none)
 	cp -f $(FS_FILE) ${FS_BIN}
@@ -192,7 +197,8 @@ clippy:
 	RUSTFLAGS="--cfg fuzzing" cargo clippy ${CLIPPY_OPTIONS} --all-features --package svsm-fuzz -- ${CLIPPY_ARGS}
 	cargo clippy ${CLIPPY_OPTIONS} --all-features --package svsm --target x86_64-unknown-none -- ${CLIPPY_ARGS}
 	cargo clippy ${CLIPPY_OPTIONS} --all-features --package stage1 --target x86_64-unknown-none -- ${CLIPPY_ARGS} ${STAGE1_RUSTC_ARGS}
-	cargo clippy ${CLIPPY_OPTIONS} --all-features --workspace --tests --exclude packit -- ${CLIPPY_ARGS}
+	cargo clippy ${CLIPPY_OPTIONS} --all-features --workspace --tests --exclude packit --exclude userlib -- ${CLIPPY_ARGS}
+	cargo clippy ${CLIPPY_OPTIONS} --package userlib --tests -- ${CLIPPY_ARGS}
 
 clean:
 	cargo clean
@@ -201,4 +207,4 @@ clean:
 
 distclean: clean
 
-.PHONY: test clean clippy bin/stage2.bin bin/svsm-kernel.elf bin/test-kernel.elf stage1_elf_full stage1_elf_trampoline stage1_elf_test distclean $(APROXYBIN) $(IGVM_FILES)
+.PHONY: test clean clippy bin/stage2.bin bin/svsm-kernel.elf bin/test-kernel.elf bin/test-userinit.elf stage1_elf_full stage1_elf_trampoline stage1_elf_test distclean $(APROXYBIN) $(IGVM_FILES)

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ FEATURES_TEST ?= vtpm,virtio-drivers
 SVSM_ARGS_TEST += --no-default-features
 ifneq ($(FEATURES_TEST),)
 SVSM_ARGS_TEST += --features ${FEATURES_TEST}
+XBUILD_ARGS_TEST += --feature ${FEATURES_TEST}
 endif
 
 TEST_ARGS ?=
@@ -49,7 +50,7 @@ else
 BUILD_FW =
 endif
 
-IGVM_FILES = bin/coconut-qemu.igvm bin/coconut-hyperv.igvm bin/coconut-vanadium.igvm
+IGVM_FILES = bin/coconut-qemu.igvm bin/coconut-hyperv.igvm bin/coconut-vanadium.igvm bin/coconut-test-qemu.igvm bin/coconut-test-hyperv.igvm bin/coconut-test-vanadium.igvm
 IGVMBUILDER = "target/${TARGET_PATH}/igvmbuilder"
 IGVMBIN = bin/igvmbld
 IGVMMEASURE = "target/${TARGET_PATH}/igvmmeasure"
@@ -97,17 +98,14 @@ bin/coconut-hyperv.igvm:
 bin/coconut-vanadium.igvm:
 	cargo xbuild $(XBUILD_ARGS) ./configs/vanadium-target.json
 
-bin/coconut-test-qemu.igvm: $(IGVMBUILDER) $(IGVMMEASURE) bin/stage1-trampoline.bin bin/test-kernel.elf bin/stage2.bin
-	$(IGVMBUILDER) --sort --output $@ --tdx-stage1 bin/stage1-trampoline.bin --stage2 bin/stage2.bin --kernel bin/test-kernel.elf qemu --snp --tdp --native
-	$(IGVMMEASURE) $@ measure
+bin/coconut-test-qemu.igvm:
+	cargo xbuild $(XBUILD_ARGS_TEST) ./configs/qemu-test-target.json
 
-bin/coconut-test-hyperv.igvm: $(IGVMBUILDER) $(IGVMMEASURE) bin/stage1-trampoline.bin bin/test-kernel.elf bin/stage2.bin
-	$(IGVMBUILDER) --sort --output $@ --tdx-stage1 bin/stage1-trampoline.bin --stage2 bin/stage2.bin --kernel bin/test-kernel.elf --comport 3 hyper-v --snp --tdp --vsm
-	$(IGVMMEASURE) $@ measure
+bin/coconut-test-hyperv.igvm:
+	cargo xbuild $(XBUILD_ARGS_TEST) ./configs/hyperv-test-target.json
 
-bin/coconut-test-vanadium.igvm: $(IGVMBUILDER) $(IGVMMEASURE) bin/stage1-trampoline.bin bin/test-kernel.elf bin/stage2.bin
-	$(IGVMBUILDER) --sort --output $@ --tdx-stage1 bin/stage1-trampoline.bin --stage2 bin/stage2.bin --kernel bin/test-kernel.elf vanadium --snp --tdp
-	$(IGVMMEASURE) --check-kvm --native-zero $@ measure
+bin/coconut-test-vanadium.igvm:
+	cargo xbuild $(XBUILD_ARGS_TEST) ./configs/vanadium-test-target.json
 
 test:
 	cargo test ${CARGO_ARGS} ${SVSM_ARGS_TEST} --workspace
@@ -153,8 +151,7 @@ bin/test-kernel.elf: bin
 # custom test runners. See https://github.com/coconut-svsm/svsm/issues/705.
 	RUSTDOC=true LINK_TEST=1 cargo +nightly test --package svsm ${CARGO_ARGS} ${SVSM_ARGS_TEST} \
 		--target=x86_64-unknown-none \
-		--config 'target.x86_64-unknown-none.runner=["sh", "-c", "cp $$0 ../${TEST_KERNEL_ELF}"]'
-	objcopy -O elf64-x86-64 --strip-unneeded ${TEST_KERNEL_ELF} bin/test-kernel.elf
+		--config 'target.x86_64-unknown-none.runner=["sh", "-c", "cp $$0 ../$@"]'
 
 ${FS_BIN}: bin
 ifneq ($(FS_FILE), none)

--- a/configs/hyperv-test-target.json
+++ b/configs/hyperv-test-target.json
@@ -1,0 +1,35 @@
+{
+    "igvm": {
+        "hyper-v": {
+            "output": "coconut-test-hyperv.igvm",
+            "platforms": [
+                "snp",
+                "tdp",
+                "vsm"
+            ],
+            "policy": "0x30000",
+            "comport": "3",
+            "measure": "print"
+        }
+    },
+    "kernel": {
+        "svsm": {
+            "type": "make",
+            "output_file": "bin/test-kernel.elf"
+        },
+        "stage2": {
+            "manifest": "kernel/Cargo.toml",
+            "binary": true,
+            "objcopy": "binary"
+        },
+        "tdx-stage1": {
+            "type": "make",
+            "output_file": "bin/stage1-trampoline",
+            "objcopy": "binary"
+        }
+    },
+    "firmware": {},
+    "fs": {
+        "modules": {}
+    }
+}

--- a/configs/qemu-test-target.json
+++ b/configs/qemu-test-target.json
@@ -1,0 +1,33 @@
+{
+    "igvm": {
+        "qemu": {
+            "output": "coconut-test-qemu.igvm",
+            "platforms": [
+                "snp",
+                "tdp",
+                "native"
+            ],
+            "measure": "print"
+        }
+    },
+    "kernel": {
+        "svsm": {
+            "type": "make",
+            "output_file": "bin/test-kernel.elf"
+        },
+        "stage2": {
+            "manifest": "kernel/Cargo.toml",
+            "binary": true,
+            "objcopy": "binary"
+        },
+        "tdx-stage1": {
+            "type": "make",
+            "output_file": "bin/stage1-trampoline",
+            "objcopy": "binary"
+        }
+    },
+    "firmware": {},
+    "fs": {
+        "modules": {}
+    }
+}

--- a/configs/qemu-test-target.json
+++ b/configs/qemu-test-target.json
@@ -28,6 +28,12 @@
     },
     "firmware": {},
     "fs": {
-        "modules": {}
+        "modules": {
+            "userinit": {
+                "path": "/init",
+                "type": "make",
+                "output_file": "bin/test-userinit.elf"
+            }
+        }
     }
 }

--- a/configs/vanadium-test-target.json
+++ b/configs/vanadium-test-target.json
@@ -1,0 +1,39 @@
+{
+    "igvm": {
+        "vanadium": {
+            "output": "coconut-vanadium.igvm",
+            "platforms": [
+                "snp",
+                "tdp"
+            ],
+            "policy": "0x30000",
+            "measure": "print",
+            "check-kvm": true,
+            "measure-native-zeroes": true
+        }
+    },
+    "kernel": {
+        "svsm": {
+            "type": "make",
+            "output_file": "bin/test-kernel.elf"
+        },
+        "svsm": {
+            "features": "vtpm",
+            "binary": false
+        },
+        "stage2": {
+            "manifest": "kernel/Cargo.toml",
+            "binary": true,
+            "objcopy": "binary"
+        },
+        "tdx-stage1": {
+            "type": "make",
+            "output_file": "bin/stage1-trampoline",
+            "objcopy": "binary"
+        }
+    },
+    "firmware": {},
+    "fs": {
+        "modules": {}
+    }
+}

--- a/kernel/src/syscall/class0.rs
+++ b/kernel/src/syscall/class0.rs
@@ -14,6 +14,13 @@ use core::ffi::c_char;
 use syscall::SysCallError;
 
 pub fn sys_exit(exit_code: u32) -> ! {
+    #[cfg(all(test, test_in_svsm))]
+    {
+        if exit_code != 0 {
+            use crate::testing::QEMUExitValue;
+            crate::testing::exit(QEMUExitValue::Fail);
+        }
+    }
     log::info!(
         "Terminating task {}, exit_code {exit_code}",
         current_task().get_task_name()

--- a/kernel/src/testing.rs
+++ b/kernel/src/testing.rs
@@ -81,9 +81,7 @@ pub fn svsm_test_runner(test_cases: &[&test::TestDescAndFn]) {
         (test_case.testfn.0)();
     }
 
-    info!("All tests passed!");
-
-    exit(QEMUExitValue::Success);
+    info!("Kernel tests passed!");
 }
 
 /// Exits the in-SVSM test session with the given exit value.

--- a/user/init/Cargo.toml
+++ b/user/init/Cargo.toml
@@ -9,8 +9,16 @@ path = "src/main.rs"
 test = false
 doctest = false
 
+[lib]
+test = true
+doctest = true
+
 [dependencies]
 userlib.workspace = true
+
+[target."x86_64-unknown-none".dev-dependencies]
+test.workspace = true
+userlib = { workspace = true, features = ["test_runner"] }
 
 [lints]
 workspace = true

--- a/user/init/build.rs
+++ b/user/init/build.rs
@@ -1,4 +1,21 @@
 fn main() {
-    println!("cargo:rustc-link-arg=-Tuser/lib/module.lds");
-    println!("cargo:rustc-link-arg=-no-pie");
+    // Extra cfgs
+    println!("cargo::rustc-check-cfg=cfg(test_in_svsm)");
+
+    // Userinit
+    println!("cargo:rustc-link-arg-bin=userinit=-Tuser/lib/module.lds");
+    println!("cargo:rustc-link-arg-bin=userinit=-no-pie");
+    println!("cargo:rustc-link-arg-bin=userinit=-nostdlib");
+
+    // Extra linker args for tests.
+    println!("cargo:rerun-if-env-changed=LINK_TEST");
+    if std::env::var("LINK_TEST").is_ok() {
+        println!("cargo:rustc-cfg=test_in_svsm");
+        println!("cargo:rustc-link-arg=-nostdlib");
+        println!("cargo:rustc-link-arg=-Tuser/lib/module.lds");
+        println!("cargo:rustc-link-arg=-no-pie");
+    }
+
+    println!("cargo:rerun-if-changed=user/lib/module.lds");
+    println!("cargo:rerun-if-changed=build.rs");
 }

--- a/user/init/src/lib.rs
+++ b/user/init/src/lib.rs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+
+#![no_std]
+#![cfg_attr(all(test, test_in_svsm), no_main)]
+#![cfg_attr(all(test, test_in_svsm), feature(custom_test_frameworks))]
+#![cfg_attr(
+    all(test, test_in_svsm),
+    test_runner(userlib::testing::svsm_userspace_test_runner)
+)]
+#![cfg_attr(
+    all(test, test_in_svsm),
+    reexport_test_harness_main = "userspace_test_main"
+)]
+
+#[test]
+fn test_nop() {}
+
+// When running tests inside the SVSM:
+// Build the crate entrypoint.
+#[cfg(all(test, test_in_svsm))]
+#[path = "main.rs"]
+pub mod userinit;

--- a/user/init/src/main.rs
+++ b/user/init/src/main.rs
@@ -1,41 +1,95 @@
-#![no_std]
-#![no_main]
+#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(test), no_main)]
 
 use userlib::*;
-
-use core::ptr::{addr_of, addr_of_mut};
-
-static mut SOME_BSS_DATA: [u64; 128] = [0; 128];
-static mut SOME_DATA: [u64; 128] = [0x01; 128];
-static SOME_RO_DATA: [u64; 128] = [0xee; 128];
-
-fn check(arr: &[u64; 128], val: u64) {
-    for v in arr.iter() {
-        if *v != val {
-            panic!("Unexpected array value");
-        }
-    }
-}
-
-fn write(arr: &mut [u64; 128], val: u64) {
-    for v in arr.iter_mut() {
-        *v = val;
-    }
-}
+extern crate alloc;
+use alloc::boxed::Box;
 
 declare_main!(main);
 
 fn main() -> u32 {
-    println!("COCONUT-SVSM init process starting");
+    #[cfg(test)]
+    {
+        crate::userspace_test_main();
+    }
 
-    // SAFETY: Single-threaded process, so no data races. Safe to access global
-    // mutable data.
-    unsafe {
-        write(&mut *addr_of_mut!(SOME_DATA), 0xcc);
-        write(&mut *addr_of_mut!(SOME_BSS_DATA), 0xaa);
-        check(&*addr_of!(SOME_DATA), 0xccu64);
-        check(&*addr_of!(SOME_RO_DATA), 0xeeu64);
-        check(&*addr_of!(SOME_BSS_DATA), 0xaa);
+    #[cfg(not(test))]
+    {
+        println!("COCONUT-SVSM init process starting");
+        let b = Box::new([0u8; 256]);
+        println!("Value: {:p}", b.as_ptr());
     }
     0
+}
+
+#[cfg(all(test, test_in_svsm))]
+mod tests {
+    use super::*;
+    use alloc::vec;
+    use core::ptr::{addr_of, addr_of_mut};
+
+    static mut SOME_BSS_DATA: [u64; 128] = [0; 128];
+    static mut SOME_DATA: [u64; 128] = [0x01; 128];
+    static SOME_RO_DATA: [u64; 128] = [0xee; 128];
+
+    fn check(arr: &[u64; 128], val: u64) {
+        for v in arr.iter() {
+            assert_eq!(*v, val, "Unexpected array value");
+        }
+    }
+
+    fn write(arr: &mut [u64; 128], val: u64) {
+        for v in arr.iter_mut() {
+            *v = val;
+        }
+    }
+
+    #[test]
+    fn test_memory_check() {
+        // SAFETY: Single-threaded process, so no data races. Safe to access global
+        // mutable data.
+        unsafe {
+            write(&mut *addr_of_mut!(SOME_DATA), 0xcc);
+            write(&mut *addr_of_mut!(SOME_BSS_DATA), 0xaa);
+            check(&*addr_of!(SOME_DATA), 0xccu64);
+            check(&*addr_of!(SOME_RO_DATA), 0xeeu64);
+            check(&*addr_of!(SOME_BSS_DATA), 0xaa);
+        }
+    }
+
+    #[test]
+    fn test_alloc_behaviour() {
+        let mut vec1 = vec![[0u8; 100]];
+        let mut vec2 = vec![0u8; 1024];
+        let mut vec3 = vec![[0u8; 1024]];
+        let mut box1 = Box::new([0u8; 256]);
+
+        let layout1 = layout_from_size(100).unwrap();
+        assert_eq!(layout1.size(), 128);
+        assert_eq!(layout1.align(), 128);
+
+        let layout2 = layout_from_size(1024).unwrap();
+        assert_eq!(layout2.size(), 1024);
+        assert_eq!(layout2.align(), 1024);
+
+        // SAFETY: The pointers are valid as they come from allocations.
+        let layout3 = unsafe { layout_from_ptr(box1.as_mut_ptr()).unwrap() };
+        assert_eq!(layout3.size(), 256);
+        assert_eq!(layout3.align(), 256);
+
+        // SAFETY: The pointers are valid as they come from allocations.
+        let layout4 = unsafe { layout_from_ptr(vec1.as_mut_ptr() as *mut u8).unwrap() };
+        assert_eq!(layout4.size(), 128);
+        assert_eq!(layout4.align(), 128);
+
+        // SAFETY: The pointers are valid as they come from allocations.
+        let layout5 = unsafe { layout_from_ptr(vec2.as_mut_ptr()).unwrap() };
+        assert_eq!(layout5.size(), 1024);
+        assert_eq!(layout5.align(), 1024);
+
+        // SAFETY: The pointers are valid as they come from allocations.
+        let layout6 = unsafe { layout_from_ptr(vec3.as_mut_ptr() as *mut u8).unwrap() };
+        assert_eq!(layout6.size(), 1024);
+        assert_eq!(layout6.align(), 1024);
+    }
 }

--- a/user/lib/Cargo.toml
+++ b/user/lib/Cargo.toml
@@ -5,6 +5,11 @@ edition = "2021"
 
 [dependencies]
 syscall.workspace = true
+test = { workspace = true, optional = true }
+
+[features]
+default = []
+test_runner = ["dep:test"]
 
 [lints]
 workspace = true

--- a/user/lib/Cargo.toml
+++ b/user/lib/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 syscall.workspace = true
+coconut-alloc.workspace = true
 test = { workspace = true, optional = true }
 
 [features]

--- a/user/lib/src/alloc.rs
+++ b/user/lib/src/alloc.rs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+
+use crate::{console_print, print, println};
+use coconut_alloc::AllocBlock;
+use core::alloc::{GlobalAlloc, Layout};
+use core::ptr;
+use core::ptr::{addr_of, addr_of_mut};
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+#[derive(Debug)]
+pub enum AllocError {
+    AlreadyInitialized,
+    NotInitialized,
+}
+
+const MAX_ALLOC_SIZE: usize = 32 * 1024; // 32 KiB
+const UNINITIALIZED: usize = 0;
+const INITIALIZING: usize = 1;
+const INITIALIZED: usize = 2;
+
+// One time initialization of a static mutable reference:
+// https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html#no_std-one-time-initialization
+static mut HEAP: AllocBlock = AllocBlock::new();
+static STATE_INITIALIZED: AtomicUsize = AtomicUsize::new(UNINITIALIZED);
+
+pub fn set_global_heap() -> Result<(), AllocError> {
+    // Just a single initialization allowed
+    if STATE_INITIALIZED
+        .compare_exchange(
+            UNINITIALIZED,
+            INITIALIZING,
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        )
+        .is_err()
+    {
+        println!("Heap initialization failed");
+        return Err(AllocError::AlreadyInitialized);
+    }
+
+    // SAFETY: Only a single thread can reach this point
+    unsafe {
+        let heap = &mut *addr_of_mut!(HEAP);
+        AllocBlock::initialize(heap);
+    }
+    STATE_INITIALIZED.store(INITIALIZED, Ordering::SeqCst);
+    Ok(())
+}
+
+fn get_global_heap() -> Result<&'static AllocBlock, AllocError> {
+    // fixme: this check can be removed.
+    if STATE_INITIALIZED.load(Ordering::SeqCst) != INITIALIZED {
+        println!("Heap not initialized");
+        return Err(AllocError::NotInitialized);
+    }
+    // SAFETY: Heap is initialized at startup before any allocations occur.
+    // STATE_INITIALIZED ensures single initialization.
+    unsafe { Ok(&*addr_of!(HEAP)) }
+}
+
+struct SvsmUserAllocator;
+
+// SAFETY: AllockBlock is lockless for allocations up to 32KB.
+// HEAP is write-once and only read via immutable references after initialization.
+// AllocBlock uses atomic operations internally to handle concurrent alloc/free safely.
+unsafe impl GlobalAlloc for SvsmUserAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if layout.size() == 0 || layout.size() > MAX_ALLOC_SIZE {
+            return ptr::null_mut();
+        }
+
+        let Ok(heap) = get_global_heap() else {
+            return ptr::null_mut();
+        };
+
+        match heap.alloc(layout.size()) {
+            Ok(off) => {
+                let base = heap as *const AllocBlock as *const u8;
+                // SAFETY: Atomic allocation just performed
+                // The offset is valid
+                unsafe { base.add(off) as *mut u8 }
+            }
+            Err(_) => ptr::null_mut(),
+        }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
+        let Ok(heap) = get_global_heap() else {
+            return;
+        };
+
+        let base = heap as *const AllocBlock as *const u8;
+        // SAFETY: ptr must have been allocated from this heap
+        let off = unsafe { ptr.offset_from(base) as usize };
+
+        heap.free(off);
+    }
+}
+
+#[global_allocator]
+static GLOBAL_ALLOC: SvsmUserAllocator = SvsmUserAllocator;

--- a/user/lib/src/lib.rs
+++ b/user/lib/src/lib.rs
@@ -13,6 +13,11 @@ pub use console::*;
 pub use locking::*;
 pub use syscall::*;
 
+#[cfg(feature = "test_runner")]
+pub mod testing;
+#[cfg(feature = "test_runner")]
+pub use testing::*;
+
 #[macro_export]
 macro_rules! declare_main {
     ($path:path) => {

--- a/user/lib/src/lib.rs
+++ b/user/lib/src/lib.rs
@@ -6,9 +6,10 @@
 
 #![cfg_attr(all(not(test), target_os = "none"), no_std)]
 
+pub mod alloc;
 pub mod console;
 pub mod locking;
-
+pub use alloc::*;
 pub use console::*;
 pub use locking::*;
 pub use syscall::*;
@@ -24,12 +25,22 @@ macro_rules! declare_main {
         const _: () = {
             #[export_name = "_start"]
             pub extern "C" fn launch_module() -> ! {
+                init();
+
                 let main_fn: fn() -> u32 = $path;
                 let ret = main_fn();
                 exit(ret);
             }
         };
     };
+}
+
+pub fn init() {
+    #[cfg(all(not(test), target_os = "none"))]
+    {
+        // Single-threaded init process, safe to initialize global heap here
+        set_global_heap().expect("Heap initialization failed");
+    }
 }
 
 #[cfg(all(not(test), target_os = "none"))]

--- a/user/lib/src/testing.rs
+++ b/user/lib/src/testing.rs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+
+use crate::{console_print, print, println};
+use test::ShouldPanic;
+
+pub fn svsm_userspace_test_runner(test_cases: &[&test::TestDescAndFn]) {
+    println!("running {} user tests", test_cases.len());
+    for mut test_case in test_cases.iter().copied().copied() {
+        if test_case.desc.should_panic == ShouldPanic::Yes {
+            test_case.desc.ignore = true;
+            test_case
+                .desc
+                .ignore_message
+                .get_or_insert("#[should_panic] not supported");
+        }
+
+        if test_case.desc.ignore {
+            if let Some(message) = test_case.desc.ignore_message {
+                println!("test {} ... ignored, {message}", test_case.desc.name.0);
+            } else {
+                println!("test {} ... ignored", test_case.desc.name.0);
+            }
+            continue;
+        }
+
+        println!("test {} ...", test_case.desc.name.0);
+        (test_case.testfn.0)();
+    }
+
+    println!("Userspace tests passed!");
+}

--- a/xbuild/src/features.rs
+++ b/xbuild/src/features.rs
@@ -72,9 +72,8 @@ impl Features {
         }
     }
 
-    pub fn feature_list(&mut self, pkg: &str, mut recipe_features: Vec<String>) -> Vec<String> {
-        let mut pkg_features: Vec<String> = self
-            .list
+    pub fn feature_list(&mut self, pkg: &str) -> Vec<String> {
+        self.list
             .iter_mut()
             .filter_map(|f| {
                 if f.pkg == pkg {
@@ -84,10 +83,6 @@ impl Features {
                     None
                 }
             })
-            .collect();
-
-        pkg_features.append(&mut recipe_features);
-
-        pkg_features
+            .collect()
     }
 }

--- a/xbuild/src/main.rs
+++ b/xbuild/src/main.rs
@@ -193,12 +193,10 @@ impl ComponentConfig {
         if args.all_features {
             cmd.args(["--all-features"]);
         } else {
-            let features = self.features();
-
-            let cargo_features = cmd_feats.feature_list(pkg, features);
-
-            if !cargo_features.is_empty() {
-                cmd.args(["--features", cargo_features.join(",").as_str()]);
+            let mut features = self.features();
+            features.append(&mut cmd_feats.feature_list(pkg));
+            if !features.is_empty() {
+                cmd.args(["--features", features.join(",").as_str()]);
             }
         }
         if let Some(manifest) = self.manifest.as_ref() {

--- a/xbuild/src/main.rs
+++ b/xbuild/src/main.rs
@@ -163,6 +163,13 @@ impl ComponentConfig {
         }
     }
 
+    fn features(&self) -> Vec<String> {
+        self.features
+            .clone()
+            .map(|feat| feat.split(',').map(|f| f.trim().to_string()).collect())
+            .unwrap_or_default()
+    }
+
     /// Build this component as a cargo binary
     fn cargo_build(
         &self,
@@ -186,11 +193,7 @@ impl ComponentConfig {
         if args.all_features {
             cmd.args(["--all-features"]);
         } else {
-            let features: Vec<String> = self
-                .features
-                .clone()
-                .map(|feat| feat.split(',').map(|f| f.trim().to_string()).collect())
-                .unwrap_or_default();
+            let features = self.features();
 
             let cargo_features = cmd_feats.feature_list(pkg, features);
 

--- a/xbuild/src/main.rs
+++ b/xbuild/src/main.rs
@@ -159,7 +159,7 @@ impl ComponentConfig {
     ) -> BuildResult<PathBuf> {
         match self.build_type {
             BuildType::Cargo => self.cargo_build(args, pkg, target, cmd_feats),
-            BuildType::Make => self.makefile_build(args),
+            BuildType::Make => self.makefile_build(args, pkg, cmd_feats),
         }
     }
 
@@ -221,7 +221,12 @@ impl ComponentConfig {
     }
 
     /// Build this component as a Makefile binary.
-    fn makefile_build(&self, args: &Args) -> BuildResult<PathBuf> {
+    fn makefile_build(
+        &self,
+        args: &Args,
+        pkg: &str,
+        cmd_feats: &mut Features,
+    ) -> BuildResult<PathBuf> {
         let Some(file) = self.output_file.as_ref() else {
             return Err("Cannot build makefile target without output_file".into());
         };
@@ -233,6 +238,18 @@ impl ComponentConfig {
         if args.verbose {
             cmd.arg("V=2");
         }
+
+        // Get feature list
+        let mut features = self.features();
+        features.append(&mut cmd_feats.feature_list(pkg));
+        let env_features = features.join(",");
+
+        // Pass features to Makefile. We don't know if this is a test
+        // target, so fill in both environment variables, and let the
+        // Makefile use the right one.
+        cmd.env("FEATURES", &env_features);
+        cmd.env("FEATURES_TEST", &env_features);
+
         run_cmd_checked(cmd, args)?;
         Ok(PathBuf::from(file))
     }


### PR DESCRIPTION
This PR introduces heap allocation support in userspace and enables running tests in userspace mode within SVSM.

The heap is a single 64KiB static block initialized by `userlib` at startup before calling the `main` function. Atomic state operations ensure that only a single initialization can occur.
The PR implements the `GlobalAlloc` trait by exploiting `AllocBlock` from coconut-alloc, which supports lockless allocations up to 32KiB using atomic operations.

The PR enables running tests in userspace by:
- Adding a custom test runner in `userlib` via the `test_runner` feature, which is included in `userinit` for the `x86_64-unknown-none` target during tests
- Updating the qemu test configuration to build userspace binaries via Makefile  with the `LINK_TEST` environment variable
- Moving filesystem initialization after kernel tests to ensure an empty filesystem for tests that require it.
- Catching test failures in userspace via the exit syscall.

## 
This PR is marked as draft as it depends on the changes from:
- [#901](https://github.com/coconut-svsm/svsm/pull/901) and [#909](https://github.com/coconut-svsm/svsm/pull/909) from SVSM: these simplify test termination and userspace test creation respectively.
- [#4](https://github.com/coconut-svsm/coconut-alloc/pull/4) from coconut-alloc: this removes an unstable feature not available in the current toolchain (1.86.0) and adds a new utility function required in this PR

All feedback and suggestions are welcome