### PR TITLE
cpu/idt: clean up vector handling

### DIFF
--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -14,8 +14,8 @@ use super::super::x86::apic_eoi;
 use super::common::{
     user_mode, IdtEntry, IdtEventType, PageFaultError, AC_VECTOR, BP_VECTOR, BR_VECTOR, CP_VECTOR,
     DB_VECTOR, DE_VECTOR, DF_VECTOR, GP_VECTOR, HV_VECTOR, IDT, INT_INJ_VECTOR, IPI_VECTOR,
-    MCE_VECTOR, MF_VECTOR, NMI_VECTOR, NM_VECTOR, NP_VECTOR, OF_VECTOR, PF_VECTOR, SS_VECTOR,
-    SX_VECTOR, TS_VECTOR, UD_VECTOR, VC_VECTOR, VE_VECTOR, XF_VECTOR,
+    MCE_VECTOR, MF_VECTOR, NMI_VECTOR, OF_VECTOR, PF_VECTOR, SS_VECTOR, UD_VECTOR, VC_VECTOR,
+    VE_VECTOR, XF_VECTOR,
 };
 use crate::address::VirtAddr;
 use crate::cpu::irq_state::{raw_get_tpr, raw_set_tpr, tpr_from_vector};
@@ -57,10 +57,7 @@ extern "C" {
     fn asm_entry_of();
     fn asm_entry_br();
     fn asm_entry_ud();
-    fn asm_entry_nm();
     fn asm_entry_df();
-    fn asm_entry_ts();
-    fn asm_entry_np();
     fn asm_entry_ss();
     fn asm_entry_gp();
     fn asm_entry_pf_early();
@@ -73,7 +70,6 @@ extern "C" {
     fn asm_entry_cp();
     fn asm_entry_hv();
     fn asm_entry_vc();
-    fn asm_entry_sx();
     fn asm_entry_int80();
     fn asm_entry_irq_int_inj();
     fn asm_entry_irq_ipi();
@@ -93,10 +89,7 @@ fn init_idt_exceptions(idt: &mut IDT<'_>) {
     idt.set_entry(OF_VECTOR, IdtEntry::entry(asm_entry_of));
     idt.set_entry(BR_VECTOR, IdtEntry::entry(asm_entry_br));
     idt.set_entry(UD_VECTOR, IdtEntry::entry(asm_entry_ud));
-    idt.set_entry(NM_VECTOR, IdtEntry::entry(asm_entry_nm));
     idt.set_entry(DF_VECTOR, IdtEntry::entry(asm_entry_df));
-    idt.set_entry(TS_VECTOR, IdtEntry::entry(asm_entry_ts));
-    idt.set_entry(NP_VECTOR, IdtEntry::entry(asm_entry_np));
     idt.set_entry(SS_VECTOR, IdtEntry::entry(asm_entry_ss));
     idt.set_entry(GP_VECTOR, IdtEntry::entry(asm_entry_gp));
     idt.set_entry(PF_VECTOR, IdtEntry::entry(asm_entry_pf_early));
@@ -108,7 +101,6 @@ fn init_idt_exceptions(idt: &mut IDT<'_>) {
     idt.set_entry(CP_VECTOR, IdtEntry::entry(asm_entry_cp));
     idt.set_entry(HV_VECTOR, IdtEntry::entry(asm_entry_hv));
     idt.set_entry(VC_VECTOR, IdtEntry::entry(asm_entry_vc));
-    idt.set_entry(SX_VECTOR, IdtEntry::entry(asm_entry_sx));
 }
 
 /// # Safety

--- a/kernel/src/cpu/idt/svsm_entry.S
+++ b/kernel/src/cpu/idt/svsm_entry.S
@@ -395,20 +395,8 @@ default_entry_no_ist	name=br		handler=terminate		error_code=0	vector=5
 // #UD Invalid-Opcode Exception (Vector 6)
 default_entry_no_ist	name=ud		handler=terminate		error_code=0	vector=6
 
-// #NM Device-Not-Available Exception (Vector 7)
-default_entry_no_ist	name=nm		handler=panic			error_code=0	vector=7
-
 // #DF Double-Fault Exception (Vector 8)
 default_entry_with_ist	name=df		handler=double_fault		error_code=1	vector=8
-
-// Coprocessor-Segment-Overrun Exception (Vector 9)
-// No handler - reserved vector
-
-// #TS Invalid-TSS Exception (Vector 10)
-default_entry_no_ist	name=ts		handler=panic			error_code=1	vector=10
-
-// #NP Segment-Not-Present Exception (Vector 11)
-default_entry_no_ist	name=np		handler=panic			error_code=1	vector=11
 
 // #SS Stack Exception (Vector 12)
 default_entry_no_ist	name=ss		handler=terminate		error_code=1	vector=12
@@ -446,9 +434,6 @@ default_entry_no_ist	name=cp		handler=control_protection			error_code=1	vector=2
 
 // #VC VMM Communication Exception (Vector 29)
 default_entry_no_ist	name=vc		handler=vmm_communication	error_code=1	vector=29
-
-// #SX Security Exception (Vector 30)
-default_entry_no_ist	name=sx		handler=panic			error_code=1	vector=30
 
 // INT 0x80 system call handler
 default_entry_no_ist	name=int80	handler=system_call		error_code=0	vector=0x80


### PR DESCRIPTION
Remove exception handlers for exceptions that can never be raised, and ensure that exceptions generated from user mode will terminate the user task instead of causing a system panic.