### PR TITLE
protocols/core: properly type accounting of max pvalidate entries

### DIFF
--- a/kernel/src/protocols/core.rs
+++ b/kernel/src/protocols/core.rs
@@ -383,8 +383,10 @@ fn core_pvalidate(params: &RequestParams) -> Result<(), SvsmReqError> {
     let entries = request.entries;
     let next = request.next;
 
-    // Each entry is 8 bytes in size, 8 bytes for the request header
-    let max_entries: u16 = ((PAGE_SIZE - offset - 8) / 8).try_into().unwrap();
+    let max_entries: u16 = ((PAGE_SIZE - offset - size_of::<PValidateRequest>())
+        / size_of::<u64>())
+    .try_into()
+    .unwrap();
 
     if entries == 0 || entries > max_entries || entries <= next {
         return Err(SvsmReqError::invalid_parameter());


### PR DESCRIPTION
When computing the maximum amount of entries for the core PVALIDATE call, use size_of() instead of hardcoding the sizes of the types involved, in order to improve code clarity.