### PR TITLE
xbuild: Introduce optional flag to enable a different toolchain for each component

### DIFF
--- a/xbuild/src/main.rs
+++ b/xbuild/src/main.rs
@@ -146,6 +146,7 @@ struct ComponentConfig {
     #[serde(default)]
     objcopy: Objcopy,
     path: Option<PathBuf>,
+    toolchain: Option<String>,
 }
 
 impl ComponentConfig {
@@ -174,6 +175,11 @@ impl ComponentConfig {
         let mut bin = PathBuf::from("target");
 
         let mut cmd = Command::new("cargo");
+
+        if let Some(toolchain) = self.toolchain.as_ref() {
+            cmd.arg(format!("+{}", toolchain));
+        }
+
         cmd.args([
             "build",
             if self.binary { "--bin" } else { "--package" },


### PR DESCRIPTION
While trying to import the [coconut-alloc](https://github.com/coconut-svsm/coconut-alloc) crate into SVSM `userlib`, I ran into the following error:
```
error[E0658]: use of unstable library feature `unsigned_is_multiple_of`

    |
108 |         assert!(offset.is_multiple_of(self.parts_desc.alloc_size));
    |                        ^^^^^^^^^^^^^^
    |
    = note: see issue #128101 <https://github.com/rust-lang/rust/issues/128101> for more information
```

This happens because SVSM currently uses Rust 1.86.0, in which this feature is not stable.

Initially, my approach was to keep a single toolchain for the whole project. I manually patched the alloc crate to work around this issue (which can be seen in this [PR](https://github.com/coconut-svsm/coconut-alloc/pull/4)).

However, another approach, which is implemented in this PR, is to allow specifying a toolchain for each `ComponentConfig`. With this change:
- If a toolchain is provided for a component, cargo will use it by adding  `+toolchain`.
- If a toolchain is not specified, the default Rust toolchain (from `rust-toolchain.toml` in the root of the workspace) is used.

This makes it easier to build different components with different Rust versions without affecting the default toolchain. 

For example,  `user` modules in the filesystem could use a different toolchain from the kernel. The toolchain can be configured in `configs/*-target.json`:
```
"fs": {
        "modules": {
            "userinit": {
                "path": "/init",
                "toolchain": "1.86.0"
            }
        }
    }
```

I’d appreciate any feedback on whether this approach makes sense or if there’s a better way to handle this.