### PR TITLE
tools/igvmbuilder: fix highest VTL for native builds

### DIFF
--- a/tools/igvmbuilder/src/igvm_builder.rs
+++ b/tools/igvmbuilder/src/igvm_builder.rs
@@ -309,7 +309,7 @@ impl IgvmBuilder {
             self.platforms.push(IgvmPlatformHeader::SupportedPlatform(
                 IGVM_VHS_SUPPORTED_PLATFORM {
                     compatibility_mask: NATIVE_COMPATIBILITY_MASK,
-                    highest_vtl: 2,
+                    highest_vtl: 0,
                     platform_type: IgvmPlatformType::NATIVE,
                     platform_version: 1,
                     shared_gpa_boundary: 0,


### PR DESCRIPTION
Support for multiple VTLs requires VSM, so IGVM files that expect to launch in VTL 2 should always specify VSM as the platform type.  Native platform configuration should specify zero as the highest VTL.