### PR TITLE
verification: add missing SPDX header

### DIFF
--- a/verification/verus_macro_stub/src/lib.rs
+++ b/verification/verus_macro_stub/src/lib.rs
@@ -1,3 +1,9 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2025 Red Hat, Inc.
+//
+// Author: Luigi Leonardi <leonardi@redhat.com>
+
 extern crate proc_macro;
 use proc_macro::TokenStream;
 

--- a/verification/verus_stub/src/lib.rs
+++ b/verification/verus_stub/src/lib.rs
@@ -1,3 +1,9 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2025 Red Hat, Inc.
+//
+// Author: Luigi Leonardi <leonardi@redhat.com>
+
 #![no_std]
 
 #[cfg(feature = "disable")]


### PR DESCRIPTION
`verus_stub` and `verus_macro_stub` are missing the SPDX header. Add it.

I'm the original author of those files.

