### PR TITLE
repo: update minimum Rust version to 1.87.0

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -2,7 +2,6 @@
 name = "svsm"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.86.0"
 
 [[bin]]
 name = "stage2"

--- a/kernel/src/protocols/vtpm.rs
+++ b/kernel/src/protocols/vtpm.rs
@@ -60,7 +60,7 @@ fn vtpm_platform_commands_supported_bitmap() -> u64 {
 
 fn is_vtpm_platform_command_supported(cmd: TpmPlatformCommand) -> bool {
     let vtpm = vtpm_get_locked();
-    vtpm.get_supported_commands().iter().any(|x| *x == cmd)
+    vtpm.get_supported_commands().contains(&cmd)
 }
 
 const SEND_COMMAND_REQ_INBUF_SIZE: usize = PAGE_SIZE - 9;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.87.0"
 targets = [ "x86_64-unknown-none" ]

--- a/stage1/Cargo.toml
+++ b/stage1/Cargo.toml
@@ -2,7 +2,6 @@
 name = "stage1"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.86.0"
 
 [[bin]]
 name = "stage1"


### PR DESCRIPTION
The [coconut-alloc](https://github.com/coconut-svsm/coconut-alloc) crate requires Rust [1.87.0](https://github.com/rust-lang/rust/releases/tag/1.87.0) for a feature stabilized in this release.

Update toolchain configuration as suggested in  [#924](https://github.com/coconut-svsm/svsm/pull/924)

Fix clippy warnings