### PR TITLE
kernel: fix some tests in svsm

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -5,10 +5,13 @@
 // Author: Nicolai Stange <nstange@suse.de>
 
 #![no_std]
-#![cfg_attr(all(test, test_in_svsm), no_main)]
-#![cfg_attr(all(test, test_in_svsm), feature(custom_test_frameworks))]
-#![cfg_attr(all(test, test_in_svsm), test_runner(crate::testing::svsm_test_runner))]
-#![cfg_attr(all(test, test_in_svsm), reexport_test_harness_main = "test_main")]
+#![cfg_attr(
+    all(test, test_in_svsm),
+    no_main,
+    feature(custom_test_frameworks),
+    test_runner(crate::testing::svsm_test_runner),
+    reexport_test_harness_main = "test_main"
+)]
 #![cfg_attr(verus_keep_ghost, feature(proc_macro_hygiene))]
 
 pub mod acpi;

--- a/kernel/src/mm/address_space.rs
+++ b/kernel/src/mm/address_space.rs
@@ -273,8 +273,6 @@ mod tests {
         ImmutAfterInitCell::uninit();
     static INITIALIZED: SpinLock<bool> = SpinLock::new(false);
 
-    #[test]
-    #[cfg_attr(test_in_svsm, ignore = "Offline testing")]
     fn init_km_testing() {
         let mut initialized = INITIALIZED.lock();
         if *initialized {
@@ -307,17 +305,17 @@ mod tests {
 
     #[test]
     #[cfg(target_os = "none")]
-    #[cfg_attr(test_in_svsm, ignore = "Offline testing")]
     fn test_virt_to_phys() {
-        let vaddr = VirtAddr::new(0x1500);
-        let paddr = virt_to_phys(vaddr);
+        let virt_start = FIXED_MAPPING.kernel_mapping.virt_start;
+        let phys_start = FIXED_MAPPING.kernel_mapping.phys_start;
 
-        assert_eq!(paddr, PhysAddr::new(0x4500));
+        let paddr = virt_to_phys(virt_start);
+
+        assert_eq!(paddr, phys_start);
     }
 
     #[test]
     #[cfg(not(target_os = "none"))]
-    #[cfg_attr(test_in_svsm, ignore = "Offline testing")]
     fn test_virt_to_phys() {
         let vaddr = VirtAddr::new(0x1500);
         let paddr = virt_to_phys(vaddr);
@@ -327,17 +325,17 @@ mod tests {
 
     #[test]
     #[cfg(target_os = "none")]
-    #[cfg_attr(test_in_svsm, ignore = "Offline testing")]
     fn test_phys_to_virt() {
-        let paddr = PhysAddr::new(0x4500);
-        let vaddr = phys_to_virt(paddr);
+        let virt_start = FIXED_MAPPING.kernel_mapping.virt_start;
+        let phys_start = FIXED_MAPPING.kernel_mapping.phys_start;
 
-        assert_eq!(vaddr, VirtAddr::new(0x1500));
+        let vaddr = phys_to_virt(phys_start);
+
+        assert_eq!(vaddr, virt_start);
     }
 
     #[test]
     #[cfg(not(target_os = "none"))]
-    #[cfg_attr(test_in_svsm, ignore = "Offline testing")]
     fn test_phys_to_virt() {
         let paddr = PhysAddr::new(0x4500);
         let vaddr = phys_to_virt(paddr);


### PR DESCRIPTION
~~This PR refactors kernel tests to properly distinguish between in-svsm and offline tests using `target_os` instead of the redundant `test_in_svsm` flag.~~

Refactor `cfg_attr` to use the compact notation in `kernel/lib.rs` for enabling test inside svsm

Additionally, some tests in `mm/address_space` were updated to run in the correct environment and their parameters were fixed.

~~Note: Removing `test_in_svsm` in favor of `target_os` might make the code less explicit and more difficult to understand. I appreciate any feedback on this approach.~~