### PR TITLE
Support MMAP and MUNMAP system calls

### DIFF
--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -435,6 +435,7 @@ extern "C" fn ex_handler_system_call(
             ctxt.regs.r9,
             ctxt.regs.r10,
         ),
+        SYS_MUNMAP => sys_munmap(ctxt.regs.rdi, ctxt.regs.rsi),
         SYS_EXEC => sys_exec(ctxt.regs.rdi, ctxt.regs.rsi, ctxt.regs.r8),
         SYS_CLOSE => sys_close(ctxt.regs.rdi as u32),
         // Class 1 SysCalls.

--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -428,6 +428,13 @@ extern "C" fn ex_handler_system_call(
     ctxt.regs.rax = match input {
         // Class 0 SysCalls.
         SYS_EXIT => sys_exit(ctxt.regs.rdi as u32),
+        SYS_MMAP => sys_mmap(
+            ctxt.regs.rdi as u32,
+            ctxt.regs.rsi,
+            ctxt.regs.r8,
+            ctxt.regs.r9,
+            ctxt.regs.r10,
+        ),
         SYS_EXEC => sys_exec(ctxt.regs.rdi, ctxt.regs.rsi, ctxt.regs.r8),
         SYS_CLOSE => sys_close(ctxt.regs.rdi as u32),
         // Class 1 SysCalls.

--- a/kernel/src/fs/obj.rs
+++ b/kernel/src/fs/obj.rs
@@ -14,7 +14,7 @@ use alloc::vec::Vec;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 #[derive(Debug)]
-struct DirectoryHandle {
+pub struct DirectoryHandle {
     dir: Arc<dyn Directory>,
     list: Vec<FileName>,
     next: AtomicUsize,
@@ -42,6 +42,22 @@ pub struct FsObj {
 }
 
 impl FsObj {
+    pub fn file_handle(&self) -> Option<&FileHandle> {
+        if let FsObjEntry::File(fh) = &self.entry {
+            Some(fh)
+        } else {
+            None
+        }
+    }
+
+    pub fn directory_handle(&self) -> Option<&DirectoryHandle> {
+        if let FsObjEntry::Directory(dh) = &self.entry {
+            Some(dh)
+        } else {
+            None
+        }
+    }
+
     pub fn new_dir(dir: &Arc<dyn Directory>) -> Self {
         FsObj {
             entry: FsObjEntry::Directory(DirectoryHandle::new(dir)),

--- a/kernel/src/mm/vm/mapping/api.rs
+++ b/kernel/src/mm/vm/mapping/api.rs
@@ -39,6 +39,26 @@ pub trait VirtualMapping: core::fmt::Debug + Send + Sync {
     /// Mapping size. Will always be a multiple of `VirtualMapping::page_size()`
     fn mapping_size(&self) -> usize;
 
+    /// Request to resize the mapping
+    ///
+    /// # Arguments
+    ///
+    /// * `size` - The requested new size of the mapping
+    ///
+    /// # Returns
+    ///
+    /// Returns Ok() with the new size of the mapping on success, Err() with
+    /// SvsmError value on failure.
+    fn resize(&mut self, _size: usize) -> Result<usize, SvsmError> {
+        Err(SvsmError::Mem)
+    }
+
+    /// Perform cleanup work after resizing the mapping
+    ///
+    /// This is a call-back to release any memory that can only be freed after
+    /// a TLB flush.
+    fn flush(&mut self) {}
+
     /// Indicates whether the mapping has any associated data.
     ///
     /// # Returns

--- a/kernel/src/mm/vm/mapping/file_mapping.rs
+++ b/kernel/src/mm/vm/mapping/file_mapping.rs
@@ -20,6 +20,8 @@ use crate::mm::{PAGE_SIZE, pagetable::PTEntryFlags};
 use crate::types::PAGE_SHIFT;
 use crate::utils::align_up;
 
+use syscall::MMFlags;
+
 bitflags! {
     #[derive(Debug, PartialEq, Copy, Clone)]
     pub struct VMFileMappingFlags : u32 {
@@ -33,6 +35,34 @@ bitflags! {
         const Private = 1 << 3;
         // Map at a fixed address
         const Fixed = 1 << 4;
+    }
+}
+
+impl From<MMFlags> for VMFileMappingFlags {
+    fn from(value: MMFlags) -> Self {
+        let mut vm_val = Self::empty();
+
+        if value.contains(MMFlags::MAP_READ) {
+            vm_val |= VMFileMappingFlags::Read;
+        }
+
+        if value.contains(MMFlags::MAP_WRITE) {
+            vm_val |= VMFileMappingFlags::Write;
+        }
+
+        if value.contains(MMFlags::MAP_EXEC) {
+            vm_val |= VMFileMappingFlags::Execute;
+        }
+
+        if value.contains(MMFlags::MAP_PRIVATE) {
+            vm_val |= VMFileMappingFlags::Private;
+        }
+
+        if value.contains(MMFlags::MAP_FIXED) {
+            vm_val |= VMFileMappingFlags::Fixed;
+        }
+
+        vm_val
     }
 }
 

--- a/kernel/src/mm/vm/mapping/rawalloc.rs
+++ b/kernel/src/mm/vm/mapping/rawalloc.rs
@@ -11,6 +11,7 @@ use crate::error::SvsmError;
 use crate::mm::alloc::PageRef;
 use crate::types::{PAGE_SHIFT, PAGE_SIZE};
 use crate::utils::align_up;
+use core::cmp::Ordering;
 
 extern crate alloc;
 use alloc::vec::Vec;
@@ -24,6 +25,9 @@ pub struct RawAllocMapping {
 
     /// Number of pages required in `pages`
     count: usize,
+
+    /// Pages to flush
+    unmapped_pages: Vec<Option<PageRef>>,
 }
 
 impl RawAllocMapping {
@@ -39,7 +43,12 @@ impl RawAllocMapping {
     pub fn new(size: usize) -> Self {
         let count = align_up(size, PAGE_SIZE) >> PAGE_SHIFT;
         let pages: Vec<Option<PageRef>> = iter::repeat_n(None, count).collect();
-        RawAllocMapping { pages, count }
+        let unmapped_pages: Vec<Option<PageRef>> = Vec::new();
+        RawAllocMapping {
+            pages,
+            count,
+            unmapped_pages,
+        }
     }
 
     /// Allocates a single backing page of type PageFile if the page has not already
@@ -61,16 +70,30 @@ impl RawAllocMapping {
         Ok(())
     }
 
+    /// Allocates backing pages for the mapping starting at a give offset
+    ///
+    /// # Arguments:
+    ///
+    /// * `offset` - Byte offset into the mapping to start allocating from
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` when all pages could be allocated, `Err(SvsmError::Mem)` otherwise
+    fn alloc_pages_offset(&mut self, offset: usize) -> Result<(), SvsmError> {
+        let start = offset / PAGE_SIZE;
+        for index in start..self.count {
+            self.alloc_page(index * PAGE_SIZE)?;
+        }
+        Ok(())
+    }
+
     /// Allocates a full set of backing pages of type PageFile
     ///
     /// # Returns
     ///
     /// `Ok(())` when all pages could be allocated, `Err(SvsmError::Mem)` otherwise
     pub fn alloc_pages(&mut self) -> Result<(), SvsmError> {
-        for index in 0..self.count {
-            self.alloc_page(index * PAGE_SIZE)?;
-        }
-        Ok(())
+        self.alloc_pages_offset(0)
     }
 
     /// Returns a reference to a page at a given index. The page must already
@@ -99,6 +122,61 @@ impl RawAllocMapping {
     /// The size of the mapping in bytes as `usize`.
     pub fn mapping_size(&self) -> usize {
         self.count * PAGE_SIZE
+    }
+
+    /// Change the size of the mapping. Note that the backing pages are not yet
+    /// freed when the mapping is shrinked. To free the pages a separate call to
+    /// the `flush()` method is required.
+    ///
+    /// # Arguments
+    ///
+    /// * `size` - The new size of the mapping. This will be rounded up to the
+    ///   next PAGE_SIZE boundary.
+    ///
+    /// # Returns
+    ///
+    /// Returns `OK(new_aligned_size)` on success, `Err(SvsmError)` on failure.
+    pub fn resize(&mut self, size: usize) -> Result<usize, SvsmError> {
+        let size = align_up(size, PAGE_SIZE);
+        let old_size = self.mapping_size();
+
+        match size.cmp(&old_size) {
+            Ordering::Equal => Ok(size),
+            Ordering::Greater => {
+                // Increase pages vector
+                let diff_count = (size - old_size) / PAGE_SIZE;
+                let new_total_count = size / PAGE_SIZE;
+                // Reserve memory in pages vector
+                self.pages
+                    .try_reserve_exact(diff_count)
+                    .map_err(|_| SvsmError::Mem)?;
+                // Increase pages vector
+                self.pages.resize_with(new_total_count, || None);
+                self.count += diff_count;
+                // Try to allocate the pages
+                if let Err(e) = self.alloc_pages_offset(old_size) {
+                    // Shrink pages vector
+                    self.count -= diff_count;
+                    // Free any stale backing pages
+                    self.pages.truncate(self.count);
+                    Err(e)
+                } else {
+                    Ok(size)
+                }
+            }
+            Ordering::Less => {
+                self.count = size / PAGE_SIZE;
+                let mut old_pages = self.pages.split_off(self.count);
+                self.unmapped_pages.append(&mut old_pages);
+                Ok(size)
+            }
+        }
+    }
+
+    /// Free unmapped pages. This needs to be called after the unmapped pages
+    /// have been flushed out of all TLBs.
+    pub fn flush(&mut self) {
+        self.unmapped_pages.clear();
     }
 
     /// Request physical address to map for a given offset

--- a/kernel/src/mm/vm/mapping/vmalloc.rs
+++ b/kernel/src/mm/vm/mapping/vmalloc.rs
@@ -74,6 +74,14 @@ impl VirtualMapping for VMalloc {
         self.alloc.mapping_size()
     }
 
+    fn resize(&mut self, size: usize) -> Result<usize, SvsmError> {
+        self.alloc.resize(size)
+    }
+
+    fn flush(&mut self) {
+        self.alloc.flush();
+    }
+
     fn map(&self, offset: usize) -> Option<PhysAddr> {
         self.alloc.map(offset)
     }

--- a/kernel/src/syscall/class0.rs
+++ b/kernel/src/syscall/class0.rs
@@ -62,6 +62,14 @@ pub fn sys_mmap(
     Ok(mmap_addr.into())
 }
 
+pub fn sys_munmap(vaddr: usize, _length: usize) -> Result<u64, SysCallError> {
+    let virt_addr = VirtAddr::from(vaddr);
+    current_task()
+        .munmap_user(virt_addr)
+        .map_err(|_| SysCallError::EINVAL)?;
+    Ok(0)
+}
+
 pub fn sys_close(obj_id: u32) -> Result<u64, SysCallError> {
     // According to syscall ABI/API spec, close always returns 0 even
     // if called with an invalid handle

--- a/kernel/src/syscall/class0.rs
+++ b/kernel/src/syscall/class0.rs
@@ -4,14 +4,15 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
-use super::obj::obj_close;
+use super::obj::{obj_close, obj_get};
 use crate::address::VirtAddr;
 use crate::cpu::percpu::current_task;
 use crate::fs::find_dir;
 use crate::mm::guestmem::UserPtr;
+use crate::mm::vm::VMFileMappingFlags;
 use crate::task::{current_task_terminated, exec_user, schedule};
 use core::ffi::c_char;
-use syscall::SysCallError;
+use syscall::{MMFlags, SysCallError};
 
 pub fn sys_exit(exit_code: u32) -> ! {
     log::info!(
@@ -33,6 +34,32 @@ pub fn sys_exec(file: usize, root: usize, _flags: usize) -> Result<u64, SysCallE
     let tid = exec_user(&file_str, real_root)?;
 
     Ok(tid.into())
+}
+
+pub fn sys_mmap(
+    obj_id: u32,
+    addr: usize,
+    offset: usize,
+    size: usize,
+    flags: usize,
+) -> Result<u64, SysCallError> {
+    let mm_flags = MMFlags::from_bits(flags).ok_or(SysCallError::EINVAL)?;
+    let virt_addr = VirtAddr::from(addr);
+    let vm_flags = VMFileMappingFlags::from(mm_flags);
+    let opt = obj_get(obj_id.into()).ok();
+    let mmap_addr = if let Some(obj) = opt {
+        let fs_obj = obj.as_fs().ok_or(SysCallError::EINVAL)?;
+        let fh = fs_obj.file_handle();
+        current_task()
+            .mmap_user(virt_addr, fh, offset, size, vm_flags)
+            .map_err(SysCallError::from)?
+    } else {
+        current_task()
+            .mmap_user(virt_addr, None, offset, size, vm_flags)
+            .map_err(SysCallError::from)?
+    };
+
+    Ok(mmap_addr.into())
 }
 
 pub fn sys_close(obj_id: u32) -> Result<u64, SysCallError> {

--- a/syscall/src/class0.rs
+++ b/syscall/src/class0.rs
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //
 // Copyright (c) 2024 Intel Corporation.
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
 //
 // Author: Chuanxiao Dong <chuanxiao.dong@intel.com>
+//         Joerg Roedel <joerg.roedel@amd.com>
 
-use super::call::{SysCallError, syscall1, syscall3};
-use super::{SYS_EXEC, SYS_EXIT};
+use super::call::{SysCallError, syscall1, syscall2, syscall3, syscall5};
+use super::{MMFlags, ObjHandle, SYS_EXEC, SYS_EXIT, SYS_MMAP, SYS_MRESIZE, SYS_MUNMAP};
 use core::ffi::CStr;
 
 pub fn exit(code: u32) -> ! {
@@ -19,6 +21,92 @@ pub fn exit(code: u32) -> ! {
 #[allow(dead_code)]
 #[derive(Debug)]
 pub struct Tid(u32);
+
+/// Creates a memory mapping in the calling task
+///
+/// # Arguments
+///
+/// * `handle` - An object handle of none for anonymous mappings.
+/// * `addr` - Virtual address hint.
+/// * `offset` - File offset.
+/// * `length` - Length of mapping.
+/// * `flags` - Mapping flags.
+///
+/// # Returns
+///
+/// Result with start address of created mapping on success and SysCallError on
+/// failure.
+///
+/// # Safety
+///
+/// Caller must ensure that changing the task memory layout does not impact
+/// Rust memory safety.
+pub unsafe fn mmap(
+    handle: Option<&ObjHandle>,
+    addr: usize,
+    offset: u64,
+    length: u64,
+    flags: MMFlags,
+) -> Result<usize, SysCallError> {
+    let obj: u64 = if let Some(fd) = handle {
+        fd.id().into()
+    } else {
+        0u64
+    };
+    // SAFETY: Safe as long as the safety requirements of the function are met.
+    unsafe {
+        syscall5(
+            SYS_MMAP,
+            obj,
+            addr as u64,
+            offset,
+            length,
+            flags.bits() as u64,
+        )
+        .map(|ret| ret.try_into().unwrap())
+    }
+}
+
+/// Removes a memory mapping from the calling task
+///
+/// # Arguments
+///
+/// * `addr` - Virtual start address of mapping.
+/// * `length` - Length of mapping, must match the length when the mapping was
+///   created or last changed.
+///
+/// # Returns
+///
+/// Returns a Result with SysCallError on failure.
+///
+/// # Safety
+///
+/// Caller must ensure that changing the task memory layout does not impact
+/// Rust memory safety.
+pub unsafe fn munmap(addr: usize, length: u64) -> Result<(), SysCallError> {
+    // SAFETY: Safe as long as the safety requirements of the function are met.
+    unsafe { syscall2(SYS_MUNMAP, addr as u64, length).map(|_| ()) }
+}
+
+/// Resizes a memory mapping in the calling task.
+///
+/// # Arguments
+///
+/// * `addr` - Virtual start address of mapping.
+/// * `length` - New length of mapping.
+///
+/// # Returns
+///
+/// Returns a Result with SysCallError on failure.
+///
+/// # Safety
+///
+/// Caller must ensure that changing the task memory layout does not impact
+/// Rust memory safety.
+pub unsafe fn mresize(addr: usize, length: u64) -> Result<(), SysCallError> {
+    // SAFETY: Safe as long as the safety requirements of the function are met.
+    unsafe { syscall2(SYS_MRESIZE, addr as u64, length).map(|_| ()) }
+}
 
 pub fn exec(file: &CStr, root: &CStr, flags: u32) -> Result<Tid, SysCallError> {
     // SAFETY:

--- a/syscall/src/def.rs
+++ b/syscall/src/def.rs
@@ -13,6 +13,9 @@ const CLASS3: u64 = 3 << 32;
 
 // Syscall number in class0
 pub const SYS_EXIT: u64 = CLASS0;
+pub const SYS_MMAP: u64 = CLASS0 + 1;
+pub const SYS_MUNMAP: u64 = CLASS0 + 2;
+pub const SYS_MRESIZE: u64 = CLASS0 + 3;
 pub const SYS_EXEC: u64 = CLASS0 + 4;
 pub const SYS_CLOSE: u64 = CLASS0 + 10;
 
@@ -42,6 +45,27 @@ pub const F_NAME_SIZE: usize = 256;
 pub enum FileType {
     File,
     Directory,
+}
+
+//
+// Memory mapping flags for MMAP system call
+//
+bitflags! {
+    #[derive(Debug, Copy, Clone, Default)]
+    pub struct MMFlags: usize {
+        /// Mapping is readable
+        const MAP_READ =  1 << 0;
+        /// Mapping is writable
+        const MAP_WRITE = 1 << 1;
+        /// Mapping is executable
+        const MAP_EXEC = 1 << 2;
+        /// File mapping is private
+        const MAP_PRIVATE = 1 << 3;
+        /// Anonymous mapping
+        const MAP_ANONYMOUS = 1 << 4;
+        /// Mapping at fixed address
+        const MAP_FIXED = 1 << 5;
+    }
 }
 
 //

--- a/syscall/src/obj.rs
+++ b/syscall/src/obj.rs
@@ -21,6 +21,10 @@ impl ObjHandle {
     pub(crate) const fn new(id: u32) -> Self {
         Self(id)
     }
+
+    pub(crate) fn id(&self) -> u32 {
+        self.0
+    }
 }
 
 impl From<&ObjHandle> for u32 {


### PR DESCRIPTION
This PR implements the MMAP and MUNMAP system calls and foundations for MRESIZE. The system calls do not have Posix semantics yet. In fact, partial unmaps are not supported. A `VMM` can only be unmapped as a whole for now.

The foundations for MRESIZE are also implemented, but that support is not finished yet. Therefore this PR is marked as Draft.