### PR TITLE
virtio: suppress virtio detection when no fw_cfg is present

### DIFF
--- a/kernel/src/config.rs
+++ b/kernel/src/config.rs
@@ -87,6 +87,10 @@ impl<'a> SvsmConfig<'a> {
         self.igvm_params.has_qemu_testdev()
     }
 
+    pub fn has_fw_cfg_port(&self) -> bool {
+        self.igvm_params.has_fw_cfg_port()
+    }
+
     pub fn has_test_iorequests(&self) -> bool {
         self.igvm_params.has_test_iorequests()
     }

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -435,7 +435,11 @@ fn svsm_init(launch_info: &KernelLaunchInfo) {
     virt_log_usage();
 
     #[cfg(feature = "virtio-drivers")]
-    initialize_virtio_mmio().expect("Failed to initialize virtio-mmio drivers");
+    if config.has_fw_cfg_port() {
+        // Virtio cannot exist if there is no fw_cfg, so do not bother to
+        // attempt initialization if it is not present.
+        initialize_virtio_mmio().expect("Failed to initialize virtio-mmio drivers");
+    }
 
     if let Err(e) = SVSM_PLATFORM.launch_fw(&config) {
         panic!("Failed to launch FW: {e:?}");


### PR DESCRIPTION
Detection of virtio relies on querying fw_cfg, but fw_cfg is not present on all systems.  If fw_cfg is not present, then suppress attempts to initialize virtio.