### PR TITLE
virtio/mmio: move fw_cfg check into probe_mmio_slots()

### DIFF
--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -162,13 +162,12 @@ fn mapping_info_init(launch_info: &KernelLaunchInfo) {
 /// Returns Ok if initialization is successful or no virtio devices are found
 /// Returns an error when a virtio device is found but its driver initialization fails.
 #[cfg(feature = "virtio-drivers")]
-fn initialize_virtio_mmio() -> Result<(), SvsmError> {
-
+fn initialize_virtio_mmio(_config: &SvsmConfig<'_>) -> Result<(), SvsmError> {
     #[cfg(feature = "block")]
     {
         use svsm::block::virtio_blk::initialize_block;
 
-        let mut slots = probe_mmio_slots();
+        let mut slots = probe_mmio_slots(_config);
         initialize_block(&mut slots)?;
     }
 
@@ -436,11 +435,7 @@ fn svsm_init(launch_info: &KernelLaunchInfo) {
     virt_log_usage();
 
     #[cfg(feature = "virtio-drivers")]
-    if config.has_fw_cfg_port() {
-        // Virtio cannot exist if there is no fw_cfg, so do not bother to
-        // attempt initialization if it is not present.
-        initialize_virtio_mmio().expect("Failed to initialize virtio-mmio drivers");
-    }
+    initialize_virtio_mmio(&config).expect("Failed to initialize virtio-mmio drivers");
 
     if let Err(e) = SVSM_PLATFORM.launch_fw(&config) {
         panic!("Failed to launch FW: {e:?}");


### PR DESCRIPTION
Move the fw_cfg availability check from svsm_init() into probe_mmio_slots(), which is the only place where fw_cfg is actually needed. Pass `SvsmConfig` as a parameter to probe_mmio_slots() to perform this check.

This prepares for future work where virtio MMIO addresses may be discovered via device tree instead of fw_cfg. By passing `SvsmConfig`, the probe function can internally decide how to discover devices without callers needing to know the details.

Also derive Default for MmioSlots to simplify returning empty slot collections.