### PR TITLE
kernel/sev: Check physical address of VMSA for 2MiB alignemnt

### DIFF
--- a/kernel/src/sev/vmsa.rs
+++ b/kernel/src/sev/vmsa.rs
@@ -35,7 +35,7 @@ impl VmsaPage {
         // Make sure the VMSA page is not 2M-aligned, as some hardware
         // generations can't handle this properly. To ensure this property, we
         // allocate 2 VMSAs and choose whichever is not 2M-aligned.
-        let idx = if page.vaddr().is_aligned(PAGE_SIZE_2M) {
+        let idx = if virt_to_phys(page.vaddr()).is_aligned(PAGE_SIZE_2M) {
             1
         } else {
             0


### PR DESCRIPTION
The VMSA creation code checked the virtual address of the VMSA for 2MiB alignment. But what matters is actually the physical address, so check for that.

This fixes a boot failure of KVM which recently got introduced by violating the assumption that 2MiB virtual alignment also means 2MiB physical alignment.