### PR TITLE
Cargo.lock: refresh after packit zerocopy update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1959,7 +1959,7 @@ name = "syscall"
 version = "0.1.0"
 dependencies = [
  "bitflags 2.10.0",
- "zerocopy 0.8.30",
+ "zerocopy",
 ]
 
 [[package]]


### PR DESCRIPTION
Running a build now causes Cargo to automatically update the lockfile, since `packit` also uses `zerocopy` 0.8.x, removing the duplicate version specification.