### PR TITLE
Update bytes to 1.11.1 and time to 0.3.47

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,9 +1334,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-traits"
@@ -1999,30 +1999,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",


### PR DESCRIPTION
`cargo audit` reports a security advisor about our `bytes` and `time` versions:

    Crate:     bytes
    Version:   1.11.0
    Title:     Integer overflow in `BytesMut::reserve`
    Date:      2026-02-03
    ID:        RUSTSEC-2026-0007
    URL:       https://github.com/advisories/GHSA-434x-w66g-qw3r
    Solution:  Upgrade to >=1.11.1
    Dependency tree:
    bytes 1.11.0
    ├── tower-http 0.6.7
    │   └── reqwest 0.12.24
    │       └── aproxy 0.1.0
    ├── reqwest 0.12.24
    ├── hyper-util 0.1.18
    │   └── reqwest 0.12.24
    ├── hyper 1.8.1
    │   ├── reqwest 0.12.24
    │   └── hyper-util 0.1.18
    ├── http-body-util 0.1.3
    │   └── reqwest 0.12.24
    ├── http-body 1.0.1
    │   ├── tower-http 0.6.7
    │   ├── reqwest 0.12.24
    │   ├── hyper-util 0.1.18
    │   ├── hyper 1.8.1
    │   └── http-body-util 0.1.3
    └── http 1.4.0
        ├── tower-http 0.6.7
        ├── reqwest 0.12.24
        ├── hyper-util 0.1.18
        ├── hyper 1.8.1
        ├── http-body-util 0.1.3
        └── http-body 1.0.1

    Crate:     time
    Version:   0.3.44
    Title:     Denial of Service via Stack Exhaustion
    Date:      2026-02-05
    ID:        RUSTSEC-2026-0009
    URL:       https://rustsec.org/advisories/RUSTSEC-2026-0009
    Severity:  6.8 (medium)
    Solution:  Upgrade to >=0.3.47
    Dependency tree:
    time 0.3.44
    ├── cookie_store 0.21.1
    │   └── reqwest 0.12.24
    │       └── aproxy 0.1.0
    └── cookie 0.18.1
        ├── reqwest 0.12.24
        └── cookie_store 0.21.1
