### PR TITLE
igvmbuilder: require tdx-stage1 for TDP

### DIFF
--- a/tools/igvmbuilder/src/gpa_map.rs
+++ b/tools/igvmbuilder/src/gpa_map.rs
@@ -105,6 +105,9 @@ impl GpaMap {
                 return Err("TDP platform must be specified when using --tdx-stage1".into());
             }
         } else {
+            if COMPATIBILITY_MASK.contains(TDP_COMPATIBILITY_MASK) {
+                return Err("TDP platform requires --tdx-stage1".into());
+            }
             GpaRange::new(0, 0)?
         };
 


### PR DESCRIPTION
The TDP platform requires the presence of stage1 and will not boot otherwise.  The IGVM builder should generate an error if the TDP platform is requested but stage1 is not specified.