### PR TITLE
block: remove unnecessary Box wrapper

### DIFF
--- a/kernel/src/block/virtio_blk.rs
+++ b/kernel/src/block/virtio_blk.rs
@@ -16,7 +16,7 @@ use virtio_drivers::transport::DeviceType::Block;
 
 extern crate alloc;
 use alloc::boxed::Box;
-pub struct VirtIOBlkDriver(Box<VirtIOBlkDevice>);
+pub struct VirtIOBlkDriver(VirtIOBlkDevice);
 
 impl core::fmt::Debug for VirtIOBlkDriver {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -25,8 +25,8 @@ impl core::fmt::Debug for VirtIOBlkDriver {
 }
 
 impl VirtIOBlkDriver {
-    pub fn new(slot: MmioSlot) -> Result<Self, SvsmError> {
-        Ok(VirtIOBlkDriver(VirtIOBlkDevice::new(slot)?))
+    pub fn new(slot: MmioSlot) -> Result<Box<Self>, SvsmError> {
+        Ok(Box::new(VirtIOBlkDriver(VirtIOBlkDevice::new(slot)?)))
     }
 }
 
@@ -96,7 +96,7 @@ pub fn initialize_block(slots: &mut MmioSlots) -> Result<(), SvsmError> {
 
     let driver = VirtIOBlkDriver::new(slot)?;
 
-    BLOCK_DEVICE.init(Box::new(driver))?;
+    BLOCK_DEVICE.init(driver)?;
 
     Ok(())
 }

--- a/kernel/src/virtio/devices.rs
+++ b/kernel/src/virtio/devices.rs
@@ -6,8 +6,6 @@
 // Author: Stefano Garzarella <sgarzare@redhat.com>
 
 use super::hal::*;
-extern crate alloc;
-use alloc::boxed::Box;
 use virtio_drivers::device::blk::VirtIOBlk;
 use virtio_drivers::transport::mmio::MmioTransport;
 
@@ -29,12 +27,12 @@ impl core::fmt::Debug for VirtIOBlkDevice {
 }
 
 impl VirtIOBlkDevice {
-    pub fn new(slot: MmioSlot) -> Result<Box<Self>, SvsmError> {
+    pub fn new(slot: MmioSlot) -> Result<Self, SvsmError> {
         let blk = VirtIOBlk::new(slot.transport).map_err(|_| VirtioError::InvalidDevice)?;
 
-        Ok(Box::new(VirtIOBlkDevice {
+        Ok(VirtIOBlkDevice {
             device: SpinLock::new(blk),
             _mmio_space: slot.mmio_range,
-        }))
+        })
     }
 }


### PR DESCRIPTION
`VirtIOBlkDevice` is always wrapped in a Box. This is not necessary anymore, as the `BLOCK_DEVICE` struct is already wrapped in a Box.

Suggested-by: Stefano Garzarella <sgarzare@redhat.com>