### PR TITLE
github/manual-verify: trigger on verification label

### DIFF
--- a/.github/workflows/manual-verify.yml
+++ b/.github/workflows/manual-verify.yml
@@ -1,8 +1,11 @@
 name: Verification
 
-# Only run this workflow when manually triggered
+# Run this workflow when manually triggered or when a PR with
+# 'verification' label is created/updated
 on:
   workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 env:
   CARGO_TERM_COLOR: always
@@ -11,6 +14,7 @@ jobs:
   check:
     name: Verification Check
     runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'verification')
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Allow the verification workflow to run automatically when a PR is labeled with 'verification', in addition to manual dispatch.
This can be useful for simplifying PR reviews that involve verification or new releases.

A PR can only be labeled by users with "triage" access.

By default, the Verification pipeline does not run, but if the "verification" label is added to the PR, then it runs (even on forced pushes, etc.) and must succeed.

By removing the label, the Verification pipeline will no longer be considered a requirement for merging the PR (e.g. if it has failed) and will no longer run on new events.