### PR TITLE
mm/alloc: remove recursion when merging and splitting pages

### DIFF
--- a/kernel/src/mm/alloc.rs
+++ b/kernel/src/mm/alloc.rs
@@ -2663,9 +2663,8 @@ mod test {
         }
 
         let page = root_mem.allocate_page();
-        if page.is_ok() {
-            panic!("unexpected page allocation success after memory exhaustion");
-        }
+        let err = page.expect_err("page allocation success after memory exhaustion");
+        assert_eq!(err, AllocError::OutOfMemory);
 
         for alloc in allocs.iter().take(MAX_ORDER) {
             for pages in &alloc[..] {


### PR DESCRIPTION
When the buddy page allocator merges and splits pages, it uses recursion to evaluate the next highest / lowest order,  e.g. a page is merged with its buddy into a higher level order page recursively, until that cannot be done anymore (and vice versa when splitting pages).

Since `MAX_ORDER` has a value of 6, this can result in consuming up to 5 stack frames when performing these operations, which is not desirable, especially in debug builds, where stack consumption is already increased due to lack of optimizations. Replace recursive behavior with iteration, allowing the compiler to produce better code, and also simplifying the logic in some places.

This further allows fixing `HeapMemoryRegion::refill_page_list()`'s return value on error. In the recursive approach, the function cannot distinguish a bad `order` value passed by the user vs exhaustion when searching for a higher-order page, while this is trivially done with the iterative approach. Modify the existing `test_page_alloc_oom()` to make sure this stays correct.