### PR TITLE
Cargo.toml: add `cpudefs` to `members`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     # internal library crates
     "boot/bootimg",
     "boot/defs",
+    "cpuarch",
     # binary targets
     "stage1",
     "kernel",


### PR DESCRIPTION
Every crate in the workspace is supposed to be included in the `members` list of the top-level Cargo.toml.  The `cpuarch` crate is used in multiple targets but is missing from the list.