### PR TITLE
sev/ghcb: calculate page state chage page size directly

### DIFF
--- a/kernel/src/boot_params.rs
+++ b/kernel/src/boot_params.rs
@@ -13,7 +13,6 @@ use crate::error::SvsmError;
 use crate::mm::alloc::free_multiple_pages;
 use crate::mm::{GuestPtr, PAGE_SIZE, PerCPUPageMappingGuard};
 use crate::platform::{PageStateChangeOp, PageValidateOp, SVSM_PLATFORM, SevFWMetaData};
-use crate::types::PageSize;
 use crate::utils::{MemoryRegion, page_align_up, round_to_pages};
 use alloc::vec::Vec;
 use bootdefs::boot_params::BootParamBlock;
@@ -214,11 +213,7 @@ impl BootParams<'_> {
             // validated.  Since the memory was not declared as part of the
             // guest firmware image, the pages must be validated here.
             if self.page_state_change_required() {
-                SVSM_PLATFORM.page_state_change(
-                    mem_map_region,
-                    PageSize::Regular,
-                    PageStateChangeOp::Private,
-                )?;
+                SVSM_PLATFORM.page_state_change(mem_map_region, PageStateChangeOp::Private)?;
             }
 
             let mem_map_va_region = MemoryRegion::new(mem_map_va, mem_map_region.len());

--- a/kernel/src/mm/page_visibility.rs
+++ b/kernel/src/mm/page_visibility.rs
@@ -19,7 +19,7 @@ use crate::mm::validate::{
 use crate::mm::{PageBox, virt_to_phys};
 use crate::platform::{PageStateChangeOp, PageValidateOp, SVSM_PLATFORM};
 use crate::protocols::errors::SvsmReqError;
-use crate::types::{PAGE_SIZE, PageSize};
+use crate::types::PAGE_SIZE;
 use crate::utils::MemoryRegion;
 
 use zerocopy::{FromBytes, FromZeros, Immutable, IntoBytes};
@@ -54,7 +54,6 @@ pub unsafe fn make_page_shared(vaddr: VirtAddr) -> Result<(), SvsmError> {
     // Ask the hypervisor to make the page shared.
     SVSM_PLATFORM.page_state_change(
         MemoryRegion::new(paddr, PAGE_SIZE),
-        PageSize::Regular,
         PageStateChangeOp::Shared,
     )?;
 
@@ -88,7 +87,6 @@ pub unsafe fn make_page_private(vaddr: VirtAddr) -> Result<(), SvsmError> {
     let paddr = virt_to_phys(vaddr);
     SVSM_PLATFORM.page_state_change(
         MemoryRegion::new(paddr, PAGE_SIZE),
-        PageSize::Regular,
         PageStateChangeOp::Private,
     )?;
 

--- a/kernel/src/mm/validate.rs
+++ b/kernel/src/mm/validate.rs
@@ -15,7 +15,8 @@ use crate::mm::pagetable::PageFrame;
 use crate::mm::virt_to_frame;
 use crate::mm::virt_to_phys;
 use crate::platform::{PageStateChangeOp, PageValidateOp, SvsmPlatform};
-use crate::types::{PAGE_SIZE, PAGE_SIZE_2M, PageSize};
+use crate::types::PAGE_SIZE;
+use crate::types::PAGE_SIZE_2M;
 use crate::utils::MemoryRegion;
 use core::num::NonZeroUsize;
 
@@ -244,7 +245,6 @@ pub unsafe fn validate_mapped_region(
                 let paddr_start = PhysAddr::new((paddr_next - paddr_len as u64) as usize);
                 platform.page_state_change(
                     MemoryRegion::new(paddr_start, paddr_len),
-                    PageSize::Huge,
                     PageStateChangeOp::Private,
                 )?;
                 paddr_len = 0;
@@ -258,7 +258,6 @@ pub unsafe fn validate_mapped_region(
             let paddr_start = PhysAddr::new((paddr_next - paddr_len as u64) as usize);
             platform.page_state_change(
                 MemoryRegion::new(paddr_start, paddr_len),
-                PageSize::Huge,
                 PageStateChangeOp::Private,
             )?;
         }

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -34,7 +34,6 @@ use crate::hyperv;
 use crate::io::IOPort;
 use crate::mm::TransitionPageTable;
 use crate::mm::alloc::free_page;
-use crate::types::PageSize;
 use crate::utils::MemoryRegion;
 use crate::utils::immut_after_init::ImmutAfterInitCell;
 
@@ -212,7 +211,6 @@ pub trait SvsmPlatform: Sync {
     fn page_state_change(
         &self,
         region: MemoryRegion<PhysAddr>,
-        size: PageSize,
         op: PageStateChangeOp,
     ) -> Result<(), SvsmError>;
 

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -148,7 +148,6 @@ impl SvsmPlatform for NativePlatform {
     fn page_state_change(
         &self,
         _region: MemoryRegion<PhysAddr>,
-        _size: PageSize,
         _op: PageStateChangeOp,
     ) -> Result<(), SvsmError> {
         Ok(())

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -47,7 +47,6 @@ use crate::sev::{
     GHCB_APIC_ACCESSOR, PvalidateOp, init_hypervisor_ghcb_features, pvalidate_range,
     sev_status_init, sev_status_verify,
 };
-use crate::types::PageSize;
 use crate::utils::MemoryRegion;
 use crate::utils::immut_after_init::ImmutAfterInitCell;
 use syscall::GlobalFeatureFlags;
@@ -339,10 +338,9 @@ impl SvsmPlatform for SnpPlatform {
     fn page_state_change(
         &self,
         region: MemoryRegion<PhysAddr>,
-        size: PageSize,
         op: PageStateChangeOp,
     ) -> Result<(), SvsmError> {
-        current_ghcb().page_state_change(region, size, op)
+        current_ghcb().page_state_change(region, op)
     }
 
     unsafe fn validate_physical_page_range(

--- a/kernel/src/platform/snp_fw.rs
+++ b/kernel/src/platform/snp_fw.rs
@@ -56,7 +56,7 @@ unsafe fn validate_fw_mem_region(
 
     if boot_params.page_state_change_required() {
         current_ghcb()
-            .page_state_change(region, PageSize::Regular, PageStateChangeOp::Private)
+            .page_state_change(region, PageStateChangeOp::Private)
             .expect("GHCB PSC call failed to validate firmware memory");
     }
 

--- a/kernel/src/platform/tdp.rs
+++ b/kernel/src/platform/tdp.rs
@@ -25,7 +25,7 @@ use crate::tdx::tdcall::{
     tdcall_vm_read, tdvmcall_halt, tdvmcall_hyperv_hypercall, tdvmcall_io_read, tdvmcall_io_write,
     tdvmcall_map_gpa, tdvmcall_report_fatal_error, tdvmcall_wrmsr,
 };
-use crate::types::{PAGE_SIZE, PageSize};
+use crate::types::PAGE_SIZE;
 use crate::utils::immut_after_init::ImmutAfterInitCell;
 use crate::utils::{MemoryRegion, is_aligned};
 
@@ -173,7 +173,6 @@ impl SvsmPlatform for TdpPlatform {
     fn page_state_change(
         &self,
         region: MemoryRegion<PhysAddr>,
-        _size: PageSize,
         op: PageStateChangeOp,
     ) -> Result<(), SvsmError> {
         if !region.start().is_aligned(PAGE_SIZE) || !is_aligned(region.len(), PAGE_SIZE) {

--- a/kernel/src/sev/ghcb.rs
+++ b/kernel/src/sev/ghcb.rs
@@ -621,7 +621,6 @@ impl GHCB {
     pub fn page_state_change(
         &self,
         region: MemoryRegion<PhysAddr>,
-        size: PageSize,
         op: PageStateChangeOp,
     ) -> Result<(), SvsmError> {
         // Maximum entries (8 bytes each_ minus 8 bytes for header
@@ -639,10 +638,7 @@ impl GHCB {
         self.clear();
 
         while paddr < end {
-            let size = if size == PageSize::Huge
-                && paddr.is_aligned(PAGE_SIZE_2M)
-                && paddr + PAGE_SIZE_2M <= end
-            {
+            let size = if paddr.is_aligned(PAGE_SIZE_2M) && paddr + PAGE_SIZE_2M <= end {
                 PageSize::Huge
             } else {
                 PageSize::Regular

--- a/kernel/src/svsm_paging.rs
+++ b/kernel/src/svsm_paging.rs
@@ -10,7 +10,6 @@ use crate::address::PhysAddr;
 use crate::boot_params::BootParams;
 use crate::error::SvsmError;
 use crate::platform::{PageStateChangeOp, PageValidateOp, SvsmPlatform};
-use crate::types::PageSize;
 use crate::utils::{MemoryRegion, page_align_up};
 use bootdefs::kernel_launch::KernelLaunchInfo;
 use bootdefs::kernel_launch::LOWMEM_END;
@@ -33,11 +32,7 @@ fn invalidate_boot_memory_region(
         }?;
 
         if boot_params.page_state_change_required() {
-            platform.page_state_change(
-                aligned_region,
-                PageSize::Regular,
-                PageStateChangeOp::Shared,
-            )?;
+            platform.page_state_change(aligned_region, PageStateChangeOp::Shared)?;
         }
     }
 


### PR DESCRIPTION
The GHCB protocol does not specify any difference in behavior between a single 2 MB page and multiple 4 KB pages; the only difference is in the encoding of the GPA list.  Therefore, the GHCB page state logic can determine the optimal encoding on its own without requiring the caller to specify a preferred page size.