### PR TITLE
fuzz: insn: provide valid pointer in TestCtx

### DIFF
--- a/fuzz/fuzz_targets/insn.rs
+++ b/fuzz/fuzz_targets/insn.rs
@@ -7,13 +7,17 @@ fuzz_target!(|input: &[u8]| -> Corpus {
     let Some(input) = input.get(..MAX_INSN_SIZE) else {
         return Corpus::Reject;
     };
+    let mut mmio_reg = 0u64;
 
     let mut data = [0u8; MAX_INSN_SIZE];
     data.copy_from_slice(input);
 
     let insn = Instruction::new(data);
     let _ = core::hint::black_box({
-        let mut ctx = TestCtx::default();
+        let mut ctx = TestCtx {
+            mmio_reg: &raw mut mmio_reg,
+            ..Default::default()
+        };
         match insn.decode(&ctx) {
             Ok(insn_ctx) => insn_ctx.emulate(&mut ctx),
             Err(e) => Err(e),


### PR DESCRIPTION
TestCtx was recently changed to take a pointer instead of storing a value, so feed in a valid pointer to prevent a NULL pointer dereference (which cannot happen under regular usage anyway).

Fixes: e29346da78fb ("kernel/insn_decode: tests: fix Miri errors")