### PR TITLE
global_asm: ensure code is marked as `.text`

### DIFF
--- a/kernel/src/boot_stage2.rs
+++ b/kernel/src/boot_stage2.rs
@@ -17,7 +17,7 @@ use svsm::{
 
 global_asm!(
     r#"
-        .text
+        .section .text
         .section ".startup.text","ax"
         .code32
 
@@ -295,6 +295,7 @@ global_asm!(
 // between SVSM and Stage2.
 global_asm!(
     r#"
+        .data
         .globl bsp_stack
         bsp_stack:
         .globl bsp_stack_end

--- a/kernel/src/cpu/idt/stage2.rs
+++ b/kernel/src/cpu/idt/stage2.rs
@@ -107,7 +107,7 @@ unsafe extern "C" {
 
 global_asm!(
     r#"
-        .text
+        .section .text
 
     generic_idt_handler_return:
         addq    $8, %rsp /* Skip ssp */

--- a/kernel/src/cpu/smp.rs
+++ b/kernel/src/cpu/smp.rs
@@ -101,6 +101,7 @@ unsafe extern "C" {
 
 global_asm!(
     r#"
+        .section .text
         .globl start_ap_indirect
     start_ap_indirect:
         /*

--- a/kernel/src/sev/ghcb.rs
+++ b/kernel/src/sev/ghcb.rs
@@ -849,6 +849,7 @@ pub fn switch_to_vmpl(vmpl: u32) {
 
 global_asm!(
     r#"
+        .section .text
         .globl hv_redirect_window_start
     hv_redirect_window_start:
 

--- a/kernel/src/stage2.rs
+++ b/kernel/src/stage2.rs
@@ -528,6 +528,7 @@ pub extern "C" fn stage2_main(launch_info: &Stage2LaunchInfo) -> ! {
 
 global_asm!(
     r#"
+        .section .text
         .globl switch_to_kernel
         switch_to_kernel:
 

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -96,7 +96,7 @@ unsafe extern "C" {
  */
 global_asm!(
     r#"
-        .text
+        .section .text
         .section ".startup.text","ax"
         .code64
 

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -606,7 +606,7 @@ pub fn schedule_task(task: TaskPointer) {
 
 global_asm!(
     r#"
-        .text
+        .section .text
 
     switch_context:
         // Save the current context. The layout must match the TaskContext structure.

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -977,7 +977,7 @@ mod tests {
 
     global_asm!(
         r#"
-    .text
+    .section .text
     test_fpu:
         movq $0x3ff, %rax
         shl $52, %rax
@@ -999,7 +999,7 @@ mod tests {
 
     global_asm!(
         r#"
-    .text
+    .section .text
     check_fpu:
         movq $1, %rax
         movq $0x3ff, %rbx
@@ -1029,7 +1029,7 @@ mod tests {
 
     global_asm!(
         r#"
-    .text
+    .section .text
     alter_fpu:
         movq $0x400, %rax
         shl $52, %rax


### PR DESCRIPTION
The `global_asm` macro doesn't provide any guarantees about where generated code is placed; it just inserts assembly code into the LLVM codegen stream, and the linker will place the assembly code into whichever section happens to be active at the time it encounters the assembly.  If that's a data section, then the code will wind up in a non-executable data area.  All assembly code must be explicitly marked with the correct section identifier (e.g. `.text`) to ensure that it will be correctly placed.

This change also makes the section choice for all assembly code explicit, placing global assembly into the section called `.text` instead of the current code section (which might be differently named based on compiler output).