### PR TITLE
switch to rust linker

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,7 +3,6 @@
 [target.x86_64-unknown-none]
 rustflags = [
 	"-C", "force-frame-pointers",
-	"-C", "linker-flavor=ld",
 	"--cfg", "aes_force_soft",
 	"--cfg", "polyval_force_soft",
 ]

--- a/boot/bldr/src/bldr.lds
+++ b/boot/bldr/src/bldr.lds
@@ -31,7 +31,8 @@ SECTIONS
 		exception_table_end = .;
 	}
 	. = ALIGN(16);
-	.data : { *(.data) }
+	.data : { *(.data) *(.data.*) }
+	.got : { *(.got) *(.got.*) }
 	edata = .;
 	. = ALIGN(16);
 	.bss : {
@@ -45,7 +46,7 @@ SECTIONS
 	 * builder does not have to parse the ELF file to know how much space
 	 * to reserve for BSS. */
 	. = ALIGN(16);
-	.rodata : { *(.rodata) }
+	.rodata : { *(.rodata) *(.rodata.*) }
 }
 
 ENTRY(base_entry)

--- a/kernel/src/svsm.lds
+++ b/kernel/src/svsm.lds
@@ -25,6 +25,8 @@ SECTIONS
 	. = ALIGN(4096);
 	.rodata : { *(.rodata) *(.rodata.*) }
 	. = ALIGN(4096);
+	.got : { *(.got) *(.got.*) }
+	. = ALIGN(4096);
 	.data : { *(.data) *(.data.*) }
 	. = ALIGN(4096);
 	.ro_after_init : {

--- a/stage1/src/stage1.rs
+++ b/stage1/src/stage1.rs
@@ -21,7 +21,7 @@ global_asm!(
         .byte 0
 
         .code32
-        .section .init
+        .section .init, "ax"
 startup:
         movl    $0xFFFFF000, %edx
 
@@ -57,7 +57,7 @@ startup:
         /* Jump to the correct AP entry point. */
         jmp     *{AP_ENTRY}(%edx)
 
-        .section .resetvector
+        .section .resetvector, "ax"
         jmp     startup
         "#,
     VP_INDEX = const offset_of!(TdpStartContext, vp_index),

--- a/stage1/stage1.lds
+++ b/stage1/stage1.lds
@@ -10,20 +10,24 @@ OUTPUT_ARCH(i386:x86-64)
 
 SECTIONS
 {
-	.sdata = ALIGN(.sinit - SIZEOF(.data) - 4095, 4096);
-	. = .sdata;
-	.data : { *(.data) }
-	edata = .;
-
-	. = 0xfffffe00;
-	.sinit = .;
-	.init : {
-		*(.init);
-		. = 512 - 16;
-		*(.resetvector);
-		. = 512;
+	.data ALIGN(.sinit - SIZEOF(.data) - 4095, 4096) : {
+		.sdata = .;
+		*(.data)
+		edata = .;
 	}
-	einit = .;
 
-	/DISCARD/ : {*(.*)}
+	.init 0xfffffe00 : {
+		.sinit = .;
+		*(.init);
+	}
+	.reset 0xfffffff0 : {
+		*(.resetvector);
+		. = 0x100000000;
+		einit = .;
+	}
+
+	/DISCARD/ : {
+		*(.eh_frame*)
+		*(.text*)
+	}
 }


### PR DESCRIPTION
With this it is possible to cross-compile most¹ of svsm, because the rust linker is (unlike the binutils linker) not limited to the native architecture.  Tested by building svsm on Fedora/aarch64.

¹ The exception is the C code in libtcgtpm, i.e. the vtpm feature.