### PR TITLE
kernel: mm/vm: multiple cleanups and improvements

### DIFF
--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -1161,7 +1161,8 @@ impl PerCpu {
     }
 
     pub fn handle_pf(&self, vaddr: VirtAddr, write: bool) -> Result<(), SvsmError> {
-        self.vm_range.handle_page_fault(vaddr, write)
+        let mut pgtable = self.get_pgtable();
+        self.vm_range.handle_page_fault(&mut pgtable, vaddr, write)
     }
 
     pub fn schedule_init(&self) -> TaskPointer {

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -762,13 +762,23 @@ impl PerCpu {
     }
 
     fn initialize_vm_ranges(&self) -> Result<(), SvsmError> {
+        const PAGE_COUNT_4K: usize = SVSM_PERCPU_TEMP_SIZE_4K / PAGE_SIZE;
+        const { assert!(PAGE_COUNT_4K < VirtualRange::CAPACITY) };
+
         let temp_mapping_4k = Arc::new(VMReserved::new_mapping(SVSM_PERCPU_TEMP_SIZE_4K));
         self.vm_range
             .insert_at(SVSM_PERCPU_TEMP_BASE_4K, temp_mapping_4k)?;
+        self.vrange_4k_mut()
+            .init(SVSM_PERCPU_TEMP_BASE_4K, PAGE_COUNT_4K, PAGE_SHIFT);
+
+        const PAGE_COUNT_2M: usize = SVSM_PERCPU_TEMP_SIZE_2M / PAGE_SIZE_2M;
+        const { assert!(PAGE_COUNT_2M < VirtualRange::CAPACITY) };
 
         let temp_mapping_2m = Arc::new(VMReserved::new_mapping(SVSM_PERCPU_TEMP_SIZE_2M));
         self.vm_range
             .insert_at(SVSM_PERCPU_TEMP_BASE_2M, temp_mapping_2m)?;
+        self.vrange_2m_mut()
+            .init(SVSM_PERCPU_TEMP_BASE_2M, PAGE_COUNT_2M, PAGE_SHIFT_2M);
 
         Ok(())
     }
@@ -792,7 +802,7 @@ impl PerCpu {
         // Map PerCpu data in own page-table
         self.map_self()?;
 
-        // Reserve ranges for temporary mappings
+        // Reserve ranges and initialize allocator for temporary mappings
         self.initialize_vm_ranges()?;
 
         if is_cet_ss_supported() {
@@ -819,9 +829,6 @@ impl PerCpu {
             // Setup ISST
             self.setup_isst();
         }
-
-        // Initialize allocator for temporary mappings
-        self.virt_range_init();
 
         self.finish_page_table();
 
@@ -1129,20 +1136,6 @@ impl PerCpu {
             limit: TSS_LIMIT as u32,
             base: &raw const self.tss as u64,
         }
-    }
-
-    fn virt_range_init(&self) {
-        // Initialize 4k range
-        const PAGE_COUNT_4K: usize = SVSM_PERCPU_TEMP_SIZE_4K / PAGE_SIZE;
-        const { assert!(PAGE_COUNT_4K < VirtualRange::CAPACITY) };
-        self.vrange_4k_mut()
-            .init(SVSM_PERCPU_TEMP_BASE_4K, PAGE_COUNT_4K, PAGE_SHIFT);
-
-        // Initialize 2M range
-        const PAGE_COUNT_2M: usize = SVSM_PERCPU_TEMP_SIZE_2M / PAGE_SIZE_2M;
-        const { assert!(PAGE_COUNT_2M < VirtualRange::CAPACITY) };
-        self.vrange_2m_mut()
-            .init(SVSM_PERCPU_TEMP_BASE_2M, PAGE_COUNT_2M, PAGE_SHIFT_2M);
     }
 
     /// Create a new virtual memory mapping in the PerCpu VMR

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -650,9 +650,8 @@ impl PerCpu {
     fn allocate_stack(&self, base: VirtAddr) -> Result<VirtAddr, SvsmError> {
         let stack = VMKernelStack::new()?;
         let top_of_stack = (base + stack.top_of_stack()).align_down(16);
-        let mapping = Arc::new(Mapping::new(stack));
 
-        self.vm_range.insert_at(base, mapping)?;
+        self.vm_range.insert_at(base, Arc::new(stack))?;
 
         Ok(top_of_stack)
     }
@@ -665,9 +664,7 @@ impl PerCpu {
         let shadow_stack = VMKernelStack::new_shadow()?;
         let offset = shadow_stack.top_of_stack();
         let shadow_stack_page = shadow_stack.shadow_page();
-        let shadow_stack_base = self
-            .vm_range
-            .insert_at(base, Arc::new(Mapping::new(shadow_stack)))?;
+        let shadow_stack_base = self.vm_range.insert_at(base, Arc::new(shadow_stack))?;
         let (_, ssp) = init_shadow_stack(&shadow_stack_page, shadow_stack_base + offset, init);
         Ok(ssp)
     }
@@ -756,7 +753,7 @@ impl PerCpu {
     pub fn map_self(&self) -> Result<(), SvsmError> {
         let vaddr = VirtAddr::from(ptr::from_ref(self));
         let paddr = virt_to_phys(vaddr);
-        let self_mapping = Arc::new(VMPhysMem::new_mapping(paddr, PAGE_SIZE, true));
+        let self_mapping = VMPhysMem::new_mapping(paddr, PAGE_SIZE, true);
         self.vm_range.insert_at(SVSM_PERCPU_BASE, self_mapping)?;
         Ok(())
     }
@@ -765,7 +762,7 @@ impl PerCpu {
         const PAGE_COUNT_4K: usize = SVSM_PERCPU_TEMP_SIZE_4K / PAGE_SIZE;
         const { assert!(PAGE_COUNT_4K < VirtualRange::CAPACITY) };
 
-        let temp_mapping_4k = Arc::new(VMReserved::new_mapping(SVSM_PERCPU_TEMP_SIZE_4K));
+        let temp_mapping_4k = VMReserved::new_mapping(SVSM_PERCPU_TEMP_SIZE_4K);
         self.vm_range
             .insert_at(SVSM_PERCPU_TEMP_BASE_4K, temp_mapping_4k)?;
         self.vrange_4k_mut()
@@ -774,7 +771,7 @@ impl PerCpu {
         const PAGE_COUNT_2M: usize = SVSM_PERCPU_TEMP_SIZE_2M / PAGE_SIZE_2M;
         const { assert!(PAGE_COUNT_2M < VirtualRange::CAPACITY) };
 
-        let temp_mapping_2m = Arc::new(VMReserved::new_mapping(SVSM_PERCPU_TEMP_SIZE_2M));
+        let temp_mapping_2m = VMReserved::new_mapping(SVSM_PERCPU_TEMP_SIZE_2M);
         self.vm_range
             .insert_at(SVSM_PERCPU_TEMP_BASE_2M, temp_mapping_2m)?;
         self.vrange_2m_mut()
@@ -960,7 +957,7 @@ impl PerCpu {
 
     fn map_guest_vmsa(&self, paddr: PhysAddr) -> Result<(), SvsmError> {
         assert!(self.shared().cpu_index == this_cpu().get_cpu_index());
-        let vmsa_mapping = Arc::new(VMPhysMem::new_mapping(paddr, PAGE_SIZE, true));
+        let vmsa_mapping = VMPhysMem::new_mapping(paddr, PAGE_SIZE, true);
         self.vm_range
             .insert_at(SVSM_PERCPU_VMSA_BASE, vmsa_mapping)?;
 
@@ -1019,7 +1016,7 @@ impl PerCpu {
     fn map_guest_caa(&self, paddr: PhysAddr) -> Result<(), SvsmError> {
         self.unmap_caa();
 
-        let caa_mapping = Arc::new(VMPhysMem::new_mapping(paddr, PAGE_SIZE, true));
+        let caa_mapping = VMPhysMem::new_mapping(paddr, PAGE_SIZE, true);
         self.vm_range.insert_at(SVSM_PERCPU_CAA_BASE, caa_mapping)?;
 
         Ok(())
@@ -1150,7 +1147,7 @@ impl PerCpu {
     /// the mapping which remains valid until the ['VRMapping'] is dropped.
     ///
     /// On error, an ['SvsmError'].
-    pub fn new_mapping(&self, mapping: Arc<Mapping>) -> Result<VMRMapping<'_>, SvsmError> {
+    pub fn new_mapping(&self, mapping: Mapping) -> Result<VMRMapping<'_>, SvsmError> {
         VMRMapping::new(&self.vm_range, mapping)
     }
 

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -35,7 +35,7 @@ use crate::mm::vm::{Mapping, VMKernelStack, VMPhysMem, VMR, VMRMapping, VMReserv
 use crate::mm::{
     PageBox, SVSM_CONTEXT_SWITCH_SHADOW_STACK, SVSM_CONTEXT_SWITCH_STACK, SVSM_PERCPU_BASE,
     SVSM_PERCPU_CAA_BASE, SVSM_PERCPU_END, SVSM_PERCPU_TEMP_BASE_2M, SVSM_PERCPU_TEMP_BASE_4K,
-    SVSM_PERCPU_TEMP_END_2M, SVSM_PERCPU_TEMP_END_4K, SVSM_PERCPU_VMSA_BASE,
+    SVSM_PERCPU_TEMP_SIZE_2M, SVSM_PERCPU_TEMP_SIZE_4K, SVSM_PERCPU_VMSA_BASE,
     SVSM_SHADOW_STACK_ISST_DF_BASE, SVSM_SHADOW_STACKS_INIT_TASK, SVSM_STACK_IST_DF_BASE,
     virt_to_phys,
 };
@@ -762,13 +762,11 @@ impl PerCpu {
     }
 
     fn initialize_vm_ranges(&self) -> Result<(), SvsmError> {
-        let size_4k = SVSM_PERCPU_TEMP_END_4K - SVSM_PERCPU_TEMP_BASE_4K;
-        let temp_mapping_4k = Arc::new(VMReserved::new_mapping(size_4k));
+        let temp_mapping_4k = Arc::new(VMReserved::new_mapping(SVSM_PERCPU_TEMP_SIZE_4K));
         self.vm_range
             .insert_at(SVSM_PERCPU_TEMP_BASE_4K, temp_mapping_4k)?;
 
-        let size_2m = SVSM_PERCPU_TEMP_END_2M - SVSM_PERCPU_TEMP_BASE_2M;
-        let temp_mapping_2m = Arc::new(VMReserved::new_mapping(size_2m));
+        let temp_mapping_2m = Arc::new(VMReserved::new_mapping(SVSM_PERCPU_TEMP_SIZE_2M));
         self.vm_range
             .insert_at(SVSM_PERCPU_TEMP_BASE_2M, temp_mapping_2m)?;
 
@@ -1135,16 +1133,16 @@ impl PerCpu {
 
     fn virt_range_init(&self) {
         // Initialize 4k range
-        let page_count = (SVSM_PERCPU_TEMP_END_4K - SVSM_PERCPU_TEMP_BASE_4K) / PAGE_SIZE;
-        assert!(page_count <= VirtualRange::CAPACITY);
+        const PAGE_COUNT_4K: usize = SVSM_PERCPU_TEMP_SIZE_4K / PAGE_SIZE;
+        const { assert!(PAGE_COUNT_4K < VirtualRange::CAPACITY) };
         self.vrange_4k_mut()
-            .init(SVSM_PERCPU_TEMP_BASE_4K, page_count, PAGE_SHIFT);
+            .init(SVSM_PERCPU_TEMP_BASE_4K, PAGE_COUNT_4K, PAGE_SHIFT);
 
         // Initialize 2M range
-        let page_count = (SVSM_PERCPU_TEMP_END_2M - SVSM_PERCPU_TEMP_BASE_2M) / PAGE_SIZE_2M;
-        assert!(page_count <= VirtualRange::CAPACITY);
+        const PAGE_COUNT_2M: usize = SVSM_PERCPU_TEMP_SIZE_2M / PAGE_SIZE_2M;
+        const { assert!(PAGE_COUNT_2M < VirtualRange::CAPACITY) };
         self.vrange_2m_mut()
-            .init(SVSM_PERCPU_TEMP_BASE_2M, page_count, PAGE_SHIFT_2M);
+            .init(SVSM_PERCPU_TEMP_BASE_2M, PAGE_COUNT_2M, PAGE_SHIFT_2M);
     }
 
     /// Create a new virtual memory mapping in the PerCpu VMR

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -421,8 +421,8 @@ where
 
 impl PerCpu {
     /// Creates a new default [`PerCpu`] struct.
-    fn new(shared: &'static PerCpuShared) -> Self {
-        Self {
+    fn new(shared: &'static PerCpuShared) -> Result<Self, SvsmError> {
+        Ok(Self {
             pgtbl: RWLock::new(None),
             apic: X86Apic::default(),
             irq_state: IrqState::new(),
@@ -431,7 +431,7 @@ impl PerCpu {
             svsm_vmsa: ImmutAfterInitCell::uninit(),
             reset_ip: AtomicU64::new(0xffff_fff0),
             vm_range: {
-                let mut vmr = VMR::new(SVSM_PERCPU_BASE, SVSM_PERCPU_END, PTEntryFlags::GLOBAL);
+                let mut vmr = VMR::new(SVSM_PERCPU_BASE, SVSM_PERCPU_END, PTEntryFlags::GLOBAL)?;
                 vmr.set_per_cpu(true);
                 vmr
             },
@@ -449,13 +449,13 @@ impl PerCpu {
             context_switch_stack: ImmutAfterInitCell::uninit(),
             ist: IstStacks::new(),
             current_stack: RWLock::new(MemoryRegion::new(VirtAddr::null(), 0)),
-        }
+        })
     }
 
     /// Creates a new default [`PerCpu`] struct, allocates it via the page
     /// allocator and adds it to the global per-cpu area list.
     pub fn alloc(shared: &'static PerCpuShared) -> Result<&'static Self, SvsmError> {
-        let page = PageBox::try_new(Self::new(shared))?;
+        let page = PageBox::try_new(Self::new(shared)?)?;
         let percpu = PageBox::leak(page);
         Ok(percpu)
     }

--- a/kernel/src/mm/address_space.rs
+++ b/kernel/src/mm/address_space.rs
@@ -235,10 +235,14 @@ pub const SVSM_PERCPU_TEMP_BASE: VirtAddr = SVSM_PERCPU_BASE.const_add(SIZE_LEVE
 /// Start and End for PAGE_SIZEed temporary mappings
 pub const SVSM_PERCPU_TEMP_BASE_4K: VirtAddr = SVSM_PERCPU_TEMP_BASE;
 pub const SVSM_PERCPU_TEMP_END_4K: VirtAddr = SVSM_PERCPU_TEMP_BASE_4K.const_add(SIZE_LEVEL1);
+pub const SVSM_PERCPU_TEMP_SIZE_4K: usize = SIZE_LEVEL1;
 
 /// Start and End for PAGE_SIZEed temporary mappings
 pub const SVSM_PERCPU_TEMP_BASE_2M: VirtAddr = SVSM_PERCPU_TEMP_BASE.const_add(SIZE_LEVEL1);
 pub const SVSM_PERCPU_TEMP_END_2M: VirtAddr = SVSM_PERCPU_TEMP_BASE.const_add(SIZE_LEVEL2);
+pub const SVSM_PERCPU_TEMP_SIZE_2M: usize = SVSM_PERCPU_TEMP_END_2M
+    .const_sub(SVSM_PERCPU_TEMP_BASE_2M.as_usize())
+    .as_usize();
 
 /// Task mappings level 3 index
 pub const PGTABLE_LVL3_IDX_PERTASK: usize = 508;

--- a/kernel/src/mm/mappings.rs
+++ b/kernel/src/mm/mappings.rs
@@ -48,17 +48,14 @@ pub fn create_file_mapping(
     offset: usize,
     size: usize,
     flags: VMFileMappingFlags,
-) -> Result<Arc<Mapping>, SvsmError> {
+) -> Result<Mapping, SvsmError> {
     let file_mapping = VMFileMapping::new(file, offset, size, flags)?;
-    Ok(Arc::new(Mapping::new(file_mapping)))
+    Ok(Arc::new(file_mapping))
 }
 
-pub fn create_anon_mapping(
-    size: usize,
-    flags: VMFileMappingFlags,
-) -> Result<Arc<Mapping>, SvsmError> {
+pub fn create_anon_mapping(size: usize, flags: VMFileMappingFlags) -> Result<Mapping, SvsmError> {
     let alloc = VMalloc::new(size, flags)?;
-    Ok(Arc::new(Mapping::new(alloc)))
+    Ok(Arc::new(alloc))
 }
 
 pub fn mmap_user(

--- a/kernel/src/mm/pagetable.rs
+++ b/kernel/src/mm/pagetable.rs
@@ -1241,18 +1241,23 @@ impl PageTable {
         }
     }
 
-    /// Populates this paghe table with the contents of the given subtree
+    /// Populates this page table with the contents of the given subtree
     /// in `part`.
-    pub fn populate_pgtbl_part(&mut self, part: &PageTablePart) {
-        if let Some(paddr) = part.address() {
-            let idx = part.index();
-            let flags = PTEntryFlags::PRESENT
-                | PTEntryFlags::WRITABLE
-                | PTEntryFlags::USER
-                | PTEntryFlags::ACCESSED;
-            let entry = &mut self.root[idx];
-            entry.set(make_private_address(paddr), flags);
-        }
+    ///
+    /// Returns `true` if the PTE contents were updated.
+    pub fn populate_pgtbl_part(&mut self, part: &PageTablePart) -> bool {
+        let Some(paddr) = part.address() else {
+            return false;
+        };
+        let idx = part.index();
+        let flags = PTEntryFlags::PRESENT
+            | PTEntryFlags::WRITABLE
+            | PTEntryFlags::USER
+            | PTEntryFlags::ACCESSED;
+        let entry = &mut self.root[idx];
+        let prev = entry.raw();
+        entry.set(make_private_address(paddr), flags);
+        prev != entry.raw()
     }
 
     /// Makes the memory region pages read-only.

--- a/kernel/src/mm/vm/mapping/api.rs
+++ b/kernel/src/mm/vm/mapping/api.rs
@@ -6,7 +6,6 @@
 
 use crate::address::{PhysAddr, VirtAddr};
 use crate::error::SvsmError;
-use crate::locking::{RWLock, ReadLockGuard, WriteLockGuard};
 use crate::mm::pagetable::PTEntryFlags;
 use crate::mm::vm::VMR;
 use crate::types::{PAGE_SHIFT, PageSize};
@@ -136,29 +135,7 @@ pub trait VirtualMapping: core::fmt::Debug + Send + Sync {
     }
 }
 
-#[derive(Debug)]
-pub struct Mapping {
-    mapping: RWLock<Box<dyn VirtualMapping>>,
-}
-
-impl Mapping {
-    pub fn new<T>(mapping: T) -> Self
-    where
-        T: VirtualMapping + 'static,
-    {
-        Mapping {
-            mapping: RWLock::new(Box::new(mapping)),
-        }
-    }
-
-    pub fn get(&self) -> ReadLockGuard<'_, Box<dyn VirtualMapping>> {
-        self.mapping.lock_read()
-    }
-
-    pub fn get_mut(&self) -> WriteLockGuard<'_, Box<dyn VirtualMapping>> {
-        self.mapping.lock_write()
-    }
-}
+pub type Mapping = Arc<dyn VirtualMapping>;
 
 /// A single mapping of virtual memory in a virtual memory range
 #[derive(Debug)]
@@ -174,8 +151,7 @@ pub struct VMM {
     range: Range<usize>,
 
     /// Pointer to the actual mapping
-    /// It is protected by an RWLock to serialize concurent accesses.
-    mapping: Arc<Mapping>,
+    mapping: Mapping,
 }
 
 intrusive_adapter!(pub VMMAdapter = Box<VMM>: VMM { link: AtomicLink });
@@ -198,8 +174,8 @@ impl VMM {
     /// # Returns
     ///
     /// New instance of VMM
-    pub fn new(start_pfn: usize, mapping: Arc<Mapping>) -> Self {
-        let size = mapping.get().mapping_size() >> PAGE_SHIFT;
+    pub fn new(start_pfn: usize, mapping: Mapping) -> Self {
+        let size = mapping.mapping_size() >> PAGE_SHIFT;
         VMM {
             link: AtomicLink::new(),
             range: Range {
@@ -232,15 +208,11 @@ impl VMM {
         )
     }
 
-    pub fn get_mapping(&self) -> ReadLockGuard<'_, Box<dyn VirtualMapping>> {
-        self.mapping.get()
+    pub fn get_mapping(&self) -> &Mapping {
+        &self.mapping
     }
 
-    pub fn get_mapping_mut(&self) -> WriteLockGuard<'_, Box<dyn VirtualMapping>> {
-        self.mapping.get_mut()
-    }
-
-    pub fn get_mapping_clone(&self) -> Arc<Mapping> {
+    pub fn get_mapping_clone(&self) -> Mapping {
         self.mapping.clone()
     }
 }

--- a/kernel/src/mm/vm/mapping/api.rs
+++ b/kernel/src/mm/vm/mapping/api.rs
@@ -144,10 +144,6 @@ pub struct VMM {
     link: AtomicLink,
 
     /// The virtual memory range covered by this mapping
-    /// It is stored in a RefCell to check borrowing rules at runtime.
-    /// This is safe as any modification to `range` is protected by a lock in
-    /// the parent data structure. This is required because changes here also
-    /// need changes in the parent data structure.
     range: Range<usize>,
 
     /// Pointer to the actual mapping

--- a/kernel/src/mm/vm/mapping/api.rs
+++ b/kernel/src/mm/vm/mapping/api.rs
@@ -126,7 +126,7 @@ pub trait VirtualMapping: core::fmt::Debug + Send + Sync {
     /// * 'write' - `true` if the fault was due to a write to the memory
     ///   location, or 'false' if the fault was due to a read.
     fn handle_page_fault(
-        &mut self,
+        &self,
         _vmr: &VMR,
         _offset: usize,
         _write: bool,

--- a/kernel/src/mm/vm/mapping/file_mapping.rs
+++ b/kernel/src/mm/vm/mapping/file_mapping.rs
@@ -163,7 +163,7 @@ impl VirtualMapping for VMFileMapping {
     }
 
     fn handle_page_fault(
-        &mut self,
+        &self,
         _vmr: &VMR,
         _offset: usize,
         _write: bool,

--- a/kernel/src/mm/vm/mapping/kernel_stack.rs
+++ b/kernel/src/mm/vm/mapping/kernel_stack.rs
@@ -16,6 +16,9 @@ use crate::utils::{MemoryRegion, page_align_up};
 use super::Mapping;
 use super::rawalloc::RawAllocMapping;
 
+extern crate alloc;
+use alloc::sync::Arc;
+
 /// Mapping to be used as a kernel stack. This maps a stack including guard
 /// pages at the top and bottom.
 #[derive(Default, Debug)]
@@ -134,7 +137,7 @@ impl VMKernelStack {
     ///
     /// Initialized Mapping to stack on success, Err(SvsmError::Mem) on error
     pub fn new_mapping() -> Result<Mapping, SvsmError> {
-        Ok(Mapping::new(Self::new()?))
+        Ok(Arc::new(Self::new()?))
     }
 
     fn alloc_pages(&mut self) -> Result<(), SvsmError> {

--- a/kernel/src/mm/vm/mapping/phys_mem.rs
+++ b/kernel/src/mm/vm/mapping/phys_mem.rs
@@ -9,6 +9,9 @@ use crate::mm::pagetable::PTEntryFlags;
 
 use super::{Mapping, VirtualMapping};
 
+extern crate alloc;
+use alloc::sync::Arc;
+
 /// Map physically contiguous memory
 #[derive(Default, Debug, Clone, Copy)]
 pub struct VMPhysMem {
@@ -52,7 +55,7 @@ impl VMPhysMem {
     ///
     /// New [`Mapping`] containing [`VMPhysMem`]
     pub fn new_mapping(base: PhysAddr, size: usize, writable: bool) -> Mapping {
-        Mapping::new(Self::new(base, size, writable))
+        Arc::new(Self::new(base, size, writable))
     }
 }
 

--- a/kernel/src/mm/vm/mapping/reserved.rs
+++ b/kernel/src/mm/vm/mapping/reserved.rs
@@ -9,6 +9,9 @@ use crate::mm::pagetable::PTEntryFlags;
 
 use super::{Mapping, VirtualMapping};
 
+extern crate alloc;
+use alloc::sync::Arc;
+
 /// Reserve a region of address space so that no other mapping will be
 /// established there. The map function for this type will always return
 /// `None`.
@@ -42,7 +45,7 @@ impl VMReserved {
     ///
     /// New Mapping of VMReserved
     pub fn new_mapping(size: usize) -> Mapping {
-        Mapping::new(Self::new(size))
+        Arc::new(Self::new(size))
     }
 }
 

--- a/kernel/src/mm/vm/mapping/vmalloc.rs
+++ b/kernel/src/mm/vm/mapping/vmalloc.rs
@@ -11,6 +11,9 @@ use crate::mm::pagetable::PTEntryFlags;
 use super::rawalloc::RawAllocMapping;
 use super::{Mapping, VMFileMappingFlags, VirtualMapping};
 
+extern crate alloc;
+use alloc::sync::Arc;
+
 /// Virtual mapping backed by allocated pages. This can be used for memory
 /// allocation if there is no need for the memory to be physically contiguous.
 ///
@@ -61,7 +64,7 @@ impl VMalloc {
     ///
     /// New [`Mapping`] on success, Err(SvsmError::Mem) on error
     pub fn new_mapping(size: usize, flags: VMFileMappingFlags) -> Result<Mapping, SvsmError> {
-        Ok(Mapping::new(Self::new(size, flags)?))
+        Ok(Arc::new(Self::new(size, flags)?))
     }
 
     fn alloc_pages(&mut self) -> Result<(), SvsmError> {

--- a/kernel/src/mm/vm/range.rs
+++ b/kernel/src/mm/vm/range.rs
@@ -102,11 +102,11 @@ impl VMR {
     ///
     /// `Ok(())` on success, Err(SvsmError::Mem) on allocation error
     fn alloc_page_tables(&self, lazy: bool) -> Result<(), SvsmError> {
-        let first = VirtAddr::from(self.start_pfn << PAGE_SHIFT);
-        let first_idx = first.to_pgtbl_idx::<3>();
+        let vregion = self.virt_range();
+
+        let first_idx = vregion.start().to_pgtbl_idx::<3>();
         let start = virt_from_idx(first_idx);
-        let last = VirtAddr::from(self.end_pfn << PAGE_SHIFT) - 1;
-        let last_idx = last.to_pgtbl_idx::<3>();
+        let last_idx = (vregion.end() - 1).to_pgtbl_idx::<3>();
         let count = last_idx + 1 - first_idx;
         let mut vec = self.pgtbl_parts.lock_write();
 
@@ -135,11 +135,10 @@ impl VMR {
     }
 
     pub fn populate_addr(&self, pgtbl: &mut PageTable, vaddr: VirtAddr) {
-        let start = VirtAddr::from(self.start_pfn << PAGE_SHIFT);
-        let end = VirtAddr::from(self.end_pfn << PAGE_SHIFT);
-        assert!(vaddr >= start && vaddr < end);
+        let vregion = self.virt_range();
+        assert!(vregion.contains(vaddr));
 
-        let idx = vaddr.to_pgtbl_idx::<3>() - start.to_pgtbl_idx::<3>();
+        let idx = vaddr.to_pgtbl_idx::<3>() - vregion.start().to_pgtbl_idx::<3>();
         let parts = self.pgtbl_parts.lock_read();
         pgtbl.populate_pgtbl_part(&parts[idx]);
     }
@@ -209,8 +208,8 @@ impl VMR {
     /// # Returns
     ///
     /// Tuple containing `start` and `end` virtual address of the memory region
-    fn virt_range(&self) -> (VirtAddr, VirtAddr) {
-        (
+    fn virt_range(&self) -> MemoryRegion<VirtAddr> {
+        MemoryRegion::from_addresses(
             VirtAddr::from(self.start_pfn << PAGE_SHIFT),
             VirtAddr::from(self.end_pfn << PAGE_SHIFT),
         )
@@ -226,7 +225,7 @@ impl VMR {
     ///
     /// `Ok(())` on success, Err(SvsmError::Mem) on allocation error
     fn map_vmm(&self, vmm: &VMM) -> Result<(), SvsmError> {
-        let (rstart, _) = self.virt_range();
+        let rstart = self.virt_range().start();
         let (vmm_start, vmm_end) = vmm.range();
         let mut pgtbl_parts = self.pgtbl_parts.lock_write();
         let mapping = vmm.get_mapping();
@@ -264,7 +263,7 @@ impl VMR {
     ///
     /// - `vmm` - Reference to a [`VMM`] instance to unmap from the page-table
     fn unmap_vmm(&self, vmm: &VMM) {
-        let (rstart, _) = self.virt_range();
+        let rstart = self.virt_range().start();
         let (vmm_start, vmm_end) = vmm.range();
         let mut pgtbl_parts = self.pgtbl_parts.lock_write();
         let mapping = vmm.get_mapping();

--- a/kernel/src/mm/vm/range.rs
+++ b/kernel/src/mm/vm/range.rs
@@ -134,13 +134,18 @@ impl VMR {
         }
     }
 
-    pub fn populate_addr(&self, pgtbl: &mut PageTable, vaddr: VirtAddr) {
+    fn populate_addr(&self, pgtbl: &mut PageTable, vaddr: VirtAddr) -> Result<(), SvsmError> {
         let vregion = self.virt_range();
-        assert!(vregion.contains(vaddr));
+        if !vregion.contains(vaddr) {
+            return Err(SvsmError::Mem);
+        }
 
         let idx = vaddr.to_pgtbl_idx::<3>() - vregion.start().to_pgtbl_idx::<3>();
         let parts = self.pgtbl_parts.lock_read();
-        pgtbl.populate_pgtbl_part(&parts[idx]);
+        if !pgtbl.populate_pgtbl_part(&parts[idx]) {
+            return Err(SvsmError::Mem);
+        }
+        Ok(())
     }
 
     /// Initialize this [`VMR`] by checking the `start` and `end` values and
@@ -482,16 +487,24 @@ impl VMR {
         }
     }
 
-    /// Notify the range that a page fault has occurred. This should be called from
-    /// the page fault handler. The mappings withing this virtual memory region are
-    /// examined and if they overlap with the page fault address then
-    /// [`VMR::handle_page_fault()`] is called to handle the page fault within that
-    /// range.
+    /// Handle a page fault for an address corresponding to this VMR.
+    ///
+    /// The fault is first handled by attemping to populate the provided page table
+    /// with the page table parts corresponding to the faulting address. If that
+    /// does not solve the fault, notify the backing mapping that a page fault has
+    /// occurred.
+    ///
+    /// This should be called from the page fault handler. The mappings within this
+    /// virtual memory region are examined and if they overlap with the page fault
+    /// address then [`VirtualMapping::handle_page_fault`] is called to handle the
+    /// page fault within that range.
+    ///
+    /// [`VirtualMapping::handle_page_fault`]: super::mapping::api::VirtualMapping::handle_page_fault
     ///
     /// # Arguments
     ///
+    /// * `pgtable`: The page table to update with the faulted-in mapping, if applicable.
     /// * `vaddr` - Virtual memory address that was the subject of the page fault
-    ///
     /// * 'write' - 'true' if a write was attempted. 'false' if a read was attempted.
     ///
     /// # Returns
@@ -499,10 +512,19 @@ impl VMR {
     /// '()' if the page fault was successfully handled.
     ///
     /// 'SvsmError::Mem' if the page fault should propogate to the next handler.
-    pub fn handle_page_fault(&self, vaddr: VirtAddr, _write: bool) -> Result<(), SvsmError> {
+    pub fn handle_page_fault(
+        &self,
+        pgtable: &mut PageTable,
+        vaddr: VirtAddr,
+        _write: bool,
+    ) -> Result<(), SvsmError> {
+        // Check first if the fault is solved by populating the page table
+        if let Ok(()) = self.populate_addr(pgtable, vaddr) {
+            return Ok(());
+        }
+
         // Get the mapping that contains the faulting address and check if the
         // fault happened on a mapped part of the range.
-
         let tree = self.tree.lock_read();
         let pfn = vaddr.pfn();
         let cursor = tree.upper_bound(Bound::Included(&pfn));

--- a/kernel/src/mm/vm/range.rs
+++ b/kernel/src/mm/vm/range.rs
@@ -208,7 +208,7 @@ impl VMR {
     /// # Returns
     ///
     /// Tuple containing `start` and `end` virtual address of the memory region
-    fn virt_range(&self) -> MemoryRegion<VirtAddr> {
+    pub fn virt_range(&self) -> MemoryRegion<VirtAddr> {
         MemoryRegion::from_addresses(
             VirtAddr::from(self.start_pfn << PAGE_SHIFT),
             VirtAddr::from(self.end_pfn << PAGE_SHIFT),

--- a/kernel/src/mm/vm/range.rs
+++ b/kernel/src/mm/vm/range.rs
@@ -456,17 +456,17 @@ impl VMR {
         let addr = base.pfn();
 
         let mut cursor = tree.find_mut(&addr);
-        if let Some(node) = cursor.get() {
-            self.unmap_vmm(node);
-            if self.per_cpu {
-                flush_tlb_global_percpu();
-            } else {
-                let range = node.range();
-                let region = MemoryRegion::from_addresses(range.0, range.1);
-                flush_tlb_global_sync_range(region, node.get_mapping().page_size());
-            }
+        let node = cursor.remove().ok_or(SvsmError::Mem)?;
+
+        self.unmap_vmm(&node);
+        if self.per_cpu {
+            flush_tlb_global_percpu();
+        } else {
+            let range = node.range();
+            let region = MemoryRegion::from_addresses(range.0, range.1);
+            flush_tlb_global_sync_range(region, node.get_mapping().page_size());
         }
-        cursor.remove().ok_or(SvsmError::Mem)
+        Ok(node)
     }
 
     /// Dump all [`VMM`] mappings in the RBTree. This function is included for

--- a/kernel/src/mm/vm/range.rs
+++ b/kernel/src/mm/vm/range.rs
@@ -22,7 +22,6 @@ use super::{Mapping, VMM, VMMAdapter};
 
 extern crate alloc;
 use alloc::boxed::Box;
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 
 /// Granularity of ranges mapped by [`struct VMR`]. The mapped region of a
@@ -289,7 +288,7 @@ impl VMR {
 
     fn do_insert(
         &self,
-        mapping: Arc<Mapping>,
+        mapping: Mapping,
         start_pfn: usize,
         cursor: &mut CursorMut<'_, VMMAdapter>,
     ) -> Result<(), SvsmError> {
@@ -309,14 +308,14 @@ impl VMR {
     /// # Arguments
     ///
     /// * `vaddr` - Virtual base address to map the [`VMM`] at
-    /// * `mapping` - `Rc` pointer to the VMM to insert
+    /// * `mapping` - `Arc` pointer to the VMM to insert
     ///
     /// # Returns
     ///
     /// Base address where the [`VMM`] was inserted on success or SvsmError::Mem on error
-    pub fn insert_at(&self, vaddr: VirtAddr, mapping: Arc<Mapping>) -> Result<VirtAddr, SvsmError> {
+    pub fn insert_at(&self, vaddr: VirtAddr, mapping: Mapping) -> Result<VirtAddr, SvsmError> {
         // mapping-size needs to be page-aligned
-        let size = mapping.get().mapping_size() >> PAGE_SHIFT;
+        let size = mapping.mapping_size() >> PAGE_SHIFT;
         let start_pfn = vaddr.pfn();
         let mut tree = self.tree.lock_write();
         let mut cursor = tree.upper_bound_mut(Bound::Included(&start_pfn));
@@ -351,7 +350,7 @@ impl VMR {
     ///
     /// # Arguments
     ///
-    /// * `mapping` - `Rc` pointer to the VMM to insert
+    /// * `mapping` - `Arc` pointer to the VMM to insert
     /// * `align` - Alignment to use for tha mapping
     ///
     /// # Returns
@@ -360,13 +359,12 @@ impl VMR {
     pub fn insert_aligned(
         &self,
         hint: VirtAddr,
-        mapping: Arc<Mapping>,
+        mapping: Mapping,
         align: usize,
     ) -> Result<VirtAddr, SvsmError> {
         assert!(align.is_power_of_two());
 
         let size = mapping
-            .get()
             .mapping_size()
             .checked_next_power_of_two()
             .unwrap_or(0)
@@ -425,12 +423,8 @@ impl VMR {
     /// # Returns
     ///
     /// Base address where the [`VMM`] was inserted on success or SvsmError::Mem on error
-    pub fn insert_hint(
-        &self,
-        addr: VirtAddr,
-        mapping: Arc<Mapping>,
-    ) -> Result<VirtAddr, SvsmError> {
-        let align = mapping.get().mapping_size().next_power_of_two();
+    pub fn insert_hint(&self, addr: VirtAddr, mapping: Mapping) -> Result<VirtAddr, SvsmError> {
+        let align = mapping.mapping_size().next_power_of_two();
         self.insert_aligned(addr, mapping, align)
     }
 
@@ -444,7 +438,7 @@ impl VMR {
     /// # Returns
     ///
     /// Base address where the [`VMM`] was inserted on success or SvsmError::Mem on error
-    pub fn insert(&self, mapping: Arc<Mapping>) -> Result<VirtAddr, SvsmError> {
+    pub fn insert(&self, mapping: Mapping) -> Result<VirtAddr, SvsmError> {
         self.insert_hint(VirtAddr::new(0), mapping)
     }
 
@@ -530,7 +524,7 @@ pub struct VMRMapping<'a> {
 }
 
 impl<'a> VMRMapping<'a> {
-    pub fn new(vmr: &'a VMR, mapping: Arc<Mapping>) -> Result<Self, SvsmError> {
+    pub fn new(vmr: &'a VMR, mapping: Mapping) -> Result<Self, SvsmError> {
         let va = vmr.insert(mapping)?;
         Ok(Self { vmr, va })
     }

--- a/kernel/src/mm/vm/range.rs
+++ b/kernel/src/mm/vm/range.rs
@@ -516,7 +516,7 @@ impl VMR {
         &self,
         pgtable: &mut PageTable,
         vaddr: VirtAddr,
-        _write: bool,
+        write: bool,
     ) -> Result<(), SvsmError> {
         // Check first if the fault is solved by populating the page table
         if let Ok(()) = self.populate_addr(pgtable, vaddr) {
@@ -534,6 +534,8 @@ impl VMR {
             return Err(SvsmError::Mem);
         }
 
+        let off = vaddr - start;
+        node.get_mapping().handle_page_fault(self, off, write)?;
         Ok(())
     }
 }

--- a/kernel/src/mm/vm/range.rs
+++ b/kernel/src/mm/vm/range.rs
@@ -78,16 +78,20 @@ impl VMR {
     /// # Returns
     ///
     /// A new instance of [`struct VMR`].
-    pub fn new(start: VirtAddr, end: VirtAddr, flags: PTEntryFlags) -> Self {
+    pub fn new(start: VirtAddr, end: VirtAddr, flags: PTEntryFlags) -> Result<Self, SvsmError> {
+        if start >= end || !start.is_aligned(VMR_GRANULE) || !end.is_aligned(VMR_GRANULE) {
+            log::warn!("Attempted to create an invalid VMR {start:#018x}-{start:#018x}");
+            return Err(SvsmError::Mem);
+        }
         // Global and User are per VMR flags
-        VMR {
+        Ok(Self {
             start_pfn: start.pfn(),
             end_pfn: end.pfn(),
             tree: RWLock::new(RBTree::new(VMMAdapter::new())),
             pgtbl_parts: RWLock::new(Vec::new()),
             pt_flags: flags,
             per_cpu: false,
-        }
+        })
     }
 
     /// Marks a [`struct VMR`] as being associated with only a single CPU
@@ -148,30 +152,6 @@ impl VMR {
         Ok(())
     }
 
-    /// Initialize this [`VMR`] by checking the `start` and `end` values and
-    /// allocating the [`PageTablePart`]s required for the mappings.
-    ///
-    /// # Safety
-    /// Callers must ensure that the bounds of the address range are
-    /// appropriately aligned to prevent the possibility that adjacent address
-    /// ranges may attempt to share top-level paging entries.  If any overlap
-    /// is attempted, page tables may be corrupted.
-    ///
-    /// # Arguments
-    ///
-    /// * `lazy` - When `true`, use lazy allocation of [`PageTablePart`] pages.
-    ///
-    /// # Returns
-    ///
-    /// `Ok(())` on success, Err(SvsmError::Mem) on allocation error
-    unsafe fn initialize_common(&self, lazy: bool) -> Result<(), SvsmError> {
-        let start = VirtAddr::from(self.start_pfn << PAGE_SHIFT);
-        let end = VirtAddr::from(self.end_pfn << PAGE_SHIFT);
-        assert!(start < end);
-
-        self.alloc_page_tables(lazy)
-    }
-
     /// Initialize this [`VMR`] by calling `VMR::initialize_common` with `lazy = false`
     ///
     /// # Safety
@@ -184,10 +164,7 @@ impl VMR {
     ///
     /// `Ok(())` on success, Err(SvsmError::Mem) on allocation error
     pub unsafe fn initialize(&self) -> Result<(), SvsmError> {
-        // SAFETY: The caller takes responsibility for ensuring that the address
-        // bounds of the range have appropriate alignment with respect to
-        // the page table alignment boundaries.
-        unsafe { self.initialize_common(false) }
+        self.alloc_page_tables(false)
     }
 
     /// Initialize this [`VMR`] by calling `VMR::initialize_common` with `lazy = true`
@@ -202,10 +179,7 @@ impl VMR {
     ///
     /// `Ok(())` on success, Err(SvsmError::Mem) on allocation error
     pub unsafe fn initialize_lazy(&self) -> Result<(), SvsmError> {
-        // SAFETY: The caller takes responsibility for ensuring that the address
-        // bounds of the range have appropriate alignment with respect to
-        // the page table alignment boundaries.
-        unsafe { self.initialize_common(true) }
+        self.alloc_page_tables(true)
     }
 
     /// Returns the virtual start and end addresses for this region

--- a/kernel/src/task/task_mm.rs
+++ b/kernel/src/task/task_mm.rs
@@ -143,7 +143,7 @@ impl TaskKernelMapping {
     /// # Returns
     ///
     /// `Some(TaskKernelMapping)` on success, `Err(SvsmError)` on failure.
-    pub fn new(mm: Arc<TaskMM>, mapping: Arc<Mapping>) -> Result<Self, SvsmError> {
+    pub fn new(mm: Arc<TaskMM>, mapping: Mapping) -> Result<Self, SvsmError> {
         let va = mm.kernel_range().insert(mapping)?;
         Ok(Self { mm, va })
     }

--- a/kernel/src/task/task_mm.rs
+++ b/kernel/src/task/task_mm.rs
@@ -79,7 +79,7 @@ impl TaskMM {
 
         // A VMR must have a size of exactly one VMR_GRANULE, so use the whole
         // per-TASK virtual address space
-        let vm_kernel_range = VMR::new(SVSM_PERTASK_BASE, SVSM_PERTASK_END, PTEntryFlags::empty());
+        let vm_kernel_range = VMR::new(SVSM_PERTASK_BASE, SVSM_PERTASK_END, PTEntryFlags::empty())?;
 
         // Now limit the usable virtual address space by inserting `VMReserved`
         // mappings. These mappings are empty, but prevent the VMR from

--- a/kernel/src/task/task_mm.rs
+++ b/kernel/src/task/task_mm.rs
@@ -112,15 +112,6 @@ impl TaskMM {
     pub fn user_range(&self) -> Option<&VMR> {
         self.vm_user_range.as_ref()
     }
-
-    /// Checks whether the task has a user-mode `[VMR]`.
-    ///
-    /// # Returns
-    ///
-    /// `True` if user-mode `[VMR]` is present, `False` otherwise.
-    pub fn has_user(&self) -> bool {
-        self.vm_user_range.is_some()
-    }
 }
 
 /// Guard a per-task kernel mapping and unmap it when going out of scope.

--- a/kernel/src/task/task_mm.rs
+++ b/kernel/src/task/task_mm.rs
@@ -12,8 +12,8 @@ use crate::address::VirtAddr;
 use crate::error::SvsmError;
 use crate::locking::SpinLock;
 use crate::mm::pagetable::PTEntryFlags;
-use crate::mm::vm::{Mapping, VMR};
-use crate::mm::{SIZE_LEVEL3, SVSM_PERTASK_BASE, alloc::AllocError};
+use crate::mm::vm::{Mapping, VMR, VMReserved};
+use crate::mm::{SIZE_LEVEL3, SVSM_PERTASK_BASE, SVSM_PERTASK_END, alloc::AllocError};
 use crate::utils::MemoryRegion;
 use crate::utils::bitmap_allocator::{BitmapAllocator, BitmapAllocator1024};
 
@@ -75,12 +75,27 @@ impl TaskMM {
     /// `Ok(TaskMM)` on success, `Err(SvsmError)` on failure.
     pub fn create(user_vmr: Option<VMR>) -> Result<Self, SvsmError> {
         let ktask_region = TaskVirtualRegionGuard::alloc()?;
-        let vaddr_region = ktask_region.vaddr_region();
-        let vm_kernel_range = VMR::new(
-            vaddr_region.start(),
-            vaddr_region.end(),
-            PTEntryFlags::empty(),
-        );
+        let kvregion = ktask_region.vaddr_region();
+
+        // A VMR must have a size of exactly one VMR_GRANULE, so use the whole
+        // per-TASK virtual address space
+        let vm_kernel_range = VMR::new(SVSM_PERTASK_BASE, SVSM_PERTASK_END, PTEntryFlags::empty());
+
+        // Now limit the usable virtual address space by inserting `VMReserved`
+        // mappings. These mappings are empty, but prevent the VMR from
+        // inserting new mappings in the address space covered by them.
+        if kvregion.start() > SVSM_PERTASK_BASE {
+            let size = kvregion.start() - SVSM_PERTASK_BASE;
+            let mapping = VMReserved::new_mapping(size);
+            vm_kernel_range.insert_at(SVSM_PERTASK_BASE, mapping)?;
+        }
+
+        if kvregion.end() < SVSM_PERTASK_END {
+            let size = SVSM_PERTASK_END - kvregion.end();
+            let mapping = VMReserved::new_mapping(size);
+            vm_kernel_range.insert_at(kvregion.end(), mapping)?;
+        }
+
         // SAFETY: The selected kernel mode task address range is the only
         // range that will live within the top-level entry associated with the
         // task address space.

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -328,8 +328,7 @@ impl Task {
             let base_token_addr;
 
             // Map shadow stack into virtual address range
-            let mapping =
-                TaskKernelMapping::new(task_mm.clone(), Arc::new(Mapping::new(shadow_stack)))?;
+            let mapping = TaskKernelMapping::new(task_mm.clone(), Arc::new(shadow_stack))?;
             let stack_base = mapping.virt_addr();
 
             // Initialize shadow stack
@@ -540,11 +539,11 @@ impl Task {
         }
     }
 
-    fn allocate_stack_common() -> Result<(Arc<Mapping>, MemoryRegion<VirtAddr>), SvsmError> {
+    fn allocate_stack_common() -> Result<(Mapping, MemoryRegion<VirtAddr>), SvsmError> {
         let stack = VMKernelStack::new()?;
         let bounds = stack.bounds(VirtAddr::from(0u64));
 
-        let mapping = Arc::new(Mapping::new(stack));
+        let mapping = Arc::new(stack);
 
         Ok((mapping, bounds))
     }
@@ -555,7 +554,7 @@ impl Task {
         start_routine: usize,
         xsa_addr: usize,
         start_parameter: usize,
-    ) -> Result<(Arc<Mapping>, MemoryRegion<VirtAddr>, usize), SvsmError> {
+    ) -> Result<(Mapping, MemoryRegion<VirtAddr>, usize), SvsmError> {
         let (mapping, bounds) = Task::allocate_stack_common()?;
 
         let percpu_mapping = cpu.new_mapping(mapping.clone())?;
@@ -618,7 +617,7 @@ impl Task {
         cpu: &PerCpu,
         user_entry: usize,
         xsa_addr: usize,
-    ) -> Result<(Arc<Mapping>, MemoryRegion<VirtAddr>, usize), SvsmError> {
+    ) -> Result<(Mapping, MemoryRegion<VirtAddr>, usize), SvsmError> {
         let (mapping, bounds) = Task::allocate_stack_common()?;
         // Do not run user-mode with IRQs enabled on platforms which are not
         // ready for it.

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -420,7 +420,7 @@ impl Task {
         root: Arc<dyn Directory>,
         name: String,
     ) -> Result<TaskPointer, SvsmError> {
-        let vm_user_range = VMR::new(USER_MEM_START, USER_MEM_END, PTEntryFlags::USER);
+        let vm_user_range = VMR::new(USER_MEM_START, USER_MEM_END, PTEntryFlags::USER)?;
         // SAFETY: the user address range is fully aligned to top-level paging
         // boundaries.
         unsafe {

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -528,15 +528,15 @@ impl Task {
     }
 
     pub fn fault(&self, vaddr: VirtAddr, write: bool) -> Result<(), SvsmError> {
-        if vaddr >= USER_MEM_START && vaddr < USER_MEM_END && self.mm.has_user() {
-            let vmr = self.mm.user_range().unwrap();
-            let mut pgtbl = self.page_table.lock();
-            vmr.populate_addr(&mut pgtbl, vaddr);
-            vmr.handle_page_fault(vaddr, write)?;
-            Ok(())
-        } else {
-            Err(SvsmError::Mem)
-        }
+        let vmr = self
+            .mm
+            .user_range()
+            .filter(|vmr| vmr.virt_range().contains(vaddr))
+            .ok_or(SvsmError::Mem)?;
+        let mut pgtbl = self.page_table.lock();
+        vmr.populate_addr(&mut pgtbl, vaddr);
+        vmr.handle_page_fault(vaddr, write)?;
+        Ok(())
     }
 
     fn allocate_stack_common() -> Result<(Mapping, MemoryRegion<VirtAddr>), SvsmError> {

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -530,8 +530,7 @@ impl Task {
             .filter(|vmr| vmr.virt_range().contains(vaddr))
             .ok_or(SvsmError::Mem)?;
         let mut pgtbl = self.page_table.lock();
-        vmr.populate_addr(&mut pgtbl, vaddr);
-        vmr.handle_page_fault(vaddr, write)?;
+        vmr.handle_page_fault(&mut pgtbl, vaddr, write)?;
         Ok(())
     }
 

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -523,10 +523,6 @@ impl Task {
         old_cpu_index
     }
 
-    pub fn handle_pf(&self, vaddr: VirtAddr, write: bool) -> Result<(), SvsmError> {
-        self.mm.kernel_range().handle_page_fault(vaddr, write)
-    }
-
     pub fn fault(&self, vaddr: VirtAddr, write: bool) -> Result<(), SvsmError> {
         let vmr = self
             .mm


### PR DESCRIPTION
This PR introduces two main improvements: 

#### 1. Removing the `Mapping` struct from the `VMR` code

The `Mapping` type is a wrapper of a `RWLock`, itself wrapping a boxed, dynamically dispatched `VirtualMapping` object. When a `Mapping` is inserted into a `VMR`, it is itself wrapped into an `Arc`, to keep track of its reference count. This introduces a double heap indirection that is simply not necessary.

There are no mutable users of `VirtualMapping` objects, and the trait requires `Sync`, so the `RWLock` is unnecessary overhead, and it can be removed. In the future, mappings that require mutation to service a `VirtualMapping` call should implement their own internal synchronization mechanism. This allows immutable `VirtualMapping` objects to have no synchronization overhead.

Moreover, `Arc` supports dyn-dispatch, so we can remove the `Box` as well. This leaves us with just an `Arc<dyn VirtualMapping>`. I left an alias of `Mapping = Arc<dyn VirtualMapping>` to reduce the diff size.

#### 2. Enforcing `VMR_GRANULE` size in `VMR::new()`

The `VMR` type expects to manage a section of the virtual address space aligned to `VMR_GRANULE`, and with the size being a multiple of `VMR_GRANULE`, although it does not make any checks in this regard. 

The task memory management code misuses `VMR` by creating `VMR`s with only subregions of the task address space, in order to keep a non-overlapping virtual address space across CPUs. Fix this by creating the `VMR` with the full task address space, and then inserting `VMReserved` mappings to prevent allocating addresses outside the intended subregion. Enforce this in `VMR::new()` to prevent future invalid uses.