### PR TITLE
xbuild: use packit as a library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2484,6 +2484,7 @@ name = "xbuild"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "packit",
  "serde",
  "serde_json",
 ]

--- a/Documentation/docs/developer/TESTING.md
+++ b/Documentation/docs/developer/TESTING.md
@@ -10,8 +10,6 @@ have no additional requirements, as they use your host's target triple with the
 same toolchain version as the rest of the codebase.
 
 ```shell
-cargo test --workspace
-# or
 make test
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -116,11 +116,14 @@ bin/coconut-test-vanadium.igvm:
 	cargo xbuild $(XBUILD_ARGS_TEST) ./configs/test/vanadium-test-target.json
 
 test:
-	cargo test ${CARGO_ARGS} ${SVSM_ARGS_TEST} --workspace
+	cargo test ${CARGO_ARGS} ${SVSM_ARGS_TEST} --package svsm
+	cargo test ${CARGO_ARGS} --workspace --exclude svsm
 
 miri:
 	MIRIFLAGS=-Zmiri-permissive-provenance \
-		cargo +nightly miri test ${CARGO_ARGS} ${SVSM_ARGS_TEST} --workspace
+		cargo +nightly miri test ${CARGO_ARGS} ${SVSM_ARGS_TEST} --package svsm
+	MIRIFLAGS=-Zmiri-permissive-provenance \
+		cargo +nightly miri test ${CARGO_ARGS} --workspace --exclude svsm
 
 test-igvm: $(IGVM_TEST_FILES)
 
@@ -176,7 +179,8 @@ clippy:
 	RUSTFLAGS="--cfg fuzzing" ${CARGO} clippy ${CLIPPY_OPTIONS} --package svsm-fuzz -- ${CLIPPY_ARGS}
 	${CARGO} clippy ${CLIPPY_OPTIONS} --package svsm --target x86_64-unknown-none -- ${CLIPPY_ARGS}
 	${CARGO} clippy ${CLIPPY_OPTIONS} --package stage1 --target x86_64-unknown-none -- ${CLIPPY_ARGS} ${STAGE1_RUSTC_ARGS}
-	${CARGO} clippy ${CLIPPY_OPTIONS} --workspace --tests --exclude packit -- ${CLIPPY_ARGS}
+	${CARGO} clippy ${CLIPPY_OPTIONS} --workspace --tests --exclude svsm -- ${CLIPPY_ARGS}
+	${CARGO} clippy ${CLIPPY_OPTIONS} --package svsm ${SVSM_ARGS_TEST} --tests -- ${CLIPPY_ARGS}
 
 clean:
 	cargo clean

--- a/kernel/src/vtpm/tcgtpm/mod.rs
+++ b/kernel/src/vtpm/tcgtpm/mod.rs
@@ -8,7 +8,7 @@
 //! Reference Implementation (by Microsoft)
 
 /// Functions required to build the TPM 2.0 Reference Implementation libraries
-#[cfg(not(any(test, fuzzing)))]
+#[cfg(target_os = "none")]
 mod wrapper;
 
 pub mod ek_templates;

--- a/libtcgtpm/Makefile
+++ b/libtcgtpm/Makefile
@@ -6,6 +6,9 @@ OPENSSL_CONFIG_TYPE = --debug
 TCGTPM_CFLAGS = -g -O0 -DDEBUG=YES
 endif
 
+# Allow user to not link in libcrt
+USE_LIBCRT ?= 1
+
 ROOT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 DEPS_DIR := $(ROOT_DIR)/deps
 OUT_DIR ?= $(ROOT_DIR)
@@ -31,7 +34,11 @@ LIBCRT_BUILD_DIR = $(OUT_DIR)/libcrt-build
 OPENSSL_BUILD_DIR = $(OUT_DIR)/openssl-build
 TCGTPM_BUILD_DIR = $(OUT_DIR)/tcgtpm-build
 
+ifeq ($(USE_LIBCRT),1)
 LIBCRT = $(LIBCRT_BUILD_DIR)/libcrt.a
+else
+LIBCRT =
+endif
 LIBCRYPTO = $(OPENSSL_BUILD_DIR)/libcrypto.a
 
 LIBTPM_TARGET = Tpm_CoreLib
@@ -50,6 +57,17 @@ OPENSSL_MAKEFILE = $(OPENSSL_BUILD_DIR)/Makefile
 TCGTPM_MAKEFILE = $(TCGTPM_BUILD_DIR)/Makefile
 
 LIBS = $(LIBCRT) $(LIBCRYPTO) $(LIBBNMATH) $(LIBTPMBIGNUM) $(LIBTPM) $(LIBPLATFORM)
+
+ifeq ($(USE_LIBCRT),1)
+LIBCRT_INCLUDE = -I$(LIBCRT_SRC_DIR)/include
+LIBCRT_LINK = -Wl,rpath=$(LIBCRT_BUILD_DIR) -lcrt
+TCGTPM_CFLAGS += -static -nostdinc -fno-stack-protector -mno-sse -mno-red-zone
+OPENSSL_CFLAGS = -static -nostdinc -nostdlib -fno-stack-protector -mno-red-zone
+else
+LIBCRT_INCLUDE =
+LIBCRT_LINK =
+OPENSSL_CFLAGS =
+endif
 
 # Avoid running jobs of this Makefile in parallel to avoid possible conflicts
 # when building the TPM libraries, which use the same Makefile and subdirectory.
@@ -176,8 +194,9 @@ $(OPENSSL_MAKEFILE):
 			no-whirlpool \
 			--with-rand-seed=getrandom \
 			$(OPENSSL_CONFIG_TYPE) \
-			-I$(LIBCRT_SRC_DIR)/include \
-			-Wl,rpath=$(LIBCRT_BUILD_DIR) -lcrt)
+			$(OPENSSL_CFLAGS) \
+			$(LIBCRT_INCLUDE) \
+			$(LIBCRT_LINK))
 
 # tcgtpm
 $(LIBBNMATH): $(TCGTPM_MAKEFILE) $(LIBCRYPTO)
@@ -192,9 +211,9 @@ $(LIBTPM): $(TCGTPM_MAKEFILE) $(LIBTPMBIGNUM)
 $(LIBPLATFORM): $(TCGTPM_MAKEFILE) $(LIBCRYPTO)
 	$(MAKE) -C $(TCGTPM_BUILD_DIR) $(LIBPLATFORM_TARGET)
 
-TCGTPM_CFLAGS += -static -nostdinc -fno-stack-protector -fPIE -mno-sse -mno-red-zone
+TCGTPM_CFLAGS += -fPIE
 TCGTPM_CFLAGS += -DFILE_BACKED_NV=NO
-TCGTPM_CFLAGS += -I$(LIBCRT_SRC_DIR)/include
+TCGTPM_CFLAGS += $(LIBCRT_INCLUDE)
 TCGTPM_CFLAGS += -I$(OPENSSL_BUILD_DIR)/include
 TCGTPM_CFLAGS += -I$(OPENSSL_SRC_DIR)/include
 

--- a/libtcgtpm/build.rs
+++ b/libtcgtpm/build.rs
@@ -10,8 +10,14 @@ use std::process::Command;
 use std::process::Stdio;
 
 fn main() {
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+
     // Build libtcgtpm.
-    let status = Command::new("make")
+    let mut cmd = Command::new("make");
+    if target_os != "none" {
+        cmd.arg("USE_LIBCRT=0");
+    }
+    let status = cmd
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
         .status()

--- a/libtcgtpm/deps/openssl_svsm.conf
+++ b/libtcgtpm/deps/openssl_svsm.conf
@@ -18,7 +18,7 @@ my %targets = (
                                           # exception 6 (invalid opcode) usually in:
                                           # vtpm_init()->libtpm:manufacture()->libcrypto:BN_CTX_new()
                                           release => "-O0"),
-                                   "-fPIE -m64 -nostdinc -nostdlib -static -fno-stack-protector -mno-red-zone")),
+                                   "-fPIE -m64")),
         bn_ops          => "SIXTY_FOUR_BIT_LONG",
         lib_cppflags    => add("-DL_ENDIAN -DNO_SYSLOG -DOPENSSL_SMALL_FOOTPRINT -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE -DOPENSSL_USE_USLEEP"),
         sys_id          => "SVSM"

--- a/xbuild/Cargo.toml
+++ b/xbuild/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 
 [dependencies]
 clap = { workspace = true, features = ["color", "derive", "help", "std", "suggestions", "usage"] }
+packit = { workspace = true, features = ["std"] }
 serde = { workspace = true, features = ["std", "derive"] }
 serde_json = { workspace = true, default-features = true }
 

--- a/xbuild/Cargo.toml
+++ b/xbuild/Cargo.toml
@@ -5,8 +5,8 @@ edition.workspace = true
 
 [dependencies]
 clap = { workspace = true, features = ["color", "derive", "help", "std", "suggestions", "usage"] }
-serde = { version = "1.0.219", features = ["derive"] }
-serde_json = "1.0.140"
+serde = { workspace = true, features = ["std", "derive"] }
+serde_json = { workspace = true, default-features = true }
 
 [lints]
 workspace = true

--- a/xbuild/src/fs.rs
+++ b/xbuild/src/fs.rs
@@ -2,14 +2,11 @@
 //
 // Author: Carlos López <carlos.lopezr4096@gmail.com>
 
-use crate::{
-    Args, BuildResult, BuildTarget, Component, ComponentConfig, features::Features,
-    helpers::HELPERS, run_cmd_checked,
-};
+use crate::{Args, BuildResult, BuildTarget, Component, ComponentConfig, features::Features};
+use packit::PackItArchiveEncoder;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 /// Components for the filesystem image.
 #[derive(Debug, Clone, Deserialize)]
@@ -42,7 +39,11 @@ impl FsConfig {
             return Ok(None);
         }
 
-        // Build all components and copy them to the output path
+        let fs_path = PathBuf::from("bin/svsm-fs.bin");
+        let mut fs = std::fs::File::create(&fs_path)?;
+        let mut enc = PackItArchiveEncoder::new(&mut fs)?;
+
+        // Build all components and add them to the archive
         for comp in self.components() {
             let bin = comp.build(args, BuildTarget::svsm_user(), cmd_feats)?;
             let mut dst_file = comp
@@ -57,19 +58,14 @@ impl FsConfig {
             }
             dst.push(dst_file);
             comp.config.objcopy.copy(&bin, &dst, args)?;
+
+            let filename = dst_file
+                .to_str()
+                .ok_or_else(|| format!("invalid file name: {}", dst_file.display()))?;
+            enc.load_file(filename, &std::fs::File::open(&dst)?)?;
             dst.pop();
         }
 
-        // Now build filesystem image from all components
-        let fs = PathBuf::from("bin/svsm-fs.bin");
-        let mut cmd = Command::new(HELPERS.packit(args, cmd_feats));
-        cmd.arg("pack")
-            .arg("--input")
-            .arg(&dst)
-            .arg("--output")
-            .arg(&fs);
-        run_cmd_checked(cmd, args)?;
-
-        Ok(Some(fs))
+        Ok(Some(fs_path))
     }
 }

--- a/xbuild/src/helpers.rs
+++ b/xbuild/src/helpers.rs
@@ -2,7 +2,7 @@
 //
 // Author: Carlos López <carlos.lopezr4096@gmail.com>
 
-use crate::{Args, BuildTarget, Component, ComponentConfig, features::Features};
+use crate::{Args, BuildTarget, Component, features::Features};
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
@@ -11,7 +11,6 @@ use std::sync::OnceLock;
 pub struct Helpers {
     igvmbuilder: OnceLock<PathBuf>,
     igvmmeasure: OnceLock<PathBuf>,
-    packit: OnceLock<PathBuf>,
 }
 
 impl Helpers {
@@ -19,7 +18,6 @@ impl Helpers {
         Self {
             igvmbuilder: OnceLock::new(),
             igvmmeasure: OnceLock::new(),
-            packit: OnceLock::new(),
         }
     }
 
@@ -36,20 +34,6 @@ impl Helpers {
             Component::new_default("igvmmeasure")
                 .build(args, BuildTarget::Host, cmd_feats)
                 .expect("failed to build igvmmeasure")
-        })
-    }
-
-    pub fn packit(&self, args: &Args, cmd_feats: &mut Features) -> &PathBuf {
-        self.packit.get_or_init(|| {
-            Component::new(
-                "packit",
-                ComponentConfig {
-                    features: Some("cli".into()),
-                    ..Default::default()
-                },
-            )
-            .build(args, BuildTarget::Host, cmd_feats)
-            .expect("failed to build packit")
         })
     }
 }


### PR DESCRIPTION
~As of right now, we have a git submodule with the packit utility because we use it as a regular binary from xbuild. Now that packit has a higher level to copy files into an archive, simply use it as a library instead. This removes the need for the git submodule, as the dependency can now be specified in Cargo.toml.~

*NOTE: kept the submodule, as discussed in the SVSM community call.*

As of right now, we build packit as a binary from xbuild in order to create the filesystem image to be embedded into the IGVM file. However, a recent change in packit simplifies using it as a Rust library, so use it as such to better integrate it into the codebase.

This unfortunately introduces issues with workspace-level feature unification, causing in some cases for packit to be linked with the combination of all of its features used in the workspace, which includes the "std" feature that xbuild needs, causing issues for the SVSM kernel. For now the only workaround in cargo is to use the `--package` option and adding `--exclude svsm` when using `--workspace`.

On the other hand, this lets us better specify that `SVSM_ARGS_TEST` in the Makefile should only be passed to the SVSM kernel target, and not the rest.

While we are at it, use workspace-level dependencies for xbuild.