### PR TITLE
cargo.toml: update gdbstub to 0.7.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -206,12 +206,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -632,7 +626,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 name = "elf"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -744,23 +738,23 @@ dependencies = [
 
 [[package]]
 name = "gdbstub"
-version = "0.6.6"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e02bf1b1a624d96925c608f1b268d82a76cbc587ce9e59f7c755e9ea11c75c"
+checksum = "5bafc7e33650ab9f05dcc16325f05d56b8d10393114e31a19a353b86fa60cfe7"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "cfg-if",
  "log",
  "managed",
  "num-traits",
- "paste",
+ "pastey",
 ]
 
 [[package]]
 name = "gdbstub_arch"
-version = "0.2.4"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eecb536c55c43593a00dde9074dbbdb0e81ce5f20dbca921400f8779c21dea9c"
+checksum = "6c02bfe7bd65f42bcda751456869dfa1eb2bd1c36e309b9ec27f4888d41cf258"
 dependencies = [
  "gdbstub",
  "num-traits",
@@ -1416,10 +1410,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "pastey"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "pem-rfc7468"
@@ -1888,7 +1882,7 @@ dependencies = [
  "aes-gcm",
  "aes-kw",
  "bitfield-struct 0.6.2",
- "bitflags 2.10.0",
+ "bitflags",
  "bootdefs",
  "bootimg",
  "cocoon-tpm-crypto",
@@ -1969,7 +1963,7 @@ dependencies = [
 name = "syscall"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "zerocopy",
 ]
 
@@ -2072,7 +2066,7 @@ version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cf146f99d442e8e68e585f5d798ccd3cad9a7835b917e09728880a862706456"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
@@ -2298,7 +2292,7 @@ dependencies = [
 name = "virtio-drivers"
 version = "0.7.5"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "enumn",
  "log",
  "zerocopy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,8 +79,8 @@ cocoon-tpm-crypto = { version = "0.1.0", default-features = false }
 cocoon-tpm-tpm2-interface = { version = "0.1.0", default-features = false }
 cocoon-tpm-utils-common = { version = "0.1.0", default-features = false }
 concat-kdf = "0.1.0"
-gdbstub = { version = "0.6.6", default-features = false }
-gdbstub_arch = { version = "0.2.4" }
+gdbstub = { version = "0.7.10", default-features = false }
+gdbstub_arch = { version = "0.3.3" }
 igvm = { version = "0.4.0", default-features = false }
 igvm_defs = { version = "0.4.0", default-features = false }
 intrusive-collections = "0.9.6"

--- a/kernel/src/debug/gdbstub.rs
+++ b/kernel/src/debug/gdbstub.rs
@@ -570,7 +570,7 @@ pub mod svsm_gdbstub {
             start_addr: <Self::Arch as gdbstub::arch::Arch>::Usize,
             data: &mut [u8],
             tid: Tid,
-        ) -> gdbstub::target::TargetResult<(), Self> {
+        ) -> gdbstub::target::TargetResult<usize, Self> {
             // Switch to the task pagetable if necessary. The switch back will
             // happen automatically when the variable falls out of scope
             // SAFETY: the debugger knows it is safe to operate in the context
@@ -584,7 +584,7 @@ pub mod svsm_gdbstub {
                 };
                 *dst = val;
             }
-            Ok(())
+            Ok(data.len())
         }
 
         fn write_addrs(


### PR DESCRIPTION
The current version of `gdbstub` depends on the `paste` crate, which is no longer maintained and triggers a warning when running `cargo audit`.

Update `gdbstub` from `0.6.6` to `0.7.10`, which removes the dependency on the `paste` crate. This requires updating `MultiThreadBase` trait implementation.

Also update `gdbstub_arch` from `0.2.4` to a newer version (`0.3.3`), because the old version only supported `gdbstub ^0.6`.

This also simplifies `Cargo.lock` file.

gdbstub 0.7.10 release [notes](https://github.com/daniel5151/gdbstub/releases/tag/0.7.10)

Fixes #817