### PR TITLE
attest: add attestation testing with kbs-test integration

### DIFF
--- a/Documentation/docs/developer/TESTING.md
+++ b/Documentation/docs/developer/TESTING.md
@@ -69,6 +69,45 @@ QEMU=/path/to/qemu make test-in-svsm TEST_ARGS='--nocc -- --no-netdev'
 A list of parameters for `launch_guest.sh` is listed in the
 [INSTALL.md](../installation/INSTALL.md) document.
 
+## Attestation tests
+
+Attestation can be tested in the same infrastructure by running the
+attest-enabled test image together with `kbs-test` and `aproxy`.
+
+### Requirements
+
+In addition to the requirements for in-SVSM tests, attestation tests require:
+
+- The `kbs-test` server from [coconut-svsm/kbs-test](https://github.com/coconut-svsm/kbs-test)
+- The `aproxy` binary (built automatically as part of the SVSM build)
+
+### Running
+
+Clone and build `kbs-test`:
+
+```shell
+git clone https://github.com/coconut-svsm/kbs-test.git ../kbs-test
+```
+
+Run attestation tests:
+
+```shell
+KBS_TEST_DIR=../kbs-test QEMU=/path/to/qemu \
+make FEATURES_TEST=vtpm,virtio-drivers,block,attest \
+     TEST_IN_SVSM_SCRIPT=./scripts/test-in-svsm-attest.sh \
+     TEST_IN_SVSM_DEPS=aproxy \
+     test-in-svsm
+```
+
+You can replace `KBS_TEST_DIR` with `KBS_TEST_BIN=/path/to/kbs-test` if you
+already have a `kbs-test` binary built.
+
+The test will:
+1. Start a local `kbs-test` server
+2. Start an `aproxy` instance
+3. Run the SVSM tests with attestation enabled
+4. Verify "attestation successful" appears in the output
+
 ## Miri
 
 Miri is an Undefined Behavior detection tool for Rust. It can run binaries and

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ XBUILD_ARGS_TEST += --feature ${FEATURES_TEST}
 endif
 
 TEST_ARGS ?=
+TEST_IN_SVSM_SCRIPT ?= ./scripts/test-in-svsm.sh
+TEST_IN_SVSM_DEPS ?=
 
 CARGO ?= cargo
 CLIPPY_OPTIONS ?= --all-features
@@ -125,8 +127,9 @@ miri:
 
 test-igvm: $(IGVM_TEST_FILES)
 
-test-in-svsm: bin/coconut-test-qemu.igvm $(IGVMMEASUREBIN)
-	./scripts/test-in-svsm.sh $(TEST_ARGS)
+test-in-svsm: $(IGVMMEASUREBIN) $(TEST_IN_SVSM_DEPS)
+	cargo xbuild $(XBUILD_ARGS_TEST) ./configs/test/qemu-test-target.json
+	TEST_IGVM=$(CURDIR)/bin/coconut-test-qemu.igvm $(TEST_IN_SVSM_SCRIPT) $(TEST_ARGS)
 
 test-in-hyperv: bin/coconut-test-hyperv.igvm
 
@@ -195,4 +198,4 @@ clean:
 
 distclean: clean
 
-.PHONY: test miri clean clippy bin/stage2.bin bin/svsm-kernel.elf bin/test-kernel.elf stage1_elf_trampoline distclean $(APROXYBIN) $(IGVM_FILES) $(IGVM_TEST_FILES)
+.PHONY: test miri clean clippy bin/stage2.bin bin/svsm-kernel.elf bin/test-kernel.elf stage1_elf_full stage1_elf_trampoline stage1_elf_test distclean $(APROXYBIN) $(IGVM_FILES) $(IGVM_TEST_FILES) test-in-svsm

--- a/kernel/src/attest.rs
+++ b/kernel/src/attest.rs
@@ -355,3 +355,110 @@ fn hash(
 
     try_to_vec(&sha.finalize()).or(Err(AttestationError::VecAlloc))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+    use cocoon_tpm_tpm2_interface::{Tpm2bEccParameter, TpmBuffer};
+
+    fn make_ecc_point(x: &[u8], y: &[u8]) -> TpmsEccPoint<'static> {
+        TpmsEccPoint {
+            x: Tpm2bEccParameter {
+                buffer: TpmBuffer::Owned(x.to_vec()),
+            },
+            y: Tpm2bEccParameter {
+                buffer: TpmBuffer::Owned(y.to_vec()),
+            },
+        }
+    }
+
+    mod negotiation_hash {
+        use super::*;
+
+        /// hash() feeds NegotiationParams into SHA-512 in the order they
+        /// appear in `response.params`. The ordering matters because
+        /// the server dictates which fields contribute to the attestation
+        /// hash and in what order. These two tests verify that
+        /// [Challenge, EcPublicKeyBytes] and [EcPublicKeyBytes, Challenge]
+        /// produce different digests, therefore confirming the function
+        /// respects the param ordering from the negotiation response.
+        #[test]
+        fn challenge_then_ec_key() {
+            let challenge = vec![0xdd; 48];
+            let x = vec![0x10; 66];
+            let y = vec![0x20; 66];
+            let response = NegotiationResponse {
+                challenge: challenge.clone(),
+                params: vec![
+                    NegotiationParam::Challenge,
+                    NegotiationParam::EcPublicKeyBytes,
+                ],
+            };
+            let pub_key = make_ecc_point(&x, &y);
+
+            let result = hash(&response, &pub_key).unwrap();
+
+            let mut sha = Sha512::new();
+            sha.update(&challenge);
+            sha.update(&x);
+            sha.update(&y);
+            let expected = sha.finalize();
+            assert_eq!(result, expected.as_slice());
+        }
+
+        #[test]
+        fn ec_key_then_challenge() {
+            let challenge = vec![0xee; 24];
+            let x = vec![0x30; 10];
+            let y = vec![0x40; 10];
+            let response = NegotiationResponse {
+                challenge: challenge.clone(),
+                params: vec![
+                    NegotiationParam::EcPublicKeyBytes,
+                    NegotiationParam::Challenge,
+                ],
+            };
+            let pub_key = make_ecc_point(&x, &y);
+
+            let result = hash(&response, &pub_key).unwrap();
+
+            let mut sha = Sha512::new();
+            sha.update(&x);
+            sha.update(&y);
+            sha.update(&challenge);
+            let expected = sha.finalize();
+            assert_eq!(result, expected.as_slice());
+        }
+
+        /// Changing the param order must change the hash. This is a
+        /// security property: if the server negotiates a different param
+        /// list, the resulting attestation evidence must differ.
+        #[test]
+        fn different_order_produces_different_hash() {
+            let challenge = vec![0x42; 32];
+            let x = vec![0x01; 10];
+            let y = vec![0x02; 10];
+            let pub_key = make_ecc_point(&x, &y);
+
+            let response_chal_first = NegotiationResponse {
+                challenge: challenge.clone(),
+                params: vec![
+                    NegotiationParam::Challenge,
+                    NegotiationParam::EcPublicKeyBytes,
+                ],
+            };
+            let response_key_first = NegotiationResponse {
+                challenge: challenge.clone(),
+                params: vec![
+                    NegotiationParam::EcPublicKeyBytes,
+                    NegotiationParam::Challenge,
+                ],
+            };
+
+            let hash1 = hash(&response_chal_first, &pub_key).unwrap();
+            let hash2 = hash(&response_key_first, &pub_key).unwrap();
+            assert_ne!(hash1, hash2);
+        }
+    }
+}

--- a/kernel/src/protocols/attest.rs
+++ b/kernel/src/protocols/attest.rs
@@ -183,6 +183,24 @@ impl AttestServicesOp {
     }
 }
 
+// Compile-time ABI layout guard: any change to field order or padding that
+// breaks the wire format with the guest will be caught here.
+const _: () = assert!(
+    core::mem::offset_of!(AttestServicesOp, report_gpa) == 0x00
+        && core::mem::offset_of!(AttestServicesOp, report_size) == 0x08
+        && core::mem::offset_of!(AttestServicesOp, reserved_1) == 0x0c
+        && core::mem::offset_of!(AttestServicesOp, nonce_gpa) == 0x10
+        && core::mem::offset_of!(AttestServicesOp, nonce_size) == 0x18
+        && core::mem::offset_of!(AttestServicesOp, reserved_2) == 0x1a
+        && core::mem::offset_of!(AttestServicesOp, manifest_gpa) == 0x20
+        && core::mem::offset_of!(AttestServicesOp, manifest_size) == 0x28
+        && core::mem::offset_of!(AttestServicesOp, reserved_3) == 0x2c
+        && core::mem::offset_of!(AttestServicesOp, certificate_gpa) == 0x30
+        && core::mem::offset_of!(AttestServicesOp, certificate_size) == 0x38
+        && core::mem::offset_of!(AttestServicesOp, reserved_4) == 0x3c
+        && core::mem::size_of::<AttestServicesOp>() == 0x40
+);
+
 #[derive(Clone)]
 struct GuidTableEntry {
     guid: uuid::Uuid,
@@ -313,6 +331,16 @@ impl AttestSingleServiceOp {
         self.op.is_extended_report()
     }
 }
+
+// Compile-time ABI layout guard for the extended single-service structure
+// that wraps AttestServicesOp.
+const _: () = assert!(
+    core::mem::offset_of!(AttestSingleServiceOp, op) == 0x00
+        && core::mem::offset_of!(AttestSingleServiceOp, guid) == 0x40
+        && core::mem::offset_of!(AttestSingleServiceOp, manifest_ver) == 0x50
+        && core::mem::offset_of!(AttestSingleServiceOp, reserved_5) == 0x54
+        && core::mem::size_of::<AttestSingleServiceOp>() == 0x58
+);
 
 fn get_attestation_report_standard(nonce: &[u8]) -> Result<Box<SnpReportResponse>, SvsmReqError> {
     let mut resp = SnpReportResponse::new_box_zeroed()
@@ -582,5 +610,206 @@ pub fn attest_protocol_request(
         SVSM_ATTEST_SERVICES => attest_multiple_services(params),
         SVSM_ATTEST_SINGLE_SERVICE => attest_single_service_handler(params),
         _ => Err(SvsmReqError::unsupported_protocol()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocols::errors::SvsmResultCode;
+    use alloc::vec;
+    use core::mem::offset_of;
+    use zerocopy::FromZeros;
+
+    fn is_invalid_parameter(err: &SvsmReqError) -> bool {
+        matches!(
+            err,
+            SvsmReqError::RequestError(SvsmResultCode::INVALID_PARAMETER)
+        )
+    }
+
+    fn is_unsupported_protocol(err: &SvsmReqError) -> bool {
+        matches!(
+            err,
+            SvsmReqError::RequestError(SvsmResultCode::UNSUPPORTED_PROTOCOL)
+        )
+    }
+
+    mod attest_services {
+        use super::*;
+
+        fn base_op() -> AttestServicesOp {
+            AttestServicesOp::new_zeroed()
+        }
+
+        /// The struct has four separate reserved regions. Iterate over
+        /// all of them to ensure is_reserved_clear() inspects every one,
+        /// not just the first.
+        #[test]
+        fn reserved_clear_rejects_each_field() {
+            for offset in [
+                offset_of!(AttestServicesOp, reserved_1),
+                offset_of!(AttestServicesOp, reserved_2),
+                offset_of!(AttestServicesOp, reserved_3),
+                offset_of!(AttestServicesOp, reserved_4),
+            ] {
+                let mut bytes = base_op().as_bytes().to_vec();
+                bytes[offset] = 0xff;
+                let op = AttestServicesOp::ref_from_bytes(&bytes).unwrap();
+                assert!(
+                    !op.is_reserved_clear(),
+                    "reserved check should fail for byte at offset {offset:#x}"
+                );
+            }
+        }
+
+        /// Parsing must reject requests with non-zero reserved fields
+        /// to enforce forward-compatibility with future spec revisions.
+        #[test]
+        fn try_from_as_ref_rejects_nonzero_reserved() {
+            for offset in [
+                offset_of!(AttestServicesOp, reserved_1),
+                offset_of!(AttestServicesOp, reserved_2),
+                offset_of!(AttestServicesOp, reserved_3),
+                offset_of!(AttestServicesOp, reserved_4),
+            ] {
+                let mut bytes = base_op().as_bytes().to_vec();
+                bytes[offset] = 1;
+                let err = AttestServicesOp::try_from_as_ref(&bytes).unwrap_err();
+                assert!(
+                    is_invalid_parameter(&err),
+                    "should reject nonzero reserved at offset {offset:#x}"
+                );
+            }
+        }
+
+        /// The certificate region is optional (size == 0 means absent).
+        /// When present, it must enforce MAX_CERTIFICATE_SIZE as an upper
+        /// bound to prevent guests from requesting unbounded allocations.
+        #[test]
+        fn certificate_region_boundary() {
+            let mut op = base_op();
+            assert!(op.get_certificate_region().unwrap().is_none());
+
+            op.certificate_gpa = 0x4000;
+            op.certificate_size = MAX_CERTIFICATE_SIZE as u32;
+            assert!(op.get_certificate_region().unwrap().is_some());
+
+            op.certificate_size = (MAX_CERTIFICATE_SIZE + 1) as u32;
+            let err = op.get_certificate_region().unwrap_err();
+            assert!(is_invalid_parameter(&err));
+        }
+    }
+
+    mod attest_single_service {
+        use super::*;
+
+        fn base_op() -> AttestSingleServiceOp {
+            AttestSingleServiceOp::new_zeroed()
+        }
+
+        /// Only manifest version 0 is currently defined by the protocol.
+        /// Parsing must reject any other version to prevent silent
+        /// misinterpretation of the manifest payload.
+        #[test]
+        fn try_from_as_ref_rejects_manifest_version() {
+            let mut bytes = base_op().as_bytes().to_vec();
+            bytes[offset_of!(AttestSingleServiceOp, manifest_ver)] = 1;
+            let err = AttestSingleServiceOp::try_from_as_ref(&bytes).unwrap_err();
+            assert!(is_invalid_parameter(&err));
+        }
+
+        /// AttestSingleServiceOp embeds an AttestServicesOp. Parsing must
+        /// validate the reserved fields of the inner struct too, not just
+        /// its own reserved_5.
+        #[test]
+        fn try_from_as_ref_rejects_inner_reserved() {
+            let mut bytes = base_op().as_bytes().to_vec();
+            bytes[offset_of!(AttestServicesOp, reserved_1)] = 1;
+            let err = AttestSingleServiceOp::try_from_as_ref(&bytes).unwrap_err();
+            assert!(is_invalid_parameter(&err));
+        }
+
+        /// GUID bytes are stored in little-endian in the wire format;
+        /// verify get_guid() reconstructs the original UUID correctly.
+        #[test]
+        fn get_guid_round_trip() {
+            let expected = uuid!("c476f1eb-0123-45a5-9641-b4e7dde5bfe3");
+            let mut op = base_op();
+            op.guid = expected.to_bytes_le();
+            assert_eq!(op.get_guid(), expected);
+        }
+    }
+
+    mod guid_table {
+        use super::*;
+
+        /// Verify the serialized wire format for a single-entry GuidTable:
+        /// header GUID, total length, entry count, per-entry GUID, offset,
+        /// size, and trailing payload must all appear at the correct byte
+        /// positions.
+        #[test]
+        fn single_entry_wire_format() {
+            let guid = uuid!("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+            let payload = vec![0x01, 0x02, 0x03, 0x04];
+
+            let mut table = GuidTable::new();
+            table.push(guid, payload.clone());
+
+            let data = table.to_vec().unwrap();
+            assert_eq!(data.len(), 48 + payload.len());
+
+            let entry_count = u32::from_le_bytes(data[20..24].try_into().unwrap());
+            assert_eq!(entry_count, 1);
+
+            assert_eq!(&data[24..40], &guid.to_bytes_le());
+            let entry_offset = u32::from_le_bytes(data[40..44].try_into().unwrap());
+            assert_eq!(entry_offset, 48);
+            let entry_size = u32::from_le_bytes(data[44..48].try_into().unwrap());
+            assert_eq!(entry_size as usize, payload.len());
+
+            assert_eq!(&data[48..], &payload);
+        }
+
+        /// With two entries the payload offsets must account for the larger
+        /// header. This catches off-by-one errors in the offset arithmetic.
+        #[test]
+        fn multiple_entries_offset_arithmetic() {
+            let guid1 = uuid!("11111111-1111-1111-1111-111111111111");
+            let guid2 = uuid!("22222222-2222-2222-2222-222222222222");
+            let payload1 = vec![0xaa; 10];
+            let payload2 = vec![0xbb; 20];
+
+            let mut table = GuidTable::new();
+            table.push(guid1, payload1.clone());
+            table.push(guid2, payload2.clone());
+
+            let data = table.to_vec().unwrap();
+            assert_eq!(data.len(), 72 + 30);
+
+            let entry_count = u32::from_le_bytes(data[20..24].try_into().unwrap());
+            assert_eq!(entry_count, 2);
+
+            let offset1 = u32::from_le_bytes(data[40..44].try_into().unwrap());
+            assert_eq!(offset1, 72);
+            let offset2 = u32::from_le_bytes(data[64..68].try_into().unwrap());
+            assert_eq!(offset2, 82);
+
+            assert_eq!(&data[72..82], &payload1);
+            assert_eq!(&data[82..102], &payload2);
+        }
+    }
+
+    mod protocol_routing {
+        use super::*;
+
+        /// The protocol handler must reject unknown request codes with
+        /// UNSUPPORTED_PROTOCOL to prevent silent misrouting.
+        #[test]
+        fn rejects_unknown_request() {
+            let mut params = RequestParams::default();
+            let err = attest_protocol_request(99, &mut params).unwrap_err();
+            assert!(is_unsupported_protocol(&err));
+        }
     }
 }

--- a/scripts/test-in-svsm-attest.sh
+++ b/scripts/test-in-svsm-attest.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# Copyright (c) 2026 Coconut-SVSM Authors
+#
+# Run in-SVSM tests with attestation enabled by starting a local kbs-test
+# server and aproxy instance.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+SVSM_DIR="$SCRIPT_DIR/.."
+
+: "${TEST_IGVM:=$SVSM_DIR/bin/coconut-test-qemu.igvm}"
+: "${KBS_TEST_URL:=http://127.0.0.1:8080}"
+# Test-only placeholder secret; not used in production.
+: "${KBS_TEST_SECRET:=00112233445566778899aabbccddeeff}"
+: "${KBS_TEST_STARTUP_TIMEOUT:=300}"
+: "${APROXY_STARTUP_TIMEOUT:=30}"
+
+declare -a LAUNCH_GUEST_ARGS
+declare -a KBS_TEST_CMD
+
+LAUNCH_GUEST_ARGS=()
+KBS_TEST_CMD=()
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --nocc)
+            echo "Attestation tests require SEV-SNP hardware and do not support --nocc."
+            exit 1
+            ;;
+        --)
+            shift
+            while [[ $# -gt 0 ]]; do
+                LAUNCH_GUEST_ARGS+=("$1")
+                shift
+            done
+            ;;
+        *)
+            echo "Invalid parameter $1"
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -n "${KBS_TEST_BIN:-}" ]]; then
+    KBS_TEST_CMD=("$KBS_TEST_BIN")
+elif [[ -n "${KBS_TEST_DIR:-}" ]]; then
+    KBS_TEST_CMD=(cargo run --manifest-path "$KBS_TEST_DIR/Cargo.toml" --)
+elif command -v kbs-test >/dev/null 2>&1; then
+    KBS_TEST_CMD=(kbs-test)
+else
+    echo "Unable to find kbs-test. Set KBS_TEST_BIN or KBS_TEST_DIR."
+    exit 1
+fi
+
+for bin in "$SVSM_DIR/bin/igvmmeasure" "$SVSM_DIR/bin/aproxy"; do
+    if [[ ! -x "$bin" ]]; then
+        echo "Required executable not found: $bin"
+        exit 1
+    fi
+done
+
+if [[ ! -f "$TEST_IGVM" ]]; then
+    echo "Required test image not found: $TEST_IGVM"
+    exit 1
+fi
+
+TEST_DIR=$(mktemp -d -q)
+KBS_LOG="$TEST_DIR/kbs-test.log"
+APROXY_LOG="$TEST_DIR/aproxy.log"
+SVSM_LOG="$TEST_DIR/test-in-svsm.log"
+APROXY_SOCKET="$TEST_DIR/svsm-proxy.sock"
+KBS_PID=0
+APROXY_PID=0
+
+cleanup() {
+    if [[ $APROXY_PID -ne 0 ]]; then
+        kill "$APROXY_PID" 2>/dev/null || true
+    fi
+    if [[ $KBS_PID -ne 0 ]]; then
+        kill "$KBS_PID" 2>/dev/null || true
+    fi
+    rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT
+
+wait_for_http() {
+    local url="$1"
+    local pid="$2"
+    local timeout="$3"
+    local deadline=$((SECONDS + timeout))
+    while (( SECONDS < deadline )); do
+        if curl -sS --max-time 1 "$url" >/dev/null 2>&1; then
+            return 0
+        fi
+        if ! kill -0 "$pid" >/dev/null 2>&1; then
+            return 1
+        fi
+        sleep 0.2
+    done
+    return 1
+}
+
+wait_for_socket() {
+    local socket="$1"
+    local pid="$2"
+    local timeout="$3"
+    local deadline=$((SECONDS + timeout))
+    while (( SECONDS < deadline )); do
+        if [[ -S "$socket" ]]; then
+            return 0
+        fi
+        if ! kill -0 "$pid" >/dev/null 2>&1; then
+            return 1
+        fi
+        sleep 0.2
+    done
+    return 1
+}
+
+MEASUREMENT=$("$SVSM_DIR/bin/igvmmeasure" "$TEST_IGVM" measure -b)
+
+"${KBS_TEST_CMD[@]}" \
+    --measurement "$MEASUREMENT" \
+    --secret "$KBS_TEST_SECRET" >"$KBS_LOG" 2>&1 &
+KBS_PID=$!
+
+if ! wait_for_http "$KBS_TEST_URL" "$KBS_PID" "$KBS_TEST_STARTUP_TIMEOUT"; then
+    echo "Timed out waiting for kbs-test at $KBS_TEST_URL"
+    cat "$KBS_LOG"
+    exit 1
+fi
+
+"$SVSM_DIR/bin/aproxy" \
+    --protocol kbs \
+    --url "$KBS_TEST_URL" \
+    --unix "$APROXY_SOCKET" \
+    --force >"$APROXY_LOG" 2>&1 &
+APROXY_PID=$!
+
+if ! wait_for_socket "$APROXY_SOCKET" "$APROXY_PID" "$APROXY_STARTUP_TIMEOUT"; then
+    echo "Timed out waiting for aproxy socket: $APROXY_SOCKET"
+    cat "$APROXY_LOG"
+    exit 1
+fi
+
+set +e
+TEST_IGVM="$TEST_IGVM" \
+    "$SCRIPT_DIR/test-in-svsm.sh" \
+    -- \
+    --aproxy "$APROXY_SOCKET" \
+    ${LAUNCH_GUEST_ARGS[@]+"${LAUNCH_GUEST_ARGS[@]}"} 2>&1 | tee "$SVSM_LOG"
+SVSM_EXIT=${PIPESTATUS[0]}
+set -e
+
+if [[ $SVSM_EXIT -ne 0 ]]; then
+    echo "SVSM test failed with status $SVSM_EXIT"
+    echo "--- aproxy log ---"
+    cat "$APROXY_LOG"
+    echo "--- kbs-test log ---"
+    cat "$KBS_LOG"
+    exit $SVSM_EXIT
+fi
+
+if ! grep -q "attestation successful" "$SVSM_LOG"; then
+    echo "Attestation success message not found in SVSM output"
+    echo "--- aproxy log ---"
+    cat "$APROXY_LOG"
+    echo "--- kbs-test log ---"
+    cat "$KBS_LOG"
+    exit 1
+fi
+
+echo "Attestation test passed"

--- a/scripts/test-in-svsm.sh
+++ b/scripts/test-in-svsm.sh
@@ -8,6 +8,7 @@
 set -e
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+: "${TEST_IGVM:=$SCRIPT_DIR/../bin/coconut-test-qemu.igvm}"
 
 test_io(){
     PIPE_IN=$1
@@ -21,7 +22,7 @@ test_io(){
             # 0x01: return SEV-SNP pre-calculated launch measurement (48 bytes)
             "01")
                 $SCRIPT_DIR/../bin/igvmmeasure \
-                    $SCRIPT_DIR/../bin/coconut-test-qemu.igvm measure -b \
+                    "$TEST_IGVM" measure -b \
                     | xxd -r -p > $PIPE_IN
                 ;;
             # 0x02 Virtio-blk test: send md5 sum of svsm state image to SVSM.
@@ -67,7 +68,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 
-$SCRIPT_DIR/launch_guest.sh --igvm $SCRIPT_DIR/../bin/coconut-test-qemu.igvm \
+$SCRIPT_DIR/launch_guest.sh --igvm "$TEST_IGVM" \
     --state "$TEST_DIR/svsm_state.raw" \
     --unit-tests $TEST_DIR/pipe \
     $LAUNCH_GUEST_ARGS "$@" || svsm_exit_code=$?


### PR DESCRIPTION
<details>
<summary>This PR adds tests for both attestation surfaces.</summary>

SVSM exposes two distinct attestation surfaces: the pre-boot attestation feature (the attest Rust feature flag), which runs before the guest OS starts and uses a KBS to retrieve secrets, and the in-guest attestation
protocol, through which a VMPL0 guest can request a hardware attestation
report via SVSM.


</details>


For the in-guest attestation protocol the wire format of AttestServicesOp and AttestSingleServiceOp is fixed by the SVSM spec (Tables 11 and 13 of "Secure VM Service Module for SEV-SNP Guests, Rev 1.00"). A silent field reorder or padding change would break the binary interface with the guest, so the layout is now enforced with compile-time `const` assertions, following the pattern established in `greq/msg.rs`. Runtime tests cover reserved-field rejection, certificate region boundary enforcement, GUID table serialization, and that unknown request codes return `UNSUPPORTED_PROTOCOL`.

For pre-boot attestation, the `hash()` function feeds `NegotiationParams` into SHA-512 in the order dictated by the
server's `NegotiationResponse`. Because the server controls which params contribute and in what sequence, ordering sensitivity is a security property.
 Tests verify that `Challenge → EcPublicKeyBytes` and `EcPublicKeyBytes → Challenge` produce the expected individual digests and that swapping the order produces a distinct output.

The third commit adds a test script that exercises the pre-boot KBS flow end-to-end: it starts `kbs-test` and
`aproxy`, launches the SVSM test image built with the attest feature, and checks that "attestation successful" appears in the output. This requires a real SNP-capable machine and is not wired into the standard QEMU CI
workflow for that reason.

Related: https://github.com/coconut-svsm/svsm/issues/773