### PR TITLE
docs: move debugging instructions in a dedicated file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ verus*.log
 **/fuzz/corpus
 **/fuzz/artifacts
 **/fuzz/coverage
+
+# local GDB history
+.gdb_history

--- a/Documentation/docs/developer/DEBUGGING.md
+++ b/Documentation/docs/developer/DEBUGGING.md
@@ -46,8 +46,11 @@ virtual machine is started. You can then connect GDB to the waiting SVSM using
 the command, replacing `[n]` with the correct device index:
 
 ```shell
-sudo gdb --ex "target extended-remote /dev/pts/[n]`
+sudo gdb --ex "target extended-remote /dev/pts/[n]"
 ```
+
+**Note**: If you don't have acces to confidential hardware, you don't need to use
+```sudo```.
 
 If you have the source code available on the host system then you can add the
 debug symbols and use source-level debugging:

--- a/Documentation/docs/developer/DEBUGGING.md
+++ b/Documentation/docs/developer/DEBUGGING.md
@@ -1,0 +1,50 @@
+# Debugging
+
+The SVSM can be built to incorporate a GDB stub that can be used to provide full
+source-level debugging of the SVSM kernel code. To enable the GDB stub pass
+```FEATURES=enable-gdb``` to the ```make``` command line:
+
+```shell
+FW_FILE=/path/to/firmware/OVMF.fd make FEATURES=enable-gdb
+```
+
+The GDB stub remains dormant until a CPU exception occurs, either through a
+kernel panic or via a debug breakpoint, at which time the GDB stub will await a
+serial port connection and display this message in the console:
+
+```plain
+[SVSM] ***********************************
+[SVSM] * Waiting for connection from GDB *
+[SVSM] ***********************************
+```
+
+The GDB stub uses a hardware serial port at IO port 0x2f8, which is the second
+simulated serial port in the QEMU configuration. Using the example configuration
+above, the serial port is configured using `-serial pty`.
+
+QEMU will create a virtual serial port on the host at `/dev/pts/[n]` where `[n]`
+is the device index. This index will be reported by QEMU in the console when the
+virtual machine is started. You can then connect GDB to the waiting SVSM using
+the command, replacing `[n]` with the correct device index:
+
+```shell
+sudo gdb --ex "target extended-remote /dev/pts/[n]`
+```
+
+If you have the source code available on the host system then you can add the
+debug symbols and use source-level debugging:
+
+```plain
+(gdb) symbol-file target/x86_64-unknown-none/debug/svsm
+```
+
+Note that some GDB features are not available for debugging the SVSM kernel due
+to limited debug capabilities inside an AMD SEV-SNP confidential container. Some
+of these limitations may be addressed in future updates.
+
+* Hardware breakpoints and watchpoints are not yet supported.
+* Interrupting a running kernel with Ctrl-C is not possible. You must insert a
+  forced breakpoint in the code to enter the debugger before stepping through
+  target code.
+* Debugging is currently limited to the SVSM kernel itself. OVMF and the guest
+  OS cannot be debugged using the SVSM GDB stub.

--- a/Documentation/docs/developer/DEBUGGING.md
+++ b/Documentation/docs/developer/DEBUGGING.md
@@ -8,6 +8,15 @@ source-level debugging of the SVSM kernel code. To enable the GDB stub pass
 FW_FILE=/path/to/firmware/OVMF.fd make FEATURES=enable-gdb
 ```
 
+To launch SVSM you can use the following command:
+
+```shell
+QEMU=/path/to/qemu scripts/launch_guest.sh --debugserial
+```
+
+If you don't have access to confidential hardware (e.g., SEV-SNP), you can
+pass the ```--nocc``` option to the script.
+
 The GDB stub remains dormant until a CPU exception occurs, either through a
 kernel panic or via a debug breakpoint, at which time the GDB stub will await a
 serial port connection and display this message in the console:
@@ -18,9 +27,18 @@ serial port connection and display this message in the console:
 [SVSM] ***********************************
 ```
 
+Debug breakpoint can be inserted using the `debug_break` function defined in
+[svsm_gdbstub](../../rustdoc/svsm/debug/gdbstub/svsm_gdbstub) module.
+Make sure that feature `enable-gdb` is enabled, otherwise a call to that function
+will not have any effect.
+
+**Note**: Currently, there is a call to `debug_break` in the `svsm_init` function in
+[svsm.rs](https://github.com/coconut-svsm/svsm/blob/main/kernel/src/svsm.rs), but it is
+commented out. In order to generate an exception, you should uncomment it.
+
 The GDB stub uses a hardware serial port at IO port 0x2f8, which is the second
-simulated serial port in the QEMU configuration. Using the example configuration
-above, the serial port is configured using `-serial pty`.
+simulated serial port in the QEMU configuration. Using the `launch_guest` script,
+the serial port is configured with the `--debugserial` option.
 
 QEMU will create a virtual serial port on the host at `/dev/pts/[n]` where `[n]`
 is the device index. This index will be reported by QEMU in the console when the

--- a/Documentation/docs/installation/INSTALL.md
+++ b/Documentation/docs/installation/INSTALL.md
@@ -388,53 +388,7 @@ The script supports a number of other options described in the table below
 Debugging using GDB
 -------------------
 
-The SVSM can be built to incorporate a GDB stub that can be used to provide full
-source-level debugging of the SVSM kernel code. To enable the GDB stub pass
-```FEATURES=enable-gdb``` to the ```make``` command line:
-
-```shell
-FW_FILE=/path/to/firmware/OVMF.fd make FEATURES=enable-gdb
-```
-
-The GDB stub remains dormant until a CPU exception occurs, either through a
-kernel panic or via a debug breakpoint, at which time the GDB stub will await a
-serial port connection and display this message in the console:
-
-```plain
-[SVSM] ***********************************
-[SVSM] * Waiting for connection from GDB *
-[SVSM] ***********************************
-```
-
-The GDB stub uses a hardware serial port at IO port 0x2f8, which is the second
-simulated serial port in the QEMU configuration. Using the example configuration
-above, the serial port is configured using `-serial pty`.
-
-QEMU will create a virtual serial port on the host at `/dev/pts/[n]` where `[n]`
-is the device index. This index will be reported by QEMU in the console when the
-virtual machine is started. You can then connect GDB to the waiting SVSM using
-the command, replacing `[n]` with the correct device index:
-
-```shell
-sudo gdb --ex "target extended-remote /dev/pts/[n]`
-```
-
-If you have the source code available on the host system then you can add the
-debug symbols and use source-level debugging:
-
-```plain
-(gdb) symbol-file target/x86_64-unknown-none/debug/svsm
-```
-
-Note that some GDB features are not available for debugging the SVSM kernel due
-to limited debug capabilities inside an AMD SEV-SNP confidential container. Some
-of these limitations may be addressed in future updates.
-
-* Hardware breakpoints and watchpoints are not yet supported.
-* Interrupting a running kernel with Ctrl-C is not possible. You must insert a
-  forced breakpoint in the code to enter the debugger before stepping through
-  target code.
-* Debugging is currently limited to the SVSM kernel itself. OVMF and the guest
-  OS cannot be debugged using the SVSM GDB stub.
+The SVSM can be debugged by following the instructions in 
+[DEBUGGING.md](../developer/DEBUGGING.md) document.
 
 Have a lot of fun!

--- a/Documentation/mkdocs.yml
+++ b/Documentation/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
     - Rustdoc Guidelines: 'developer/RUSTDOC-GUIDELINES.md'
     - Testing: 'developer/TESTING.md'
     - Fuzzing: 'developer/FUZZING.md'
+    - Debugging: 'developer/DEBUGGING.md'
     - Contributing to COCONUT-SVSM: 'developer/CONTRIBUTING.md'
     - Formal Verification: 'developer/VERIFICATION.md'
     - Attestation: 'developer/ATTESTATION.md'


### PR DESCRIPTION
Move debug information in a dedicated file (`DEBUGGING.md) in the developer folder.

Add new information and instructions to launch a debug session.

Avoid tracking `.gdb_history`

Fix a typo in a gdb command in the documentation.

More information are available in the commits description.