### PR TITLE
github/workflows: fix audit and update some actions to Node24

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install cargo-audit
-        run: cargo install cargo-audit
+        run: cargo install cargo-audit --locked
 
       - name: Run cargo audit
         run: cargo audit

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -22,7 +22,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install cargo-audit
         run: cargo install cargo-audit

--- a/.github/workflows/qemu.yml
+++ b/.github/workflows/qemu.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Get QEMU from cache
         id: qemu_cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: citests/qemu
           key: qemu-${{ env.QEMU_SHA }}--config-${{ env.QEMU_YML_SHA }}

--- a/.github/workflows/spdx.yml
+++ b/.github/workflows/spdx.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0


### PR DESCRIPTION
The `audit` workflow was using an old version of `actions/checkout`, which has the problem on
Nodejs version 20. See issue [1020](https://github.com/coconut-svsm/svsm/issues/1020) and PR [1016](https://github.com/coconut-svsm/svsm/pull/1016). Update it to the same version as any other workflow.

The same applies to workflow `spdx` and `qemu`, with the actions `checkout` and `harden-runner` for the former and the action `cache` for the latter.

Additionally, when trying to run `audit`, see an [example](https://github.com/n-ramacciotti/svsm/actions/runs/23689497141) on my fork (which shows both the annotations), it fails with the following error:
```
...
error: failed to compile `cargo-audit v0.22.1`, intermediate artifacts can be found at `/tmp/cargo-installoPVcZT`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

Caused by:
  rustc 1.88.0 is not supported by the following package:
    smol_str@0.3.6 requires rustc 1.89
  Try re-running `cargo install` with `--locked`
```

Adding `--locked` solves the issue.


---

Note: There is the [audit-check](https://github.com/rustsec/audit-check) action, which seems to support Node24. However, it doesn't seem to be maintained frequently. Probably it doesn't require much attention, as it seems the case for other actions that I've seen. Could it be useful? ~~I will look into it in the next few days.~~

**update**: it doesn't seem to have an actual release with that commit, so it is probably better to wait for one before changing the workflow.