### PR TITLE
kernel: cpu/tlb: enable partial per-CPU TLB flushes

### DIFF
--- a/kernel/src/cpu/tlb.rs
+++ b/kernel/src/cpu/tlb.rs
@@ -95,8 +95,8 @@ impl TlbFlushScope {
     /// Flushes all the entries in the TLB for the current CPU.
     fn flush_percpu_all(&self) {
         match self.global {
-            true => flush_tlb_global_percpu(),
-            false => flush_tlb_percpu(),
+            true => __flush_tlb_global_percpu(),
+            false => __flush_tlb_percpu(),
         }
     }
 
@@ -147,6 +147,26 @@ pub fn flush_tlb_global_sync_page(vaddr: VirtAddr, pgsize: PageSize) {
 }
 
 pub fn flush_tlb_global_percpu() {
+    TlbFlushScope::all().with_global(true).flush_percpu();
+}
+
+pub fn flush_tlb_global_percpu_range(region: MemoryRegion<VirtAddr>, pgsize: PageSize) {
+    TlbFlushScope::range(region, pgsize)
+        .with_global(true)
+        .flush_percpu();
+}
+
+pub fn flush_tlb_global_percpu_page(vaddr: VirtAddr, pgsize: PageSize) {
+    TlbFlushScope::page(vaddr, pgsize)
+        .with_global(true)
+        .flush_percpu();
+}
+
+pub fn flush_tlb_percpu() {
+    TlbFlushScope::all().with_global(false).flush_percpu();
+}
+
+fn __flush_tlb_global_percpu() {
     let cr4 = read_cr4();
 
     // SAFETY: we are not changing any execution-state relevant flags
@@ -156,7 +176,7 @@ pub fn flush_tlb_global_percpu() {
     }
 }
 
-pub fn flush_tlb_percpu() {
+fn __flush_tlb_percpu() {
     // SAFETY: reloading CR3 with its current value is always safe.
     unsafe {
         write_cr3(read_cr3());

--- a/kernel/src/cpu/tlb.rs
+++ b/kernel/src/cpu/tlb.rs
@@ -43,6 +43,36 @@ pub struct TlbFlushScope {
 }
 
 impl TlbFlushScope {
+    /// Creates a TLB flush scope for all all addresses (including global).
+    pub const fn all() -> Self {
+        Self {
+            global: true,
+            range: TlbFlushRange::All,
+        }
+    }
+
+    /// Updates the scope to include or exclude global pages, as indicated.
+    pub const fn with_global(mut self, global: bool) -> Self {
+        self.global = global;
+        self
+    }
+
+    /// Creates a new TLB flush scope, including only a range of virtual addresses
+    /// (which may be global).
+    pub const fn range(region: MemoryRegion<VirtAddr>, pgsize: PageSize) -> Self {
+        Self {
+            global: true,
+            range: TlbFlushRange::Range { region, pgsize },
+        }
+    }
+
+    /// Creates a new TLB flush scope, including only a single page (which may be
+    /// global).
+    pub fn page(va: VirtAddr, pgsize: PageSize) -> Self {
+        let region = MemoryRegion::new(va, usize::from(pgsize));
+        Self::range(region, pgsize)
+    }
+
     /// Flushes the TLB for the current CPU.
     pub fn flush_percpu(&self) {
         match self.range {
@@ -101,23 +131,19 @@ pub fn set_tlb_flush_smp() {
 }
 
 pub fn flush_tlb_global_sync() {
-    let flush_scope = TlbFlushScope {
-        global: true,
-        range: TlbFlushRange::All,
-    };
-    flush_scope.flush_all_cpus();
+    TlbFlushScope::all().with_global(true).flush_all_cpus();
 }
 
 pub fn flush_tlb_global_sync_range(region: MemoryRegion<VirtAddr>, pgsize: PageSize) {
-    let flush_scope = TlbFlushScope {
-        global: true,
-        range: TlbFlushRange::Range { region, pgsize },
-    };
-    flush_scope.flush_all_cpus();
+    TlbFlushScope::range(region, pgsize)
+        .with_global(true)
+        .flush_all_cpus();
 }
 
 pub fn flush_tlb_global_sync_page(vaddr: VirtAddr, pgsize: PageSize) {
-    flush_tlb_global_sync_range(MemoryRegion::new(vaddr, pgsize.into()), pgsize);
+    TlbFlushScope::page(vaddr, pgsize)
+        .with_global(true)
+        .flush_all_cpus();
 }
 
 pub fn flush_tlb_global_percpu() {

--- a/kernel/src/mm/ptguards.rs
+++ b/kernel/src/mm/ptguards.rs
@@ -7,7 +7,7 @@
 use super::pagetable::PTEntryFlags;
 use crate::address::{Address, PhysAddr, VirtAddr};
 use crate::cpu::percpu::this_cpu;
-use crate::cpu::tlb::flush_address_percpu;
+use crate::cpu::tlb::flush_tlb_global_percpu_range;
 use crate::error::SvsmError;
 use crate::mm::virtualrange::VRangeAlloc;
 use crate::types::{PAGE_SIZE, PAGE_SIZE_2M, PageSize};
@@ -128,11 +128,8 @@ impl Drop for PerCPUPageMappingGuard {
             this_cpu().get_pgtable().unmap_region_4k(region);
             PageSize::Regular
         };
-        // This iterative flush is acceptable for same-CPU mappings because no
-        // broadcast is involved for each iteration.
-        for page in region.iter_pages(size) {
-            flush_address_percpu(page);
-        }
+
+        flush_tlb_global_percpu_range(region, size);
     }
 }
 

--- a/kernel/src/mm/vm/range.rs
+++ b/kernel/src/mm/vm/range.rs
@@ -5,7 +5,7 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 
 use crate::address::{Address, VirtAddr};
-use crate::cpu::{flush_tlb_global_percpu, flush_tlb_global_sync_range};
+use crate::cpu::{flush_tlb_global_percpu_range, flush_tlb_global_sync_range};
 use crate::error::SvsmError;
 use crate::locking::RWLock;
 use crate::mm::pagetable::{PTEntryFlags, PageTable, PageTablePart};
@@ -435,15 +435,18 @@ impl VMR {
 
         let mut cursor = tree.find_mut(&addr);
         let node = cursor.remove().ok_or(SvsmError::Mem)?;
-
         self.unmap_vmm(&node);
+
+        let range = node.range();
+        let region = MemoryRegion::from_addresses(range.0, range.1);
+        let pgsize = node.get_mapping().page_size();
+
         if self.per_cpu {
-            flush_tlb_global_percpu();
+            flush_tlb_global_percpu_range(region, pgsize);
         } else {
-            let range = node.range();
-            let region = MemoryRegion::from_addresses(range.0, range.1);
-            flush_tlb_global_sync_range(region, node.get_mapping().page_size());
+            flush_tlb_global_sync_range(region, pgsize);
         }
+
         Ok(node)
     }
 


### PR DESCRIPTION
Now that partial SMP TLB flushes are enabled using `TlbFlushScope`, update the per-CPU TLB flush methods to use the type as well. This also includes adding `TlbFlushScope` constructor methods for convenience.