### PR TITLE
bldr: introduce a new boot loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "bldr"
+version = "0.1.0"
+dependencies = [
+ "bootdefs",
+ "cpuarch",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1813,6 +1821,7 @@ name = "stage1"
 version = "0.1.0"
 dependencies = [
  "bootdefs",
+ "cpuarch",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,6 +485,7 @@ name = "cpuarch"
 version = "0.1.0"
 dependencies = [
  "bitfield-struct 0.6.2",
+ "bitflags",
  "zerocopy",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     # binary targets
     "stage1",
     "kernel",
+    "boot/bldr",
     # fuzzing
     "fuzz",
     # ELF loader
@@ -50,6 +51,7 @@ edition = "2024"
 
 [workspace.dependencies]
 # internal library crates
+bldr = { path = "boot/bldr" }
 bootdefs = { path = "boot/defs" }
 bootimg = { path = "boot/bootimg" }
 cpuarch = { path = "cpuarch" }

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ STAGE1_RUSTC_ARGS += -C panic=abort
 
 STAGE1_ELF = "target/x86_64-unknown-none/${TARGET_PATH}/stage1"
 STAGE2_ELF = "target/x86_64-unknown-none/${TARGET_PATH}/stage2"
+BLDR_ELF = "target/x86_64-unknown-none/$(TARGET_PATH)/bldr"
 SVSM_KERNEL_ELF = "target/x86_64-unknown-none/${TARGET_PATH}/svsm"
 FS_BIN=bin/svsm-fs.bin
 FS_FILE ?= none
@@ -144,6 +145,10 @@ docsite:
 docsite-serve:
 	mkdocs serve -f Documentation/mkdocs.yml
 
+bin/bldr.bin: bin
+	cargo build --package bldr $(CARGO_ARGS) --target=x86_64-unknown-none
+	objcopy -O binary $(BLDR_ELF) $@
+
 bin/stage2.bin: bin
 	cargo build --package svsm --bin stage2 ${CARGO_ARGS} --target=x86_64-unknown-none
 	objcopy -O binary ${STAGE2_ELF} $@
@@ -178,6 +183,7 @@ clippy:
 	${CARGO} clippy ${CLIPPY_OPTIONS} --workspace --exclude svsm --exclude stage1 --exclude svsm-fuzz -- ${CLIPPY_ARGS}
 	RUSTFLAGS="--cfg fuzzing" ${CARGO} clippy ${CLIPPY_OPTIONS} --package svsm-fuzz -- ${CLIPPY_ARGS}
 	${CARGO} clippy ${CLIPPY_OPTIONS} --package svsm --target x86_64-unknown-none -- ${CLIPPY_ARGS}
+	${CARGO} clippy ${CLIPPY_OPTIONS} --package bldr --target x86_64-unknown-none -- ${CLIPPY_ARGS}
 	${CARGO} clippy ${CLIPPY_OPTIONS} --package stage1 --target x86_64-unknown-none -- ${CLIPPY_ARGS} ${STAGE1_RUSTC_ARGS}
 	${CARGO} clippy ${CLIPPY_OPTIONS} --workspace --tests --exclude svsm -- ${CLIPPY_ARGS}
 	${CARGO} clippy ${CLIPPY_OPTIONS} --package svsm ${SVSM_ARGS_TEST} --tests -- ${CLIPPY_ARGS}
@@ -189,4 +195,4 @@ clean:
 
 distclean: clean
 
-.PHONY: test miri clean clippy bin/stage2.bin bin/svsm-kernel.elf bin/test-kernel.elf stage1_elf_trampoline distclean $(APROXYBIN) $(IGVM_FILES) $(IGVM_TEST_FILES)
+.PHONY: test miri clean clippy bin/bldr.bin bin/stage2.bin bin/svsm-kernel.elf bin/test-kernel.elf stage1_elf_trampoline distclean $(APROXYBIN) $(IGVM_FILES) $(IGVM_TEST_FILES)

--- a/boot/bldr/.cargo/config.toml
+++ b/boot/bldr/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "x86_64-unknown-none"

--- a/boot/bldr/Cargo.toml
+++ b/boot/bldr/Cargo.toml
@@ -1,20 +1,17 @@
 [package]
-name = "stage1"
+name = "bldr"
 version = "0.1.0"
 edition.workspace = true
 
 [[bin]]
-name = "stage1"
-path = "src/stage1.rs"
+name = "bldr"
+path = "src/main.rs"
 test = false
-
-[features]
-default = []
-load-stage2 = []
+doc = false
 
 [dependencies]
-bootdefs.workspace = true
 cpuarch.workspace = true
+bootdefs.workspace = true
 
 [lints]
 workspace = true

--- a/boot/bldr/build.rs
+++ b/boot/bldr/build.rs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2022-2023 SUSE LLC
+//
+// Author: Joerg Roedel <jroedel@suse.de>
+
+fn main() {
+    let target = std::env::var("TARGET").unwrap();
+
+    if target == "x86_64-unknown-none" {
+        println!("cargo:rustc-link-arg=--build-id=none");
+    }
+
+    println!("cargo:rustc-link-arg=-nostdlib");
+    println!("cargo:rustc-link-arg=-Tboot/bldr/src/bldr.lds");
+    println!("cargo:rustc-link-arg=-no-pie");
+
+    println!("cargo:rerun-if-changed=boot/bldr/src/bldr.lds");
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/boot/bldr/src/bldr.lds
+++ b/boot/bldr/src/bldr.lds
@@ -1,0 +1,51 @@
+/* SPDX-License-Identifier: MIT OR Apache-2.0 */
+
+/*
+ * Copyright (c) 2022-2023 SUSE LLC
+ *
+ * Author: Joerg Roedel <jroedel@suse.de>
+ */
+
+OUTPUT_ARCH(i386:x86-64)
+
+SECTIONS
+{
+	/* Base address is 8 MB + 32 KB */
+	. = 8m + 32k;
+	.stext = .;
+	.text : {
+		*(.startup.*)
+		*(.text)
+		*(.text.*)
+		. = ALIGN(16);
+		entry_code_start = .;
+		*(.entry.text)
+		entry_code_end = .;
+		. = ALIGN(16);
+		early_exception_table_start = .;
+		KEEP(*(__early_exception_table))
+		early_exception_table_end = .;
+		. = ALIGN(16);
+		exception_table_start = .;
+		KEEP(*(__exception_table))
+		exception_table_end = .;
+	}
+	. = ALIGN(16);
+	.data : { *(.data) }
+	edata = .;
+	. = ALIGN(16);
+	.bss : {
+		_bss = .;
+		*(.bss) *(.bss.[0-9a-zA-Z_]*)
+		. = ALIGN(16);
+		_ebss = .;
+	}
+	/* Move rodata to follow bss so that the in-memory image has the same
+	 * length as the ELF image.  This is required so that the IGVM
+	 * builder does not have to parse the ELF file to know how much space
+	 * to reserve for BSS. */
+	. = ALIGN(16);
+	.rodata : { *(.rodata) }
+}
+
+ENTRY(startup_32)

--- a/boot/bldr/src/main.rs
+++ b/boot/bldr/src/main.rs
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Jon Lange <jlange@microsoft.com>
+
+#![no_std]
+#![no_main]
+
+mod temp_maps;
+
+use crate::temp_maps::TempMappings;
+use bootdefs::kernel_launch::BldrLaunchInfo;
+use bootdefs::kernel_launch::KernelLaunchInfo;
+use bootdefs::platform::SvsmPlatformType;
+use core::alloc::GlobalAlloc;
+use core::alloc::Layout;
+use core::arch::global_asm;
+use core::mem::offset_of;
+use core::slice;
+use cpuarch::sev_status::MSR_SEV_STATUS;
+use cpuarch::sev_status::SEVStatusFlags;
+use cpuarch::x86::CR0Flags;
+use cpuarch::x86::EFERFlags;
+use cpuarch::x86::MSR_EFER;
+
+global_asm!(
+    r#"
+        .section .text
+        .section .startup.text,"ax"
+        .code32
+
+        .globl startup_32
+        startup_32:
+
+        /* Upon entry, ESI holds the high 32 bits of VTOM. */
+
+        /* Save pointer to startup structure in EBP */
+        movl %esp, %ebp
+
+        /* Save the platform type for future use.  The platform type is loaded
+         * in EAX upon entry. */
+        movl %eax, {PLATFORM}(%ebp)
+
+        /* Check to see whether this is an SNP system.  If not, no page table
+         * manipulation is required. */
+        cmpl $1, %eax
+        jnz page_tables_ready
+
+        /* Check to see whether vTOM is active on this system.  If so, no page
+         * table manipulation is necessary */
+        movl ${MSR_SEV_STATUS}, %ecx
+        rdmsr
+        testl ${VTOM}, %eax
+        jnz page_tables_ready
+
+        /* Locate the CPUID page */
+        movl {CPUID_PAGE}(%ebp), %edx
+
+        /* Determine the number of entries and the address of the first
+         * entry.  The contents of the CPUID page have been validated by
+         * the SNP firmware so the data can be trusted directly. */
+        movl (%edx), %ecx
+        leal 16(%edx), %edx
+
+    10:
+        /* Check to see whether this entry is the extended SEV leaf.  If not,
+         * keep searching */
+        cmpl $0x8000001F, (%edx)
+        jz 11f
+        leal 48(%edx), %edx
+        dec %ecx
+        jnz 10b
+        ud2
+
+    11:
+        /* The C-bit position is encoded as the low 6 bits of the EBX field. */
+        mov 28(%edx), %eax
+        andl $0x3F, %eax
+
+        /* Save the C-bit position for later use. */
+        movl %eax, {C_BIT_POS}(%ebp)
+
+        /* Obtain the bounds of the page tables. */
+        movl {PT_START}(%ebp), %ecx
+        movl {PT_END}(%ebp), %edx
+
+        /* Insert the C-bit into each valid PTE. */
+    1:
+        testl $1, (%ecx)
+        jz 2f
+        bts %eax, (%ecx)
+    2:
+        addl $8, %ecx
+        cmp %edx, %ecx
+        jb 1b
+
+    page_tables_ready:
+        /* The page tables are now configured, so enable long mode. */
+        movl ${MSR_EFER}, %ecx
+        rdmsr
+        movl %eax, %ebx
+
+        /* Include both EFER.LME and EFER.NXE since the page tables will use
+         * the NX bit. */
+        orl $({EFER_LME} | {EFER_NXE}), %eax
+
+        /* Don't write the MSR if it is already correct. */
+        cmpl %eax, %ebx
+        jz 3f
+        wrmsr
+    3:
+        /* Enable paging so that long mode can be activated. */
+        movl {PT_ROOT}(%ebp), %edx
+        movl %edx, %cr3
+        movl %cr0, %eax
+        bts ${PG_SHIFT}, %eax
+        movl %eax, %cr0
+
+        /* Establish the correct GDT and jump to the 64-bit entry point. */
+        movl $gdt64_desc, %eax
+        lgdt (%eax)
+        ljmpl $0x8, $startup_64
+
+        .code64
+
+    startup_64:
+        /* Reload the data segments with 64bit descriptors. */
+        movw $0x10, %ax
+        movw %ax, %ds
+        movw %ax, %es
+        movw %ax, %fs
+        movw %ax, %gs
+        movw %ax, %ss
+
+        /*
+         * Follow the C calling convention for x86-64:
+         *
+         * - Pass &BldrLaunchInfo as the first argument (%rdi)
+         * - Pass VTOM as the second argument (%rsi)
+         * - Make sure (%rsp + 8) is 16b-aligned when control is transferred
+         *   to stage2_main
+         */
+        movl %ebp, %edi
+        shlq $32, %rsi
+        andq $~0xf, %rsp
+
+        /* Mark the next stack frame as the bottom frame */
+        xor %rbp, %rbp
+
+        call bldr_main
+
+        .globl switch_to_kernel
+    switch_to_kernel:
+        /* Switch to the kernel stack. */
+        movq %rsi, %rsp
+
+        /* Load the platform type into rax as expected by the kernel */
+        movq %rdx, %rax
+
+        /* Enter the kernel. */
+        push %rdi
+        ret
+
+        .globl pvalidate_one
+    pvalidate_one:
+        movq %rdi, %rax
+        xorl %ecx, %ecx
+        movl $1, %edx
+        pvalidate
+        jb 1f
+        ret
+    1:
+        ud2
+
+        .data
+        .align 16
+    gdt64:
+        .quad 0
+        .quad 0x00af9a000000ffff /* 64 bit code segment */
+        .quad 0x00cf92000000ffff /* 64 bit data segment */
+    gdt64_end:
+
+    gdt64_desc:
+        .word gdt64_end - gdt64 - 1
+        .quad gdt64
+        "#,
+    MSR_EFER = const MSR_EFER,
+    EFER_NXE = const EFERFlags::NXE.bits(),
+    EFER_LME = const EFERFlags::LME.bits(),
+    PG_SHIFT = const CR0Flags::PG.bits().trailing_zeros(),
+    MSR_SEV_STATUS = const MSR_SEV_STATUS,
+    VTOM = const SEVStatusFlags::VTOM.bits(),
+    PT_START = const offset_of!(BldrLaunchInfo, page_table_start) as u32,
+    PT_END = const offset_of!(BldrLaunchInfo, page_table_end) as u32,
+    PT_ROOT = const offset_of!(BldrLaunchInfo, page_table_root) as u32,
+    CPUID_PAGE = const offset_of!(BldrLaunchInfo, cpuid_addr) as u32,
+    PLATFORM = const offset_of!(BldrLaunchInfo, platform_type) as u32,
+    C_BIT_POS = const offset_of!(BldrLaunchInfo, c_bit_position) as u32,
+    options(att_syntax)
+);
+
+unsafe extern "C" {
+    fn switch_to_kernel(entry: u64, initial_stack: u64, platform_type: u64) -> !;
+    fn pvalidate_one(addr: u64);
+}
+
+fn copy_cpuid_page(launch_info: &BldrLaunchInfo, kernel_launch_info: &mut KernelLaunchInfo) {
+    // SAFETY: the addresses described in the launch info pages are correct
+    // for use for copying.
+    unsafe {
+        // The kernel CPUID page must be validated before it can be filled
+        // since it behaves like a loader-populated page.
+        pvalidate_one(kernel_launch_info.cpuid_page);
+        let src = slice::from_raw_parts(launch_info.cpuid_addr as usize as *const u8, 0x1000);
+        let dst = slice::from_raw_parts_mut(kernel_launch_info.cpuid_page as *mut u8, 0x1000);
+        dst.copy_from_slice(src);
+    }
+}
+
+fn update_kernel_page_tables(launch_info: &BldrLaunchInfo, confidentiality_mask: u64) {
+    // SAFETY: the launch info is trusted to describe the temporary mapping
+    // region correctly.
+    let mut temp_maps = unsafe { TempMappings::new(launch_info, confidentiality_mask) };
+
+    // Proceed through each of the kernel page table pages and map each one
+    // into the address space so it can be updated.
+    for i in 0..launch_info.kernel_pt_count {
+        // SAFETY: the launch info is trusted to provide correct physical
+        // addresses for the kernel page tables.
+        let mut page_table_ref =
+            unsafe { temp_maps.map_page(launch_info.kernel_pt_paddr + (i << 12)) };
+        // SAFETY: the page table physical address is trusted to represent a
+        // page of page table entries.
+        let page_table = unsafe { page_table_ref.as_slice::<u64>() };
+
+        // Update all valid PTEs in this page with the confidentiality mask.
+        for pte in page_table {
+            if (*pte & 1) != 0 {
+                *pte |= confidentiality_mask;
+            }
+        }
+
+        drop(page_table_ref);
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn bldr_main(launch_info: &BldrLaunchInfo, vtom: u64) -> ! {
+    // Map the kernel virtual address range into the current page tables.
+    // SAFETY: the launch information correctly describes the current page
+    // tables so their contents can be obtained as a slice.
+    let page_tables =
+        unsafe { slice::from_raw_parts_mut(launch_info.page_table_root as usize as *mut u64, 512) };
+
+    // Determine the correct confidentiality mask for this platform.
+    let platform_type = SvsmPlatformType::from(launch_info.platform_type);
+    let confidentiality_mask =
+        if (platform_type == SvsmPlatformType::Snp) && (launch_info.c_bit_position != 0) {
+            1u64 << launch_info.c_bit_position
+        } else {
+            0
+        };
+
+    // If this platform uses a confidentiality mask, then update the kernel
+    // page tables now.
+    if confidentiality_mask != 0 {
+        update_kernel_page_tables(launch_info, confidentiality_mask);
+    }
+
+    // Insert the kernel page tables into the current address space.
+    page_tables[launch_info.kernel_pml4e_index as usize] =
+        launch_info.kernel_pdpt_paddr | 0x63 | confidentiality_mask;
+
+    // Obtain a reference to the kernel launch parameters in the kernel address
+    // space.
+    // SAFETY: the boot loader launch parameters supply the correct virtual
+    // address of the kernel launch parameters.
+    let kernel_launch_info =
+        unsafe { &mut *(launch_info.kernel_launch_info as *mut KernelLaunchInfo) };
+
+    kernel_launch_info.lowmem_page_table_paddr = launch_info.page_table_start;
+    kernel_launch_info.lowmem_page_table_count =
+        (launch_info.page_table_end - launch_info.page_table_start) / 0x1000;
+    kernel_launch_info.vtom = vtom;
+
+    // If this is an SNP system, copy the CPUID page from the boot loader
+    // address space into the kernel CPUID page.
+    if launch_info.platform_type == u32::from(SvsmPlatformType::Snp) {
+        copy_cpuid_page(launch_info, kernel_launch_info);
+    }
+
+    // Transition to the kernel.
+    // SAFETY: the kernel launch context is correctly specified in the boot
+    // loader launch parameters.
+    unsafe {
+        switch_to_kernel(
+            launch_info.kernel_entry,
+            launch_info.kernel_stack,
+            launch_info.platform_type as u64,
+        );
+    }
+}
+
+#[cfg(not(test))]
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo<'_>) -> ! {
+    // SAFETY: raising an undefined instuction exception is always safe.
+    unsafe { core::arch::asm!("ud2") }
+    unreachable!("");
+}
+
+struct Alloc;
+
+// SAFETY: A global allocator is required to satisfy linkage requirements of
+// external crates.  However, the bootloader never performs heap allocation.
+// Consequently, all methods panic, which is sound.
+unsafe impl GlobalAlloc for Alloc {
+    /// # Safety
+    /// All allocator functions are unsafe.  This one simply panics.
+    unsafe fn alloc(&self, _: Layout) -> *mut u8 {
+        panic!("");
+    }
+
+    /// # Safety
+    /// All allocator functions are unsafe.  This one simply panics.
+    unsafe fn dealloc(&self, _: *mut u8, _: Layout) {
+        panic!("");
+    }
+
+    /// # Safety
+    /// All allocator functions are unsafe.  This one simply panics.
+    unsafe fn alloc_zeroed(&self, _: Layout) -> *mut u8 {
+        panic!("");
+    }
+
+    /// # Safety
+    /// All allocator functions are unsafe.  This one simply panics.
+    unsafe fn realloc(&self, _: *mut u8, _: Layout, _: usize) -> *mut u8 {
+        panic!("");
+    }
+}
+
+#[global_allocator]
+static ALLOC: Alloc = Alloc;

--- a/boot/bldr/src/temp_maps.rs
+++ b/boot/bldr/src/temp_maps.rs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Jon Lange <jlange@microsoft.com>
+
+use bootdefs::kernel_launch::BldrLaunchInfo;
+use core::arch::asm;
+use core::slice;
+
+#[derive(Debug)]
+pub struct TempMappings<'a> {
+    ptes: &'a mut [u64],
+    mappings_vaddr: u64,
+    confidentiality_mask: u64,
+    index: usize,
+    active: bool,
+}
+
+impl<'a> TempMappings<'a> {
+    /// # Safety
+    /// The caller must ensure that the physical and virtual addresses for the
+    /// page table mappings specified in the launch info are correct and can
+    /// be used for mapping purposes.
+    pub unsafe fn new(launch_info: &BldrLaunchInfo, confidentiality_mask: u64) -> Self {
+        // SAFETY: the caller guarantees the correctness of the page table
+        // addresses.
+        let ptes = unsafe {
+            slice::from_raw_parts_mut(launch_info.page_table_start as usize as *mut u64, 0x200)
+        };
+        Self {
+            ptes,
+            mappings_vaddr: launch_info.page_table_map_vaddr,
+            confidentiality_mask,
+            index: 0,
+            active: false,
+        }
+    }
+
+    /// # Safety
+    /// The caller must guarantee that the address describes memory that can
+    /// be modified safely.
+    pub unsafe fn map_page<'b>(&'b mut self, paddr: u64) -> TempMappingRef<'b, 'a> {
+        // A second mapping cannot be created while another mapping is active.
+        assert!(!self.active);
+
+        // If the next index in sequence is beyond the end of this page, then
+        // force a TLB flush so the PTEs can be reused.
+        if self.index == self.ptes.len() {
+            // SAFETY: the paging root will be reloaded with its current
+            // value, which is always safe.
+            unsafe {
+                asm!("movq %cr3, %rax",
+                     "movq %rax, %cr3",
+                     out("rax") _,
+                     options(att_syntax));
+            }
+
+            self.index = 0;
+        }
+
+        // Construct a new PTE to map the specified physical address, which
+        // must be aligned to a page boundary.  The PTE encodes valid,
+        // write, accessed, and dirty.
+        assert!((paddr & 0xFFF) == 0);
+        self.ptes[self.index] = 0x63 | paddr | self.confidentiality_mask;
+        let vaddr = self.mappings_vaddr as usize + (self.index << 12);
+        self.index += 1;
+        self.active = true;
+
+        // Construct a mapping reference that describes this mapping.  The
+        // reference object will release the `active` state once the mapping
+        // has been dropped.
+        TempMappingRef {
+            mappings: self,
+            vaddr,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct TempMappingRef<'b, 'a> {
+    mappings: &'b mut TempMappings<'a>,
+    vaddr: usize,
+}
+
+impl TempMappingRef<'_, '_> {
+    /// # Safety
+    /// The caller must ensure that the mapping that was created can be
+    /// interpreted as a slice of type `T`.
+    pub unsafe fn as_slice<T>(&mut self) -> &mut [T] {
+        // SAFETY: the caller guarantees the correct usability of type `T`
+        // when generating the slice.
+        unsafe { slice::from_raw_parts_mut(self.vaddr as *mut T, 0x1000 / size_of::<T>()) }
+    }
+}
+
+impl Drop for TempMappingRef<'_, '_> {
+    fn drop(&mut self) {
+        self.mappings.active = false;
+    }
+}

--- a/boot/bootimg/src/defs.rs
+++ b/boot/bootimg/src/defs.rs
@@ -43,6 +43,7 @@ pub struct BootImageContext {
 pub struct BootImageInfo {
     pub context: BootImageContext,
     pub kernel_page_tables_base: u64,
+    pub kernel_page_tables_virt_base: u64,
     pub total_pt_pages: u64,
     pub kernel_launch_info: u64,
     pub boot_params_paddr: u64,

--- a/boot/bootimg/src/lib.rs
+++ b/boot/bootimg/src/lib.rs
@@ -142,7 +142,8 @@ where
 
     // Now that all mapping is complete, add the page table contents into the
     // boot image.
-    let (paging_root, total_pt_pages) = kernel_page_tables.add_to_image(add_page_data)?;
+    let (paging_root, paging_root_virt, total_pt_pages) =
+        kernel_page_tables.add_to_image(add_page_data)?;
 
     // Allocate memory to hold the kernel launch info block.
     let (launch_info_paddr, launch_info_vaddr) =
@@ -174,6 +175,8 @@ where
         suppress_svsm_interrupts: false,
         vmsa_in_kernel_heap,
         lowmem_validated: false,
+        lowmem_page_table_paddr: 0,
+        lowmem_page_table_count: 0,
         _reserved: Default::default(),
     };
     add_page_contents(add_page_data, launch_info_paddr, launch_info.as_bytes())?;
@@ -204,6 +207,7 @@ where
         kernel_pml4e_index: kernel_page_tables.kernel_pml4e_index(),
         total_pt_pages,
         kernel_page_tables_base: paging_root,
+        kernel_page_tables_virt_base: paging_root_virt,
         context: BootImageContext {
             entry_point: kernel_entry,
             paging_root,

--- a/boot/bootimg/src/page_tables.rs
+++ b/boot/bootimg/src/page_tables.rs
@@ -225,7 +225,7 @@ impl KernelPageTables {
         }
     }
 
-    pub fn add_to_image<F>(&self, add_page_data: &mut F) -> Result<(u64, u64), BootImageError>
+    pub fn add_to_image<F>(&self, add_page_data: &mut F) -> Result<(u64, u64, u64), BootImageError>
     where
         F: FnMut(u64, Option<&[u8]>, u64) -> Result<(), BootImageError>,
     {
@@ -234,7 +234,7 @@ impl KernelPageTables {
             self.starting_paddr,
             self.pte_allocation.as_bytes(),
         )
-        .and(Ok((self.paging_root, self.total_pt_pages)))
+        .and(Ok((self.paging_root, self.root_vaddr, self.total_pt_pages)))
     }
 }
 

--- a/boot/defs/src/kernel_launch.rs
+++ b/boot/defs/src/kernel_launch.rs
@@ -52,6 +52,8 @@ pub struct KernelLaunchInfo {
     pub kernel_strtab_len: u64,
     pub vtom: u64,
     pub kernel_page_table_vaddr: u64,
+    pub lowmem_page_table_paddr: u32,
+    pub lowmem_page_table_count: u32,
     pub debug_serial_port: u16,
     pub vmsa_in_kernel_heap: bool,
     pub use_alternate_injection: bool,
@@ -96,6 +98,27 @@ pub struct Stage2LaunchInfo {
     pub kernel_fs_start: u32,
     pub kernel_fs_end: u32,
     pub boot_params: u32,
+    pub kernel_pml4e_index: u32,
+    pub _reserved: u32,
+}
+
+// This structure describes the parameters passed to the boot loader.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, IntoBytes, Immutable)]
+pub struct BldrLaunchInfo {
+    pub kernel_pdpt_paddr: u64,
+    pub kernel_launch_info: u64,
+    pub kernel_entry: u64,
+    pub kernel_stack: u64,
+    pub kernel_pt_paddr: u64,
+    pub kernel_pt_count: u64,
+    pub page_table_map_vaddr: u64,
+    pub page_table_start: u32,
+    pub page_table_end: u32,
+    pub page_table_root: u32,
+    pub cpuid_addr: u32,
+    pub platform_type: u32,
+    pub c_bit_position: u32,
     pub kernel_pml4e_index: u32,
     pub _reserved: u32,
 }

--- a/configs/all-targets.json
+++ b/configs/all-targets.json
@@ -38,8 +38,8 @@
             "features": "vtpm,enable-gdb",
             "binary": false
         },
-        "stage2": {
-            "manifest": "kernel/Cargo.toml",
+        "bldr": {
+            "manifest": "boot/bldr/Cargo.toml",
             "binary": true,
             "objcopy": "binary"
         },

--- a/configs/hyperv-target.json
+++ b/configs/hyperv-target.json
@@ -17,8 +17,8 @@
             "features": "vtpm",
             "binary": false
         },
-        "stage2": {
-            "manifest": "kernel/Cargo.toml",
+        "bldr": {
+            "manifest": "boot/bldr/Cargo.toml",
             "binary": true,
             "objcopy": "binary"
         },

--- a/configs/qemu-target.json
+++ b/configs/qemu-target.json
@@ -17,8 +17,8 @@
             "features": "vtpm",
             "binary": false
         },
-        "stage2": {
-            "manifest": "kernel/Cargo.toml",
+        "bldr": {
+            "manifest": "boot/bldr/Cargo.toml",
             "binary": true,
             "objcopy": "binary"
         },

--- a/configs/test/hyperv-test-target.json
+++ b/configs/test/hyperv-test-target.json
@@ -17,8 +17,8 @@
             "type": "make",
             "output_file": "bin/test-kernel.elf"
         },
-        "stage2": {
-            "manifest": "kernel/Cargo.toml",
+        "bldr": {
+            "manifest": "boot/bldr/Cargo.toml",
             "binary": true,
             "objcopy": "binary"
         },

--- a/configs/test/qemu-test-target.json
+++ b/configs/test/qemu-test-target.json
@@ -15,8 +15,8 @@
             "type": "make",
             "output_file": "bin/test-kernel.elf"
         },
-        "stage2": {
-            "manifest": "kernel/Cargo.toml",
+        "bldr": {
+            "manifest": "boot/bldr/Cargo.toml",
             "binary": true,
             "objcopy": "binary"
         },

--- a/configs/test/vanadium-test-target.json
+++ b/configs/test/vanadium-test-target.json
@@ -17,8 +17,8 @@
             "type": "make",
             "output_file": "bin/test-kernel.elf"
         },
-        "stage2": {
-            "manifest": "kernel/Cargo.toml",
+        "bldr": {
+            "manifest": "boot/bldr/Cargo.toml",
             "binary": true,
             "objcopy": "binary"
         },

--- a/configs/vanadium-target.json
+++ b/configs/vanadium-target.json
@@ -17,8 +17,8 @@
             "features": "vtpm",
             "binary": false
         },
-        "stage2": {
-            "manifest": "kernel/Cargo.toml",
+        "bldr": {
+            "manifest": "boot/bldr/Cargo.toml",
             "binary": true,
             "objcopy": "binary"
         },

--- a/cpuarch/Cargo.toml
+++ b/cpuarch/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 
 [dependencies]
+bitflags.workspace = true
 bitfield-struct.workspace = true
 zerocopy.workspace = true
 

--- a/cpuarch/src/lib.rs
+++ b/cpuarch/src/lib.rs
@@ -3,5 +3,7 @@
 
 #![no_std]
 
+pub mod sev_status;
 pub mod snp_cpuid;
 pub mod vmsa;
+pub mod x86;

--- a/cpuarch/src/sev_status.rs
+++ b/cpuarch/src/sev_status.rs
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2022-2023 SUSE LLC
+//
+// Author: Joerg Roedel <jroedel@suse.de>
+
+use bitflags::bitflags;
+use core::fmt;
+use core::fmt::Write;
+
+pub const MSR_SEV_STATUS: u32 = 0xC001_0131;
+
+bitflags! {
+    #[derive(Copy, Clone, PartialEq, Eq)]
+    pub struct SEVStatusFlags: u64 {
+        const SEV           = 1 << 0;
+        const SEV_ES        = 1 << 1;
+        const SEV_SNP       = 1 << 2;
+        const VTOM          = 1 << 3;
+        const REFLECT_VC    = 1 << 4;
+        const REST_INJ      = 1 << 5;
+        const ALT_INJ       = 1 << 6;
+        const DBGSWP        = 1 << 7;
+        const PREV_HOST_IBS = 1 << 8;
+        const BTB_ISOLATION = 1 << 9;
+        const VMPL_SSS      = 1 << 10;
+        const SECURE_TSC    = 1 << 11;
+        const VMSA_REG_PROT = 1 << 16;
+        const SMT_PROT      = 1 << 17;
+    }
+}
+
+impl fmt::Display for SEVStatusFlags {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut first = true;
+
+        if self.contains(SEVStatusFlags::SEV) {
+            f.write_str("SEV")?;
+            first = false;
+        }
+
+        if self.contains(SEVStatusFlags::SEV_ES) {
+            if !first {
+                f.write_char(' ')?;
+            }
+            f.write_str("SEV-ES")?;
+            first = false;
+        }
+
+        if self.contains(SEVStatusFlags::SEV_SNP) {
+            if !first {
+                f.write_char(' ')?;
+            }
+            f.write_str("SEV-SNP")?;
+            first = false;
+        }
+
+        if self.contains(SEVStatusFlags::VTOM) {
+            if !first {
+                f.write_char(' ')?;
+            }
+            f.write_str("VTOM")?;
+            first = false;
+        }
+
+        if self.contains(SEVStatusFlags::REFLECT_VC) {
+            if !first {
+                f.write_char(' ')?;
+            }
+            f.write_str("REFLECT_VC")?;
+            first = false;
+        }
+
+        if self.contains(SEVStatusFlags::REST_INJ) {
+            if !first {
+                f.write_char(' ')?;
+            }
+            f.write_str("RESTRICTED_INJECTION")?;
+            first = false;
+        }
+
+        if self.contains(SEVStatusFlags::ALT_INJ) {
+            if !first {
+                f.write_char(' ')?;
+            }
+            f.write_str("ALTERNATE_INJECTION")?;
+            first = false;
+        }
+
+        if self.contains(SEVStatusFlags::DBGSWP) {
+            if !first {
+                f.write_char(' ')?;
+            }
+            f.write_str("DEBUG_SWAP")?;
+            first = false;
+        }
+
+        if self.contains(SEVStatusFlags::PREV_HOST_IBS) {
+            if !first {
+                f.write_char(' ')?;
+            }
+            f.write_str("PREVENT_HOST_IBS")?;
+            first = false;
+        }
+
+        if self.contains(SEVStatusFlags::BTB_ISOLATION) {
+            if !first {
+                f.write_char(' ')?;
+            }
+            f.write_str("SNP_BTB_ISOLATION")?;
+            first = false;
+        }
+
+        if self.contains(SEVStatusFlags::SECURE_TSC) {
+            if !first {
+                f.write_char(' ')?;
+            }
+            f.write_str("SECURE_TSC")?;
+            first = false;
+        }
+
+        if self.contains(SEVStatusFlags::VMSA_REG_PROT) {
+            if !first {
+                f.write_char(' ')?;
+            }
+            f.write_str("VMSA_REG_PROT")?;
+        }
+
+        Ok(())
+    }
+}
+
+impl SEVStatusFlags {
+    pub fn from_sev_features(sev_features: u64) -> Self {
+        SEVStatusFlags::from_bits(sev_features << 2).unwrap()
+    }
+
+    pub fn as_sev_features(&self) -> u64 {
+        let sev_features = self.bits();
+        sev_features >> 2
+    }
+}

--- a/cpuarch/src/x86.rs
+++ b/cpuarch/src/x86.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2022-2023 SUSE LLC
+//
+// Author: Joerg Roedel <jroedel@suse.de>
+
+use bitflags::bitflags;
+
+pub const MSR_EFER: u32 = 0xC000_0080;
+
+bitflags! {
+    #[derive(Clone, Copy, Debug)]
+    pub struct EFERFlags: u64 {
+        const SCE   = 1 << 0;  // System Call Extensions
+        const LME   = 1 << 8;  // Long Mode Enable
+        const LMA   = 1 << 10; // Long Mode Active
+        const NXE   = 1 << 11; // No-Execute Enable
+        const SVME  = 1 << 12; // Secure Virtual Machine Enable
+        const LMSLE = 1 << 13; // Long Mode Segment Limit Enable
+        const FFXSR = 1 << 14; // Fast FXSAVE/FXRSTOR
+        const TCE   = 1 << 15; // Translation Cache Extension
+        const MCOMMIT   = 1 << 17; // Enable MCOMMIT instruction
+        const INTWB = 1 << 18; // Interruptible WBINVD/WBNOINVD enable
+        const UAIE  = 1 << 20; // Upper Address Ignore Enable
+    }
+}
+
+impl From<usize> for EFERFlags {
+    fn from(bits: usize) -> Self {
+        EFERFlags::from_bits_truncate(bits as u64)
+    }
+}
+
+bitflags! {
+    #[derive(Debug, Clone, Copy)]
+    pub struct CR0Flags: u64 {
+        const PE = 1 << 0;  // Protection Enabled
+        const MP = 1 << 1;  // Monitor Coprocessor
+        const EM = 1 << 2;  // Emulation
+        const TS = 1 << 3;  // Task Switched
+        const ET = 1 << 4;  // Extension Type
+        const NE = 1 << 5;  // Numeric Error
+        const WP = 1 << 16; // Write Protect
+        const AM = 1 << 18; // Alignment Mask
+        const NW = 1 << 29; // Not Writethrough
+        const CD = 1 << 30; // Cache Disable
+        const PG = 1 << 31; // Paging
+    }
+}
+
+bitflags! {
+    #[derive(Debug, Clone, Copy)]
+    pub struct CR4Flags: u64 {
+        const VME       = 1 << 0;  // Virtual-8086 Mode Extensions
+        const PVI       = 1 << 1;  // Protected-Mode Virtual Interrupts
+        const TSD       = 1 << 2;  // Time Stamp Disable
+        const DE        = 1 << 3;  // Debugging Extensions
+        const PSE       = 1 << 4;  // Page Size Extensions
+        const PAE       = 1 << 5;  // Physical-Address Extension
+        const MCE       = 1 << 6;  // Machine Check Enable
+        const PGE       = 1 << 7;  // Page-Global Enable
+        const PCE       = 1 << 8;  // Performance-Monitoring Counter Enable
+        const OSFXSR        = 1 << 9;  // Operating System FXSAVE/FXRSTOR Support
+        const OSXMMEXCPT    = 1 << 10; // Operating System Unmasked Exception Support
+        const UMIP      = 1 << 11; // User Mode Instruction Prevention
+        const LA57      = 1 << 12; // 57-bit linear address
+        const FSGSBASE      = 1 << 16; // Enable RDFSBASE, RDGSBASE, WRFSBASE, and WRGSBASE instructions
+        const PCIDE     = 1 << 17; // Process Context Identifier Enable
+        const OSXSAVE       = 1 << 18; // XSAVE and Processor Extended States Enable Bit
+        const SMEP      = 1 << 20; // Supervisor Mode Execution Prevention
+        const SMAP      = 1 << 21; // Supervisor Mode Access Protection
+        const PKE       = 1 << 22; // Protection Key Enable
+        const CET       = 1 << 23; // Control-flow Enforcement Technology
+    }
+}
+
+impl From<usize> for CR4Flags {
+    fn from(bits: usize) -> Self {
+        CR4Flags::from_bits_truncate(bits as u64)
+    }
+}

--- a/kernel/src/boot_params.rs
+++ b/kernel/src/boot_params.rs
@@ -8,7 +8,6 @@ extern crate alloc;
 
 use crate::acpi::tables::{ACPICPUInfo, ACPITable, load_acpi_cpu_info};
 use crate::address::{Address, PhysAddr, VirtAddr};
-use crate::cpu::efer::EFERFlags;
 use crate::error::SvsmError;
 use crate::mm::alloc::free_multiple_pages;
 use crate::mm::{GuestPtr, PAGE_SIZE, PerCPUPageMappingGuard};
@@ -24,6 +23,7 @@ use core::ops::Deref;
 use core::ptr;
 use core::slice;
 use cpuarch::vmsa::VMSA;
+use cpuarch::x86::EFERFlags;
 use igvm_defs::{IGVM_VHS_MEMORY_MAP_ENTRY, IgvmEnvironmentInfo, MemoryMapEntryType};
 
 const IGVM_MEMORY_ENTRIES_PER_PAGE: usize = PAGE_SIZE / size_of::<IGVM_VHS_MEMORY_MAP_ENTRY>();

--- a/kernel/src/boot_stage2.rs
+++ b/kernel/src/boot_stage2.rs
@@ -7,15 +7,11 @@
 use bootdefs::kernel_launch::Stage2LaunchInfo;
 use core::arch::global_asm;
 use core::mem::offset_of;
-
-use svsm::{
-    cpu::{
-        efer::EFERFlags,
-        msr::{EFER, SEV_STATUS},
-    },
-    mm::PGTABLE_LVL3_IDX_PTE_SELFMAP,
-    types::PAGE_SIZE,
-};
+use cpuarch::sev_status::MSR_SEV_STATUS;
+use cpuarch::x86::EFERFlags;
+use cpuarch::x86::MSR_EFER;
+use svsm::mm::PGTABLE_LVL3_IDX_PTE_SELFMAP;
+use svsm::types::PAGE_SIZE;
 
 global_asm!(
     r#"
@@ -290,10 +286,10 @@ global_asm!(
     pgtable_end:"#,
     PAGE_SIZE = const PAGE_SIZE,
     PGTABLE_LVL3_IDX_PTE_SELFMAP = const PGTABLE_LVL3_IDX_PTE_SELFMAP,
-    EFER = const EFER,
+    EFER = const MSR_EFER,
     LME = const EFERFlags::LME.bits(),
     NXE = const EFERFlags::NXE.bits(),
-    SEV_STATUS = const SEV_STATUS,
+    SEV_STATUS = const MSR_SEV_STATUS,
     PLATFORM_TYPE_OFF = const offset_of!(Stage2LaunchInfo, platform_type) as u32,
     CPUID_OFF = const offset_of!(Stage2LaunchInfo, cpuid_page) as u32,
     options(att_syntax)

--- a/kernel/src/cpu/control_regs.rs
+++ b/kernel/src/cpu/control_regs.rs
@@ -9,8 +9,9 @@ use crate::address::{Address, PhysAddr};
 use crate::cpu::features::{cpu_has_smap, cpu_has_smep, cpu_has_umip};
 use crate::cpu::shadow_stack::is_cet_ss_supported;
 use crate::platform::SvsmPlatform;
-use bitflags::bitflags;
 use core::arch::asm;
+use cpuarch::x86::CR0Flags;
+use cpuarch::x86::CR4Flags;
 
 #[inline]
 pub fn cr0_init() {
@@ -103,29 +104,6 @@ pub fn cr4_xsave_enable() {
     }
 }
 
-bitflags! {
-    #[derive(Debug, Clone, Copy)]
-    pub struct CR0Flags: u64 {
-        const PE = 1 << 0;  // Protection Enabled
-        const MP = 1 << 1;  // Monitor Coprocessor
-        const EM = 1 << 2;  // Emulation
-        const TS = 1 << 3;  // Task Switched
-        const ET = 1 << 4;  // Extension Type
-        const NE = 1 << 5;  // Numeric Error
-        const WP = 1 << 16; // Write Protect
-        const AM = 1 << 18; // Alignment Mask
-        const NW = 1 << 29; // Not Writethrough
-        const CD = 1 << 30; // Cache Disable
-        const PG = 1 << 31; // Paging
-    }
-}
-
-impl From<usize> for CR0Flags {
-    fn from(bits: usize) -> Self {
-        CR0Flags::from_bits_truncate(bits as u64)
-    }
-}
-
 #[inline]
 pub fn read_cr0() -> CR0Flags {
     let cr0: u64;
@@ -199,39 +177,6 @@ pub unsafe fn write_cr3(cr3: PhysAddr) {
         asm!("mov %rax, %cr3",
              in("rax") cr3.bits(),
              options(att_syntax));
-    }
-}
-
-bitflags! {
-    #[derive(Debug, Clone, Copy)]
-    pub struct CR4Flags: u64 {
-        const VME       = 1 << 0;  // Virtual-8086 Mode Extensions
-        const PVI       = 1 << 1;  // Protected-Mode Virtual Interrupts
-        const TSD       = 1 << 2;  // Time Stamp Disable
-        const DE        = 1 << 3;  // Debugging Extensions
-        const PSE       = 1 << 4;  // Page Size Extensions
-        const PAE       = 1 << 5;  // Physical-Address Extension
-        const MCE       = 1 << 6;  // Machine Check Enable
-        const PGE       = 1 << 7;  // Page-Global Enable
-        const PCE       = 1 << 8;  // Performance-Monitoring Counter Enable
-        const OSFXSR        = 1 << 9;  // Operating System FXSAVE/FXRSTOR Support
-        const OSXMMEXCPT    = 1 << 10; // Operating System Unmasked Exception Support
-        const UMIP      = 1 << 11; // User Mode Instruction Prevention
-        const LA57      = 1 << 12; // 57-bit linear address
-        const FSGSBASE      = 1 << 16; // Enable RDFSBASE, RDGSBASE, WRFSBASE, and
-                           // WRGSBASE instructions
-        const PCIDE     = 1 << 17; // Process Context Identifier Enable
-        const OSXSAVE       = 1 << 18; // XSAVE and Processor Extended States Enable Bit
-        const SMEP      = 1 << 20; // Supervisor Mode Execution Prevention
-        const SMAP      = 1 << 21; // Supervisor Mode Access Protection
-        const PKE       = 1 << 22; // Protection Key Enable
-        const CET       = 1 << 23; // Control-flow Enforcement Technology
-    }
-}
-
-impl From<usize> for CR4Flags {
-    fn from(bits: usize) -> Self {
-        CR4Flags::from_bits_truncate(bits as u64)
     }
 }
 

--- a/kernel/src/cpu/efer.rs
+++ b/kernel/src/cpu/efer.rs
@@ -4,28 +4,13 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
-use super::msr::{EFER, read_msr, write_msr};
-use bitflags::bitflags;
-
-bitflags! {
-    #[derive(Clone, Copy, Debug)]
-    pub struct EFERFlags: u64 {
-        const SCE   = 1 << 0;  // System Call Extensions
-        const LME   = 1 << 8;  // Long Mode Enable
-        const LMA   = 1 << 10; // Long Mode Active
-        const NXE   = 1 << 11; // No-Execute Enable
-        const SVME  = 1 << 12; // Secure Virtual Machine Enable
-        const LMSLE = 1 << 13; // Long Mode Segment Limit Enable
-        const FFXSR = 1 << 14; // Fast FXSAVE/FXRSTOR
-        const TCE   = 1 << 15; // Translation Cache Extension
-        const MCOMMIT   = 1 << 17; // Enable MCOMMIT instruction
-        const INTWB = 1 << 18; // Interruptible WBINVD/WBNOINVD enable
-        const UAIE  = 1 << 20; // Upper Address Ignore Enable
-    }
-}
+use super::msr::read_msr;
+use super::msr::write_msr;
+use cpuarch::x86::EFERFlags;
+use cpuarch::x86::MSR_EFER;
 
 pub fn read_efer() -> EFERFlags {
-    EFERFlags::from_bits_truncate(read_msr(EFER))
+    EFERFlags::from_bits_truncate(read_msr(MSR_EFER))
 }
 
 /// # Safety
@@ -36,12 +21,6 @@ pub unsafe fn write_efer(efer: EFERFlags) {
     let val = efer.bits();
     // SAFETY: requirements should be verified by the caller.
     unsafe {
-        write_msr(EFER, val);
-    }
-}
-
-impl From<usize> for EFERFlags {
-    fn from(bits: usize) -> Self {
-        EFERFlags::from_bits_truncate(bits as u64)
+        write_msr(MSR_EFER, val);
     }
 }

--- a/kernel/src/cpu/msr.rs
+++ b/kernel/src/cpu/msr.rs
@@ -6,8 +6,6 @@
 
 use core::arch::asm;
 
-pub const EFER: u32 = 0xC000_0080;
-pub const SEV_STATUS: u32 = 0xC001_0131;
 pub const SEV_GHCB: u32 = 0xC001_0130;
 pub const MSR_GS_BASE: u32 = 0xC000_0101;
 

--- a/kernel/src/cpu/smp.rs
+++ b/kernel/src/cpu/smp.rs
@@ -7,7 +7,6 @@
 use super::idt::load_static_idt;
 use crate::acpi::tables::ACPICPUInfo;
 use crate::address::{Address, VirtAddr};
-use crate::cpu::efer::EFERFlags;
 use crate::cpu::ipi::ipi_start_cpu;
 use crate::cpu::percpu::{PERCPU_AREAS, PerCpu, PerCpuShared, this_cpu, this_cpu_shared};
 use crate::cpu::shadow_stack::{MODE_64BIT, S_CET, SCetFlags, is_cet_ss_enabled};
@@ -21,6 +20,7 @@ use crate::mm::TransitionPageTable;
 use crate::platform::{SVSM_PLATFORM, SvsmPlatform};
 use crate::task::schedule_init;
 use crate::utils::MemoryRegion;
+use cpuarch::x86::EFERFlags;
 
 use bootdefs::kernel_launch::ApStartContext;
 use core::arch::global_asm;

--- a/kernel/src/cpu/tlb.rs
+++ b/kernel/src/cpu/tlb.rs
@@ -5,14 +5,14 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 
 use crate::address::{Address, VirtAddr};
-use crate::cpu::control_regs::{CR4Flags, read_cr3, read_cr4, write_cr3, write_cr4};
+use crate::cpu::control_regs::{read_cr3, read_cr4, write_cr3, write_cr4};
 use crate::cpu::ipi::{IpiMessage, IpiTarget, send_multicast_ipi};
 use crate::platform::SVSM_PLATFORM;
 use crate::types::PageSize;
 use crate::utils::MemoryRegion;
-
 use core::arch::asm;
 use core::sync::atomic::{AtomicBool, Ordering};
+use cpuarch::x86::CR4Flags;
 
 static FLUSH_SMP: AtomicBool = AtomicBool::new(false);
 

--- a/kernel/src/cpu/vmsa.rs
+++ b/kernel/src/cpu/vmsa.rs
@@ -5,8 +5,9 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 
 use crate::hyperv;
-use crate::sev::status::{SEVStatusFlags, sev_flags};
+use crate::sev::status::sev_flags;
 use crate::types::{GUEST_VMPL, SVSM_CS, SVSM_CS_ATTRIBUTES, SVSM_DS, SVSM_DS_ATTRIBUTES};
+use cpuarch::sev_status::SEVStatusFlags;
 use cpuarch::vmsa::{VMSA, VMSASegment};
 
 use super::gdt::GLOBAL_GDT;

--- a/kernel/src/insn_decode/decode.rs
+++ b/kernel/src/insn_decode/decode.rs
@@ -42,11 +42,12 @@
 use super::insn::{DecodedInsn, Immediate, MAX_INSN_SIZE, Operand};
 use super::opcode::{OpCodeClass, OpCodeDesc, OpCodeFlags};
 use super::{InsnError, Register, SegRegister};
-use crate::cpu::control_regs::{CR0Flags, CR4Flags};
-use crate::cpu::efer::EFERFlags;
 use crate::cpu::registers::{RFlags, SegDescAttrFlags};
 use crate::types::Bytes;
 use bitflags::bitflags;
+use cpuarch::x86::CR0Flags;
+use cpuarch::x86::CR4Flags;
+use cpuarch::x86::EFERFlags;
 use zerocopy::{FromBytes, IntoBytes};
 
 /// Represents the raw bytes of an instruction and

--- a/kernel/src/insn_decode/insn.rs
+++ b/kernel/src/insn_decode/insn.rs
@@ -100,10 +100,11 @@ impl Instruction {
 
 #[cfg(any(test, fuzzing))]
 pub mod test_utils {
-    use crate::cpu::control_regs::{CR0Flags, CR4Flags};
-    use crate::cpu::efer::EFERFlags;
     use crate::insn_decode::*;
     use crate::types::Bytes;
+    use cpuarch::x86::CR0Flags;
+    use cpuarch::x86::CR4Flags;
+    use cpuarch::x86::EFERFlags;
     use zerocopy::{FromBytes, IntoBytes};
 
     pub const TEST_PORT: u16 = 0xE0;

--- a/kernel/src/mm/pagetable.rs
+++ b/kernel/src/mm/pagetable.rs
@@ -6,8 +6,7 @@
 
 use crate::BIT_MASK;
 use crate::address::{Address, PhysAddr, VirtAddr};
-use crate::cpu::control_regs::{CR0Flags, CR4Flags, write_cr3};
-use crate::cpu::efer::EFERFlags;
+use crate::cpu::control_regs::write_cr3;
 use crate::cpu::flush_tlb_global_sync;
 use crate::cpu::idt::common::PageFaultError;
 use crate::cpu::registers::RFlags;
@@ -24,6 +23,9 @@ use bitflags::bitflags;
 use core::cmp;
 use core::ops::{Index, IndexMut};
 use core::ptr::NonNull;
+use cpuarch::x86::CR0Flags;
+use cpuarch::x86::CR4Flags;
+use cpuarch::x86::EFERFlags;
 use zerocopy::FromBytes;
 use zerocopy::FromZeros;
 

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -190,6 +190,13 @@ pub trait SvsmPlatform: Sync {
     /// platform.
     fn get_io_port(&self) -> &'static dyn IOPort;
 
+    /// Revokes validation of page tables stored in low memory and used by
+    /// early boot.
+    fn invalidate_lowmem_page_tables(&self, _paddr: u32, _count: usize) -> Result<(), SvsmError> {
+        // By default, platforms have no work to do here.
+        Ok(())
+    }
+
     /// Validates low memory below the specified physical address, with the
     /// exception of addresses reserved for use by the platform object which
     /// may pre-validated.  Intended only for use during early boot.

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -335,6 +335,12 @@ impl SvsmPlatform for SnpPlatform {
         &GHCB_IO_DRIVER
     }
 
+    fn invalidate_lowmem_page_tables(&self, paddr: u32, count: usize) -> Result<(), SvsmError> {
+        let region = MemoryRegion::new(PhysAddr::from(paddr as usize), count * PAGE_SIZE);
+        // SAFETY: invalidation is always safe.
+        unsafe { self.validate_physical_page_range(region, PageValidateOp::Invalidate) }
+    }
+
     /// The caller is required to ensure that it is safe to validate low
     /// memory.
     unsafe fn validate_low_memory(&self, addr: u64, vaddr_valid: bool) -> Result<(), SvsmError> {

--- a/kernel/src/sev/status.rs
+++ b/kernel/src/sev/status.rs
@@ -4,135 +4,15 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
-use crate::cpu::msr::{SEV_STATUS, read_msr};
+use crate::cpu::msr::read_msr;
 use crate::utils::immut_after_init::ImmutAfterInitCell;
-use bitflags::bitflags;
-use core::fmt::{self, Write};
-
-bitflags! {
-    #[derive(Copy, Clone, PartialEq, Eq)]
-    pub struct SEVStatusFlags: u64 {
-        const SEV           = 1 << 0;
-        const SEV_ES        = 1 << 1;
-        const SEV_SNP       = 1 << 2;
-        const VTOM          = 1 << 3;
-        const REFLECT_VC    = 1 << 4;
-        const REST_INJ      = 1 << 5;
-        const ALT_INJ       = 1 << 6;
-        const DBGSWP        = 1 << 7;
-        const PREV_HOST_IBS = 1 << 8;
-        const BTB_ISOLATION = 1 << 9;
-        const VMPL_SSS      = 1 << 10;
-        const SECURE_TSC    = 1 << 11;
-        const VMSA_REG_PROT = 1 << 16;
-        const SMT_PROT      = 1 << 17;
-    }
-}
-
-impl fmt::Display for SEVStatusFlags {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut first = true;
-
-        if self.contains(SEVStatusFlags::SEV) {
-            f.write_str("SEV")?;
-            first = false;
-        }
-
-        if self.contains(SEVStatusFlags::SEV_ES) {
-            if !first {
-                f.write_char(' ')?;
-            }
-            f.write_str("SEV-ES")?;
-            first = false;
-        }
-
-        if self.contains(SEVStatusFlags::SEV_SNP) {
-            if !first {
-                f.write_char(' ')?;
-            }
-            f.write_str("SEV-SNP")?;
-            first = false;
-        }
-
-        if self.contains(SEVStatusFlags::VTOM) {
-            if !first {
-                f.write_char(' ')?;
-            }
-            f.write_str("VTOM")?;
-            first = false;
-        }
-
-        if self.contains(SEVStatusFlags::REFLECT_VC) {
-            if !first {
-                f.write_char(' ')?;
-            }
-            f.write_str("REFLECT_VC")?;
-            first = false;
-        }
-
-        if self.contains(SEVStatusFlags::REST_INJ) {
-            if !first {
-                f.write_char(' ')?;
-            }
-            f.write_str("RESTRICTED_INJECTION")?;
-            first = false;
-        }
-
-        if self.contains(SEVStatusFlags::ALT_INJ) {
-            if !first {
-                f.write_char(' ')?;
-            }
-            f.write_str("ALTERNATE_INJECTION")?;
-            first = false;
-        }
-
-        if self.contains(SEVStatusFlags::DBGSWP) {
-            if !first {
-                f.write_char(' ')?;
-            }
-            f.write_str("DEBUG_SWAP")?;
-            first = false;
-        }
-
-        if self.contains(SEVStatusFlags::PREV_HOST_IBS) {
-            if !first {
-                f.write_char(' ')?;
-            }
-            f.write_str("PREVENT_HOST_IBS")?;
-            first = false;
-        }
-
-        if self.contains(SEVStatusFlags::BTB_ISOLATION) {
-            if !first {
-                f.write_char(' ')?;
-            }
-            f.write_str("SNP_BTB_ISOLATION")?;
-            first = false;
-        }
-
-        if self.contains(SEVStatusFlags::SECURE_TSC) {
-            if !first {
-                f.write_char(' ')?;
-            }
-            f.write_str("SECURE_TSC")?;
-            first = false;
-        }
-
-        if self.contains(SEVStatusFlags::VMSA_REG_PROT) {
-            if !first {
-                f.write_char(' ')?;
-            }
-            f.write_str("VMSA_REG_PROT")?;
-        }
-
-        Ok(())
-    }
-}
+use cpuarch::sev_status::MSR_SEV_STATUS;
+use cpuarch::sev_status::SEVStatusFlags;
 
 static SEV_FLAGS: ImmutAfterInitCell<SEVStatusFlags> = ImmutAfterInitCell::uninit();
 
 fn read_sev_status() -> SEVStatusFlags {
-    SEVStatusFlags::from_bits_truncate(read_msr(SEV_STATUS))
+    SEVStatusFlags::from_bits_truncate(read_msr(MSR_SEV_STATUS))
 }
 
 pub fn sev_flags() -> SEVStatusFlags {
@@ -176,16 +56,5 @@ pub fn sev_status_verify() {
     if !not_supported_check.is_empty() {
         log::error!("Unsupported features enabled: {not_supported_check}");
         panic!("Unsupported SEV features enabled");
-    }
-}
-
-impl SEVStatusFlags {
-    pub fn from_sev_features(sev_features: u64) -> Self {
-        SEVStatusFlags::from_bits(sev_features << 2).unwrap()
-    }
-
-    pub fn as_sev_features(&self) -> u64 {
-        let sev_features = self.bits();
-        sev_features >> 2
     }
 }

--- a/kernel/src/sev/vmsa.rs
+++ b/kernel/src/sev/vmsa.rs
@@ -9,11 +9,11 @@ use crate::address::{Address, PhysAddr, VirtAddr};
 use crate::error::SvsmError;
 use crate::mm::{PageBox, virt_to_phys};
 use crate::platform::guest_cpu::GuestCpuState;
-use crate::sev::status::SEVStatusFlags;
 use crate::types::{PAGE_SIZE_2M, PageSize};
 use core::mem::{ManuallyDrop, size_of};
 use core::ops::{Deref, DerefMut};
 use core::ptr;
+use cpuarch::sev_status::SEVStatusFlags;
 
 use cpuarch::vmsa::{VMSA, VmsaEventInject, VmsaEventType};
 

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -462,6 +462,16 @@ fn svsm_init(launch_info: &KernelLaunchInfo) {
     // a remote GDB connection
     //debug_break();
 
+    // Invalidate low-memory page tables if required for consistency.
+    if launch_info.lowmem_page_table_count != 0 {
+        SVSM_PLATFORM
+            .invalidate_lowmem_page_tables(
+                launch_info.lowmem_page_table_paddr,
+                launch_info.lowmem_page_table_count as usize,
+            )
+            .expect("failed to invalidate low-memory page tables");
+    }
+
     // Validate low memory if it was not validated in stage2.
     if !launch_info.lowmem_validated {
         // SAFETY: the launch information is trusted to represent the

--- a/tools/igvmbuilder/src/cmd_options.rs
+++ b/tools/igvmbuilder/src/cmd_options.rs
@@ -16,6 +16,10 @@ pub struct CmdOptions {
     #[arg(short, long)]
     pub stage2: Option<String>,
 
+    /// Boot loader binary file
+    #[arg(short, long)]
+    pub bldr: Option<String>,
+
     /// Kernel elf file
     #[arg(short, long)]
     pub kernel: String,

--- a/tools/igvmbuilder/src/context.rs
+++ b/tools/igvmbuilder/src/context.rs
@@ -19,17 +19,24 @@ use std::fs;
 use zerocopy::FromZeros;
 use zerocopy::IntoBytes;
 
-pub fn construct_start_context(
-    start_rip: u64,
-    start_rsp: u64,
-    initial_cr3: u64,
-    long_mode: bool,
-) -> Vec<X86Register> {
+#[derive(Clone, Debug, Default)]
+pub struct StartContextInfo {
+    pub start_rip: u64,
+    pub start_rsp: u64,
+    pub initial_cr3: u64,
+    pub long_mode: bool,
+}
+
+pub fn construct_start_context(context_info: StartContextInfo) -> Vec<X86Register> {
     let mut vec: Vec<X86Register> = Vec::new();
 
     // Determine the code segment attributes as 32-bit or 64-bit depending on
     // whether long mode was requested.
-    let cs_attributes = if long_mode { 0xa09b } else { 0xc09b };
+    let cs_attributes = if context_info.long_mode {
+        0xa09b
+    } else {
+        0xc09b
+    };
     let cs = SegmentRegister {
         attributes: cs_attributes,
         base: 0,
@@ -56,7 +63,7 @@ pub fn construct_start_context(
     // must recalculate the page tables.
     vec.push(X86Register::Cr0(0x80000031));
 
-    vec.push(X86Register::Cr3(initial_cr3));
+    vec.push(X86Register::Cr3(context_info.initial_cr3));
 
     // CR4.MCE | CR4.PAE.
     vec.push(X86Register::Cr4(0x60));
@@ -66,8 +73,8 @@ pub fn construct_start_context(
     vec.push(X86Register::Efer(0xD00));
 
     vec.push(X86Register::Rflags(2));
-    vec.push(X86Register::Rip(start_rip));
-    vec.push(X86Register::Rsp(start_rsp));
+    vec.push(X86Register::Rip(context_info.start_rip));
+    vec.push(X86Register::Rsp(context_info.start_rsp));
 
     vec
 }

--- a/tools/igvmbuilder/src/gpa_map.rs
+++ b/tools/igvmbuilder/src/gpa_map.rs
@@ -20,6 +20,9 @@ use crate::cmd_options::{CmdOptions, Hypervisor};
 use crate::firmware::Firmware;
 use crate::igvm_builder::{COMPATIBILITY_MASK, TDP_COMPATIBILITY_MASK};
 
+pub const LOWMEM_PT_START: u64 = 0x10000;
+pub const LOWMEM_PT_COUNT: usize = 4;
+
 #[derive(Debug, Copy, Clone)]
 pub struct GpaRange {
     start: u64,
@@ -219,7 +222,10 @@ impl GpaMap {
             kernel_max_size,
             vmsa,
             vmsa_in_kernel_range,
-            init_page_tables: GpaRange::new(0x10000, 2 * PAGE_SIZE_4K)?,
+            init_page_tables: GpaRange::new(
+                LOWMEM_PT_START,
+                LOWMEM_PT_COUNT as u64 * PAGE_SIZE_4K,
+            )?,
         };
         if options.verbose {
             println!("GPA Map: {gpa_map:#X?}");

--- a/tools/igvmbuilder/src/gpa_map.rs
+++ b/tools/igvmbuilder/src/gpa_map.rs
@@ -67,6 +67,14 @@ impl GpaRange {
 }
 
 #[derive(Debug)]
+struct GpaLayoutInfo {
+    stage2_image: GpaRange,
+    stage2_stack: GpaRange,
+    boot_param_block: GpaRange,
+    kernel_fs_start: u64,
+}
+
+#[derive(Debug)]
 pub struct GpaMap {
     pub base_addr: u64,
     pub stage1_image: GpaRange,
@@ -102,6 +110,11 @@ impl GpaMap {
         //   0x8nnnnn-0x8nnnnn: general and memory map parameter pages
         //   0x8nnnnn-0x8nnnnn: filesystem
         //   0xFFnn0000-0xFFFFFFFF: [TDX stage 1 +] OVMF firmware (QEMU only, if specified)
+
+        // Only one of stage 2 and the boot loader can be specified.
+        if options.stage2.is_some() && options.bldr.is_some() {
+            return Err("Cannot specify both --bldr and --stage2".into());
+        }
 
         let stage1_image = if let Some(stage1) = &options.tdx_stage1 {
             if COMPATIBILITY_MASK.contains(TDP_COMPATIBILITY_MASK) {
@@ -155,36 +168,54 @@ impl GpaMap {
 
         // If stage2 is present, then get its size and configure the data it
         // requires.
-        let (stage2_image, stage2_stack, boot_param_block, kernel_fs_start) =
-            if let Some(stage2) = options.stage2.as_ref() {
-                let stage2_len = Self::get_metadata(stage2)?.len() as usize;
-                if stage2_len > STAGE2_MAXLEN as usize {
-                    return Err(format!(
-                        "Stage2 binary size ({stage2_len:#x}) exceeds limit: {STAGE2_MAXLEN:#x}"
-                    )
-                    .into());
-                }
+        let gpa_layout_info = if let Some(stage2) = options.stage2.as_ref() {
+            let stage2_len = Self::get_metadata(stage2)?.len() as usize;
+            if stage2_len > STAGE2_MAXLEN as usize {
+                return Err(format!(
+                    "Stage2 binary size ({stage2_len:#x}) exceeds limit: {STAGE2_MAXLEN:#x}"
+                )
+                .into());
+            }
 
-                let stage2_image = GpaRange::new(STAGE2_START.into(), stage2_len as u64)?;
-                let boot_param_block = GpaRange::new(
-                    stage2_image.get_end(),
-                    boot_param_layout.total_size() as u64,
-                )?;
-                (
-                    stage2_image,
-                    GpaRange::new_page(STAGE2_STACK_PAGE.into())?,
-                    boot_param_block,
-                    boot_param_block.get_end(),
+            let stage2_image = GpaRange::new(STAGE2_START.into(), stage2_len as u64)?;
+            let boot_param_block = GpaRange::new(
+                stage2_image.get_end(),
+                boot_param_layout.total_size() as u64,
+            )?;
+            GpaLayoutInfo {
+                stage2_image,
+                stage2_stack: GpaRange::new_page(STAGE2_STACK_PAGE.into())?,
+                boot_param_block,
+                kernel_fs_start: boot_param_block.get_end(),
+            }
+        } else if let Some(ref bldr) = options.bldr {
+            // For simplicity, the boot loader ranges are encoded as stage2
+            // ranges.  Since the two are mutually exclusive, there is no
+            // conflict.
+            let bldr_len = Self::get_metadata(bldr)?.len() as usize;
+            if bldr_len > STAGE2_MAXLEN as usize {
+                return Err(format!(
+                    "Boot loader binary size ({bldr_len:#x}) exceeds limit: {STAGE2_MAXLEN:#x}"
                 )
-            } else {
-                let stage2_image = GpaRange::new(STAGE2_BASE.into(), 0)?;
-                (
-                    stage2_image,
-                    stage2_image,
-                    GpaRange::new(0, 0)?,
-                    stage2_image.get_start(),
-                )
-            };
+                .into());
+            }
+
+            let bldr_image = GpaRange::new(STAGE2_START.into(), bldr_len as u64)?;
+            GpaLayoutInfo {
+                stage2_image: bldr_image,
+                stage2_stack: GpaRange::new_page(STAGE2_STACK_PAGE.into())?,
+                boot_param_block: GpaRange::new(0, 0)?,
+                kernel_fs_start: bldr_image.get_end(),
+            }
+        } else {
+            let stage2_image = GpaRange::new(STAGE2_BASE.into(), 0)?;
+            GpaLayoutInfo {
+                stage2_image,
+                stage2_stack: stage2_image,
+                boot_param_block: GpaRange::new(0, 0)?,
+                kernel_fs_start: stage2_image.get_end(),
+            }
+        };
 
         // Obtain the length of the kernel filesystem.
         let kernel_fs_len = if let Some(fs) = &options.filesystem {
@@ -195,7 +226,7 @@ impl GpaMap {
 
         // The kernel filesystem is placed after all other images so it can
         // mark the end of the valid stage2 memory area.
-        let kernel_fs = GpaRange::new(kernel_fs_start, kernel_fs_len as u64)?;
+        let kernel_fs = GpaRange::new(gpa_layout_info.kernel_fs_start, kernel_fs_len as u64)?;
 
         let (vmsa, vmsa_in_kernel_range) = match options.hypervisor {
             Hypervisor::Qemu | Hypervisor::Vanadium => {
@@ -211,11 +242,11 @@ impl GpaMap {
         let gpa_map = Self {
             base_addr: STAGE2_BASE.into(),
             stage1_image,
-            stage2_stack,
-            stage2_image,
+            stage2_stack: gpa_layout_info.stage2_stack,
+            stage2_image: gpa_layout_info.stage2_image,
             cpuid_page: GpaRange::new_page(CPUID_PAGE.into())?,
             kernel_fs,
-            boot_param_block,
+            boot_param_block: gpa_layout_info.boot_param_block,
             boot_param_layout,
             kernel: GpaRange::new(kernel_base, kernel_min_size)?,
             kernel_min_size: kernel_min_size.try_into().unwrap(),

--- a/tools/igvmbuilder/src/igvm_builder.rs
+++ b/tools/igvmbuilder/src/igvm_builder.rs
@@ -32,21 +32,28 @@ use zerocopy::IntoBytes;
 use crate::GpaMap;
 use crate::boot_params::BootParamType;
 use crate::cmd_options::{CmdOptions, Hypervisor};
+use crate::context::StartContextInfo;
 use crate::context::construct_native_start_context;
 use crate::context::construct_stage1_image;
 use crate::context::construct_start_context;
 use crate::context::construct_vmsa;
 use crate::cpuid::SnpCpuidPage;
 use crate::firmware::{Firmware, parse_firmware};
-use crate::paging::construct_init_page_tables;
+use crate::initial_stack::BootLoaderStack;
+use crate::initial_stack::InitialStack;
+use crate::initial_stack::Stage2Stack;
+use crate::paging::setup_init_page_tables;
 use crate::platform::PlatformMask;
 use crate::sipi::add_sipi_stub;
-use crate::stage2_stack::Stage2Stack;
 
 pub const SNP_COMPATIBILITY_MASK: u32 = 1u32 << 0;
 pub const NATIVE_COMPATIBILITY_MASK: u32 = 1u32 << 1;
 pub const TDP_COMPATIBILITY_MASK: u32 = 1u32 << 2;
 pub const VSM_COMPATIBILITY_MASK: u32 = 1u32 << 4;
+pub const FULL_COMPATIBILITY_MASK: u32 = SNP_COMPATIBILITY_MASK
+    | NATIVE_COMPATIBILITY_MASK
+    | TDP_COMPATIBILITY_MASK
+    | VSM_COMPATIBILITY_MASK;
 pub static COMPATIBILITY_MASK: PlatformMask = PlatformMask::new();
 
 pub const ANY_NATIVE_COMPATIBILITY_MASK: u32 = NATIVE_COMPATIBILITY_MASK | VSM_COMPATIBILITY_MASK;
@@ -64,6 +71,7 @@ const _: () = assert!(size_of::<InitialGuestContext>() as u64 <= PAGE_SIZE_4K);
 struct ImageLayout {
     cpuid_addr: u64,
     boot_params_gpa: u64,
+    stage2_boot_params: bool,
 }
 
 pub struct IgvmBuilder {
@@ -390,7 +398,8 @@ impl IgvmBuilder {
         )?;
 
         // Process stage2 data if present.
-        let (start_context, image_layout) = if let Some(stage2) = self.options.stage2.as_ref() {
+        let (start_context_info, image_layout) = if let Some(stage2) = self.options.stage2.as_ref()
+        {
             // Populate the stage 2 binary.
             self.add_data_pages_from_file(
                 &stage2.clone(),
@@ -398,77 +407,126 @@ impl IgvmBuilder {
                 COMPATIBILITY_MASK.get(),
             )?;
 
+            // Construct initial page tables if required.
+            let init_page_table_info = setup_init_page_tables(
+                self.gpa_map.init_page_tables.get_start(),
+                ANY_NATIVE_COMPATIBILITY_MASK,
+                &mut self.directives,
+            );
+
             // Populate the stage 2 stack.  This has different contents on each
             // platform.
-            let stage2_stack = Stage2Stack::new(&self.gpa_map, &boot_image_info);
+            let mut stage2_stack = Stage2Stack::new(&self.gpa_map, &boot_image_info);
             if COMPATIBILITY_MASK.contains(SNP_COMPATIBILITY_MASK) {
+                stage2_stack.stack_data().platform_type = SvsmPlatformType::Snp as u32;
                 stage2_stack.add_directive(
                     self.gpa_map.stage2_stack.get_start(),
-                    SvsmPlatformType::Snp,
                     SNP_COMPATIBILITY_MASK,
                     &mut self.directives,
                 );
             }
             if COMPATIBILITY_MASK.contains(TDP_COMPATIBILITY_MASK) {
+                stage2_stack.stack_data().platform_type = SvsmPlatformType::Tdp as u32;
                 stage2_stack.add_directive(
                     self.gpa_map.stage2_stack.get_start(),
-                    SvsmPlatformType::Tdp,
                     TDP_COMPATIBILITY_MASK,
                     &mut self.directives,
                 );
             }
+            // Native must be added last because it changes the common contents
+            // of the stack data.
             if COMPATIBILITY_MASK.contains(ANY_NATIVE_COMPATIBILITY_MASK) {
+                stage2_stack.stack_data().platform_type = SvsmPlatformType::Native as u32;
                 stage2_stack.add_directive(
                     self.gpa_map.stage2_stack.get_start(),
-                    SvsmPlatformType::Native,
-                    ANY_NATIVE_COMPATIBILITY_MASK,
-                    &mut self.directives,
-                );
-            }
-
-            let paging_root = if COMPATIBILITY_MASK.contains(ANY_NATIVE_COMPATIBILITY_MASK) {
-                // Include initial page tables.
-                construct_init_page_tables(
-                    self.gpa_map.init_page_tables.get_start(),
                     ANY_NATIVE_COMPATIBILITY_MASK,
                     &mut self.directives,
                 )
-            } else {
-                0
-            };
+            }
 
             // Construct a native context object to capture the start context.
             let start_rip = self.gpa_map.stage2_image.get_start();
             let start_rsp = self.gpa_map.stage2_stack.get_end() - size_of::<Stage2Stack>() as u64;
-            let start_context = construct_start_context(start_rip, start_rsp, paging_root, false);
+            let start_context_info = StartContextInfo {
+                start_rip,
+                start_rsp,
+                initial_cr3: init_page_table_info.paging_root,
+                long_mode: false,
+            };
             let image_layout = ImageLayout {
                 cpuid_addr: self.gpa_map.cpuid_page.get_start(),
                 boot_params_gpa: self.gpa_map.boot_param_block.get_start(),
+                stage2_boot_params: true,
             };
-            (start_context, image_layout)
+            (start_context_info, image_layout)
+        } else if let Some(ref bldr) = self.options.bldr {
+            // Populate the boot loader binary.
+            self.add_data_pages_from_file(
+                &bldr.clone(),
+                self.gpa_map.stage2_image.get_start(),
+                COMPATIBILITY_MASK.get(),
+            )?;
+
+            // Construct initial page tables if required.
+            let init_page_table_info = setup_init_page_tables(
+                self.gpa_map.init_page_tables.get_start(),
+                FULL_COMPATIBILITY_MASK,
+                &mut self.directives,
+            );
+
+            // Populate the boot loader stack.
+            let bldr_stack =
+                BootLoaderStack::new(&self.gpa_map, &boot_image_info, &init_page_table_info);
+            bldr_stack.add_directive(
+                self.gpa_map.stage2_stack.get_start(),
+                COMPATIBILITY_MASK.get(),
+                &mut self.directives,
+            );
+
+            // Construct a native context object to capture the start context.
+            let start_rip = self.gpa_map.stage2_image.get_start();
+            let start_rsp =
+                self.gpa_map.stage2_stack.get_end() - size_of::<BootLoaderStack>() as u64;
+            let start_context_info = StartContextInfo {
+                start_rip,
+                start_rsp,
+                initial_cr3: init_page_table_info.paging_root,
+                long_mode: false,
+            };
+            let image_layout = ImageLayout {
+                cpuid_addr: self.gpa_map.cpuid_page.get_start(),
+                boot_params_gpa: boot_image_info.boot_params_paddr,
+                stage2_boot_params: false,
+            };
+            (start_context_info, image_layout)
         } else {
-            // Stage2 is required on TDP and on SNP when VTOM is not enabled.
+            // Either a boot loader or stage2 is required on TDP and on SNP
+            // when VTOM is not enabled.
             if COMPATIBILITY_MASK.contains(TDP_COMPATIBILITY_MASK)
                 || (COMPATIBILITY_MASK.contains(SNP_COMPATIBILITY_MASK) && self.vtom == 0)
             {
-                return Err("stage2 required but not specified".into());
+                return Err("--bldr or --stage2 required but not specified".into());
             }
 
             // Generate a start context that describes the kernel entry point.
             let start_rip = boot_image_info.context.entry_point;
             let start_rsp = boot_image_info.context.initial_stack;
-            let start_context = construct_start_context(
+            let start_context_info = StartContextInfo {
                 start_rip,
                 start_rsp,
-                boot_image_info.context.paging_root,
-                true,
-            );
+                initial_cr3: 0,
+                long_mode: true,
+            };
             let image_layout = ImageLayout {
                 cpuid_addr: boot_image_info.cpuid_paddr,
                 boot_params_gpa: boot_image_info.boot_params_paddr,
+                stage2_boot_params: false,
             };
-            (start_context, image_layout)
+            (start_context_info, image_layout)
         };
+
+        // Construct a native context object to capture the start context.
+        let start_context = construct_start_context(start_context_info);
 
         // Populate firmware directives.
         if let Some(firmware) = &self.firmware {
@@ -598,7 +656,9 @@ impl IgvmBuilder {
         }
 
         // Add the boot parameter block
-        self.add_param_block(param_block, &image_layout);
+        if image_layout.stage2_boot_params {
+            self.add_param_block(param_block, &image_layout);
+        }
 
         // Add optional filesystem image
         if let Some(fs) = &self.options.filesystem {
@@ -627,9 +687,24 @@ impl IgvmBuilder {
             )?;
         }
         if COMPATIBILITY_MASK.contains(TDP_COMPATIBILITY_MASK) {
-            // Insert a zero page in place of the CPUID page
+            // Insert a zero page in place of the CPUID page.  If not using
+            // stage2, this should be placed at the kernel CPUID location and
+            // not the stage2 CPUID location since the boot loader will not
+            // take action to copy the empty page.  This means the page at the
+            // boot loader address will not be accepted, but it's not
+            // referenced in the boot loader so the lack of acceptance will
+            // not cause a problem.  When the boot loader range is invalidated
+            // later by the kernel, this page will already be invalidated,
+            // but since invalidation on TDX is a no-op, this will not create
+            // any problems.
+            let cpuid_addr = if self.options.stage2.is_some() {
+                image_layout.cpuid_addr
+            } else {
+                boot_image_info.cpuid_paddr
+            };
+
             self.add_empty_pages(
-                image_layout.cpuid_addr,
+                cpuid_addr,
                 PAGE_SIZE_4K,
                 TDP_COMPATIBILITY_MASK,
                 IgvmPageDataType::NORMAL,

--- a/tools/igvmbuilder/src/igvm_builder.rs
+++ b/tools/igvmbuilder/src/igvm_builder.rs
@@ -426,24 +426,21 @@ impl IgvmBuilder {
                 );
             }
 
-            if COMPATIBILITY_MASK.contains(ANY_NATIVE_COMPATIBILITY_MASK) {
+            let paging_root = if COMPATIBILITY_MASK.contains(ANY_NATIVE_COMPATIBILITY_MASK) {
                 // Include initial page tables.
                 construct_init_page_tables(
                     self.gpa_map.init_page_tables.get_start(),
                     ANY_NATIVE_COMPATIBILITY_MASK,
                     &mut self.directives,
-                );
-            }
+                )
+            } else {
+                0
+            };
 
             // Construct a native context object to capture the start context.
             let start_rip = self.gpa_map.stage2_image.get_start();
             let start_rsp = self.gpa_map.stage2_stack.get_end() - size_of::<Stage2Stack>() as u64;
-            let start_context = construct_start_context(
-                start_rip,
-                start_rsp,
-                self.gpa_map.init_page_tables.get_start(),
-                false,
-            );
+            let start_context = construct_start_context(start_rip, start_rsp, paging_root, false);
             let image_layout = ImageLayout {
                 cpuid_addr: self.gpa_map.cpuid_page.get_start(),
                 boot_params_gpa: self.gpa_map.boot_param_block.get_start(),

--- a/tools/igvmbuilder/src/initial_stack.rs
+++ b/tools/igvmbuilder/src/initial_stack.rs
@@ -6,14 +6,15 @@
 
 use std::mem::size_of;
 
+use bootdefs::kernel_launch::BldrLaunchInfo;
 use bootdefs::kernel_launch::Stage2LaunchInfo;
-use bootdefs::platform::SvsmPlatformType;
 use bootimg::BootImageInfo;
 use igvm::IgvmDirectiveHeader;
 use igvm_defs::{IgvmPageDataFlags, IgvmPageDataType, PAGE_SIZE_4K};
 use zerocopy::IntoBytes;
 
 use crate::gpa_map::GpaMap;
+use crate::paging::InitPageTableInfo;
 
 pub struct Stage2Stack {
     stage2_stack: Stage2LaunchInfo,
@@ -44,26 +45,75 @@ impl Stage2Stack {
         Self { stage2_stack }
     }
 
-    pub fn add_directive(
+    pub fn stack_data(&mut self) -> &mut Stage2LaunchInfo {
+        &mut self.stage2_stack
+    }
+}
+
+pub struct BootLoaderStack {
+    bldr_stack: BldrLaunchInfo,
+}
+
+const _: () = assert!((size_of::<BootLoaderStack>() as u64) <= PAGE_SIZE_4K);
+
+impl BootLoaderStack {
+    pub fn new(
+        gpa_map: &GpaMap,
+        boot_image_info: &BootImageInfo,
+        init_page_table_info: &InitPageTableInfo,
+    ) -> Self {
+        let bldr_stack = BldrLaunchInfo {
+            kernel_entry: boot_image_info.context.entry_point,
+            kernel_stack: boot_image_info.context.initial_stack,
+            kernel_launch_info: boot_image_info.kernel_launch_info,
+            kernel_pt_paddr: boot_image_info.kernel_page_tables_base,
+            kernel_pt_count: boot_image_info.total_pt_pages,
+            kernel_pdpt_paddr: boot_image_info.kernel_pdpt_paddr,
+            kernel_pml4e_index: boot_image_info.kernel_pml4e_index,
+            page_table_start: gpa_map.init_page_tables.get_start() as u32,
+            page_table_end: gpa_map.init_page_tables.get_end() as u32,
+            page_table_root: init_page_table_info.paging_root as u32,
+            page_table_map_vaddr: init_page_table_info.map_vaddr,
+            cpuid_addr: gpa_map.cpuid_page.get_start() as u32,
+            c_bit_position: 0,
+            platform_type: 0,
+            _reserved: Default::default(),
+        };
+        Self { bldr_stack }
+    }
+}
+
+pub trait InitialStack {
+    fn data_bytes(&self) -> &[u8];
+
+    fn add_directive(
         &self,
         gpa: u64,
-        platform: SvsmPlatformType,
         compatibility_mask: u32,
         directives: &mut Vec<IgvmDirectiveHeader>,
     ) {
-        let mut stage2_stack = self.stage2_stack;
-        stage2_stack.platform_type = u32::from(platform);
-
-        let stage2_stack_data = stage2_stack.as_bytes();
-        let mut stage2_stack_page = vec![0u8; PAGE_SIZE_4K as usize - stage2_stack_data.len()];
-        stage2_stack_page.extend_from_slice(stage2_stack_data);
+        let stack_data = self.data_bytes();
+        let mut stack_page = vec![0u8; PAGE_SIZE_4K as usize - stack_data.len()];
+        stack_page.extend_from_slice(stack_data);
 
         directives.push(IgvmDirectiveHeader::PageData {
             gpa,
             compatibility_mask,
             flags: IgvmPageDataFlags::new(),
             data_type: IgvmPageDataType::NORMAL,
-            data: stage2_stack_page,
+            data: stack_page,
         });
+    }
+}
+
+impl InitialStack for Stage2Stack {
+    fn data_bytes(&self) -> &[u8] {
+        self.stage2_stack.as_bytes()
+    }
+}
+
+impl InitialStack for BootLoaderStack {
+    fn data_bytes(&self) -> &[u8] {
+        self.bldr_stack.as_bytes()
     }
 }

--- a/tools/igvmbuilder/src/main.rs
+++ b/tools/igvmbuilder/src/main.rs
@@ -16,11 +16,11 @@ mod firmware;
 mod gpa_map;
 mod igvm_builder;
 mod igvm_firmware;
+mod initial_stack;
 mod ovmf_firmware;
 mod paging;
 mod platform;
 mod sipi;
-mod stage2_stack;
 
 fn build_igvm() -> Result<(), Box<dyn Error>> {
     let builder = IgvmBuilder::new()?;

--- a/tools/igvmbuilder/src/paging.rs
+++ b/tools/igvmbuilder/src/paging.rs
@@ -9,6 +9,8 @@ use igvm_defs::{IgvmPageDataFlags, IgvmPageDataType, PAGE_SIZE_4K};
 
 use zerocopy::{Immutable, IntoBytes};
 
+use crate::gpa_map::LOWMEM_PT_COUNT;
+
 #[derive(Clone, Copy, Immutable, IntoBytes)]
 struct PageTablePage {
     ptes: [u64; 512],
@@ -16,7 +18,7 @@ struct PageTablePage {
 
 #[derive(Clone, Copy, Default)]
 struct InitPageTables {
-    pages: [PageTablePage; 2],
+    pages: [PageTablePage; LOWMEM_PT_COUNT],
 }
 
 impl Default for PageTablePage {
@@ -29,19 +31,27 @@ pub fn construct_init_page_tables(
     init_page_table_gpa: u64,
     compatibility_mask: u32,
     directives: &mut Vec<IgvmDirectiveHeader>,
-) {
+) -> u64 {
     let mut page_tables: InitPageTables = InitPageTables::default();
 
-    // The initial page tables comprise a single PML4E that points to a page
-    // that includes entries which map the low 4 GB of the address space
-    // with an identity map of 1 GB pages.
-    // This PML4E is present, writable, accessed, and dirty.
-    page_tables.pages[0].ptes[0] = 0x63 | (init_page_table_gpa + PAGE_SIZE_4K);
+    // Construct a PTE mask that represents writable, accessed, and dirty.
+    let pte_mask: u64 = 0x63;
+
+    // The initial page tables comprise four pages: one PML4E that points to
+    // a page that includes entries which map the low 4 GB of the address space
+    // with an identity map of 1 GB pages, and which also contains pages
+    // sufficient to map 2 MB worth of data using 4 KB PTEs.  These pages are
+    // constructed in reverse order, so the first page is the placeholder
+    // for the 4 KB PTEs, and the last page is the paging root.
+    page_tables.pages[3].ptes[0] = pte_mask | (init_page_table_gpa + 2 * PAGE_SIZE_4K);
 
     for i in 0..4 {
         // This PTE is present, writable, accessed, dirty, and large page.
-        page_tables.pages[1].ptes[i] = 0xE3 | ((i as u64) << 30);
+        page_tables.pages[2].ptes[i] = 0xE3 | ((i as u64) << 30);
     }
+
+    page_tables.pages[2].ptes[4] = pte_mask | (init_page_table_gpa + PAGE_SIZE_4K);
+    page_tables.pages[1].ptes[0] = pte_mask | init_page_table_gpa;
 
     for (i, data) in page_tables.pages.iter().enumerate() {
         // Allocate a byte vector to contain a copy of the initial page table
@@ -57,4 +67,7 @@ pub fn construct_init_page_tables(
             data: page_table_data,
         });
     }
+
+    // The paging root is the last of the pages.
+    init_page_table_gpa + 3 * PAGE_SIZE_4K
 }

--- a/tools/igvmbuilder/src/paging.rs
+++ b/tools/igvmbuilder/src/paging.rs
@@ -10,6 +10,13 @@ use igvm_defs::{IgvmPageDataFlags, IgvmPageDataType, PAGE_SIZE_4K};
 use zerocopy::{Immutable, IntoBytes};
 
 use crate::gpa_map::LOWMEM_PT_COUNT;
+use crate::igvm_builder::COMPATIBILITY_MASK;
+
+#[derive(Clone, Debug, Default)]
+pub struct InitPageTableInfo {
+    pub paging_root: u64,
+    pub map_vaddr: u64,
+}
 
 #[derive(Clone, Copy, Immutable, IntoBytes)]
 struct PageTablePage {
@@ -27,11 +34,23 @@ impl Default for PageTablePage {
     }
 }
 
-pub fn construct_init_page_tables(
+pub fn setup_init_page_tables(
     init_page_table_gpa: u64,
     compatibility_mask: u32,
     directives: &mut Vec<IgvmDirectiveHeader>,
-) -> u64 {
+) -> InitPageTableInfo {
+    if COMPATIBILITY_MASK.contains(compatibility_mask) {
+        construct_init_page_tables(init_page_table_gpa, compatibility_mask, directives)
+    } else {
+        InitPageTableInfo::default()
+    }
+}
+
+fn construct_init_page_tables(
+    init_page_table_gpa: u64,
+    compatibility_mask: u32,
+    directives: &mut Vec<IgvmDirectiveHeader>,
+) -> InitPageTableInfo {
     let mut page_tables: InitPageTables = InitPageTables::default();
 
     // Construct a PTE mask that represents writable, accessed, and dirty.
@@ -69,5 +88,14 @@ pub fn construct_init_page_tables(
     }
 
     // The paging root is the last of the pages.
-    init_page_table_gpa + 3 * PAGE_SIZE_4K
+    let paging_root = init_page_table_gpa + 3 * PAGE_SIZE_4K;
+
+    // The virtual address used for mappings is 4 GB, immediately following the
+    // identity map of the low 4 GB that was established.
+    let map_vaddr: u64 = 4 << 30;
+
+    InitPageTableInfo {
+        paging_root,
+        map_vaddr,
+    }
 }

--- a/xbuild/src/igvm.rs
+++ b/xbuild/src/igvm.rs
@@ -131,6 +131,9 @@ impl IgvmTargetConfig {
         if let Some(s2) = parts.stage2.as_ref() {
             cmd.arg("--stage2").arg(s2);
         }
+        if let Some(bldr) = parts.bldr.as_ref() {
+            cmd.arg("--bldr").arg(bldr);
+        }
         if let Some(fw) = parts.firmware.as_ref() {
             cmd.arg("--firmware").arg(fw);
         }

--- a/xbuild/src/main.rs
+++ b/xbuild/src/main.rs
@@ -133,7 +133,7 @@ impl Objcopy {
 }
 
 /// The recipe for a single kernel component (e.g. `tdx-stage1`,
-/// `stage2` or `svsm`.
+/// `bldr` or `svsm`.
 #[derive(Clone, Debug, Deserialize, Default)]
 struct ComponentConfig {
     #[serde(rename = "type", default)]
@@ -284,6 +284,7 @@ impl Recipe {
             match obj.file_name().and_then(|s| s.to_str()).unwrap_or_default() {
                 "tdx-stage1" => parts.set_stage1(obj),
                 "stage2" => parts.set_stage2(obj),
+                "bldr" => parts.set_bldr(obj),
                 "svsm" => parts.set_kernel(obj),
                 n => eprintln!("WARN: kernel: ignoring unknown component: {n}"),
             }
@@ -315,6 +316,7 @@ impl Recipe {
 struct RecipePartsBuilder {
     stage1: Option<PathBuf>,
     stage2: Option<PathBuf>,
+    bldr: Option<PathBuf>,
     kernel: Option<PathBuf>,
     firmware: Option<PathBuf>,
     fs: Option<PathBuf>,
@@ -331,6 +333,10 @@ impl RecipePartsBuilder {
 
     fn set_stage2(&mut self, v: PathBuf) {
         self.stage2 = Some(v);
+    }
+
+    fn set_bldr(&mut self, v: PathBuf) {
+        self.bldr = Some(v);
     }
 
     fn set_kernel(&mut self, v: PathBuf) {
@@ -351,6 +357,7 @@ impl RecipePartsBuilder {
         Ok(RecipeParts {
             stage1: self.stage1,
             stage2: self.stage2,
+            bldr: self.bldr,
             kernel: self.kernel.ok_or("kernel: missing main kernel")?,
             firmware: self.firmware,
             fs: self.fs,
@@ -364,6 +371,7 @@ impl RecipePartsBuilder {
 struct RecipeParts {
     stage1: Option<PathBuf>,
     stage2: Option<PathBuf>,
+    bldr: Option<PathBuf>,
     kernel: PathBuf,
     firmware: Option<PathBuf>,
     fs: Option<PathBuf>,


### PR DESCRIPTION
Since the kernel boot image is fully prepared in the IGVM file builder (or nearly so), the requirements for a boot loader have been dramatically reduced.  This PR introduces a new boot loader which performs the necessary finalization of the boot image based on runtime configuration when necessary (such as modification of page tables for the SNP C-bit).  Because this boot loader is so simple, it does not rely on any of the code built into the kernel, so it can eliminate the need to share complex kernel code across multiple binary components.

In the future, this boot loader can be expanded to perform additional tasks (such as randomization of the kernel address space) but even that additional logic can be built using either small, dedicated code or small, shared components rather than having to rely on the complexity of the kernel logic that initializes a full runtime environment to support boot loader functionality.