### PR TITLE
kernel: centralize CPUID feature discovery

### DIFF
--- a/kernel/src/cpu/control_regs.rs
+++ b/kernel/src/cpu/control_regs.rs
@@ -4,9 +4,8 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
-use super::features::cpu_has_pge;
 use crate::address::{Address, PhysAddr};
-use crate::cpu::features::{cpu_has_smap, cpu_has_smep, cpu_has_umip};
+use crate::cpu::features::{Feature, cpu_has_feat};
 use crate::cpu::shadow_stack::is_cet_ss_supported;
 use core::arch::asm;
 use cpuarch::x86::CR0Flags;
@@ -35,21 +34,21 @@ pub fn cr4_init() {
     // All processors that are capable of virtualization will support global
     // page table entries, so there is no reason to support any processor that
     // does not enumerate PGE capability.
-    assert!(cpu_has_pge(), "CPU does not support PGE");
+    assert!(cpu_has_feat(Feature::Pge), "CPU does not support PGE");
 
     cr4.insert(CR4Flags::PGE); // Enable Global Pages
 
     if !cfg!(feature = "nosmep") {
-        assert!(cpu_has_smep(), "CPU does not support SMEP");
+        assert!(cpu_has_feat(Feature::Smep), "CPU does not support SMEP");
         cr4.insert(CR4Flags::SMEP);
     }
 
     if !cfg!(feature = "nosmap") {
-        assert!(cpu_has_smap(), "CPU does not support SMAP");
+        assert!(cpu_has_feat(Feature::Smap), "CPU does not support SMAP");
         cr4.insert(CR4Flags::SMAP);
     }
 
-    if cpu_has_umip() {
+    if cpu_has_feat(Feature::Umip) {
         cr4.insert(CR4Flags::UMIP);
     }
 

--- a/kernel/src/cpu/control_regs.rs
+++ b/kernel/src/cpu/control_regs.rs
@@ -8,7 +8,6 @@ use super::features::cpu_has_pge;
 use crate::address::{Address, PhysAddr};
 use crate::cpu::features::{cpu_has_smap, cpu_has_smep, cpu_has_umip};
 use crate::cpu::shadow_stack::is_cet_ss_supported;
-use crate::platform::SvsmPlatform;
 use core::arch::asm;
 use cpuarch::x86::CR0Flags;
 use cpuarch::x86::CR4Flags;
@@ -28,7 +27,7 @@ pub fn cr0_init() {
 }
 
 #[inline]
-pub fn cr4_init(platform: &dyn SvsmPlatform) {
+pub fn cr4_init() {
     let mut cr4 = read_cr4();
 
     cr4.insert(CR4Flags::PSE); // Enable Page Size Extensions
@@ -36,21 +35,21 @@ pub fn cr4_init(platform: &dyn SvsmPlatform) {
     // All processors that are capable of virtualization will support global
     // page table entries, so there is no reason to support any processor that
     // does not enumerate PGE capability.
-    assert!(cpu_has_pge(platform), "CPU does not support PGE");
+    assert!(cpu_has_pge(), "CPU does not support PGE");
 
     cr4.insert(CR4Flags::PGE); // Enable Global Pages
 
     if !cfg!(feature = "nosmep") {
-        assert!(cpu_has_smep(platform), "CPU does not support SMEP");
+        assert!(cpu_has_smep(), "CPU does not support SMEP");
         cr4.insert(CR4Flags::SMEP);
     }
 
     if !cfg!(feature = "nosmap") {
-        assert!(cpu_has_smap(platform), "CPU does not support SMAP");
+        assert!(cpu_has_smap(), "CPU does not support SMAP");
         cr4.insert(CR4Flags::SMAP);
     }
 
-    if cpu_has_umip(platform) {
+    if cpu_has_umip() {
         cr4.insert(CR4Flags::UMIP);
     }
 

--- a/kernel/src/cpu/control_regs.rs
+++ b/kernel/src/cpu/control_regs.rs
@@ -6,7 +6,6 @@
 
 use crate::address::{Address, PhysAddr};
 use crate::cpu::features::{Feature, cpu_has_feat};
-use crate::cpu::shadow_stack::is_cet_ss_supported;
 use core::arch::asm;
 use cpuarch::x86::CR0Flags;
 use cpuarch::x86::CR4Flags;
@@ -52,7 +51,7 @@ pub fn cr4_init() {
         cr4.insert(CR4Flags::UMIP);
     }
 
-    if is_cet_ss_supported() {
+    if cpu_has_feat(Feature::CetSS) {
         cr4.insert(CR4Flags::CET);
     }
 

--- a/kernel/src/cpu/cpuid.rs
+++ b/kernel/src/cpu/cpuid.rs
@@ -9,7 +9,7 @@ use crate::types::PAGE_SIZE;
 use crate::utils::immut_after_init::ImmutAfterInitCell;
 use cpuarch::snp_cpuid::SnpCpuidTable;
 
-use core::arch::asm;
+use core::arch::x86_64::CpuidResult;
 
 static CPUID_PAGE: ImmutAfterInitCell<&SnpCpuidTable> = ImmutAfterInitCell::uninit();
 
@@ -87,45 +87,6 @@ impl CpuidLeaf {
             ebx: 0,
             ecx: 0,
             edx: 0,
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-pub struct CpuidResult {
-    pub eax: u32,
-    pub ebx: u32,
-    pub ecx: u32,
-    pub edx: u32,
-}
-
-impl CpuidResult {
-    pub fn get(cpuid_fn: u32, cpuid_subfn: u32) -> Self {
-        let mut result_eax: u32;
-        let mut result_ebx: u32;
-        let mut result_ecx: u32;
-        let mut result_edx: u32;
-        // SAFETY: Inline assembly to execute the CPUID instruction which does
-        // not change any state. Input registers (EAX, ECX) and output
-        // registers (EAX, EBX, ECX, EDX) are safely managed.
-        unsafe {
-            asm!("push %rbx",
-                 "cpuid",
-                 "movl %ebx, %edi",
-                 "pop %rbx",
-                 in("eax") cpuid_fn,
-                 in("ecx") cpuid_subfn,
-                 lateout("eax") result_eax,
-                 lateout("edi") result_ebx,
-                 lateout("ecx") result_ecx,
-                 lateout("edx") result_edx,
-                 options(att_syntax));
-        }
-        Self {
-            eax: result_eax,
-            ebx: result_ebx,
-            ecx: result_ecx,
-            edx: result_edx,
         }
     }
 }

--- a/kernel/src/cpu/features.rs
+++ b/kernel/src/cpu/features.rs
@@ -155,9 +155,16 @@ pub fn cpu_get_feat(feat: Feature) -> u32 {
 }
 
 define_cpu_feats! {
+    Xsave => CpuFeat::new_bit(0x0000_0001, CpuidReg::Ecx, 26),
     Pge => CpuFeat::new_bit(0x0000_0001, CpuidReg::Edx, 13),
+    Sse1 => CpuFeat::new_bit(0x0000_0001, CpuidReg::Edx, 25),
     Smep => CpuFeat::new_bit(0x0000_0007, CpuidReg::Ebx, 7),
     Smap => CpuFeat::new_bit(0x0000_0007, CpuidReg::Ebx, 20),
     Umip => CpuFeat::new_bit(0x0000_0007, CpuidReg::Ecx, 2),
     CetSS => CpuFeat::new_bit(0x0000_0007, CpuidReg::Ecx, 7),
+    Xcr0X87 => CpuFeat::new_bit(0x0000_000d, CpuidReg::Eax, 0),
+    Xcr0Sse => CpuFeat::new_bit(0x0000_000d, CpuidReg::Eax, 1),
+    Xcr0Avx => CpuFeat::new_bit(0x0000_000d, CpuidReg::Eax, 2),
+    XsaveSize => CpuFeat::new_u32(0x0000_000d, CpuidReg::Ecx, 0),
+    XsaveOpt => CpuFeat::new_bit(0x0000_000d, CpuidReg::Eax, 0).with_subfn(1),
 }

--- a/kernel/src/cpu/features.rs
+++ b/kernel/src/cpu/features.rs
@@ -167,4 +167,5 @@ define_cpu_feats! {
     Xcr0Avx => CpuFeat::new_bit(0x0000_000d, CpuidReg::Eax, 2),
     XsaveSize => CpuFeat::new_u32(0x0000_000d, CpuidReg::Ecx, 0),
     XsaveOpt => CpuFeat::new_bit(0x0000_000d, CpuidReg::Eax, 0).with_subfn(1),
+    HyperV => CpuFeat::new_u32(0x40000001, CpuidReg::Eax, 0x31237648),
 }

--- a/kernel/src/cpu/features.rs
+++ b/kernel/src/cpu/features.rs
@@ -4,33 +4,25 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
-use crate::platform::SvsmPlatform;
+use crate::platform::cpuid;
 
 const X86_FEATURE_PGE: u32 = 13;
 const X86_FEATURE_SMEP: u32 = 7;
 const X86_FEATURE_SMAP: u32 = 20;
 const X86_FEATURE_UMIP: u32 = 2;
 
-pub fn cpu_has_pge(platform: &dyn SvsmPlatform) -> bool {
-    platform
-        .cpuid(0x0000_0001, 0)
-        .map_or_else(|| false, |c| (c.edx >> X86_FEATURE_PGE) & 1 == 1)
+pub fn cpu_has_pge() -> bool {
+    cpuid(0x0000_0001, 0).map_or_else(|| false, |c| (c.edx >> X86_FEATURE_PGE) & 1 == 1)
 }
 
-pub fn cpu_has_smep(platform: &dyn SvsmPlatform) -> bool {
-    platform
-        .cpuid(0x0000_0007, 0)
-        .map_or_else(|| false, |c| (c.ebx >> X86_FEATURE_SMEP & 1) == 1)
+pub fn cpu_has_smep() -> bool {
+    cpuid(0x0000_0007, 0).map_or_else(|| false, |c| (c.ebx >> X86_FEATURE_SMEP & 1) == 1)
 }
 
-pub fn cpu_has_smap(platform: &dyn SvsmPlatform) -> bool {
-    platform
-        .cpuid(0x0000_0007, 0)
-        .map_or_else(|| false, |c| (c.ebx >> X86_FEATURE_SMAP & 1) == 1)
+pub fn cpu_has_smap() -> bool {
+    cpuid(0x0000_0007, 0).map_or_else(|| false, |c| (c.ebx >> X86_FEATURE_SMAP & 1) == 1)
 }
 
-pub fn cpu_has_umip(platform: &dyn SvsmPlatform) -> bool {
-    platform
-        .cpuid(0x0000_0007, 0)
-        .map_or_else(|| false, |c| (c.ecx >> X86_FEATURE_UMIP & 1) == 1)
+pub fn cpu_has_umip() -> bool {
+    cpuid(0x0000_0007, 0).map_or_else(|| false, |c| (c.ecx >> X86_FEATURE_UMIP & 1) == 1)
 }

--- a/kernel/src/cpu/features.rs
+++ b/kernel/src/cpu/features.rs
@@ -159,4 +159,5 @@ define_cpu_feats! {
     Smep => CpuFeat::new_bit(0x0000_0007, CpuidReg::Ebx, 7),
     Smap => CpuFeat::new_bit(0x0000_0007, CpuidReg::Ebx, 20),
     Umip => CpuFeat::new_bit(0x0000_0007, CpuidReg::Ecx, 2),
+    CetSS => CpuFeat::new_bit(0x0000_0007, CpuidReg::Ecx, 7),
 }

--- a/kernel/src/cpu/features.rs
+++ b/kernel/src/cpu/features.rs
@@ -155,6 +155,7 @@ pub fn cpu_get_feat(feat: Feature) -> u32 {
 }
 
 define_cpu_feats! {
+    X2Apic => CpuFeat::new_bit(0x0000_0001, CpuidReg::Ecx, 21),
     Xsave => CpuFeat::new_bit(0x0000_0001, CpuidReg::Ecx, 26),
     Pge => CpuFeat::new_bit(0x0000_0001, CpuidReg::Edx, 13),
     Sse1 => CpuFeat::new_bit(0x0000_0001, CpuidReg::Edx, 25),

--- a/kernel/src/cpu/features.rs
+++ b/kernel/src/cpu/features.rs
@@ -1,28 +1,162 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //
-// Copyright (c) 2022-2023 SUSE LLC
+// Copyright (c) 2022-2023, 2026 SUSE LLC
 //
-// Author: Joerg Roedel <jroedel@suse.de>
+// Authors: Joerg Roedel <jroedel@suse.de>
+//          Carlos López <clopez@suse.de>
 
-use crate::platform::cpuid;
+use core::arch::x86_64::CpuidResult;
 
-const X86_FEATURE_PGE: u32 = 13;
-const X86_FEATURE_SMEP: u32 = 7;
-const X86_FEATURE_SMAP: u32 = 20;
-const X86_FEATURE_UMIP: u32 = 2;
+use crate::{platform::cpuid, utils::immut_after_init::ImmutAfterInitCell};
 
-pub fn cpu_has_pge() -> bool {
-    cpuid(0x0000_0001, 0).map_or_else(|| false, |c| (c.edx >> X86_FEATURE_PGE) & 1 == 1)
+/// The CPUID output register for a particular feature
+#[derive(Clone, Copy, Debug)]
+enum CpuidReg {
+    Eax,
+    Ebx,
+    Ecx,
+    Edx,
 }
 
-pub fn cpu_has_smep() -> bool {
-    cpuid(0x0000_0007, 0).map_or_else(|| false, |c| (c.ebx >> X86_FEATURE_SMEP & 1) == 1)
+/// A discoverable CPU feature.
+///
+/// At the moment this type is used for CPUID detection, but it can
+/// be expanded to use other sources of information.
+#[derive(Debug)]
+struct CpuFeat {
+    /// Raw value
+    val: ImmutAfterInitCell<u32>,
+    /// CPUID leaf
+    leaf: u32,
+    /// CPUID subleaf
+    subleaf: u32,
+    /// CPUID output register
+    reg: CpuidReg,
+    /// Bitshift to apply to raw value
+    shift: u8,
+    /// Bitmask to apply to raw value
+    bitsize: u8,
+    /// Expected value after shift + mask
+    expected: u32,
 }
 
-pub fn cpu_has_smap() -> bool {
-    cpuid(0x0000_0007, 0).map_or_else(|| false, |c| (c.ebx >> X86_FEATURE_SMAP & 1) == 1)
+impl CpuFeat {
+    /// Create a new feature, indicated by a single bit in the specified
+    /// register in the given CPUID leaf.
+    const fn new_bit(leaf: u32, reg: CpuidReg, bit: u8) -> Self {
+        Self::new(leaf, reg, bit, 1, 1)
+    }
+
+    /// Create a new feature, indicated by the full value of a register
+    /// in the given CPUID leaf.
+    const fn new_u32(leaf: u32, reg: CpuidReg, expected: u32) -> Self {
+        Self::new(leaf, reg, 0, u32::BITS as u8, expected)
+    }
+
+    /// Create a new CPU feature, detected by querying the given CPUID leaf, and applying
+    /// a bitshift and bitmask on the specified output register to compare it to the given
+    /// expected value.
+    const fn new(leaf: u32, reg: CpuidReg, shift: u8, bitsize: u8, expected: u32) -> Self {
+        // This method is only called from const context, so these assertions have no
+        // runtime effect.
+        assert!((shift as u32) < u32::BITS);
+        assert!((bitsize as u32) <= u32::BITS);
+        Self {
+            val: ImmutAfterInitCell::uninit(),
+            leaf,
+            subleaf: 0,
+            reg,
+            shift,
+            bitsize,
+            expected,
+        }
+    }
+
+    /// Create a copy of the given CPU feature, but with the specified
+    /// subleaf.
+    const fn with_subfn(mut self, subleaf: u32) -> Self {
+        self.subleaf = subleaf;
+        self
+    }
+
+    /// Get the CPUID register that corresponds to this feature
+    const fn get_reg(&self, cpuid: &CpuidResult) -> u32 {
+        match self.reg {
+            CpuidReg::Eax => cpuid.eax,
+            CpuidReg::Ebx => cpuid.ebx,
+            CpuidReg::Ecx => cpuid.ecx,
+            CpuidReg::Edx => cpuid.edx,
+        }
+    }
+
+    const fn mask(&self) -> u32 {
+        ((1u64 << self.bitsize) - 1) as u32
+    }
+
+    fn get_or_init(&self) -> u32 {
+        if let Ok(val) = self.val.try_get_inner() {
+            return *val;
+        }
+        let val = cpuid(self.leaf, self.subleaf).map_or(0, |c| self.get_reg(&c));
+        // If init() fails it means the cell got initialized by someone else
+        // concurrently, which is always benign.
+        let _ = self.val.init(val);
+        val
+    }
+
+    /// Gets the raw value of this feature, lazily querying CPUID if
+    /// the value is not cached from a previous query
+    fn get(&self) -> u32 {
+        (self.get_or_init() >> self.shift) & self.mask()
+    }
+
+    /// Checks whether this feature is available by comparing it to
+    /// its expected value, lazily querying CPUID if the value is not
+    /// cached from a previous query
+    fn enabled(&self) -> bool {
+        self.get() == self.expected
+    }
 }
 
-pub fn cpu_has_umip() -> bool {
-    cpuid(0x0000_0007, 0).map_or_else(|| false, |c| (c.ecx >> X86_FEATURE_UMIP & 1) == 1)
+/// Macro to generate a CPU feature lookup table
+macro_rules! define_cpu_feats {
+    (
+        $(
+            $variant:ident => $feat_expr:expr
+        ),* $(,)?
+    ) => {
+
+        // Feature enum to use as index
+        #[repr(usize)]
+        #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+        pub enum Feature {
+            $( $variant, )*
+        }
+
+        /// The number of defined features
+        const NUM_FEATS: usize = [ $( stringify!($variant) ),* ].len();
+
+        static CPU_FEATS: [CpuFeat; NUM_FEATS] = [
+            $( $feat_expr, )*
+        ];
+    };
+}
+
+/// Check if the given feature is enabled by comparing it to its expected
+/// value.
+pub fn cpu_has_feat(feat: Feature) -> bool {
+    // Because of #[repr(usize)], this cast matches the array index perfectly.
+    CPU_FEATS[feat as usize].enabled()
+}
+
+/// Gets the raw value of the given feature
+pub fn cpu_get_feat(feat: Feature) -> u32 {
+    CPU_FEATS[feat as usize].get()
+}
+
+define_cpu_feats! {
+    Pge => CpuFeat::new_bit(0x0000_0001, CpuidReg::Edx, 13),
+    Smep => CpuFeat::new_bit(0x0000_0007, CpuidReg::Ebx, 7),
+    Smap => CpuFeat::new_bit(0x0000_0007, CpuidReg::Ebx, 20),
+    Umip => CpuFeat::new_bit(0x0000_0007, CpuidReg::Ecx, 2),
 }

--- a/kernel/src/cpu/features.rs
+++ b/kernel/src/cpu/features.rs
@@ -168,4 +168,5 @@ define_cpu_feats! {
     XsaveSize => CpuFeat::new_u32(0x0000_000d, CpuidReg::Ecx, 0),
     XsaveOpt => CpuFeat::new_bit(0x0000_000d, CpuidReg::Eax, 0).with_subfn(1),
     HyperV => CpuFeat::new_u32(0x40000001, CpuidReg::Eax, 0x31237648),
+    InvlpgbMax => CpuFeat::new(0x80000008, CpuidReg::Edx, 0, u16::BITS as u8, 0),
 }

--- a/kernel/src/cpu/features.rs
+++ b/kernel/src/cpu/features.rs
@@ -168,5 +168,6 @@ define_cpu_feats! {
     XsaveSize => CpuFeat::new_u32(0x0000_000d, CpuidReg::Ecx, 0),
     XsaveOpt => CpuFeat::new_bit(0x0000_000d, CpuidReg::Eax, 0).with_subfn(1),
     HyperV => CpuFeat::new_u32(0x40000001, CpuidReg::Eax, 0x31237648),
+    PhysAddrSizes => CpuFeat::new_u32(0x80000008, CpuidReg::Eax, 0),
     InvlpgbMax => CpuFeat::new(0x80000008, CpuidReg::Edx, 0, u16::BITS as u8, 0),
 }

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -6,11 +6,12 @@
 
 extern crate alloc;
 
+use super::features::{Feature, cpu_has_feat};
 use super::gdt::GDT;
 use super::ipi::IpiState;
 use super::isst::Isst;
 use super::msr::write_msr;
-use super::shadow_stack::{ISST_ADDR, init_shadow_stack, is_cet_ss_enabled, is_cet_ss_supported};
+use super::shadow_stack::{ISST_ADDR, init_shadow_stack, is_cet_ss_enabled};
 use super::tss::{IST_DF, X86Tss};
 use crate::address::{Address, PhysAddr, VirtAddr};
 use crate::cpu::control_regs::{read_cr0, read_cr4};
@@ -802,14 +803,14 @@ impl PerCpu {
         // Reserve ranges and initialize allocator for temporary mappings
         self.initialize_vm_ranges()?;
 
-        if is_cet_ss_supported() {
+        if cpu_has_feat(Feature::CetSS) {
             self.allocate_init_shadow_stack()?;
         }
 
         // Allocate per-cpu context switch stack
         self.allocate_context_switch_stack()?;
 
-        if is_cet_ss_supported() {
+        if cpu_has_feat(Feature::CetSS) {
             self.allocate_context_switch_shadow_stack()?;
         }
 
@@ -819,7 +820,7 @@ impl PerCpu {
         // Setup TSS
         self.setup_tss();
 
-        if is_cet_ss_supported() {
+        if cpu_has_feat(Feature::CetSS) {
             // Allocate ISST shadow stacks
             self.allocate_isst_shadow_stacks()?;
 

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -23,8 +23,8 @@ use crate::cpu::vmsa::{svsm_code_segment, svsm_data_segment, svsm_gdt_segment, s
 use crate::cpu::x86::{ApicAccess, X86Apic};
 use crate::cpu::{IrqGuard, IrqState, LocalApic, ShadowStackInit};
 use crate::error::{ApicError, SvsmError};
+use crate::hyperv::HypercallPagesGuard;
 use crate::hyperv::{self, HypercallPage};
-use crate::hyperv::{HypercallPagesGuard, IS_HYPERV};
 use crate::locking::{
     LockGuard, RWLock, RWLockIrqSafe, ReadLockGuard, ReadLockGuardIrqSafe, SpinLock,
     WriteLockGuard, WriteLockGuardIrqSafe,
@@ -835,7 +835,7 @@ impl PerCpu {
 
         // Allocate hypercall pages if running on Hyper-V, unless this is the
         // BSP (where they will be allocated later).
-        if self.shared.cpu_index() != 0 && *IS_HYPERV {
+        if self.shared.cpu_index() != 0 && cpu_has_feat(Feature::HyperV) {
             self.allocate_hypercall_pages()?;
         }
 

--- a/kernel/src/cpu/shadow_stack.rs
+++ b/kernel/src/cpu/shadow_stack.rs
@@ -5,7 +5,6 @@
 // Author: Tom Dohrmann <erbse.13@gmx.de>
 
 use crate::address::{Address, VirtAddr};
-use crate::platform::{SvsmPlatform, cpuid};
 
 use crate::mm::{PAGE_SIZE, PageRef};
 use core::sync::atomic::{AtomicBool, Ordering};
@@ -24,28 +23,8 @@ pub const BUSY: usize = 1;
 pub static IS_CET_SUPPORTED: AtomicBool = AtomicBool::new(false);
 pub static IS_CET_ENABLED: AtomicBool = AtomicBool::new(false);
 
-// Try to enable the CET feature in CR4 and set `IS_CET_SUPPORTED` if successful.
-pub fn determine_cet_support(platform: &dyn SvsmPlatform) {
-    if platform.determine_cet_support() {
-        IS_CET_SUPPORTED.store(true, Ordering::Relaxed);
-    }
-}
-
 pub fn set_cet_ss_enabled() {
     IS_CET_ENABLED.store(true, Ordering::Relaxed);
-}
-
-pub fn determine_cet_support_from_cpuid() -> bool {
-    let ecx = cpuid(7, 0).map_or(0, |res| res.ecx);
-    (ecx & 0x80) != 0
-}
-
-/// Returns whether shadow stacks are supported by the CPU and the kernel.
-#[inline(always)]
-pub fn is_cet_ss_supported() -> bool {
-    // In theory CPUs can have support for CET, but not CET_SS, but in practice
-    // no such CPUs exist. Treat CET being supported as CET_SS being supported.
-    IS_CET_SUPPORTED.load(Ordering::Relaxed)
 }
 
 /// Returns whether shadow stacks are currently enabled.

--- a/kernel/src/cpu/shadow_stack.rs
+++ b/kernel/src/cpu/shadow_stack.rs
@@ -5,14 +5,13 @@
 // Author: Tom Dohrmann <erbse.13@gmx.de>
 
 use crate::address::{Address, VirtAddr};
-use crate::platform::SvsmPlatform;
+use crate::platform::{SvsmPlatform, cpuid};
 
 use crate::mm::{PAGE_SIZE, PageRef};
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use bitflags::bitflags;
 
-use super::cpuid::CpuidResult;
 use super::msr::read_msr;
 
 pub const S_CET: u32 = 0x6a2;
@@ -37,8 +36,8 @@ pub fn set_cet_ss_enabled() {
 }
 
 pub fn determine_cet_support_from_cpuid() -> bool {
-    let cpuid = CpuidResult::get(7, 0);
-    (cpuid.ecx & 0x80) != 0
+    let ecx = cpuid(7, 0).map_or(0, |res| res.ecx);
+    (ecx & 0x80) != 0
 }
 
 /// Returns whether shadow stacks are supported by the CPU and the kernel.

--- a/kernel/src/cpu/sse.rs
+++ b/kernel/src/cpu/sse.rs
@@ -5,47 +5,25 @@
 // Author: Vasant Karasulli <vkarasulli@suse.de>
 
 use crate::cpu::control_regs::{cr0_sse_enable, cr4_osfxsr_enable, cr4_xsave_enable};
-use crate::platform::cpuid;
 use core::arch::asm;
 use core::arch::x86_64::{_xgetbv, _xsetbv};
 use core::sync::atomic::{AtomicU64, Ordering};
 
-const CPUID_EDX_SSE1: u32 = 25;
-const CPUID_ECX_XSAVE: u32 = 26;
-const CPUID_EAX_XSAVEOPT: u32 = 0;
+use super::features::{Feature, cpu_has_feat};
+
 const XCR0_X87_ENABLE: u64 = 0x1;
 const XCR0_SSE_ENABLE: u64 = 0x2;
 const XCR0_YMM_ENABLE: u64 = 0x4;
 
 static SVSM_XCR0: AtomicU64 = AtomicU64::new(XCR0_X87_ENABLE | XCR0_SSE_ENABLE);
 
-fn legacy_sse_supported() -> bool {
-    let edx = cpuid(1, 0).map_or(0, |res| res.edx);
-    (edx & (1 << CPUID_EDX_SSE1)) != 0
-}
-
 fn legacy_sse_enable() {
-    if legacy_sse_supported() {
+    if cpu_has_feat(Feature::Sse1) {
         cr4_osfxsr_enable();
         cr0_sse_enable();
     } else {
         panic!("Legacy SSE unsupported");
     }
-}
-
-fn extended_sse_supported() -> bool {
-    let eax = cpuid(0xd, 0).map_or(0, |res| res.eax);
-    (eax & 0x7) == 0x7
-}
-
-fn xsave_supported() -> bool {
-    let ecx = cpuid(1, 0).map_or(0, |res| res.ecx);
-    (ecx & (1 << CPUID_ECX_XSAVE)) != 0
-}
-
-fn xsaveopt_supported() -> bool {
-    let eax = cpuid(0xd, 1).map_or(0, |res| res.eax);
-    (eax & (1 << CPUID_EAX_XSAVEOPT)) != 0
 }
 
 fn xcr0_set() {
@@ -57,13 +35,12 @@ fn xcr0_set() {
     }
 }
 
-pub fn get_xsave_area_size() -> u32 {
-    cpuid(0xd, 0).map_or(0, |res| res.ecx)
-}
-
 fn xsave_enable() {
-    if xsave_supported() && xsaveopt_supported() {
-        if extended_sse_supported() {
+    if cpu_has_feat(Feature::Xsave) && cpu_has_feat(Feature::XsaveOpt) {
+        if cpu_has_feat(Feature::Xcr0X87)
+            && cpu_has_feat(Feature::Xcr0Sse)
+            && cpu_has_feat(Feature::Xcr0Avx)
+        {
             SVSM_XCR0.fetch_or(XCR0_YMM_ENABLE, Ordering::Relaxed);
         }
         cr4_xsave_enable();

--- a/kernel/src/cpu/sse.rs
+++ b/kernel/src/cpu/sse.rs
@@ -5,7 +5,7 @@
 // Author: Vasant Karasulli <vkarasulli@suse.de>
 
 use crate::cpu::control_regs::{cr0_sse_enable, cr4_osfxsr_enable, cr4_xsave_enable};
-use crate::cpu::cpuid::CpuidResult;
+use crate::platform::cpuid;
 use core::arch::asm;
 use core::arch::x86_64::{_xgetbv, _xsetbv};
 use core::sync::atomic::{AtomicU64, Ordering};
@@ -20,8 +20,8 @@ const XCR0_YMM_ENABLE: u64 = 0x4;
 static SVSM_XCR0: AtomicU64 = AtomicU64::new(XCR0_X87_ENABLE | XCR0_SSE_ENABLE);
 
 fn legacy_sse_supported() -> bool {
-    let res = CpuidResult::get(1, 0);
-    (res.edx & (1 << CPUID_EDX_SSE1)) != 0
+    let edx = cpuid(1, 0).map_or(0, |res| res.edx);
+    (edx & (1 << CPUID_EDX_SSE1)) != 0
 }
 
 fn legacy_sse_enable() {
@@ -34,18 +34,18 @@ fn legacy_sse_enable() {
 }
 
 fn extended_sse_supported() -> bool {
-    let res = CpuidResult::get(0xD, 0);
-    (res.eax & 0x7) == 0x7
+    let eax = cpuid(0xd, 0).map_or(0, |res| res.eax);
+    (eax & 0x7) == 0x7
 }
 
 fn xsave_supported() -> bool {
-    let res = CpuidResult::get(1, 0);
-    (res.ecx & (1 << CPUID_ECX_XSAVE)) != 0
+    let ecx = cpuid(1, 0).map_or(0, |res| res.ecx);
+    (ecx & (1 << CPUID_ECX_XSAVE)) != 0
 }
 
 fn xsaveopt_supported() -> bool {
-    let res = CpuidResult::get(0xD, 1);
-    (res.eax & (1 << CPUID_EAX_XSAVEOPT)) != 0
+    let eax = cpuid(0xd, 1).map_or(0, |res| res.eax);
+    (eax & (1 << CPUID_EAX_XSAVEOPT)) != 0
 }
 
 fn xcr0_set() {
@@ -58,8 +58,7 @@ fn xcr0_set() {
 }
 
 pub fn get_xsave_area_size() -> u32 {
-    let res = CpuidResult::get(0xD, 0);
-    res.ecx
+    cpuid(0xd, 0).map_or(0, |res| res.ecx)
 }
 
 fn xsave_enable() {

--- a/kernel/src/cpu/vc.rs
+++ b/kernel/src/cpu/vc.rs
@@ -8,7 +8,7 @@ use super::idt::common::X86ExceptionContext;
 use crate::address::Address;
 use crate::address::VirtAddr;
 use crate::cpu::X86GeneralRegs;
-use crate::cpu::cpuid::{CpuidLeaf, cpuid_table_raw};
+use crate::cpu::cpuid::cpuid_table_raw;
 use crate::cpu::percpu::current_ghcb;
 use crate::cpu::percpu::this_cpu;
 use crate::debug::gdbstub::svsm_gdbstub::handle_debug_exception;
@@ -248,26 +248,22 @@ fn handle_cpuid(ctx: &mut X86ExceptionContext) -> Result<(), SvsmError> {
 }
 
 fn snp_cpuid(ctx: &mut X86ExceptionContext) -> Result<(), SvsmError> {
-    let mut leaf = CpuidLeaf::new(ctx.regs.rax as u32, ctx.regs.rcx as u32);
-    let xcr0_in = if leaf.cpuid_fn == 0xD && (leaf.cpuid_subfn == 1 || leaf.cpuid_subfn == 0) {
+    let cpuid_fn = ctx.regs.rax as u32;
+    let cpuid_subfn = ctx.regs.rcx as u32;
+    let xcr0_in = if cpuid_fn == 0xD && (cpuid_subfn == 1 || cpuid_subfn == 0) {
         1
     } else {
         0
     };
 
-    let Some(ret) = cpuid_table_raw(leaf.cpuid_fn, leaf.cpuid_subfn, xcr0_in, 0) else {
+    let Some(ret) = cpuid_table_raw(cpuid_fn, cpuid_subfn, xcr0_in, 0) else {
         return Err(VcError::new(ctx, VcErrorType::UnknownCpuidLeaf).into());
     };
 
-    leaf.eax = ret.eax;
-    leaf.ebx = ret.ebx;
-    leaf.ecx = ret.ecx;
-    leaf.edx = ret.edx;
-
-    ctx.regs.rax = leaf.eax as usize;
-    ctx.regs.rbx = leaf.ebx as usize;
-    ctx.regs.rcx = leaf.ecx as usize;
-    ctx.regs.rdx = leaf.edx as usize;
+    ctx.regs.rax = ret.eax as usize;
+    ctx.regs.rbx = ret.ebx as usize;
+    ctx.regs.rcx = ret.ecx as usize;
+    ctx.regs.rdx = ret.edx as usize;
 
     Ok(())
 }

--- a/kernel/src/hyperv/hv.rs
+++ b/kernel/src/hyperv/hv.rs
@@ -5,6 +5,7 @@
 // Author: Jon Lange (jlange@microsoft.com)
 
 use crate::address::{PhysAddr, VirtAddr};
+use crate::cpu::features::{Feature, cpu_has_feat};
 use crate::cpu::mem::unsafe_copy_bytes;
 use crate::cpu::msr::write_msr;
 use crate::cpu::percpu::{PerCpu, this_cpu};
@@ -18,7 +19,7 @@ use crate::mm::alloc::allocate_pages;
 use crate::mm::page_visibility::SharedBox;
 use crate::mm::pagetable::PTEntryFlags;
 use crate::mm::{SVSM_HYPERCALL_CODE_PAGE, virt_to_page_frame};
-use crate::platform::{SVSM_PLATFORM, cpuid};
+use crate::platform::SVSM_PLATFORM;
 use crate::types::PAGE_SIZE;
 use crate::utils::immut_after_init::ImmutAfterInitCell;
 
@@ -281,16 +282,6 @@ pub const HV_STATUS_TIMEOUT: u16 = 0x78;
 
 static HYPERV_HYPERCALL_CODE_PAGE: ImmutAfterInitCell<VirtAddr> = ImmutAfterInitCell::uninit();
 static CURRENT_VTL: ImmutAfterInitCell<u8> = ImmutAfterInitCell::uninit();
-pub static IS_HYPERV: ImmutAfterInitCell<bool> = ImmutAfterInitCell::uninit();
-
-fn is_hyperv_hypervisor() -> bool {
-    // Get the hypervisor interface signature.
-    if let Some(cpuid_result) = cpuid(0x40000001, 0) {
-        cpuid_result.eax == 0x31237648
-    } else {
-        false
-    }
-}
 
 pub fn setup_hypercall_page() -> Result<(), SvsmError> {
     // Allocate a page to use as the hypercall code page.
@@ -342,12 +333,7 @@ fn hyperv_setup_hypercalls() -> Result<(), SvsmError> {
 
 pub fn hyperv_setup() -> Result<(), SvsmError> {
     // First, determine if this is a Hyper-V system.
-    let is_hyperv = is_hyperv_hypervisor();
-    IS_HYPERV
-        .init(is_hyperv)
-        .expect("Hyper-V support already initialized");
-
-    if is_hyperv {
+    if cpu_has_feat(Feature::HyperV) {
         // If this is the BSP, then configure hypercall pages.
         this_cpu().allocate_hypercall_pages()?;
 

--- a/kernel/src/hyperv/hv.rs
+++ b/kernel/src/hyperv/hv.rs
@@ -18,7 +18,7 @@ use crate::mm::alloc::allocate_pages;
 use crate::mm::page_visibility::SharedBox;
 use crate::mm::pagetable::PTEntryFlags;
 use crate::mm::{SVSM_HYPERCALL_CODE_PAGE, virt_to_page_frame};
-use crate::platform::SVSM_PLATFORM;
+use crate::platform::{SVSM_PLATFORM, cpuid};
 use crate::types::PAGE_SIZE;
 use crate::utils::immut_after_init::ImmutAfterInitCell;
 
@@ -285,8 +285,7 @@ pub static IS_HYPERV: ImmutAfterInitCell<bool> = ImmutAfterInitCell::uninit();
 
 fn is_hyperv_hypervisor() -> bool {
     // Get the hypervisor interface signature.
-    let result = SVSM_PLATFORM.cpuid(0x40000001, 0);
-    if let Some(cpuid_result) = result {
+    if let Some(cpuid_result) = cpuid(0x40000001, 0) {
         cpuid_result.eax == 0x31237648
     } else {
         false

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -27,7 +27,6 @@ use crate::address::{PhysAddr, VirtAddr};
 use crate::boot_params::BootParams;
 use crate::cpu::IrqGuard;
 use crate::cpu::percpu::PerCpu;
-use crate::cpu::shadow_stack::determine_cet_support_from_cpuid;
 use crate::cpu::tlb::{TlbFlushScope, flush_tlb};
 use crate::error::SvsmError;
 use crate::hyperv;
@@ -149,11 +148,6 @@ pub trait SvsmPlatform: Sync {
 
     /// Determines the paging encryption masks for the current architecture.
     fn get_page_encryption_masks(&self) -> PageEncryptionMasks;
-
-    /// Determine whether shadow stacks are supported.
-    fn determine_cet_support(&self) -> bool {
-        determine_cet_support_from_cpuid()
-    }
 
     /// Get the features and the capabilities of the platform.
     fn capabilities(&self) -> Caps;

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -19,13 +19,13 @@ use snp::{SnpPlatform, SnpStage2Platform};
 use tdp::{TdpPlatform, TdpStage2Platform};
 
 use core::arch::asm;
+use core::arch::x86_64::{__cpuid_count, CpuidResult};
 use core::fmt::Debug;
 use core::mem::MaybeUninit;
 
 use crate::address::{PhysAddr, VirtAddr};
 use crate::boot_params::BootParams;
 use crate::cpu::IrqGuard;
-use crate::cpu::cpuid::CpuidResult;
 use crate::cpu::percpu::PerCpu;
 use crate::cpu::shadow_stack::determine_cet_support_from_cpuid;
 use crate::cpu::tlb::{TlbFlushScope, flush_tlb};
@@ -179,7 +179,8 @@ pub trait SvsmPlatform: Sync {
     where
         Self: Sized,
     {
-        Some(CpuidResult::get(eax, ecx))
+        // SAFETY: CPUID is always safe
+        unsafe { Some(__cpuid_count(eax, ecx)) }
     }
 
     /// Write a host-owned MSR.

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -177,7 +177,10 @@ pub trait SvsmPlatform: Sync {
     /// Obtain CPUID using platform-specific tables.
     fn cpuid(eax: u32, ecx: u32) -> Option<CpuidResult>
     where
-        Self: Sized;
+        Self: Sized,
+    {
+        Some(CpuidResult::get(eax, ecx))
+    }
 
     /// Write a host-owned MSR.
     /// # Safety

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -175,7 +175,9 @@ pub trait SvsmPlatform: Sync {
     ) -> hyperv::HvHypercallOutput;
 
     /// Obtain CPUID using platform-specific tables.
-    fn cpuid(&self, eax: u32, ecx: u32) -> Option<CpuidResult>;
+    fn cpuid(eax: u32, ecx: u32) -> Option<CpuidResult>
+    where
+        Self: Sized;
 
     /// Write a host-owned MSR.
     /// # Safety
@@ -406,6 +408,11 @@ macro_rules! platform_method {
             SvsmPlatformType::Tdp => TdpPlatform::$fn($($arg),*),
         }
     };
+}
+
+#[inline]
+pub fn cpuid(leaf: u32, subleaf: u32) -> Option<CpuidResult> {
+    platform_method!(cpuid, leaf, subleaf)
 }
 
 pub fn halt() {

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -398,22 +398,24 @@ pub fn init_capabilities() {
     CAPS.init(caps).unwrap();
 }
 
+macro_rules! platform_method {
+    ($fn:ident $(, $arg:expr )*) => {
+        match *SVSM_PLATFORM_TYPE {
+            SvsmPlatformType::Native => NativePlatform::$fn($($arg),*),
+            SvsmPlatformType::Snp => SnpPlatform::$fn($($arg),*),
+            SvsmPlatformType::Tdp => TdpPlatform::$fn($($arg),*),
+        }
+    };
+}
+
 pub fn halt() {
     // Use a platform-specific halt.  However, the SVSM_PLATFORM global may not
     // yet be initialized, so go choose the halt implementation based on the
     // platform-specific halt instead.
-    match *SVSM_PLATFORM_TYPE {
-        SvsmPlatformType::Native => NativePlatform::halt(),
-        SvsmPlatformType::Snp => SnpPlatform::halt(),
-        SvsmPlatformType::Tdp => TdpPlatform::halt(),
-    }
+    platform_method!(halt)
 }
 
 /// Terminates the guest with a platform-specific mechanism
 pub fn terminate() -> ! {
-    match *SVSM_PLATFORM_TYPE {
-        SvsmPlatformType::Native => NativePlatform::terminate(),
-        SvsmPlatformType::Snp => SnpPlatform::terminate(),
-        SvsmPlatformType::Tdp => TdpPlatform::terminate(),
-    }
+    platform_method!(terminate)
 }

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -12,7 +12,6 @@ use crate::address::{PhysAddr, VirtAddr};
 use crate::console::init_svsm_console;
 use crate::cpu::IrqGuard;
 use crate::cpu::apic::{ApicIcr, IcrMessageType};
-use crate::cpu::cpuid::CpuidResult;
 use crate::cpu::irq_state::raw_irqs_disable;
 use crate::cpu::msr::write_msr;
 use crate::cpu::percpu::PerCpu;
@@ -51,7 +50,7 @@ pub struct NativePlatform {}
 impl NativePlatform {
     pub fn new(_suppress_svsm_interrupts: bool) -> Self {
         // Execution is not possible unless X2APIC is supported.
-        let features = CpuidResult::get(1, 0);
+        let features = Self::cpuid(1, 0).unwrap();
         if (features.ecx & 0x200000) == 0 {
             panic!("X2APIC is not supported");
         }
@@ -99,7 +98,7 @@ impl SvsmPlatform for NativePlatform {
 
     fn get_page_encryption_masks(&self) -> PageEncryptionMasks {
         // Find physical address size.
-        let res = CpuidResult::get(0x80000008, 0);
+        let res = Self::cpuid(0x80000008, 0).unwrap();
         PageEncryptionMasks {
             private_pte_mask: 0,
             shared_pte_mask: 0,

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -50,8 +50,7 @@ pub struct NativePlatform {}
 impl NativePlatform {
     pub fn new(_suppress_svsm_interrupts: bool) -> Self {
         // Execution is not possible unless X2APIC is supported.
-        let features = Self::cpuid(1, 0).unwrap();
-        if (features.ecx & 0x200000) == 0 {
+        if !cpu_has_feat(Feature::X2Apic) {
             panic!("X2APIC is not supported");
         }
         Self {}

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -131,13 +131,6 @@ impl SvsmPlatform for NativePlatform {
         unsafe { hyperv::execute_hypercall(input_control, hypercall_pages) }
     }
 
-    fn cpuid(eax: u32, ecx: u32) -> Option<CpuidResult>
-    where
-        Self: Sized,
-    {
-        Some(CpuidResult::get(eax, ecx))
-    }
-
     unsafe fn write_host_msr(&self, msr: u32, value: u64) {
         // SAFETY: the caller takes responsibility for ensuring the safety
         // of the MSR write.

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -12,6 +12,7 @@ use crate::address::{PhysAddr, VirtAddr};
 use crate::console::init_svsm_console;
 use crate::cpu::IrqGuard;
 use crate::cpu::apic::{ApicIcr, IcrMessageType};
+use crate::cpu::features::{Feature, cpu_has_feat};
 use crate::cpu::irq_state::raw_irqs_disable;
 use crate::cpu::msr::write_msr;
 use crate::cpu::percpu::PerCpu;
@@ -21,7 +22,6 @@ use crate::cpu::x86::{
 };
 use crate::error::SvsmError;
 use crate::hyperv;
-use crate::hyperv::IS_HYPERV;
 use crate::hyperv::hyperv_start_cpu;
 use crate::io::{DEFAULT_IO_DRIVER, IOPort};
 use crate::mm::PerCPUMapping;
@@ -215,7 +215,7 @@ impl SvsmPlatform for NativePlatform {
         transition_page_table: &TransitionPageTable,
     ) -> Result<(), SvsmError> {
         let context = cpu.get_initial_context(start_rip);
-        if *IS_HYPERV {
+        if cpu_has_feat(Feature::HyperV) {
             return hyperv_start_cpu(cpu, &context);
         }
 

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -12,7 +12,7 @@ use crate::address::{PhysAddr, VirtAddr};
 use crate::console::init_svsm_console;
 use crate::cpu::IrqGuard;
 use crate::cpu::apic::{ApicIcr, IcrMessageType};
-use crate::cpu::features::{Feature, cpu_has_feat};
+use crate::cpu::features::{Feature, cpu_get_feat, cpu_has_feat};
 use crate::cpu::irq_state::raw_irqs_disable;
 use crate::cpu::msr::write_msr;
 use crate::cpu::percpu::PerCpu;
@@ -98,12 +98,12 @@ impl SvsmPlatform for NativePlatform {
 
     fn get_page_encryption_masks(&self) -> PageEncryptionMasks {
         // Find physical address size.
-        let res = Self::cpuid(0x80000008, 0).unwrap();
+        let phys_addr_sizes = cpu_get_feat(Feature::PhysAddrSizes);
         PageEncryptionMasks {
             private_pte_mask: 0,
             shared_pte_mask: 0,
             addr_mask_width: 64,
-            phys_addr_sizes: res.eax,
+            phys_addr_sizes,
         }
     }
 

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -131,7 +131,10 @@ impl SvsmPlatform for NativePlatform {
         unsafe { hyperv::execute_hypercall(input_control, hypercall_pages) }
     }
 
-    fn cpuid(&self, eax: u32, ecx: u32) -> Option<CpuidResult> {
+    fn cpuid(eax: u32, ecx: u32) -> Option<CpuidResult>
+    where
+        Self: Sized,
+    {
         Some(CpuidResult::get(eax, ecx))
     }
 

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -299,7 +299,10 @@ impl SvsmPlatform for SnpPlatform {
         })
     }
 
-    fn cpuid(&self, eax: u32, ecx: u32) -> Option<CpuidResult> {
+    fn cpuid(eax: u32, ecx: u32) -> Option<CpuidResult>
+    where
+        Self: Sized,
+    {
         // If this is an architectural CPUID leaf, then extract the result
         // from the CPUID table.  Otherwise, request the value from the
         // hypervisor.

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -266,17 +266,6 @@ impl SvsmPlatform for SnpPlatform {
         }
     }
 
-    fn determine_cet_support(&self) -> bool {
-        // Examine CPUID information to see whether CET is supported by the
-        // hypervisor.  If no CPUID information is present, then assume that
-        // CET is supported.
-        if let Some(cpuid) = cpuid_table(7, 0) {
-            (cpuid.ecx & 0x80) != 0
-        } else {
-            todo!()
-        }
-    }
-
     fn capabilities(&self) -> Caps {
         // VMPL0 is SVSM. VMPL1 to VMPL3 are guest.
         let vm_bitmap: u64 = 0xE;

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -19,6 +19,7 @@ use crate::boot_params::BootParams;
 use crate::console::init_svsm_console;
 use crate::cpu::cpuid::CpuidResult;
 use crate::cpu::cpuid::cpuid_table;
+use crate::cpu::cpuid::cpuid_table_raw;
 use crate::cpu::cpuid::init_cpuid_table;
 use crate::cpu::irq_state::raw_irqs_disable;
 use crate::cpu::percpu::{PerCpu, current_ghcb, this_cpu};
@@ -309,7 +310,12 @@ impl SvsmPlatform for SnpPlatform {
         if (eax >> 28) == 4 {
             current_ghcb().cpuid(eax, ecx).ok()
         } else {
-            cpuid_table(eax, ecx)
+            let xcr0 = if eax == 0xd && (ecx == 1 || ecx == 0) {
+                1
+            } else {
+                0
+            };
+            cpuid_table_raw(eax, ecx, xcr0, 0)
         }
     }
 

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -17,7 +17,6 @@ use super::snp_fw::{
 use crate::address::{Address, PhysAddr, VirtAddr};
 use crate::boot_params::BootParams;
 use crate::console::init_svsm_console;
-use crate::cpu::cpuid::CpuidResult;
 use crate::cpu::cpuid::cpuid_table;
 use crate::cpu::cpuid::cpuid_table_raw;
 use crate::cpu::cpuid::init_cpuid_table;
@@ -55,6 +54,7 @@ use syscall::GlobalFeatureFlags;
 use bootdefs::kernel_launch::Stage2LaunchInfo;
 #[cfg(test)]
 use bootdefs::platform::SvsmPlatformType;
+use core::arch::x86_64::CpuidResult;
 use core::mem::MaybeUninit;
 use core::ptr;
 use core::sync::atomic::{AtomicU32, Ordering};

--- a/kernel/src/platform/tdp.rs
+++ b/kernel/src/platform/tdp.rs
@@ -127,7 +127,10 @@ impl SvsmPlatform for TdpPlatform {
         })
     }
 
-    fn cpuid(&self, eax: u32, ecx: u32) -> Option<CpuidResult> {
+    fn cpuid(eax: u32, ecx: u32) -> Option<CpuidResult>
+    where
+        Self: Sized,
+    {
         Some(CpuidResult::get(eax, ecx))
     }
 

--- a/kernel/src/platform/tdp.rs
+++ b/kernel/src/platform/tdp.rs
@@ -8,7 +8,6 @@ use super::capabilities::Caps;
 use super::{PageEncryptionMasks, PageStateChangeOp, PageValidateOp, Stage2Platform, SvsmPlatform};
 use crate::address::{Address, PhysAddr, VirtAddr};
 use crate::console::init_svsm_console;
-use crate::cpu::cpuid::CpuidResult;
 use crate::cpu::irq_state::raw_irqs_disable;
 use crate::cpu::percpu::PerCpu;
 use crate::cpu::smp::create_ap_start_context;
@@ -95,7 +94,7 @@ impl SvsmPlatform for TdpPlatform {
 
     fn get_page_encryption_masks(&self) -> PageEncryptionMasks {
         // Find physical address size.
-        let res = CpuidResult::get(0x80000008, 0);
+        let res = Self::cpuid(0x80000008, 0).unwrap();
         let vtom = *VTOM;
         PageEncryptionMasks {
             private_pte_mask: 0,

--- a/kernel/src/platform/tdp.rs
+++ b/kernel/src/platform/tdp.rs
@@ -8,7 +8,7 @@ use super::capabilities::Caps;
 use super::{PageEncryptionMasks, PageStateChangeOp, PageValidateOp, Stage2Platform, SvsmPlatform};
 use crate::address::{Address, PhysAddr, VirtAddr};
 use crate::console::init_svsm_console;
-use crate::cpu::features::{Feature, cpu_has_feat};
+use crate::cpu::features::{Feature, cpu_get_feat, cpu_has_feat};
 use crate::cpu::irq_state::raw_irqs_disable;
 use crate::cpu::percpu::PerCpu;
 use crate::cpu::smp::create_ap_start_context;
@@ -95,13 +95,13 @@ impl SvsmPlatform for TdpPlatform {
 
     fn get_page_encryption_masks(&self) -> PageEncryptionMasks {
         // Find physical address size.
-        let res = Self::cpuid(0x80000008, 0).unwrap();
+        let phys_addr_sizes = cpu_get_feat(Feature::PhysAddrSizes);
         let vtom = *VTOM;
         PageEncryptionMasks {
             private_pte_mask: 0,
             shared_pte_mask: vtom,
             addr_mask_width: vtom.trailing_zeros(),
-            phys_addr_sizes: res.eax,
+            phys_addr_sizes,
         }
     }
 

--- a/kernel/src/platform/tdp.rs
+++ b/kernel/src/platform/tdp.rs
@@ -127,13 +127,6 @@ impl SvsmPlatform for TdpPlatform {
         })
     }
 
-    fn cpuid(eax: u32, ecx: u32) -> Option<CpuidResult>
-    where
-        Self: Sized,
-    {
-        Some(CpuidResult::get(eax, ecx))
-    }
-
     unsafe fn write_host_msr(&self, msr: u32, value: u64) {
         tdvmcall_wrmsr(msr, value);
     }

--- a/kernel/src/platform/tdp.rs
+++ b/kernel/src/platform/tdp.rs
@@ -8,13 +8,14 @@ use super::capabilities::Caps;
 use super::{PageEncryptionMasks, PageStateChangeOp, PageValidateOp, Stage2Platform, SvsmPlatform};
 use crate::address::{Address, PhysAddr, VirtAddr};
 use crate::console::init_svsm_console;
+use crate::cpu::features::{Feature, cpu_has_feat};
 use crate::cpu::irq_state::raw_irqs_disable;
 use crate::cpu::percpu::PerCpu;
 use crate::cpu::smp::create_ap_start_context;
 use crate::cpu::x86::{apic_in_service, apic_initialize, apic_sw_enable};
 use crate::error::SvsmError;
 use crate::hyperv;
-use crate::hyperv::{IS_HYPERV, hyperv_start_cpu};
+use crate::hyperv::hyperv_start_cpu;
 use crate::io::IOPort;
 use crate::mm::{PerCPUMapping, TransitionPageTable};
 use crate::platform::IrqGuard;
@@ -294,7 +295,7 @@ impl SvsmPlatform for TdpPlatform {
 
         // When running under Hyper-V, the target vCPU does not begin running
         // until a start hypercall is issued, so make that hypercall now.
-        if *IS_HYPERV {
+        if cpu_has_feat(Feature::HyperV) {
             // Do not expose the actual CPU context via the hypercall since it
             // is not needed.  Use a default context instead.
             let ctx = hyperv::HvInitialVpContext::default();

--- a/kernel/src/sev/ghcb.rs
+++ b/kernel/src/sev/ghcb.rs
@@ -5,7 +5,6 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 
 use crate::address::{Address, PhysAddr, VirtAddr};
-use crate::cpu::cpuid::CpuidResult;
 use crate::cpu::msr::{SEV_GHCB, write_msr};
 use crate::cpu::percpu::this_cpu;
 use crate::cpu::{IrqGuard, X86GeneralRegs, flush_tlb_global_sync_page};
@@ -22,6 +21,7 @@ use crate::utils::MemoryRegion;
 
 use crate::mm::PageBox;
 use core::arch::global_asm;
+use core::arch::x86_64::CpuidResult;
 use core::mem::{self, MaybeUninit, offset_of};
 use core::ops::Deref;
 use core::ptr;

--- a/kernel/src/sev/tlb.rs
+++ b/kernel/src/sev/tlb.rs
@@ -8,11 +8,10 @@ use bitfield_struct::bitfield;
 
 use crate::address::{Address, VirtAddr};
 use crate::cpu::TlbFlushRange;
+use crate::cpu::features::{Feature, cpu_get_feat};
 use crate::cpu::tlb::TlbFlushScope;
-use crate::platform::cpuid;
 use crate::types::PageSize;
 use crate::utils::MemoryRegion;
-use crate::utils::immut_after_init::ImmutAfterInitCell;
 
 use core::arch::asm;
 
@@ -36,31 +35,6 @@ struct InvlpgbEcx {
     #[bits(15)]
     _rsvd: u16,
     huge: bool,
-}
-
-/// Determines the maximum amount of pages that may be flushed with
-/// a single INVLPGB instruction by querying CPUID.
-fn __invlpgb_max_count() -> u32 {
-    let edx = cpuid(0x80000008, 0).map_or(0, |c| c.edx);
-    // EDX[15:0] contains the maximum number of pages that can be
-    // invalidated in one instruction. A value of 0 indicates a
-    // single page.
-    (edx & ((1 << 16) - 1)) + 1
-}
-
-/// Determines the maximum amount of pages that may be flushed with
-/// a single INVLPGB instruction, by lazily querying CPUID if the
-/// value has not been cached from a previous query.
-fn invlpgb_max_count() -> u32 {
-    static MAX_COUNT: ImmutAfterInitCell<u32> = ImmutAfterInitCell::uninit();
-    if let Ok(count) = MAX_COUNT.try_get_inner() {
-        return *count;
-    }
-    let count = __invlpgb_max_count();
-    // If this fails, someone else initialized the cell, which is not an issue,
-    // as probing CPUID multiple times is benign.
-    let _ = MAX_COUNT.init(count);
-    count
 }
 
 #[inline]
@@ -96,7 +70,8 @@ fn flush_tlb_sync(global: bool) {
 }
 
 fn flush_tlb_sync_range(global: bool, region: MemoryRegion<VirtAddr>, pgsize: PageSize) {
-    let max_count = invlpgb_max_count() as usize;
+    // A value of 0 indicates a single page, so add 1
+    let max_count = cpu_get_feat(Feature::InvlpgbMax) as usize + 1;
 
     for start in region.iter_pages(pgsize).step_by(max_count) {
         // Take up to `max_count` pages

--- a/kernel/src/sev/tlb.rs
+++ b/kernel/src/sev/tlb.rs
@@ -8,8 +8,8 @@ use bitfield_struct::bitfield;
 
 use crate::address::{Address, VirtAddr};
 use crate::cpu::TlbFlushRange;
-use crate::cpu::cpuid::CpuidResult;
 use crate::cpu::tlb::TlbFlushScope;
+use crate::platform::cpuid;
 use crate::types::PageSize;
 use crate::utils::MemoryRegion;
 use crate::utils::immut_after_init::ImmutAfterInitCell;
@@ -41,11 +41,11 @@ struct InvlpgbEcx {
 /// Determines the maximum amount of pages that may be flushed with
 /// a single INVLPGB instruction by querying CPUID.
 fn __invlpgb_max_count() -> u32 {
-    let cpuid = CpuidResult::get(0x80000008, 0);
+    let edx = cpuid(0x80000008, 0).map_or(0, |c| c.edx);
     // EDX[15:0] contains the maximum number of pages that can be
     // invalidated in one instruction. A value of 0 indicates a
     // single page.
-    (cpuid.edx & ((1 << 16) - 1)) + 1
+    (edx & ((1 << 16) - 1)) + 1
 }
 
 /// Determines the maximum amount of pages that may be flushed with

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -23,13 +23,13 @@ use svsm::boot_params::BootParams;
 use svsm::console::install_console_logger;
 use svsm::cpu::control_regs::{cr0_init, cr4_init};
 use svsm::cpu::cpuid::dump_cpuid_table;
+use svsm::cpu::features::{Feature, cpu_has_feat};
 use svsm::cpu::gdt::GLOBAL_GDT;
 use svsm::cpu::idt::svsm::{early_idt_init, idt_init};
 use svsm::cpu::idt::{EARLY_IDT_ENTRIES, IDT, IdtEntry};
 use svsm::cpu::percpu::{PERCPU_AREAS, PerCpu, cpu_idle_loop, this_cpu, try_this_cpu};
 use svsm::cpu::shadow_stack::{
-    MODE_64BIT, S_CET, SCetFlags, determine_cet_support, is_cet_ss_supported, set_cet_ss_enabled,
-    shadow_stack_info,
+    MODE_64BIT, S_CET, SCetFlags, set_cet_ss_enabled, shadow_stack_info,
 };
 use svsm::cpu::smp::start_secondary_cpus;
 use svsm::cpu::sse::sse_init;
@@ -330,7 +330,6 @@ unsafe fn svsm_start(
     }
 
     cr0_init();
-    determine_cet_support(platform);
     cr4_init();
 
     install_console_logger("SVSM").expect("Console logger already initialized");
@@ -435,7 +434,7 @@ unsafe extern "C" fn svsm_entry(li: *mut KernelLaunchInfo, platform_type: SvsmPl
 
     // Shadow stacks must be enabled once no further function returns are
     // possible.
-    if is_cet_ss_supported() {
+    if cpu_has_feat(Feature::CetSS) {
         set_cet_ss_enabled();
         let ssp_token_addr = ssp_token.unwrap();
         enable_shadow_stacks!(ssp_token_addr);

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -331,7 +331,7 @@ unsafe fn svsm_start(
 
     cr0_init();
     determine_cet_support(platform);
-    cr4_init(platform);
+    cr4_init();
 
     install_console_logger("SVSM").expect("Console logger already initialized");
     platform

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -19,10 +19,11 @@ use core::sync::atomic::AtomicUsize;
 use core::sync::atomic::Ordering;
 
 use crate::address::{Address, VirtAddr};
+use crate::cpu::features::{Feature, cpu_has_feat};
 use crate::cpu::idt::svsm::return_new_task;
 use crate::cpu::irq_state::EFLAGS_IF;
 use crate::cpu::percpu::{PerCpu, current_task};
-use crate::cpu::shadow_stack::{init_shadow_stack, is_cet_ss_supported};
+use crate::cpu::shadow_stack::init_shadow_stack;
 use crate::cpu::sse::{get_xsave_area_size, sse_restore_context};
 use crate::cpu::{ShadowStackInit, X86ExceptionContext, X86GeneralRegs, irqs_enable};
 use crate::error::SvsmError;
@@ -382,7 +383,7 @@ impl Task {
 
         let mut shadow_stack_offset = VirtAddr::null();
         let mut shadow_stack_base = VirtAddr::null();
-        let shadow_stack_mapping = if is_cet_ss_supported() {
+        let shadow_stack_mapping = if cpu_has_feat(Feature::CetSS) {
             // Allocate shadow stack and safe top_of_stack offset
             let shadow_stack = VMKernelStack::new_shadow()?;
             let offset = shadow_stack.top_of_stack();

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -19,12 +19,12 @@ use core::sync::atomic::AtomicUsize;
 use core::sync::atomic::Ordering;
 
 use crate::address::{Address, VirtAddr};
-use crate::cpu::features::{Feature, cpu_has_feat};
+use crate::cpu::features::{Feature, cpu_get_feat, cpu_has_feat};
 use crate::cpu::idt::svsm::return_new_task;
 use crate::cpu::irq_state::EFLAGS_IF;
 use crate::cpu::percpu::{PerCpu, current_task};
 use crate::cpu::shadow_stack::init_shadow_stack;
-use crate::cpu::sse::{get_xsave_area_size, sse_restore_context};
+use crate::cpu::sse::sse_restore_context;
 use crate::cpu::{ShadowStackInit, X86ExceptionContext, X86GeneralRegs, irqs_enable};
 use crate::error::SvsmError;
 use crate::fs::{Directory, FileHandle, opendir, stdout_open};
@@ -745,7 +745,7 @@ impl Task {
     }
 
     fn allocate_xsave_area() -> PageBox<[u8]> {
-        let len = get_xsave_area_size() as usize;
+        let len = cpu_get_feat(Feature::XsaveSize) as usize;
         let xsa = PageBox::<[u8]>::try_new_slice(0u8, NonZeroUsize::new(len).unwrap());
         if xsa.is_err() {
             panic!("Error while allocating xsave area");

--- a/kernel/src/tdx/tdcall.rs
+++ b/kernel/src/tdx/tdcall.rs
@@ -8,7 +8,6 @@ use super::error::TdVmcallError::Retry;
 use super::error::{TdxError, TdxSuccess, tdvmcall_result, tdx_recoverable_error, tdx_result};
 use crate::address::{Address, PhysAddr, VirtAddr};
 use crate::cpu::X86GeneralRegs;
-use crate::cpu::cpuid::CpuidResult;
 use crate::error::SvsmError;
 use crate::mm::pagetable::PageFrame;
 use crate::mm::{PerCPUPageMappingGuard, virt_to_frame};
@@ -18,6 +17,7 @@ use crate::utils::MemoryRegion;
 use bitfield_struct::bitfield;
 use bitflags::bitflags;
 use core::arch::asm;
+use core::arch::x86_64::CpuidResult;
 
 const TDG_VP_TDVMCALL: u32 = 0;
 const TDG_VP_VEINFO_GET: u32 = 3;


### PR DESCRIPTION
The SVSM uses CPUID in multiple places to discover certain features about the environment it runs in (like CET support, FPU features or hypervisor enumeration). The use of CPUID is not consistent, as sometimes the actual instruction is used, but other times the platform abstraction is used.

This PR centralizes the use of CPUID in the following manner:
1. A new universal `cpuid()` function is added, using the `SvsmPlatform` as a backend.
2. Users of CPUID are converted to the new `cpuid()` function. On SEV-SNP in particular this reduces the amount of #VC exceptions that need to be handled.
3. Centralize all CPUID discovery into a lookup table. Items in the lookup table are cached, so CPUID usage is drastically reduced in the long run. This makes uses of CPUID much cleaner, and removes the need for manual, ad-hoc caching for the values queried from CPUID.