### PR TITLE
kernel: cpu/cpuid: traverse CPUID page using an iterator

### DIFF
--- a/cpuarch/src/snp_cpuid.rs
+++ b/cpuarch/src/snp_cpuid.rs
@@ -29,6 +29,16 @@ pub struct SnpCpuidTable {
     pub func: [SnpCpuidFn; SNP_CPUID_MAX_COUNT],
 }
 
+impl SnpCpuidTable {
+    pub fn entries(&self) -> &[SnpCpuidFn] {
+        &self.func[..self.count as usize]
+    }
+
+    pub fn entries_mut(&mut self) -> &mut [SnpCpuidFn] {
+        &mut self.func[..self.count as usize]
+    }
+}
+
 impl Default for SnpCpuidTable {
     fn default() -> Self {
         SnpCpuidTable {

--- a/kernel/src/cpu/cpuid.rs
+++ b/kernel/src/cpu/cpuid.rs
@@ -36,7 +36,7 @@ pub unsafe fn init_cpuid_table(addr: VirtAddr) {
             .expect("Misaligned SNP CPUID table address")
     };
 
-    for func in table.func.iter_mut().take(table.count as usize) {
+    for func in table.entries_mut() {
         if func.eax_in == 0x8000001f {
             func.eax_out |= 1 << 28;
         }
@@ -131,24 +131,16 @@ impl CpuidResult {
 }
 
 pub fn cpuid_table_raw(eax: u32, ecx: u32, xcr0: u64, xss: u64) -> Option<CpuidResult> {
-    let count: usize = CPUID_PAGE.count as usize;
-
-    for i in 0..count {
-        if eax == CPUID_PAGE.func[i].eax_in
-            && ecx == CPUID_PAGE.func[i].ecx_in
-            && xcr0 == CPUID_PAGE.func[i].xcr0_in
-            && xss == CPUID_PAGE.func[i].xss_in
-        {
-            return Some(CpuidResult {
-                eax: CPUID_PAGE.func[i].eax_out,
-                ebx: CPUID_PAGE.func[i].ebx_out,
-                ecx: CPUID_PAGE.func[i].ecx_out,
-                edx: CPUID_PAGE.func[i].edx_out,
-            });
-        }
-    }
-
-    None
+    CPUID_PAGE
+        .entries()
+        .iter()
+        .find(|f| eax == f.eax_in && ecx == f.ecx_in && xcr0 == f.xcr0_in && xss == f.xss_in)
+        .map(|f| CpuidResult {
+            eax: f.eax_out,
+            ebx: f.ebx_out,
+            ecx: f.ecx_out,
+            edx: f.edx_out,
+        })
 }
 
 pub fn cpuid_table(eax: u32, ecx: u32) -> Option<CpuidResult> {
@@ -157,19 +149,18 @@ pub fn cpuid_table(eax: u32, ecx: u32) -> Option<CpuidResult> {
 
 pub fn dump_cpuid_table() {
     if let Ok(table) = CPUID_PAGE.try_get_inner() {
-        let count = table.count as usize;
+        let entries = table.entries();
+        log::trace!("CPUID Table entry count: {}", entries.len());
 
-        log::trace!("CPUID Table entry count: {count}");
-
-        for i in 0..count {
-            let eax_in = table.func[i].eax_in;
-            let ecx_in = table.func[i].ecx_in;
-            let xcr0_in = table.func[i].xcr0_in;
-            let xss_in = table.func[i].xss_in;
-            let eax_out = table.func[i].eax_out;
-            let ebx_out = table.func[i].ebx_out;
-            let ecx_out = table.func[i].ecx_out;
-            let edx_out = table.func[i].edx_out;
+        for func in entries {
+            let eax_in = func.eax_in;
+            let ecx_in = func.ecx_in;
+            let xcr0_in = func.xcr0_in;
+            let xss_in = func.xss_in;
+            let eax_out = func.eax_out;
+            let ebx_out = func.ebx_out;
+            let ecx_out = func.ecx_out;
+            let edx_out = func.edx_out;
             log::trace!(
                 "EAX_IN: {eax_in:#010x} ECX_IN: {ecx_in:#010x} XCR0_IN: {xcr0_in:#010x} XSS_IN: {xss_in:#010x} EAX_OUT: {eax_out:#010x} EBX_OUT: {ebx_out:#010x} ECX_OUT: {ecx_out:#010x} EDX_OUT: {edx_out:#010x}"
             );


### PR DESCRIPTION
The amount of items in the CPUID page is indicated by the count field, so use it to take that amount of items from an iterator and simplify cpuid_table_raw() and dump_cpuid_table(). No functional change.