### PR TITLE
libtcgtpm: remove nested archive libtcgtpm.a

### DIFF
--- a/libtcgtpm/Makefile
+++ b/libtcgtpm/Makefile
@@ -56,8 +56,6 @@ LIBBNMATH = $(TCGTPM_BUILD_DIR)/cryptolib_Ossl/lib$(LIBBNMATH_TARGET).a
 OPENSSL_MAKEFILE = $(OPENSSL_BUILD_DIR)/Makefile
 TCGTPM_MAKEFILE = $(TCGTPM_BUILD_DIR)/Makefile
 
-LIBS = $(LIBCRT) $(LIBCRYPTO) $(LIBBNMATH) $(LIBTPMBIGNUM) $(LIBTPM) $(LIBPLATFORM)
-
 ifeq ($(USE_LIBCRT),1)
 LIBCRT_INCLUDE = -I$(LIBCRT_SRC_DIR)/include
 LIBCRT_LINK = -Wl,rpath=$(LIBCRT_BUILD_DIR) -lcrt
@@ -74,11 +72,7 @@ endif
 # Parallel builds are still used inside the sub-targets (-j flag)
 .NOTPARALLEL:
 
-all: $(OUT_DIR)/libtcgtpm.a
-
-$(OUT_DIR)/libtcgtpm.a: $(LIBS)
-	rm -f $@
-	ar rcsTPD $@ $^
+all: $(LIBCRT) $(LIBCRYPTO) $(LIBBNMATH) $(LIBTPMBIGNUM) $(LIBTPM) $(LIBPLATFORM)
 
 .PHONY: $(LIBCRT)
 
@@ -232,7 +226,6 @@ clean:
 	$(MAKE) -C $(LIBCRT_SRC_DIR) OUT_DIR=$(LIBCRT_BUILD_DIR) clean
 	[ ! -f $(OPENSSL_MAKEFILE) ] || $(MAKE) -C $(OPENSSL_BUILD_DIR) clean
 	[ ! -f $(TCGTPM_MAKEFILE) ] || $(MAKE) -C $(TCGTPM_BUILD_DIR) clean
-	rm -f $(OUT_DIR)/libtcgtpm.a
 
 distclean: clean
 	rm -rf $(LIBCRT_BUILD_DIR)
@@ -241,9 +234,8 @@ distclean: clean
 
 .PHONY: all clean distclean
 
-.PHONY: libcrt configure_openssl configure_tcgtpm libcrypto tcgtpm
+.PHONY: libcrt configure_openssl configure_tcgtpm libcrypto
 libcrt: $(LIBCRT)
 configure_openssl: $(OPENSSL_MAKEFILE)
 libcrypto: $(LIBCRYPTO)
 configure_tcgtpm: $(TCGTPM_MAKEFILE)
-tcgtpm: $(OUT_DIR)/libtcgtpm.a

--- a/libtcgtpm/build.rs
+++ b/libtcgtpm/build.rs
@@ -53,9 +53,26 @@ fn main() {
         .write_to_file(out_path.join("bindings.rs"))
         .unwrap_or_else(|_| panic!("Unable to write bindings.rs"));
 
-    // Tell cargo to link libtcgtpm and where to find it.
-    println!("cargo:rustc-link-search={out_dir}");
-    println!("cargo:rustc-link-lib=tcgtpm");
+    // 'static=...' is needed because core lib + platform lib have
+    // circular dependencies.
+    println!("cargo:rustc-link-search={out_dir}/tcgtpm-build/tpm/src");
+    println!("cargo:rustc-link-lib=static=Tpm_CoreLib");
+    println!("cargo:rustc-link-search={out_dir}/tcgtpm-build/Platform");
+    println!("cargo:rustc-link-lib=static=Tpm_PlatformLib");
+
+    println!("cargo:rustc-link-search={out_dir}/tcgtpm-build/tpm/cryptolibs/TpmBigNum");
+    println!("cargo:rustc-link-lib=Tpm_CryptoLib_TpmBigNum");
+
+    println!("cargo:rustc-link-search={out_dir}/tcgtpm-build/cryptolib_Ossl");
+    println!("cargo:rustc-link-lib=Tpm_CryptoLib_Math_Ossl");
+
+    println!("cargo:rustc-link-search={out_dir}/openssl-build");
+    println!("cargo:rustc-link-lib=crypto");
+
+    if target_os == "none" {
+        println!("cargo:rustc-link-search={out_dir}/libcrt-build");
+        println!("cargo:rustc-link-lib=crt");
+    }
 
     // Tell cargo not to rerun the build-script unless anything in this
     // directory changes.


### PR DESCRIPTION
The rust linker can not handle nested archives, i.e. archives containing
other archives instead of object files only.  The libtcgtpm.a archive is
such a nested archive, lets remove it.

This is one step toward being able to use the rust linker to build svsm.
