### PR TITLE
github/workflows: drop explicit checkout ref in PR workflows

### DIFF
--- a/.github/workflows/pr-compliance.yml
+++ b/.github/workflows/pr-compliance.yml
@@ -18,7 +18,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Fetch base branch


### PR DESCRIPTION
The SPDX and SignedOff workflows override the checkout ref to `github.event.pull_request.head.sha`. This breaks PRs whose branches were created before the scripts used by the pipelines were added to main. For example the CI of PR #1002 is failing to execute the SPDX pipeline [1] with the following:

    scripts/check-spdx.sh: No such file or directory
    Process completed with exit code 127.

For `pull_request` events, GitHub runs workflows from a merge commit of the PR head into the target branch [2]:

    "GITHUB_SHA for this event is the last merge commit on the
     pull request merge branch."

So the workflow file from main is picked up and executed, but the checkout then switches to the PR head, where the scripts do not exist.

Drop the `ref:` override to let actions/checkout use its default, which checks out the merge commit. Both the scripts (from main) and the PR changes are available there. The SPDX script reads files from the working tree and the SignedOff script only inspects git objects, so both work correctly with the merge commit.

[1] https://github.com/coconut-svsm/svsm/actions/runs/23894438075/job/69675546900
[2] https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request