### PR TITLE
task: enforce mutual exclusion of execution

### DIFF
--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -30,6 +30,7 @@
 
 extern crate alloc;
 
+use super::tasks::TASK_ACTIVE_OFFSET;
 use super::{
     INITIAL_TASK_ID, KernelThreadStartInfo, Task, TaskListAdapter, TaskPointer, TaskRunListAdapter,
 };
@@ -609,6 +610,12 @@ global_asm!(
         .section .text
 
     switch_context:
+        // Arguments:
+        // R12: previous task pointer
+        // R13: new task pointer
+        // R14: per-CPU global-scope stack pointer
+        // R15: paging root of the new task
+        //
         // Save the current context. The layout must match the TaskContext structure.
         pushfq
         pushq   %rax
@@ -640,7 +647,7 @@ global_asm!(
         mov     %r14, %rsp
 
         cmpb    $0, {IS_CET_ENABLED}(%rip)
-        je      1f
+        je      4f
         // Save the current shadow stack pointer
         rdssp   %rax
         sub     $8, %rax
@@ -651,11 +658,28 @@ global_asm!(
         rstorssp (%rax)
         saveprevssp
 
+    4:
+        // Mark the previous task as inactive.  This must be done after
+        // switching off of its stack because as soon as it is marked as
+        // inactive, another processor is free to immediately switch to that
+        // thread's stack.
+        andb    $0, {TASK_STATE_ACTIVE}(%r12)
+
     1:
         // Switch to the new task state
 
         // Switch to the new task page tables
         mov     %r15, %cr3
+
+        // Wait until the new task is inactive.  It may still be running
+        // on another processor so its stack cannot be consumed until its
+        // stack is no longer active on any processor.
+    3:
+        pause
+        movb    $1, %al
+        lock xchgb {TASK_STATE_ACTIVE}(%r13), %al
+        testb   %al, %al
+        jnz     3b
 
         cmpb    $0, {IS_CET_ENABLED}(%rip)
         je      2f
@@ -694,6 +718,7 @@ global_asm!(
     "#,
     TASK_RSP_OFFSET = const offset_of!(Task, rsp),
     TASK_SSP_OFFSET = const offset_of!(Task, ssp),
+    TASK_STATE_ACTIVE = const TASK_ACTIVE_OFFSET,
     IS_CET_ENABLED = sym IS_CET_ENABLED,
     CONTEXT_SWITCH_RESTORE_TOKEN = const CONTEXT_SWITCH_RESTORE_TOKEN.as_usize(),
     options(att_syntax)

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -12,7 +12,10 @@ use alloc::sync::Arc;
 use core::fmt;
 use core::mem::size_of;
 use core::num::NonZeroUsize;
-use core::sync::atomic::{AtomicU32, Ordering};
+use core::sync::atomic::AtomicBool;
+use core::sync::atomic::AtomicU32;
+use core::sync::atomic::AtomicUsize;
+use core::sync::atomic::Ordering;
 
 use crate::address::{Address, VirtAddr};
 use crate::cpu::idt::svsm::return_new_task;
@@ -117,11 +120,28 @@ enum ThreadStartInfo {
 }
 
 #[derive(PartialEq, Debug, Copy, Clone, Default)]
+#[repr(u32)]
 pub enum TaskState {
     RUNNING,
     BLOCKED,
     #[default]
     TERMINATED,
+}
+
+impl From<u32> for TaskState {
+    fn from(v: u32) -> Self {
+        match v {
+            x if x == Self::RUNNING as u32 => Self::RUNNING,
+            x if x == Self::BLOCKED as u32 => Self::BLOCKED,
+            _ => Self::TERMINATED,
+        }
+    }
+}
+
+impl From<TaskState> for u32 {
+    fn from(s: TaskState) -> u32 {
+        s as u32
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -176,21 +196,41 @@ pub struct TaskContext {
 #[repr(C)]
 struct TaskSchedState {
     /// Whether this is an idle task
-    idle_task: bool,
+    idle_task: AtomicBool,
 
     /// Current state of the task
-    state: TaskState,
+    state: AtomicU32,
 
     /// CPU this task is currently assigned to
-    cpu_index: usize,
+    cpu_index: AtomicUsize,
 }
 
 impl TaskSchedState {
-    pub fn panic_on_idle(&mut self, msg: &str) -> &mut Self {
-        if self.idle_task {
+    fn new(cpu_index: usize) -> Self {
+        Self {
+            idle_task: AtomicBool::new(false),
+            state: AtomicU32::new(TaskState::RUNNING.into()),
+            cpu_index: AtomicUsize::new(cpu_index),
+        }
+    }
+
+    fn panic_on_idle(&self, msg: &str) -> &Self {
+        if self.idle_task.load(Ordering::Relaxed) {
             panic!("{}", msg);
         }
         self
+    }
+
+    fn update_cpu(&self, new_cpu_index: usize) -> usize {
+        self.cpu_index.swap(new_cpu_index, Ordering::Relaxed)
+    }
+
+    fn set_state(&self, state: TaskState) {
+        self.state.store(state.into(), Ordering::Release);
+    }
+
+    fn get_state(&self) -> TaskState {
+        self.state.load(Ordering::Acquire).into()
     }
 }
 
@@ -219,7 +259,7 @@ pub struct Task {
     mm: Arc<TaskMM>,
 
     /// State relevant for scheduler
-    sched_state: RWLock<TaskSchedState>,
+    sched_state: TaskSchedState,
 
     /// User-visible name of task
     name: String,
@@ -264,7 +304,7 @@ impl fmt::Debug for Task {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Task")
             .field("rsp", &self.rsp)
-            .field("state", &self.sched_state.lock_read().state)
+            .field("state", &self.sched_state.get_state())
             .field("id", &self.id)
             .finish()
     }
@@ -386,11 +426,7 @@ impl Task {
             _kernel_stack: kernel_stack_mapping,
             _shadow_stack: shadow_stack_mapping,
             mm: task_mm,
-            sched_state: RWLock::new(TaskSchedState {
-                idle_task: false,
-                state: TaskState::RUNNING,
-                cpu_index: cpu.get_cpu_index(),
-            }),
+            sched_state: TaskSchedState::new(cpu.get_cpu_index()),
             name: args.name,
             id: TASK_ID_ALLOCATOR.next_id(),
             rootdir: args.rootdir,
@@ -484,44 +520,39 @@ impl Task {
     }
 
     pub fn set_task_running(&self) {
-        self.sched_state.lock_write().state = TaskState::RUNNING;
+        self.sched_state.set_state(TaskState::RUNNING);
     }
 
     pub fn set_task_terminated(&self) {
         self.sched_state
-            .lock_write()
             .panic_on_idle("Trying to terminate idle task")
-            .state = TaskState::TERMINATED;
+            .set_state(TaskState::TERMINATED);
     }
 
     pub fn set_task_blocked(&self) {
         self.sched_state
-            .lock_write()
             .panic_on_idle("Trying to block idle task")
-            .state = TaskState::BLOCKED;
+            .set_state(TaskState::BLOCKED);
     }
 
     pub fn is_running(&self) -> bool {
-        self.sched_state.lock_read().state == TaskState::RUNNING
+        self.sched_state.get_state() == TaskState::RUNNING
     }
 
     pub fn is_terminated(&self) -> bool {
-        self.sched_state.lock_read().state == TaskState::TERMINATED
+        self.sched_state.get_state() == TaskState::TERMINATED
     }
 
     pub fn set_idle_task(&self) {
-        self.sched_state.lock_write().idle_task = true;
+        self.sched_state.idle_task.store(true, Ordering::Relaxed);
     }
 
     pub fn is_idle_task(&self) -> bool {
-        self.sched_state.lock_read().idle_task
+        self.sched_state.idle_task.load(Ordering::Relaxed)
     }
 
     pub fn update_cpu(&self, new_cpu_index: usize) -> usize {
-        let mut state = self.sched_state.lock_write();
-        let old_cpu_index = state.cpu_index;
-        state.cpu_index = new_cpu_index;
-        old_cpu_index
+        self.sched_state.update_cpu(new_cpu_index)
     }
 
     pub fn handle_pf(&self, vaddr: VirtAddr, write: bool) -> Result<(), SvsmError> {

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -10,6 +10,7 @@ use alloc::collections::btree_map::BTreeMap;
 use alloc::string::String;
 use alloc::sync::Arc;
 use core::fmt;
+use core::mem::offset_of;
 use core::mem::size_of;
 use core::num::NonZeroUsize;
 use core::sync::atomic::AtomicBool;
@@ -198,6 +199,9 @@ struct TaskSchedState {
     /// Whether this is an idle task
     idle_task: AtomicBool,
 
+    /// Whether this task is currently active on any CPU
+    active: AtomicBool,
+
     /// Current state of the task
     state: AtomicU32,
 
@@ -209,6 +213,7 @@ impl TaskSchedState {
     fn new(cpu_index: usize) -> Self {
         Self {
             idle_task: AtomicBool::new(false),
+            active: AtomicBool::new(false),
             state: AtomicU32::new(TaskState::RUNNING.into()),
             cpu_index: AtomicUsize::new(cpu_index),
         }
@@ -219,6 +224,12 @@ impl TaskSchedState {
             panic!("{}", msg);
         }
         self
+    }
+
+    fn set_active(&self) {
+        if self.active.swap(true, Ordering::Release) {
+            panic!("attempted switch to an active task");
+        }
     }
 
     fn update_cpu(&self, new_cpu_index: usize) -> usize {
@@ -280,6 +291,9 @@ pub struct Task {
     objs: Arc<RWLock<BTreeMap<ObjHandle, Arc<dyn Obj>>>>,
 }
 
+pub const TASK_ACTIVE_OFFSET: usize =
+    offset_of!(Task, sched_state) + offset_of!(TaskSchedState, active);
+
 // SAFETY: Send + Sync is required for Arc<Task> to implement Send. All members
 // of  `Task` are Send + Sync except for the intrusive_collection links, which
 // are only Send. The only access to these is via the intrusive_adapter!
@@ -307,6 +321,14 @@ impl fmt::Debug for Task {
             .field("state", &self.sched_state.get_state())
             .field("id", &self.id)
             .finish()
+    }
+}
+
+impl Drop for Task {
+    fn drop(&mut self) {
+        // A task must be inactive to be terminated.  Otherwise, its stack
+        // might be freed while it is actively executing.
+        assert!(!self.sched_state.active.load(Ordering::Relaxed));
     }
 }
 
@@ -517,6 +539,10 @@ impl Task {
 
     pub fn rootdir(&self) -> Arc<dyn Directory> {
         self.rootdir.clone()
+    }
+
+    pub fn set_task_active(&self) {
+        self.sched_state.set_active();
     }
 
     pub fn set_task_running(&self) {


### PR DESCRIPTION
The current task scheduler code has a subtle bug when moving a task between running and blocked states, leading to a race condition between sleep and wake events.  Consider the following sequence.

1. Task A, running on CPU 1, decides to wait for some event, so it marks itself as `TaskState::BLOCKED`.
2. Task A now adds itself to the wait queue for the event it wants to wait for.
3. CPU 2 now detects that the event is due and the wait should be satisfied.
4. CPU 2 observes that the wait queue for the event contains task A, and that task A is marked `TaskState::BLOCKED`, so it selects task B for execution and adds it to its own run queue.
5. CPU 2 now enters the scheduler and selects task A for immediate execution.
6. The scheduler running on CPU 2 switches to task A's stack and address space.
7. CPU 1 now enters the scheduler, still in the task A context, to select a different task to run.

This results in task A's stack being active simultaneously on both CPU 1 and CPU 2, which will lead to serious corruption.  This problem cannot be addressed by changing the ordering of items 1 and 2 because any ordering of those will still not change the fact that task A is actively executing on CPU 1 up until the point that a different task is active - and by that point, the scheduler has no idea of the disposition of task A.  Task A must complete the entry into the wait queue while it is still running.

The best solution is to introduce a new flag in the task structure to indicate whether a task is still actively executing somewhere.  This permits the scheduler to avoid switching to a new task while that task is still executing in the scheduler on its old CPU.

None of this is actually observable today because wait queues are not yet fully implemented, but they will be impossible to implement without tracking task activity protection to prevent simultaneous execution on multiple CPUs.