### PR TITLE
[verification] Support Verus's verita test via cargo-verus.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -14,5 +14,5 @@ rustflags = [
 ]
 
 [alias]
-verify = "v build --features verus"
+verify = "verus focus --features verus"
 xbuild = "run --package xbuild --release --"

--- a/.github/workflows/manual-verify.yml
+++ b/.github/workflows/manual-verify.yml
@@ -36,18 +36,10 @@ jobs:
         run: |
           verusfmt --check `find ./ -name *.verus.rs` --verus-only
 
-      # cargo-v doesn't propagate the `cargo build` exit code, so we need
-      # to check stderr for errors.
-      # When https://github.com/microsoft/verismo/issues/23 will be fixed
-      # we can remove it.
       - name: Verify svsm with verus
-        run: |
-          cargo verify 2>&1 | tee verify.log
-          ! grep -q 'cargo build failed' verify.log
+        run: cargo verify
         working-directory: kernel
 
       - name: Verify extra proof libs with verus
-        run: |
-          cargo verify 2>&1 | tee verify.log
-          ! grep -q 'cargo build failed' verify.log
+        run: cargo verify
         working-directory: verification/verify_proof

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2205,15 +2205,15 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "verus_builtin"
-version = "0.0.0-2025-12-07-0054"
+version = "0.0.0-2026-04-12-0118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83b30b06298351ce552909373b5c17caa59ece56d9605ecceaf5830bb7e187e"
+checksum = "a46cb431066009ad2035f6bca936b1c2b7e293bffec93a2090fead0f35ab4276"
 
 [[package]]
 name = "verus_builtin_macros"
-version = "0.0.0-2025-12-07-0054"
+version = "0.0.0-2026-04-12-0118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10da8352d708967c867ad9f51a3028af567e4aae519a78c9ca54d19be74631c1"
+checksum = "5a4db9c476e75215dc079b3b9a740099ae26e318b410a0063b3c97c624bba991"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2232,9 +2232,9 @@ dependencies = [
 
 [[package]]
 name = "verus_prettyplease"
-version = "0.0.0-2025-11-16-0050"
+version = "0.0.0-2026-04-12-0118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f6851d9ddf5bfdd1c7a7abff8cb797df18b67b80c3da35e0cbfa939d725ef1"
+checksum = "4b246e61b068e807cb05a030fc1d7efa83d2a0d227eaf67921661419edfe8e83"
 dependencies = [
  "proc-macro2",
  "verus_syn",
@@ -2242,9 +2242,9 @@ dependencies = [
 
 [[package]]
 name = "verus_state_machines_macros"
-version = "0.0.0-2025-11-23-0053"
+version = "0.0.0-2026-04-05-0114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f0d2b64ab30b4d79d55b8ba83df03dcb6a550805d0f9586f700b4bb6e82be8a"
+checksum = "e799e4fb96bff36ea1356624d8b633887a46b3558f34cc20e8e228d0d7bcac2b"
 dependencies = [
  "indexmap",
  "proc-macro2",
@@ -2263,9 +2263,9 @@ dependencies = [
 
 [[package]]
 name = "verus_syn"
-version = "0.0.0-2025-11-16-0050"
+version = "0.0.0-2026-04-05-0114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8fd239518d302792a2c1b2a6bfe2286268810b9627c5507fbc502ea3e88b805"
+checksum = "285b554a87b470ee705634ea1cdc92c14ba088a7b8bdacbb9116b32e832fe272"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2284,9 +2284,9 @@ dependencies = [
 
 [[package]]
 name = "vstd"
-version = "0.0.0-2025-12-07-0054"
+version = "0.0.0-2026-04-12-0118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c39bcb97ecc798037404389ad4410274629b57ea103f57ae32c38ac4c33539"
+checksum = "4fd22791c5bc9db0227a3be72721e969ac0165028ffa40c9479558b7a73006c5"
 dependencies = [
  "verus_builtin",
  "verus_builtin_macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2278,15 +2278,15 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "verus_builtin"
-version = "0.0.0-2025-12-07-0054"
+version = "0.0.0-2026-04-12-0118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83b30b06298351ce552909373b5c17caa59ece56d9605ecceaf5830bb7e187e"
+checksum = "a46cb431066009ad2035f6bca936b1c2b7e293bffec93a2090fead0f35ab4276"
 
 [[package]]
 name = "verus_builtin_macros"
-version = "0.0.0-2025-12-07-0054"
+version = "0.0.0-2026-04-12-0118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10da8352d708967c867ad9f51a3028af567e4aae519a78c9ca54d19be74631c1"
+checksum = "5a4db9c476e75215dc079b3b9a740099ae26e318b410a0063b3c97c624bba991"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2305,9 +2305,9 @@ dependencies = [
 
 [[package]]
 name = "verus_prettyplease"
-version = "0.0.0-2025-11-16-0050"
+version = "0.0.0-2026-04-12-0118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f6851d9ddf5bfdd1c7a7abff8cb797df18b67b80c3da35e0cbfa939d725ef1"
+checksum = "4b246e61b068e807cb05a030fc1d7efa83d2a0d227eaf67921661419edfe8e83"
 dependencies = [
  "proc-macro2",
  "verus_syn",
@@ -2315,9 +2315,9 @@ dependencies = [
 
 [[package]]
 name = "verus_state_machines_macros"
-version = "0.0.0-2025-11-23-0053"
+version = "0.0.0-2026-04-05-0114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f0d2b64ab30b4d79d55b8ba83df03dcb6a550805d0f9586f700b4bb6e82be8a"
+checksum = "e799e4fb96bff36ea1356624d8b633887a46b3558f34cc20e8e228d0d7bcac2b"
 dependencies = [
  "indexmap",
  "proc-macro2",
@@ -2336,9 +2336,9 @@ dependencies = [
 
 [[package]]
 name = "verus_syn"
-version = "0.0.0-2025-11-16-0050"
+version = "0.0.0-2026-04-05-0114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8fd239518d302792a2c1b2a6bfe2286268810b9627c5507fbc502ea3e88b805"
+checksum = "285b554a87b470ee705634ea1cdc92c14ba088a7b8bdacbb9116b32e832fe272"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2367,9 +2367,9 @@ dependencies = [
 
 [[package]]
 name = "vstd"
-version = "0.0.0-2025-12-07-0054"
+version = "0.0.0-2026-04-12-0118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c39bcb97ecc798037404389ad4410274629b57ea103f57ae32c38ac4c33539"
+checksum = "4fd22791c5bc9db0227a3be72721e969ac0165028ffa40c9479558b7a73006c5"
 dependencies = [
  "verus_builtin",
  "verus_builtin_macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,10 +99,10 @@ zerocopy = { version = "0.8.2", features = ["derive"] }
 embedded-io = { version = "0.6.1" }
 
 # Verus repos
-verus_builtin = { version = "=0.0.0-2025-12-07-0054", default-features = false }
-verus_builtin_macros = { version = "=0.0.0-2025-12-07-0054", features = ["vpanic"], default-features = false }
-verus_state_machines_macros = { version = "=0.0.0-2025-11-23-0053", default-features = false }
-vstd = { version = "0.0.0-2025-12-07-0054", features = ["alloc", "allow_panic"], default-features = false }
+verus_builtin = { version = "=0.0.0-2026-04-12-0118", default-features = false }
+verus_builtin_macros = { version = "=0.0.0-2026-04-12-0118", features = ["vpanic"], default-features = false }
+verus_state_machines_macros = { version = "=0.0.0-2026-04-05-0114", default-features = false }
+vstd = { version = "=0.0.0-2026-04-12-0118", features = ["alloc", "allow_panic"], default-features = false }
 
 # Verification libs
 verify_proof = { path = "verification/verify_proof", default-features = false  }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,10 +101,10 @@ zerocopy = { version = "0.8.2", features = ["derive"] }
 embedded-io = { version = "0.6.1" }
 
 # Verus repos
-verus_builtin = { version = "=0.0.0-2025-12-07-0054", default-features = false }
-verus_builtin_macros = { version = "=0.0.0-2025-12-07-0054", features = ["vpanic"], default-features = false }
-verus_state_machines_macros = { version = "=0.0.0-2025-11-23-0053", default-features = false }
-vstd = { version = "0.0.0-2025-12-07-0054", features = ["alloc", "allow_panic"], default-features = false }
+verus_builtin = { version = "=0.0.0-2026-04-12-0118", default-features = false }
+verus_builtin_macros = { version = "=0.0.0-2026-04-12-0118", features = ["vpanic"], default-features = false }
+verus_state_machines_macros = { version = "=0.0.0-2026-04-05-0114", default-features = false }
+vstd = { version = "=0.0.0-2026-04-12-0118", features = ["alloc", "allow_panic"], default-features = false }
 
 # Verification libs
 verify_proof = { path = "verification/verify_proof", default-features = false  }

--- a/Documentation/docs/developer/VERIFICATION.md
+++ b/Documentation/docs/developer/VERIFICATION.md
@@ -33,6 +33,10 @@ Run the following commands to install Verus tools.
 cd svsm
 ./scripts/vinstall.sh
 ```
+> Can I use latest Verus toolchain?
+>> The `vinstall.sh` script and our Cargo dependencies are pinned to a specific
+ Verus version, but newer releases may work as well. Verus runs cross-project CI
+ to check whether new Verus changes remain compatible with Coconut SVSM.
 
 > Why am I using a different Rust toolchain?
 >> Verus requires a specific version of Rust (e.g., 1.88.0) because it depends
@@ -50,29 +54,28 @@ cd svsm/kernel
 cargo verify
 ```
 
-By default, it only verifies the current crate (`cargo verify` is an alias of `cargo v --features verus`), while using spec/proof from external crates. To verify all external crates, run `cargo v --features verusall`
-
-
+By default, `cargo verify` verifies only the current crate. It is an alias for
+`cargo verus focus --features verus` and uses specifications and proofs from
+dependency crates without re-verifying them. To verify dependency crates as
+well, run `cargo verus verify --features verus`.
 
 ### Pass verus arguments for verification
 
 For debugging purposes, it is helpful to pass additional Verus arguments.
-You can specify extra arguments using the environmental variable
-{crate}_{lib/bin}_VERUS_ARGS for a specific crate
-{crate} or VERUS_ARGS for all crates.
+You can specify extra arguments using `cargo verify -- $extra_verus_args`
 
 **Examples**
 
 * Compiles a crate without verifying svsm crate using verus compilation:
 
     ```shell
-    svsm_lib_VERUS_ARGS="--no-verify" cargo verify
+    cargo verify -- --no-verify
     ```
 
 * Compiles a crate while only verifying address module in svsm crate:
 
     ```shell
-    svsm_lib_VERUS_ARGS="--verify-module address --verify-function VirtAddr::new" cargo verify
+    cargo verify -- --verify-only-module address --verify-function VirtAddr::new
     ```
 
 ### Build without verification

--- a/Documentation/docs/developer/VERIFICATION.md
+++ b/Documentation/docs/developer/VERIFICATION.md
@@ -31,8 +31,17 @@ Run the following commands to install Verus tools.
 
 ```shell
 cd svsm
-./scripts/vinstall.sh
+./scripts/vinstall.sh --use-prebuilt
 ```
+
+The script skips installation if a matching version of Verus is already installed.
+To force reinstallation (e.g., some verus-related tools are missing), add the --force flag.
+To build both Verus and Z3 from source instead of using prebuilt binaries, omit the --use-prebuilt flag. Building from source is required for CI.
+
+> Can I use latest Verus toolchain?
+>> The `vinstall.sh` script and our Cargo dependencies are pinned to a specific
+ Verus version, but newer releases may work as well. Verus runs cross-project CI
+ to check whether new Verus changes remain compatible with Coconut SVSM.
 
 > Why am I using a different Rust toolchain?
 >> Verus requires a specific version of Rust (e.g., 1.88.0) because it depends
@@ -50,29 +59,28 @@ cd svsm/kernel
 cargo verify
 ```
 
-By default, it only verifies the current crate (`cargo verify` is an alias of `cargo v --features verus`), while using spec/proof from external crates. To verify all external crates, run `cargo v --features verusall`
-
-
+By default, `cargo verify` verifies only the current crate. It is an alias for
+`cargo verus focus --features verus` and uses specifications and proofs from
+dependency crates without re-verifying them. To verify dependency crates as
+well, run `cargo verus verify --features verus`.
 
 ### Pass verus arguments for verification
 
 For debugging purposes, it is helpful to pass additional Verus arguments.
-You can specify extra arguments using the environmental variable
-{crate}_{lib/bin}_VERUS_ARGS for a specific crate
-{crate} or VERUS_ARGS for all crates.
+You can specify extra arguments using `cargo verify -- $extra_verus_args`
 
 **Examples**
 
 * Compiles a crate without verifying svsm crate using verus compilation:
 
     ```shell
-    svsm_lib_VERUS_ARGS="--no-verify" cargo verify
+    cargo verify -- --no-verify
     ```
 
 * Compiles a crate while only verifying address module in svsm crate:
 
     ```shell
-    svsm_lib_VERUS_ARGS="--verify-module address --verify-function VirtAddr::new" cargo verify
+    cargo verify -- --verify-only-module address --verify-function VirtAddr::new
     ```
 
 ### Build without verification

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -92,5 +92,8 @@ sha2 = { workspace = true, features = ["force-soft"] }
 [build-dependencies]
 rustc_version = "0.4"
 
+[package.metadata.verus]
+verify = true
+
 [lints]
 workspace = true

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -87,5 +87,8 @@ sha2 = { workspace = true, features = ["force-soft"] }
 [build-dependencies]
 rustc_version = "0.4"
 
+[package.metadata.verus]
+verify = true
+
 [lints]
 workspace = true

--- a/kernel/src/mm/alloc.rs
+++ b/kernel/src/mm/alloc.rs
@@ -95,10 +95,7 @@ enum PageType {
 #[verus_verify]
 impl TryFrom<u64> for PageType {
     type Error = AllocError;
-    #[verus_spec(ret =>
-        ensures
-            PageType::ens_try_from(val, ret),
-    )]
+    #[verus_spec]
     fn try_from(val: u64) -> Result<Self, Self::Error> {
         match val {
             v if v == Self::Free as u64 => Ok(Self::Free),
@@ -1217,7 +1214,7 @@ impl HeapMemoryRegion {
             old(self).req_allocate_pfn(pfn, order)
         ensures
             ret.is_ok() ==> old(self).ens_allocate_pfn(self, pfn, order, *perm),
-            !ret.is_ok() ==> old(self) === self,
+            !ret.is_ok() ==> *old(self) === *self,
     )]
     #[verus_verify(spinoff_prover, rlimit(2))]
     fn allocate_pfn(&mut self, pfn: usize, order: usize) -> Result<(), AllocError> {
@@ -1249,7 +1246,7 @@ impl HeapMemoryRegion {
 
         #[cfg_attr(verus_keep_ghost, verus_spec(
             invariant
-                self === old(self),
+                *self === *old(self),
                 self.wf_next_pages(),
                 self.req_allocate_pfn(pfn, order),
                 self.req_allocate_pfn(old_pfn, order),

--- a/kernel/src/mm/alloc.rs
+++ b/kernel/src/mm/alloc.rs
@@ -95,10 +95,7 @@ enum PageType {
 #[verus_verify]
 impl TryFrom<u64> for PageType {
     type Error = AllocError;
-    #[verus_spec(ret =>
-        ensures
-            PageType::ens_try_from(val, ret),
-    )]
+    #[verus_spec]
     fn try_from(val: u64) -> Result<Self, Self::Error> {
         match val {
             v if v == Self::Free as u64 => Ok(Self::Free),
@@ -1210,7 +1207,7 @@ impl HeapMemoryRegion {
             old(self).req_allocate_pfn(pfn, order)
         ensures
             ret.is_ok() ==> old(self).ens_allocate_pfn(self, pfn, order, *perm),
-            !ret.is_ok() ==> old(self) === self,
+            !ret.is_ok() ==> *old(self) === *self,
     )]
     #[verus_verify(spinoff_prover, rlimit(2))]
     fn allocate_pfn(&mut self, pfn: usize, order: usize) -> Result<(), AllocError> {
@@ -1242,7 +1239,7 @@ impl HeapMemoryRegion {
 
         #[cfg_attr(verus_keep_ghost, verus_spec(
             invariant
-                self === old(self),
+                *self === *old(self),
                 self.wf_next_pages(),
                 self.req_allocate_pfn(pfn, order),
                 self.req_allocate_pfn(old_pfn, order),

--- a/kernel/src/mm/alloc_types.verus.rs
+++ b/kernel/src/mm/alloc_types.verus.rs
@@ -6,6 +6,7 @@
 //
 // Proves the encode/decode functions for PageInfo used in alloc.rs.
 use vstd::simple_pptr::MemContents;
+use vstd::std_specs::convert::TryFromSpec;
 verus! {
 
 // prove the size of PageStorageType
@@ -408,22 +409,21 @@ impl SpecDecoderProof<PageStorageType> for ReservedInfo {
     }
 }
 
-impl PageType {
-    spec fn spec_try_from(val: u64) -> Option<Self> {
-        match val {
-            v if v == Self::Free as u64 => Some(Self::Free),
-            v if v == Self::Allocated as u64 => Some(Self::Allocated),
-            v if v == Self::SlabPage as u64 => Some(Self::SlabPage),
-            v if v == Self::Compound as u64 => Some(Self::Compound),
-            v if v == Self::File as u64 => Some(Self::File),
-            v if v == Self::Reserved as u64 => Some(Self::Reserved),
-            _ => None,
-        }
+impl vstd::std_specs::convert::TryFromSpecImpl<u64> for PageType {
+    closed spec fn obeys_try_from_spec() -> bool {
+        true
     }
 
-    pub closed spec fn ens_try_from(val: u64, ret: Result<Self, AllocError>) -> bool {
-        &&& ret.is_ok() == PageType::spec_try_from(val).is_some()
-        &&& ret.is_ok() ==> ret.unwrap() == PageType::spec_try_from(val).unwrap()
+    closed spec fn try_from_spec(val: u64) -> Result<Self, Self::Error> {
+        match val {
+            v if v == Self::Free as u64 => Ok(Self::Free),
+            v if v == Self::Allocated as u64 => Ok(Self::Allocated),
+            v if v == Self::SlabPage as u64 => Ok(Self::SlabPage),
+            v if v == Self::Compound as u64 => Ok(Self::Compound),
+            v if v == Self::File as u64 => Ok(Self::File),
+            v if v == Self::Reserved as u64 => Ok(Self::Reserved),
+            _ => Err(AllocError::InvalidPageType),
+        }
     }
 }
 
@@ -434,7 +434,7 @@ impl SpecDecoderProof<PageStorageType> for PageType {
 
     spec fn spec_decode(mem: PageStorageType) -> Option<Self> {
         let val = mem.0 & PageStorageType::TYPE_MASK;
-        PageType::spec_try_from(val)
+        PageType::try_from_spec(val).ok()
     }
 
     proof fn lemma_encode_decode(&self) {

--- a/scripts/vinstall.sh
+++ b/scripts/vinstall.sh
@@ -5,14 +5,55 @@
 #
 # Author: Ziqiao Zhou <ziqiaozhou@microsoft.com>
 # A script to install verus tools
-VERISMO_REV=1840262abbcf32f0bd5e622e47fb18d7dfaca795
+set -e
+trap 'echo "Error at line $LINENO: $BASH_COMMAND"' ERR
+VERUS_RELEASE=0.2026.04.12.f1166c4 # May need to update if vstd or other verus library changes
 VERUS_RUST_VERSION=1.94.0
 VERUSFMT_REV=beff2fa686d856d5e60df368fd027d94ead11ac5 # v0.5.7
 
 # Install x86_64-unknown-none target for verus-compatible Rust version
 export RUSTUP_TOOLCHAIN=$VERUS_RUST_VERSION
 rustup target add x86_64-unknown-none --toolchain $RUSTUP_TOOLCHAIN
-# Install the verus toolchain
-cargo install --git https://github.com/microsoft/verismo/ --rev $VERISMO_REV cargo-v
-cargo v install-verus
+
+# Install verusfmt
 cargo install --git https://github.com/verus-lang/verusfmt  --rev $VERUSFMT_REV
+
+# Install verus toolchain
+# Verus cannot be installed via cargo and its build is slow, so we download the prebuilt binaries
+VERUS_ASSETS=(
+    "verus"
+    "rust_verify"
+    "z3"
+    "cargo-verus"
+    "verus-root"
+)
+
+# Detect platform
+ARCH=$(uname -m)
+OS=$(uname -s)
+case "$ARCH" in
+    x86_64)        PLATFORM_ARCH="x86" ;;
+    aarch64|arm64) PLATFORM_ARCH="arm64" ;;
+    *) echo "Error: unsupported architecture: $ARCH" >&2; exit 1 ;;
+esac
+case "$OS" in
+    Linux)  PLATFORM_OS="linux" ;;
+    Darwin) PLATFORM_OS="macos" ;;
+    *) echo "Error: unsupported OS: $OS" >&2; exit 1 ;;
+esac
+
+PLATFORM="${PLATFORM_ARCH}-${PLATFORM_OS}"
+ZIPFILE="verus-${VERUS_RELEASE}-${PLATFORM}.zip"
+DOWNLOAD_URL="https://github.com/verus-lang/verus/releases/download/release/${VERUS_RELEASE}/${ZIPFILE}"
+TMPDIR=$(mktemp -d)
+
+# Download Verus prebuilt into a tmp folder
+curl -sfL "$DOWNLOAD_URL" -o "$TMPDIR/$ZIPFILE"
+unzip -q "$TMPDIR/$ZIPFILE" -d "$TMPDIR"
+
+# Move the extracted Verus assets to the final directory
+for asset in "${VERUS_ASSETS[@]}"; do
+    echo "Installing $asset to ~/.cargo/bin/"
+    mv "$TMPDIR/verus-$PLATFORM/$asset" ~/.cargo/bin/
+done
+rm -rf "$TMPDIR"

--- a/scripts/vinstall.sh
+++ b/scripts/vinstall.sh
@@ -5,8 +5,8 @@
 #
 # Author: Ziqiao Zhou <ziqiaozhou@microsoft.com>
 # A script to install verus tools
-VERISMO_REV=4f504b72ddd7a6d5b194b65db159e55a41831ab9
-VERUS_RUST_VERSION=1.91.0
+VERISMO_REV=1840262abbcf32f0bd5e622e47fb18d7dfaca795
+VERUS_RUST_VERSION=1.94.0
 VERUSFMT_REV=beff2fa686d856d5e60df368fd027d94ead11ac5 # v0.5.7
 
 # Install x86_64-unknown-none target for verus-compatible Rust version
@@ -14,8 +14,5 @@ export RUSTUP_TOOLCHAIN=$VERUS_RUST_VERSION
 rustup target add x86_64-unknown-none --toolchain $RUSTUP_TOOLCHAIN
 # Install the verus toolchain
 cargo install --git https://github.com/microsoft/verismo/ --rev $VERISMO_REV cargo-v
-# verus-rustc as a wrapper to call verus with proper rustc flags.
-cargo install --git https://github.com/microsoft/verismo/ --rev $VERISMO_REV verus-rustc
 cargo v install-verus
-
 cargo install --git https://github.com/verus-lang/verusfmt  --rev $VERUSFMT_REV

--- a/scripts/vinstall.sh
+++ b/scripts/vinstall.sh
@@ -5,14 +5,136 @@
 #
 # Author: Ziqiao Zhou <ziqiaozhou@microsoft.com>
 # A script to install verus tools
-VERISMO_REV=1840262abbcf32f0bd5e622e47fb18d7dfaca795
+set -e
+trap 'echo "Error at line $LINENO: $BASH_COMMAND"' ERR
+
+# Verus release version and commit hash
+VERUS_VERSION=0.2026.04.12.f1166c4
+VERUS_REV=f1166c42c3decd42c1cca2916ef2880d27cfb7d9
 VERUS_RUST_VERSION=1.94.0
+
+# Verusfmt version and commit hash
+VERUSFMT_VERSION=v0.5.7
 VERUSFMT_REV=beff2fa686d856d5e60df368fd027d94ead11ac5 # v0.5.7
+
+# Z3 version and commit hash
+VERUS_Z3_VERSION=4.12.5
+VERUS_Z3_REV=a7b564cafe3b96c8a868388bc4b96b319facea44
+
+VERUS_INSTALL_DIR="$HOME/.cargo/bin"
+
+# Parse arguments
+INSTALL_PREBUILT=false
+FORCE_INSTALL=false
+for arg in "$@"; do
+    case "$arg" in
+        --use-prebuilt) INSTALL_PREBUILT=true ;;
+        --force) FORCE_INSTALL=true ;;
+        *) echo "Unknown argument: $arg" >&2; exit 1 ;;
+    esac
+done
 
 # Install x86_64-unknown-none target for verus-compatible Rust version
 export RUSTUP_TOOLCHAIN=$VERUS_RUST_VERSION
 rustup target add x86_64-unknown-none --toolchain $RUSTUP_TOOLCHAIN
-# Install the verus toolchain
-cargo install --git https://github.com/microsoft/verismo/ --rev $VERISMO_REV cargo-v
-cargo v install-verus
+
+fetch_code() {
+    url=$1
+    commit=$2
+    destdir=$3
+    git clone --no-checkout --depth 1 "$url" "$destdir"
+    pushd "$destdir" > /dev/null
+    git fetch --depth 1 origin "$commit"
+    git checkout FETCH_HEAD -b "$commit"
+    popd > /dev/null
+}
+
+# Install verus toolchain into your ~/.cargo/bin
+install_verus_assets() {
+    VERUS_ASSETS=(
+        "verus"
+        "rust_verify"
+        "z3"
+        "cargo-verus"
+        "verus-root"
+    )
+    local src_dir=$1
+    local dst_dir=$2
+    for asset in "${VERUS_ASSETS[@]}"; do
+        echo "Installing $asset to $dst_dir"
+        install "$src_dir/$asset" $dst_dir
+    done
+}
+
+# Skip building Verus from source if the correct version is already installed
+if (verus --version | grep -q "$VERUS_VERSION") &> /dev/null && ! $FORCE_INSTALL; then
+    echo "Verus version $VERUS_VERSION already installed, skipping build."
+    exit 0
+fi
+
+# Prebuilt path: download binaries and exit early
+install_prebuilt() {
+    ARCH=$(uname -m)
+    OS=$(uname -s)
+    case "$ARCH" in
+        x86_64)        PLATFORM_ARCH="x86" ;;
+        aarch64|arm64) PLATFORM_ARCH="arm64" ;;
+        *) echo "Error: unsupported architecture: $ARCH" >&2; exit 1 ;;
+    esac
+    case "$OS" in
+        Linux)  PLATFORM_OS="linux" ;;
+        Darwin) PLATFORM_OS="macos" ;;
+        *) echo "Error: unsupported OS: $OS" >&2; exit 1 ;;
+    esac
+    PLATFORM="${PLATFORM_ARCH}-${PLATFORM_OS}"
+    ZIPFILE="verus-${VERUS_VERSION}-${PLATFORM}.zip"
+    VERUS_RELEASE_URL="https://github.com/verus-lang/verus/releases/download/release/${VERUS_VERSION}/${ZIPFILE}"
+
+    # Install verusfmt
+    curl --proto '=https' --tlsv1.2 -LsSf https://github.com/verus-lang/verusfmt/releases/download/$VERUSFMT_VERSION/verusfmt-installer.sh | sh
+
+    TMPDIR=$(mktemp -d)
+    trap 'rm -rf "$TMPDIR"' EXIT
+    curl --proto '=https' --tlsv1.2 -LsSf "$VERUS_RELEASE_URL" -o "$TMPDIR/$ZIPFILE"
+    unzip -q "$TMPDIR/$ZIPFILE" -d "$TMPDIR"
+    install_verus_assets "$TMPDIR/verus-$PLATFORM" "$VERUS_INSTALL_DIR"
+}
+
+if $INSTALL_PREBUILT; then
+    install_prebuilt
+    exit 0
+fi
+
+# Install verusfmt
 cargo install --git https://github.com/verus-lang/verusfmt  --rev $VERUSFMT_REV
+
+# Create a temporary directory
+TMPDIR=$(mktemp -d)
+VERUS_DIR=$TMPDIR/verus
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Fetch Verus source code
+fetch_code https://github.com/verus-lang/verus.git "$VERUS_REV" "$VERUS_DIR"
+
+# Build and install Z3 from source if not exists or version is wrong
+if ! (z3 --version | grep -q "$VERUS_Z3_VERSION") &> /dev/null || $FORCE_INSTALL; then
+    fetch_code https://github.com/Z3Prover/z3 "$VERUS_Z3_REV" "$TMPDIR/z3"
+    pushd "$TMPDIR/z3" > /dev/null
+    python3 scripts/mk_make.py
+    pushd build && make -j$(nproc)
+    cp z3 $VERUS_DIR/source
+    popd > /dev/null
+    popd > /dev/null
+else
+    echo "Z3 found and version matches $VERUS_Z3_VERSION, skipping build."
+    cp $(which z3) $VERUS_DIR/source
+fi
+
+# Build and install Verus from source
+source $VERUS_DIR/tools/activate
+pushd $VERUS_DIR/source
+rustup component add rust-src rustc-dev llvm-tools-preview --toolchain $RUSTUP_TOOLCHAIN
+vargo build --release --vstd-no-verify
+popd > /dev/null
+install_verus_assets "$VERUS_DIR/source/target-verus/release" "$VERUS_INSTALL_DIR"
+rm -r $TMPDIR

--- a/verification/verify_external/Cargo.toml
+++ b/verification/verify_external/Cargo.toml
@@ -15,3 +15,6 @@ workspace = true
 default = []
 noverify = []
 verus = ["verus_builtin", "vstd"]
+
+[package.metadata.verus]
+verify = true

--- a/verification/verify_proof/Cargo.toml
+++ b/verification/verify_proof/Cargo.toml
@@ -19,3 +19,6 @@ workspace = true
 default = []
 noverify = []
 verus = ["verus_builtin", "vstd"]
+
+[package.metadata.verus]
+verify = true


### PR DESCRIPTION
Update to latest verus to use cargo-verus.
Enable including SVSM in Verus Verita tests through cargo-verus. Helps catch Verus breaking changes that impact SVSM verification.

Changes due to Verus updates:
Use new style of specification for TryFrom in updated Verus. Change referece comparison to value comparison due to changed mut ref feature in Verus.