### PR TITLE
task: refactor task scheduling

### DIFF
--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -1178,8 +1178,8 @@ impl PerCpu {
         drop(guard);
     }
 
-    pub fn schedule_prepare(&self) -> Option<(TaskPointer, TaskPointer)> {
-        let ret = self.runqueue_mut().schedule_prepare();
+    pub fn schedule_prepare(&self, reschedule: bool) -> Option<(TaskPointer, TaskPointer)> {
+        let ret = self.runqueue_mut().schedule_prepare(reschedule);
         if let Some((_, ref next)) = ret {
             self.set_current_stack(next.stack_bounds());
         };

--- a/kernel/src/syscall/class0.rs
+++ b/kernel/src/syscall/class0.rs
@@ -9,7 +9,8 @@ use crate::address::VirtAddr;
 use crate::cpu::percpu::current_task;
 use crate::fs::find_dir;
 use crate::mm::guestmem::UserPtr;
-use crate::task::{current_task_terminated, exec_user, schedule};
+use crate::task::exec_user;
+use crate::task::terminate;
 use core::ffi::c_char;
 use syscall::SysCallError;
 
@@ -18,9 +19,7 @@ pub fn sys_exit(exit_code: u32) -> ! {
         "Terminating task {}, exit_code {exit_code}",
         current_task().get_task_name()
     );
-    current_task_terminated();
-    schedule();
-    unreachable!("schedule() returned in sys_exit()");
+    terminate();
 }
 
 pub fn sys_exec(file: usize, root: usize, _flags: usize) -> Result<u64, SysCallError> {

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -11,9 +11,9 @@ mod tasks;
 mod waiting;
 
 pub use schedule::{
-    RunQueue, TASKLIST, create_user_task, current_task, current_task_terminated, finish_user_task,
-    go_idle, is_current_task, schedule, schedule_init, schedule_task, scheduler_idle, set_affinity,
-    start_kernel_task, start_kernel_thread, terminate,
+    RunQueue, TASKLIST, create_user_task, current_task, finish_user_task, go_idle, is_current_task,
+    schedule, schedule_init, schedule_task, scheduler_idle, set_affinity, start_kernel_task,
+    start_kernel_thread, terminate,
 };
 
 pub use tasks::{

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -402,7 +402,7 @@ pub fn terminate() -> ! {
     current_task_terminated();
 
     // The current task will not run again, so switch to a different task.
-    select_new_task(false);
+    select_new_task(false, None);
     unreachable!("terminated task rescheduled");
 }
 
@@ -423,7 +423,7 @@ pub fn go_idle() {
 
     // Find another task to run.  If no other task is runnable, then the idle
     // thread will execute.
-    select_new_task(false);
+    select_new_task(false, None);
 }
 
 pub fn set_affinity(cpu_index: usize) {
@@ -446,7 +446,7 @@ pub fn set_affinity(cpu_index: usize) {
 
         // Find another task to run.  The scheduler will complete the affinity
         // change once a new task has been selected on this processor.
-        select_new_task(false);
+        select_new_task(false, None);
     }
 }
 
@@ -538,14 +538,16 @@ pub fn schedule() {
     // check if preemption is safe
     preemption_checks();
 
-    select_new_task(true);
+    select_new_task(true, None);
 }
 
 /// Select another task to run.  If rescheduling is requested, the current
 /// task will be placed back on the current processor's run queue so it can
 /// be eligible to run again.
-fn select_new_task(reschedule: bool) {
-    let guard = IrqGuard::new();
+fn select_new_task(reschedule: bool, irq_guard: Option<IrqGuard>) {
+    // If the caller has not already disabled interrupts, then disable them
+    // now.
+    let guard = irq_guard.unwrap_or_default();
 
     let work = this_cpu().schedule_prepare(reschedule);
 

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -110,15 +110,12 @@ impl RunQueue {
             .unwrap_or_else(|| self.idle_task.clone().unwrap())
     }
 
-    /// Update state before a task is scheduled out. Non-idle tasks in RUNNING
-    /// state will be put at the end of the run_list. Terminated tasks will be
-    /// stored in the terminated_task field of the RunQueue and be destroyed
-    /// after the task-switch.
-    fn handle_task(&mut self, task: TaskPointer) {
-        if task.is_running() && !task.is_idle_task() {
+    /// Place a task back onto the run queue so it can be scheduled again.
+    fn enqueue_task(&mut self, task: TaskPointer) {
+        // Task termination should not follow this path.
+        debug_assert!(!task.is_terminated());
+        if !task.is_idle_task() {
             self.run_list.push_back(task);
-        } else if task.is_terminated() {
-            self.terminated_task = Some(task);
         }
     }
 
@@ -137,8 +134,14 @@ impl RunQueue {
 
     /// Prepares a task switch. The function checks if a task switch needs to
     /// be done and return pointers to the current and next task. It will
-    /// also call `handle_task()` on the current task in case a task-switch
+    /// also call `enqueue_task()` on the current task in case a task-switch
     /// is requested.
+    ///
+    /// # Parameters
+    ///
+    /// - `reschedule`: Indicates whether the current task being rescheduled.
+    ///   If so, it will be reinserted on the run list of the current
+    ///   processor.
     ///
     /// # Returns
     ///
@@ -148,12 +151,18 @@ impl RunQueue {
     /// # Panics
     ///
     /// Panics if there is no current task.
-    pub fn schedule_prepare(&mut self) -> Option<(TaskPointer, TaskPointer)> {
-        // Remove current and put it back into the RunQueue in case it is still
-        // runnable. This is important to make sure the last runnable task
-        // keeps running, even if it calls schedule()
-        let current = self.current_task.take().unwrap();
-        self.handle_task(current.clone());
+    pub fn schedule_prepare(&mut self, reschedule: bool) -> Option<(TaskPointer, TaskPointer)> {
+        let current = if reschedule {
+            // Remove current and put it back into the RunQueue.  This is
+            // important to make sure the last runnable task keeps running,
+            // even if it calls schedule()
+            let current = self.current_task.take().unwrap();
+            debug_assert!(current.is_running());
+            self.enqueue_task(current.clone());
+            current
+        } else {
+            self.current_task.as_ref().unwrap().clone()
+        };
 
         // Get next task and update current_task state
         let next = self.get_next_task();
@@ -163,6 +172,9 @@ impl RunQueue {
         if current != next {
             Some((current, next))
         } else {
+            // A task switch is expected unless the current task is being
+            // rescheduled.
+            debug_assert!(reschedule);
             None
         }
     }
@@ -277,7 +289,7 @@ pub fn start_kernel_task(
     TASKLIST.lock().list().push_back(task.clone());
 
     // Put task on the runqueue of this CPU
-    cpu.runqueue_mut().handle_task(task.clone());
+    cpu.runqueue_mut().enqueue_task(task.clone());
 
     schedule();
 
@@ -308,7 +320,7 @@ pub fn start_kernel_thread(start_info: KernelThreadStartInfo) -> Result<TaskPoin
     TASKLIST.lock().list().push_back(task.clone());
 
     // Put task on the runqueue of this CPU
-    cpu.runqueue_mut().handle_task(task.clone());
+    cpu.runqueue_mut().enqueue_task(task.clone());
 
     schedule();
 
@@ -345,7 +357,7 @@ pub fn finish_user_task(task: TaskPointer) {
     TASKLIST.lock().list().push_back(task.clone());
 
     // Put task on the runqueue of this CPU
-    this_cpu().runqueue_mut().handle_task(task);
+    this_cpu().runqueue_mut().enqueue_task(task);
 }
 
 pub fn current_task() -> TaskPointer {
@@ -365,9 +377,14 @@ pub fn is_current_task(id: u32) -> bool {
 /// # Panic
 ///
 /// This function must only be called after scheduling is initialized, otherwise it will panic.
-pub fn current_task_terminated() {
+fn current_task_terminated() {
     let cpu = this_cpu();
     let mut rq = cpu.runqueue_mut();
+
+    // Capture a reference to the current task so that it remains referenced
+    // until the next scheduling operation completes.
+    rq.terminated_task = rq.current_task.clone();
+
     let task_node = rq
         .current_task
         .as_mut()
@@ -378,12 +395,22 @@ pub fn current_task_terminated() {
     unsafe { TASKLIST.lock().terminate(task_node.clone()) }
 }
 
-pub fn terminate() {
+pub fn terminate() -> ! {
+    // Terminating a task will result in a task change, so preemption must
+    // be allowable.
+    preemption_checks();
     current_task_terminated();
-    schedule();
+
+    // The current task will not run again, so switch to a different task.
+    select_new_task(false);
+    unreachable!("terminated task rescheduled");
 }
 
 pub fn go_idle() {
+    // Entering an idle state will result in a task change, so preemption must
+    // be allowable.
+    preemption_checks();
+
     // Mark this task as blocked and indicate that it is waiting for wake after
     // idle.  Only one task on each CPU can be in the wake-from-idle state at
     // one time.
@@ -396,10 +423,14 @@ pub fn go_idle() {
 
     // Find another task to run.  If no other task is runnable, then the idle
     // thread will execute.
-    schedule();
+    select_new_task(false);
 }
 
 pub fn set_affinity(cpu_index: usize) {
+    // Changes to affinity mak cause a scheduling change, so verify that
+    // scheduling operations are safe.
+    preemption_checks();
+
     // Affinity signaling is only required if the target CPU is not the current
     // CPU.
     if cpu_index != this_cpu().get_cpu_index() {
@@ -415,7 +446,7 @@ pub fn set_affinity(cpu_index: usize) {
 
         // Find another task to run.  The scheduler will complete the affinity
         // change once a new task has been selected on this processor.
-        schedule();
+        select_new_task(false);
     }
 }
 
@@ -507,9 +538,16 @@ pub fn schedule() {
     // check if preemption is safe
     preemption_checks();
 
+    select_new_task(true);
+}
+
+/// Select another task to run.  If rescheduling is requested, the current
+/// task will be placed back on the current processor's run queue so it can
+/// be eligible to run again.
+fn select_new_task(reschedule: bool) {
     let guard = IrqGuard::new();
 
-    let work = this_cpu().schedule_prepare();
+    let work = this_cpu().schedule_prepare(reschedule);
 
     // !!! Runqueue lock must be release here !!!
     if let Some((current, next)) = work {
@@ -597,7 +635,7 @@ pub fn after_task_switch() {
 
 fn enqueue_task(task: TaskPointer) {
     task.set_task_running();
-    this_cpu().runqueue_mut().handle_task(task);
+    this_cpu().runqueue_mut().enqueue_task(task);
 }
 
 pub fn schedule_task(task: TaskPointer) {

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -769,10 +769,33 @@ global_asm!(
 /// 0x1ff8 = Size(GuardPage) + Size(ShadowStack) - 8; where Size(GuardPage) == Size(ShadowStack) == PAGE_SIZE.
 const CONTEXT_SWITCH_RESTORE_TOKEN: VirtAddr = SVSM_CONTEXT_SWITCH_SHADOW_STACK.const_add(0x1ff8);
 
-#[cfg(test)]
+#[cfg(all(test, test_in_svsm))]
 mod test {
+    extern crate alloc;
     use crate::cpu::percpu::{PERCPU_AREAS, this_cpu};
+    use crate::task::KernelThreadStartInfo;
     use crate::task::set_affinity;
+    use crate::task::start_kernel_task;
+    use alloc::string::String;
+    use core::sync::atomic::AtomicU32;
+    use core::sync::atomic::Ordering;
+
+    static EMPTY_TASK_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    fn empty_task(_parameter: usize) {
+        EMPTY_TASK_COUNTER.fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[test]
+    #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
+    fn test_task_termination() {
+        // Start a task that will immediately terminate.
+        start_kernel_task(
+            KernelThreadStartInfo::new(empty_task, 0),
+            String::from("test termination task"),
+        )
+        .expect("Failed to start test termination task");
+    }
 
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -40,7 +40,8 @@ use crate::types::{SVSM_USER_CS, SVSM_USER_DS};
 use crate::utils::{MemoryRegion, is_aligned};
 use intrusive_collections::{LinkedListAtomicLink, intrusive_adapter};
 
-use super::schedule::{after_task_switch, current_task_terminated, schedule};
+use super::schedule::after_task_switch;
+use super::schedule::terminate;
 use super::task_mm::{TaskKernelMapping, TaskMM};
 
 pub const INITIAL_TASK_ID: u32 = 1;
@@ -1003,8 +1004,7 @@ unsafe fn run_kernel_task<T: KernelThreadStartParameter>(
 }
 
 fn task_exit() {
-    current_task_terminated();
-    schedule();
+    terminate();
 }
 
 #[cfg(all(test, test_in_svsm))]


### PR DESCRIPTION
To support wait states and other scenarios in which tasks are not immediately scheduled for execution, it is helpful to change the scheduler logic so that it does not unconditionally prepare the current task to be resumed later on the current CPU.  Instead, modify the scheduler interface so that different scheduler entry points can control the behavior to reschedule when the time comes to select a different task for execution.