### PR TITLE
Makefile: fix clippy with CARGO_HACK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ clippy:
 	${CARGO} clippy ${CLIPPY_OPTIONS} --package svsm --target x86_64-unknown-none -- ${CLIPPY_ARGS}
 	${CARGO} clippy ${CLIPPY_OPTIONS} --package stage1 --target x86_64-unknown-none -- ${CLIPPY_ARGS} ${STAGE1_RUSTC_ARGS}
 	${CARGO} clippy ${CLIPPY_OPTIONS} --workspace --tests --exclude svsm -- ${CLIPPY_ARGS}
-	${CARGO} clippy ${CLIPPY_OPTIONS} --package svsm ${SVSM_ARGS_TEST} --tests -- ${CLIPPY_ARGS}
+	${CARGO} clippy ${CLIPPY_OPTIONS} --package svsm --tests -- ${CLIPPY_ARGS}
 
 clean:
 	cargo clean


### PR DESCRIPTION
Running `make clippy CARGO_HACK=1` fails with:

    error: --no-default-features may not be used together with --each-feature

The `SVSM_ARGS_TEST` variable is only used to run tests. No need to use
it in clippy.