### PR TITLE
task: implement `wait_for_termination`

### DIFF
--- a/kernel/src/syscall/class0.rs
+++ b/kernel/src/syscall/class0.rs
@@ -31,7 +31,7 @@ pub fn sys_exec(file: usize, root: usize, _flags: usize) -> Result<u64, SysCallE
     let real_root = find_dir(current_task().rootdir(), &root_str)?;
     let tid = exec_user(&file_str, real_root)?;
 
-    Ok(tid.into())
+    Ok(tid.get_task_id().into())
 }
 
 pub fn sys_close(obj_id: u32) -> Result<u64, SysCallError> {

--- a/kernel/src/task/exec.rs
+++ b/kernel/src/task/exec.rs
@@ -52,7 +52,7 @@ fn task_name(binary: &str) -> String {
 ///
 /// # Returns
 ///
-/// [`Ok(tid)`] on success, [`Err(SvsmError)`] on failure.
+/// [`Ok(TaskPointer)`] on success, [`Err(SvsmError)`] on failure.
 pub fn exec_user(binary: &str, root: Arc<dyn Directory>) -> Result<TaskPointer, SvsmError> {
     let fh = open_read(binary)?;
     let file_size = fh.size();

--- a/kernel/src/task/exec.rs
+++ b/kernel/src/task/exec.rs
@@ -6,6 +6,7 @@
 
 extern crate alloc;
 
+use super::TaskPointer;
 use crate::address::{Address, VirtAddr};
 use crate::error::SvsmError;
 use crate::fs::{Directory, open_read};
@@ -52,7 +53,7 @@ fn task_name(binary: &str) -> String {
 /// # Returns
 ///
 /// [`Ok(tid)`] on success, [`Err(SvsmError)`] on failure.
-pub fn exec_user(binary: &str, root: Arc<dyn Directory>) -> Result<u32, SvsmError> {
+pub fn exec_user(binary: &str, root: Arc<dyn Directory>) -> Result<TaskPointer, SvsmError> {
     let fh = open_read(binary)?;
     let file_size = fh.size();
 
@@ -117,5 +118,5 @@ pub fn exec_user(binary: &str, root: Arc<dyn Directory>) -> Result<u32, SvsmErro
     finish_user_task(new_task.clone());
     schedule();
 
-    Ok(new_task.get_task_id())
+    Ok(new_task)
 }

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -13,7 +13,7 @@ mod waiting;
 pub use schedule::{
     RunQueue, TASKLIST, create_user_task, current_task, finish_user_task, go_idle, is_current_task,
     schedule, schedule_init, schedule_task, scheduler_idle, set_affinity, start_kernel_task,
-    start_kernel_thread, terminate,
+    start_kernel_thread, terminate, wait_for_termination,
 };
 
 pub use tasks::{

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -274,15 +274,18 @@ impl TaskList {
     /// # Safety
     /// The caller must ensure that `task` is already a member of this task
     /// list.
-    unsafe fn terminate(&mut self, task: TaskPointer) {
+    unsafe fn terminate(&mut self, task: TaskPointer) -> Option<TaskPointer> {
         // Set the task state as terminated. If the task being terminated is the
         // current task then the task context will still need to be in scope until
         // the next schedule() has completed. Schedule will keep a reference to this
         // task until some time after the context switch.
-        task.set_task_terminated();
+        let wakeup = task.set_task_terminated();
         // SAFETY: `task` must be a task pointer that is part of this list.
         let mut cursor = unsafe { self.list().cursor_mut_from_ptr(task.as_ref()) };
         cursor.remove();
+
+        // Inform the caller about any task that may need to be woken.
+        wakeup
     }
 }
 
@@ -390,6 +393,22 @@ pub fn is_current_task(id: u32) -> bool {
     }
 }
 
+/// Waits for a task to terminate
+pub fn wait_for_termination(task: TaskPointer) {
+    // Waiting may require a task switch, so ensure that this is safe.
+    preemption_checks();
+
+    // Prepare a wait state based on the current execution state of the target
+    // task.
+    let wait_result = task.wait_for_exit();
+
+    // If a wait is required, then switch to a different task until the wait
+    // can be satisfied.
+    if let Some(guard) = wait_result {
+        select_new_task(false, Some(guard));
+    }
+}
+
 /// Terminates the current task.
 ///
 /// # Panic
@@ -410,7 +429,14 @@ fn current_task_terminated() {
     // SAFETY: the scheduler guarantees that `current_task` always points to a
     // valid task, and every task has its pointer pushed into the global task
     // list during its creation.
-    unsafe { TASKLIST.lock().terminate(task_node.clone()) }
+    let wakeup = unsafe { TASKLIST.lock().terminate(task_node.clone()) };
+    drop(rq);
+
+    // If another thread must be woken as a result of the termination, then
+    // schedule it now.
+    if let Some(wake_task) = wakeup {
+        enqueue_task(wake_task);
+    }
 }
 
 pub fn terminate() -> ! {
@@ -839,17 +865,24 @@ const CONTEXT_SWITCH_RESTORE_TOKEN: VirtAddr = SVSM_CONTEXT_SWITCH_SHADOW_STACK.
 #[cfg(all(test, test_in_svsm))]
 mod test {
     extern crate alloc;
+    use super::KernelThreadStartInfo;
+    use super::set_affinity;
+    use super::start_kernel_task;
+    use super::wait_for_termination;
     use crate::cpu::percpu::{PERCPU_AREAS, this_cpu};
-    use crate::task::KernelThreadStartInfo;
-    use crate::task::set_affinity;
-    use crate::task::start_kernel_task;
     use alloc::string::String;
     use core::sync::atomic::AtomicU32;
     use core::sync::atomic::Ordering;
 
     static EMPTY_TASK_COUNTER: AtomicU32 = AtomicU32::new(0);
 
-    fn empty_task(_parameter: usize) {
+    fn empty_task(parameter: usize) {
+        // Move to a different processor if the caller requested it.
+        if parameter != 0 {
+            let target_cpu = PERCPU_AREAS.len() - 1;
+            set_affinity(target_cpu);
+        }
+
         EMPTY_TASK_COUNTER.fetch_add(1, Ordering::Relaxed);
     }
 
@@ -862,6 +895,33 @@ mod test {
             String::from("test termination task"),
         )
         .expect("Failed to start test termination task");
+    }
+
+    #[test]
+    #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
+    fn test_wait_for_termination() {
+        // Reset the task execution counter.
+        EMPTY_TASK_COUNTER.store(0, Ordering::Relaxed);
+
+        // Start a task that will move to a remote processor (if available)
+        // and will then terminate.
+        let task = start_kernel_task(
+            KernelThreadStartInfo::new(empty_task, 1),
+            String::from("test termination task"),
+        )
+        .expect("Failed to start test termination task");
+
+        // Wait for that task to terminate.  This might or might not involve
+        // waiting, depending on how quickly the new task migrates to another
+        // processor.
+        wait_for_termination(task.clone());
+
+        // Verify that the task ran.
+        assert_eq!(EMPTY_TASK_COUNTER.load(Ordering::Relaxed), 1);
+
+        // Wait again for the task to terminate.  This should return
+        // immediately.
+        wait_for_termination(task);
     }
 
     #[test]

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -19,18 +19,24 @@ use core::sync::atomic::AtomicUsize;
 use core::sync::atomic::Ordering;
 
 use crate::address::{Address, VirtAddr};
+use crate::cpu::IrqGuard;
 use crate::cpu::ShadowStackInit;
 use crate::cpu::X86ExceptionContext;
 use crate::cpu::features::{Feature, cpu_has_feat};
 use crate::cpu::idt::svsm::return_new_task;
 use crate::cpu::irq_state::EFLAGS_IF;
 use crate::cpu::irqs_enable;
-use crate::cpu::percpu::{PerCpu, current_task};
+use crate::cpu::percpu::PerCpu;
+use crate::cpu::percpu::current_task;
+use crate::cpu::percpu::this_cpu;
 use crate::cpu::shadow_stack::init_shadow_stack;
-use crate::cpu::sse::{sse_restore_context, xsave_area_size};
+use crate::cpu::sse::sse_restore_context;
+use crate::cpu::sse::xsave_area_size;
 use crate::error::SvsmError;
 use crate::fs::{Directory, FileHandle, opendir, stdout_open};
-use crate::locking::{RWLock, SpinLock};
+use crate::locking::RWLock;
+use crate::locking::SpinLock;
+use crate::locking::SpinLockIrqSafe;
 use crate::mm::pagetable::{PTEntryFlags, PageTable};
 use crate::mm::vm::{Mapping, VMFileMappingFlags, VMKernelStack, VMR};
 use crate::mm::{
@@ -43,6 +49,7 @@ use crate::types::{SVSM_USER_CS, SVSM_USER_DS};
 use crate::utils::{MemoryRegion, is_aligned};
 use intrusive_collections::{LinkedListAtomicLink, intrusive_adapter};
 
+use super::WaitQueue;
 use super::schedule::after_task_switch;
 use super::schedule::terminate;
 use super::task_mm::{TaskKernelMapping, TaskMM};
@@ -304,6 +311,9 @@ pub struct Task {
 
     /// Objects shared among threads within the same process
     objs: Arc<RWLock<BTreeMap<ObjHandle, Arc<dyn Obj>>>>,
+
+    /// Queue of tasks waiting for completion of this task.
+    wait_queue: SpinLockIrqSafe<WaitQueue>,
 }
 
 // Expose the offsets of critical task fields to assembly.
@@ -472,6 +482,7 @@ impl Task {
             list_link: LinkedListAtomicLink::default(),
             runlist_link: LinkedListAtomicLink::default(),
             objs: objtree,
+            wait_queue: SpinLockIrqSafe::new(WaitQueue::new()),
         }))
     }
 
@@ -566,10 +577,11 @@ impl Task {
         self.sched_state.set_state(TaskState::RUNNING);
     }
 
-    pub fn set_task_terminated(&self) {
+    pub fn set_task_terminated(&self) -> Option<TaskPointer> {
         self.sched_state
             .panic_on_idle("Trying to terminate idle task")
             .set_state(TaskState::TERMINATED);
+        self.wait_queue.lock().wakeup()
     }
 
     pub fn set_task_blocked(&self) {
@@ -757,6 +769,35 @@ impl Task {
             panic!("Error while allocating xsave area");
         }
         xsa.unwrap()
+    }
+
+    pub fn wait_for_exit(&self) -> Option<IrqGuard> {
+        let current_task = this_cpu().current_task();
+
+        // Lock the wait queue before examining the current state.  This must
+        // be done with interrupts disabled, since once the current task has
+        // joined the wait queue and the wait queue is unlocked, the task is
+        // subject to an immediate attempt to wake, and therefore the current
+        // task must be descheduled as quickly as possible to prevent
+        // contention on the waking CPU.
+        let guard = IrqGuard::new();
+
+        // Determine whether this task has already terminated, and only join
+        // the wait queue if the task has not already terminated.  Since a task
+        // is marked terminated before its wait queue is examined, this
+        // sequence guarantees that a task will not block unless it is
+        // guaranteed to be woken.
+        let mut wait_queue = self.wait_queue.lock();
+        if self.is_terminated() {
+            return None;
+        }
+
+        // Join the wait queue of the target task.
+        wait_queue.wait_for_event(current_task);
+        drop(wait_queue);
+
+        // Return the IRQ guard as an indication that the caller must wait.
+        Some(guard)
     }
 
     pub fn mmap_common(


### PR DESCRIPTION
Implement a new function that permits waiting for a task to terminate.  No wait is performed if the task has already terminated.  If the task is still executing, the caller will enter a wait state and will be woken on the same CPU on which the terminating task last ran.