### PR TITLE
github/workflows: add apt update before apt install in publish-docs

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -34,6 +34,9 @@ jobs:
             profile: minimal
             override: true
 
+      - name: Update apt package list
+        run: sudo apt update
+
       - name: Install TPM 2.0 Reference Implementation build dependencies
         run: sudo apt install -y build-essential cmake pkg-config
 


### PR DESCRIPTION
GitHub Actions runners ship with a pre-populated apt cache that can become stale. When this happens, apt install fails because the cached index references package URLs that no longer exist on the mirror:

`E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?`

Add an explicit apt update step to ensure the package index is current.

This adds ~12 seconds to CI time, but does not impact PRs CI time as this workflow is only executed on pushes to the main branch.