### PR TITLE
task: fix conflict in per-CPU mapping update

### DIFF
--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -1179,11 +1179,7 @@ impl PerCpu {
     }
 
     pub fn schedule_prepare(&self, reschedule: bool) -> Option<(TaskPointer, TaskPointer)> {
-        let ret = self.runqueue_mut().schedule_prepare(reschedule);
-        if let Some((_, ref next)) = ret {
-            self.set_current_stack(next.stack_bounds());
-        };
-        ret
+        self.runqueue_mut().schedule_prepare(reschedule)
     }
 
     pub fn runqueue(&self) -> ReadLockGuardIrqSafe<'_, RunQueue> {

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -478,6 +478,13 @@ unsafe fn switch_to(prev: *const Task, next: *const Task) {
     // the page table and stack information in those tasks are correct and
     // can be used to switch to the correct page table and execution stack.
     unsafe {
+        // Before manipulating the new task, wait until it has stopped running,
+        // and mark it as active again.  It is not safe to change per-CPU
+        // mappings or stack pointers until the task is exclusively claimed
+        // by the current CPU.
+        (*next).make_active();
+        (*next).update_cpu();
+
         let cr3 = (*next).page_table.lock().cr3_value().bits() as u64;
 
         // The location of a cpu-local stack that's mapped into every set of
@@ -564,14 +571,9 @@ fn select_new_task(reschedule: bool, irq_guard: Option<IrqGuard>) {
 
     // !!! Runqueue lock must be release here !!!
     if let Some((current, next)) = work {
-        // Update per-cpu mappings if needed
-        let cpu_index = this_cpu().get_cpu_index();
-
-        if next.update_cpu(cpu_index) != cpu_index {
-            // Task has changed CPU, update per-cpu mappings
-            let mut pt = next.page_table.lock();
-            this_cpu().populate_page_table(&mut pt);
-        }
+        // Ensure that the current stack bounds of the current CPU are adjusted
+        // to reflect the task being scheduled.
+        this_cpu().set_current_stack(next.stack_bounds());
 
         // SAFETY: ths stack pointer is known to be correct.
         unsafe {
@@ -721,17 +723,6 @@ global_asm!(
 
         // Switch to the new task page tables
         mov     %r15, %cr3
-
-        // Wait until the new task is inactive.  It may still be running
-        // on another processor so its stack cannot be consumed until its
-        // stack is no longer active on any processor.
-    3:
-        pause
-        movb    $1, %al
-        lock xchgb {TASK_STATE_ACTIVE}(%r13), %al
-        testb   %al, %al
-        jnz     3b
-
         cmpb    $0, {IS_CET_ENABLED}(%rip)
         je      2f
         // Switch to the new task shadow stack and move the "shadow stack

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -119,15 +119,17 @@ impl RunQueue {
         }
     }
 
-    /// Initialized the scheduler for this (RunQueue)[RunQueue]. This method is
+    /// Initializes the scheduler for this (RunQueue)[RunQueue]. This method is
     /// called on the very first scheduling event when there is no current task
-    /// yet.
+    /// yet.  For consistency, it will always invoke the idle task using an
+    /// abbreviated task switch flow, and if there is another task that can
+    /// run, a full task switch will then occur.
     ///
     /// # Returns
     ///
     /// [TaskPointer] to the first task to run
     pub fn schedule_init(&mut self) -> TaskPointer {
-        let task = self.get_next_task();
+        let task = self.idle_task.as_ref().unwrap().clone();
         self.current_task = Some(task.clone());
         task
     }
@@ -202,6 +204,15 @@ impl RunQueue {
         TASKLIST.lock().list().push_front(task.clone());
 
         self.idle_task.replace(task);
+    }
+
+    /// Gets a pointer to the idle task
+    ///
+    /// # Panics
+    ///
+    /// Panics if the idle task has not yet been set.
+    pub fn get_idle_task(&self) -> TaskPointer {
+        self.idle_task.as_ref().unwrap().clone()
     }
 
     /// Gets a pointer to the current task

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -21,7 +21,9 @@ use core::sync::atomic::Ordering;
 use crate::address::{Address, VirtAddr};
 use crate::cpu::idt::svsm::return_new_task;
 use crate::cpu::irq_state::EFLAGS_IF;
-use crate::cpu::percpu::{PerCpu, current_task};
+use crate::cpu::percpu::PerCpu;
+use crate::cpu::percpu::current_task;
+use crate::cpu::percpu::this_cpu;
 use crate::cpu::shadow_stack::{init_shadow_stack, is_cet_ss_supported};
 use crate::cpu::sse::{get_xsave_area_size, sse_restore_context};
 use crate::cpu::{ShadowStackInit, X86ExceptionContext, X86GeneralRegs, irqs_enable};
@@ -227,9 +229,9 @@ impl TaskSchedState {
         self
     }
 
-    fn set_active(&self) {
-        if self.active.swap(true, Ordering::Release) {
-            panic!("attempted switch to an active task");
+    fn make_active(&self) {
+        while self.active.swap(true, Ordering::AcqRel) {
+            core::hint::spin_loop();
         }
     }
 
@@ -541,8 +543,8 @@ impl Task {
         self.rootdir.clone()
     }
 
-    pub fn set_task_active(&self) {
-        self.sched_state.set_active();
+    pub fn make_active(&self) {
+        self.sched_state.make_active();
     }
 
     pub fn set_task_running(&self) {
@@ -577,8 +579,14 @@ impl Task {
         self.sched_state.idle_task.load(Ordering::Relaxed)
     }
 
-    pub fn update_cpu(&self, new_cpu_index: usize) -> usize {
-        self.sched_state.update_cpu(new_cpu_index)
+    pub fn update_cpu(&self) {
+        // Check to see whether this task has moved across CPUs.
+        let new_cpu_index = this_cpu().get_cpu_index();
+        if self.sched_state.update_cpu(new_cpu_index) != new_cpu_index {
+            // Task has changed CPU, update per-cpu mappings.
+            let mut pt = self.page_table.lock();
+            this_cpu().populate_page_table(&mut pt);
+        }
     }
 
     pub fn fault(&self, vaddr: VirtAddr, write: bool) -> Result<(), SvsmError> {


### PR DESCRIPTION
When a task is moving from one processor to another, it is not sufficient to wait until its stack is no longer consumed before scheduling it.  Remapping of the current per-CPU virtual address space must also wait until the new task has stopped running on its previous processor.