### PR TITLE
github/workflows: Remove unmaintained action

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -26,13 +26,8 @@ jobs:
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
 
-      - name: Install latest Rust stable
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
-        with:
-            toolchain: stable
-            target: x86_64-unknown-none
-            profile: minimal
-            override: true
+      - name: Install rust toolchain
+        run: rustup toolchain install --profile minimal
 
       - name: Update apt package list
         run: sudo apt update


### PR DESCRIPTION
The `action-rs` repository has been archived, so
the `toolchain` action is no longer maintained.

This causes several warnings in the CI, in particular:
- "The `set-output` command is deprecated and will be disabled soon..."
- "Node.js 20 actions are deprecated..."

As the action installs a specific toolchain, it can be replaced with `rustup`.