### PR TITLE
github/workflows: update dependency review to node 24

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -24,4 +24,4 @@ jobs:
       - name: 'Checkout Repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0


### PR DESCRIPTION
In CI, the `dependency-review` workflow runs the `dependency-review-action` on node 20, which causes a warning as node.js 20 actions are deprecated.

Use a new version (`5.0.0`) of the action, which runs on node 24.

Fixes: #1020

Release details: https://github.com/actions/dependency-review-action/releases/tag/v5.0.0