### PR TITLE
mm/alloc.verus: update phys_to_virt proof after stage2 removal

### DIFF
--- a/kernel/src/mm/alloc.rs
+++ b/kernel/src/mm/alloc.rs
@@ -572,8 +572,6 @@ impl HeapMemoryRegion {
     fn phys_to_virt(&self, paddr: PhysAddr) -> Option<VirtAddr> {
         proof! {
             reveal(<LinearMap as SpecMemMapTr>::to_vaddr);
-            use_type_invariant(self.start_virt);
-            broadcast use group_addr_proofs;
         }
         if paddr < self.start_phys || (paddr - self.start_phys) >= (self.page_count * PAGE_SIZE) {
             return None;

--- a/kernel/src/mm/alloc.verus.rs
+++ b/kernel/src/mm/alloc.verus.rs
@@ -574,13 +574,7 @@ impl HeapMemoryRegion {
     }
 
     spec fn ens_phys_to_virt(&self, paddr: PhysAddr, ret: Option<VirtAddr>) -> bool {
-        let identity_map = self.map().is_identity_map();
-        let valid_identity_map = identity_map && (self.start_phys@ == self.start_virt.offset());
-        &&& !identity_map ==> (ret.is_some() == self.map().to_vaddr(paddr@ as int).is_some())
-        &&& (!identity_map && ret.is_some()) ==> (ret.unwrap() == self.map().to_vaddr(
-            paddr@ as int,
-        ).unwrap())
-        &&& valid_identity_map ==> (ret == Some(VirtAddr::from_spec(paddr@)))
+        self.map().to_vaddr(paddr@ as int) == ret
     }
 }
 


### PR DESCRIPTION
Fix broken proof due to changes made in #1053.

Adjust the allocation proof to match the updated phys_to_virt behavior from the stage2 removal. Since phys_to_virt no longer treats the stage2 identity mapping as a special case, the spec can be simplified by removing that exception.