### PR TITLE
task: fix cross-CPU race conditions during task switch

### DIFF
--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -64,7 +64,11 @@ use core::mem::size_of;
 use core::ops::Deref;
 use core::ptr::{self, NonNull};
 use core::slice::Iter;
-use core::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
+use core::sync::atomic::AtomicBool;
+use core::sync::atomic::AtomicU32;
+use core::sync::atomic::AtomicU64;
+use core::sync::atomic::AtomicUsize;
+use core::sync::atomic::Ordering;
 use cpuarch::vmsa::VMSA;
 
 // PERCPU areas virtual addresses into shared memory
@@ -387,7 +391,7 @@ where
     /// PerCpu IRQ state tracking
     irq_state: IrqState,
 
-    pgtbl: RWLock<Option<&'static mut PageTable>>,
+    pgtbl: AtomicUsize,
     tss: X86Tss,
     isst: RWLock<Isst>,
     svsm_vmsa: ImmutAfterInitCell<VmsaPage>,
@@ -413,7 +417,7 @@ where
     hv_doorbell: ImmutAfterInitCell<SharedBox<HVDoorbell>>,
 
     init_shadow_stack: ImmutAfterInitCell<VirtAddr>,
-    context_switch_stack: ImmutAfterInitCell<VirtAddr>,
+    context_switch_stack: AtomicUsize,
     ist: IstStacks,
 
     /// Stack boundaries of the currently running task.
@@ -424,7 +428,7 @@ impl PerCpu {
     /// Creates a new default [`PerCpu`] struct.
     fn new(shared: &'static PerCpuShared) -> Result<Self, SvsmError> {
         Ok(Self {
-            pgtbl: RWLock::new(None),
+            pgtbl: AtomicUsize::new(0),
             apic: X86Apic::default(),
             irq_state: IrqState::new(),
             tss: X86Tss::new(),
@@ -447,7 +451,7 @@ impl PerCpu {
             hypercall_pages: RWLock::new(None),
             hv_doorbell: ImmutAfterInitCell::uninit(),
             init_shadow_stack: ImmutAfterInitCell::uninit(),
-            context_switch_stack: ImmutAfterInitCell::uninit(),
+            context_switch_stack: AtomicUsize::new(0),
             ist: IstStacks::new(),
             current_stack: RWLock::new(MemoryRegion::new(VirtAddr::null(), 0)),
         })
@@ -602,7 +606,8 @@ impl PerCpu {
     }
 
     pub fn get_top_of_context_switch_stack(&self) -> Option<VirtAddr> {
-        self.context_switch_stack.try_get_inner().ok().copied()
+        let vaddr = self.context_switch_stack.load(Ordering::Relaxed);
+        if vaddr == 0 { None } else { Some(vaddr.into()) }
     }
 
     pub fn get_top_of_df_stack(&self) -> Option<VirtAddr> {
@@ -645,7 +650,14 @@ impl PerCpu {
     }
 
     pub fn set_pgtable(&self, pgtable: &'static mut PageTable) {
-        *self.pgtbl.write_noblock() = Some(pgtable);
+        self.pgtbl
+            .compare_exchange(
+                0,
+                ptr::from_ref(pgtable) as usize,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            )
+            .unwrap();
     }
 
     fn allocate_stack(&self, base: VirtAddr) -> Result<VirtAddr, SvsmError> {
@@ -678,8 +690,10 @@ impl PerCpu {
     }
 
     fn allocate_context_switch_stack(&self) -> Result<(), SvsmError> {
+        let stack = self.allocate_stack(SVSM_CONTEXT_SWITCH_STACK)?;
         self.context_switch_stack
-            .try_init_from_fn(|| self.allocate_stack(SVSM_CONTEXT_SWITCH_STACK))?;
+            .compare_exchange(0, stack.into(), Ordering::Relaxed, Ordering::Relaxed)
+            .unwrap();
         Ok(())
     }
 
@@ -706,10 +720,15 @@ impl PerCpu {
         Ok(())
     }
 
-    pub fn get_pgtable(&self) -> WriteLockGuard<'_, PageTable> {
-        WriteLockGuard::map(self.pgtbl.write_noblock(), |pgtbl| {
-            &mut **pgtbl.as_mut().unwrap()
-        })
+    pub fn get_pgtable(&self) -> &'static mut PageTable {
+        // SAFETY: `self.pgtbl` is a write-once variable that holds the
+        // physical address of this processor's paging root.  It is stored as
+        // an `AtomicUsize` so it can be read from contexts that cannot
+        // acquire locks.
+        unsafe {
+            let mut p = NonNull::new(self.pgtbl.load(Ordering::Relaxed) as *mut PageTable).unwrap();
+            p.as_mut()
+        }
     }
 
     /// Registers an already set up GHCB page for this CPU.
@@ -774,8 +793,8 @@ impl PerCpu {
     }
 
     fn finish_page_table(&self) {
-        let mut pgtable = self.get_pgtable();
-        self.vm_range.populate(&mut pgtable);
+        let pgtable = self.get_pgtable();
+        self.vm_range.populate(pgtable);
     }
 
     pub fn dump_vm_ranges(&self) {
@@ -1154,8 +1173,8 @@ impl PerCpu {
     }
 
     pub fn handle_pf(&self, vaddr: VirtAddr, write: bool) -> Result<(), SvsmError> {
-        let mut pgtable = self.get_pgtable();
-        self.vm_range.handle_page_fault(&mut pgtable, vaddr, write)
+        let pgtable = self.get_pgtable();
+        self.vm_range.handle_page_fault(pgtable, vaddr, write)
     }
 
     pub fn schedule_init(&self) -> TaskPointer {

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -60,6 +60,7 @@ use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::arch::asm;
 use core::cell::UnsafeCell;
+use core::mem::offset_of;
 use core::mem::size_of;
 use core::ops::Deref;
 use core::ptr::{self, NonNull};
@@ -360,6 +361,12 @@ impl PerCpuShared {
     }
 }
 
+// Expose the offsets of critical per-CPU fields to assembly.
+pub const PERCPU_CTXT_SWITCH_STACK_OFFSET: usize = offset_of!(PerCpu, context_switch_stack);
+pub const PERCPU_PAGING_ROOT_OFFSET: usize = offset_of!(PerCpu, cr3);
+pub const PERCPU_SHARED_OFFSET: usize = offset_of!(PerCpu, shared);
+pub const PERCPU_SHARED_INDEX_OFFSET: usize = offset_of!(PerCpuShared, cpu_index);
+
 const _: () = assert!(size_of::<PerCpu>() <= PAGE_SIZE);
 
 /// CPU-local data.
@@ -392,6 +399,7 @@ where
     irq_state: IrqState,
 
     pgtbl: AtomicUsize,
+    cr3: AtomicUsize,
     tss: X86Tss,
     isst: RWLock<Isst>,
     svsm_vmsa: ImmutAfterInitCell<VmsaPage>,
@@ -429,6 +437,7 @@ impl PerCpu {
     fn new(shared: &'static PerCpuShared) -> Result<Self, SvsmError> {
         Ok(Self {
             pgtbl: AtomicUsize::new(0),
+            cr3: AtomicUsize::new(0),
             apic: X86Apic::default(),
             irq_state: IrqState::new(),
             tss: X86Tss::new(),
@@ -650,14 +659,13 @@ impl PerCpu {
     }
 
     pub fn set_pgtable(&self, pgtable: &'static mut PageTable) {
+        let vaddr = VirtAddr::from(ptr::from_ref(pgtable) as usize);
         self.pgtbl
-            .compare_exchange(
-                0,
-                ptr::from_ref(pgtable) as usize,
-                Ordering::Relaxed,
-                Ordering::Relaxed,
-            )
+            .compare_exchange(0, vaddr.into(), Ordering::Relaxed, Ordering::Relaxed)
             .unwrap();
+        // Capture the physical address as well for use in task switch.
+        let paddr = virt_to_phys(vaddr);
+        self.cr3.store(paddr.into(), Ordering::Relaxed);
     }
 
     fn allocate_stack(&self, base: VirtAddr) -> Result<VirtAddr, SvsmError> {
@@ -1191,11 +1199,7 @@ impl PerCpu {
     }
 
     pub fn schedule_prepare(&self, reschedule: bool) -> Option<(TaskPointer, TaskPointer)> {
-        let ret = self.runqueue_mut().schedule_prepare(reschedule);
-        if let Some((_, ref next)) = ret {
-            self.set_current_stack(next.stack_bounds());
-        };
-        ret
+        self.runqueue_mut().schedule_prepare(reschedule)
     }
 
     pub fn runqueue(&self) -> ReadLockGuardIrqSafe<'_, RunQueue> {

--- a/kernel/src/debug/gdbstub.rs
+++ b/kernel/src/debug/gdbstub.rs
@@ -462,27 +462,29 @@ pub mod svsm_gdbstub {
 
     impl From<&TaskContext> for X86_64CoreRegs {
         fn from(value: &TaskContext) -> Self {
+            // Construct registers based on the entry to the context switch
+            // function.
+            let rsp = core::ptr::from_ref(value) as usize + size_of::<TaskContext>();
             let mut regs = X86_64CoreRegs::default();
             regs.rip = value.ret_addr;
             regs.regs = [
-                value.regs.rax as u64,
+                0, // rax
                 value.regs.rbx as u64,
-                value.regs.rcx as u64,
-                value.regs.rdx as u64,
-                value.regs.rsi as u64,
-                value.regs.rdi as u64,
+                0, // rcx
+                0, // rdx
+                0, // rsi
+                0, // rdi
                 value.regs.rbp as u64,
-                value.rsp,
-                value.regs.r8 as u64,
-                value.regs.r9 as u64,
-                value.regs.r10 as u64,
-                value.regs.r11 as u64,
-                value.regs.r12 as u64,
-                value.regs.r13 as u64,
-                value.regs.r14 as u64,
-                value.regs.r15 as u64,
+                rsp as u64,
+                0, // r8
+                0, // r9
+                0, // r10
+                0, // r11
+                0, // r12
+                0, // r13
+                0, // r14
+                0, // r15
             ];
-            regs.eflags = value.flags as u32;
             regs
         }
     }

--- a/kernel/src/debug/gdbstub.rs
+++ b/kernel/src/debug/gdbstub.rs
@@ -12,7 +12,6 @@
 #[cfg(feature = "enable-gdb")]
 pub mod svsm_gdbstub {
     use crate::address::{Address, VirtAddr};
-    use crate::cpu::X86GeneralRegs;
     use crate::cpu::control_regs::read_cr3;
     use crate::cpu::idt::common::{BP_VECTOR, DB_VECTOR, VC_VECTOR, X86ExceptionContext};
     use crate::cpu::percpu::this_cpu;
@@ -99,28 +98,6 @@ pub mod svsm_gdbstub {
     pub fn handle_debug_exception(ctx: &mut X86ExceptionContext, exception: usize) {
         let exception_type = ExceptionType::from(exception);
         let id = this_cpu().runqueue().current_task_id();
-        let mut task_ctx = TaskContext {
-            regs: X86GeneralRegs {
-                r15: ctx.regs.r15,
-                r14: ctx.regs.r14,
-                r13: ctx.regs.r13,
-                r12: ctx.regs.r12,
-                r11: ctx.regs.r11,
-                r10: ctx.regs.r10,
-                r9: ctx.regs.r9,
-                r8: ctx.regs.r8,
-                rbp: ctx.regs.rbp,
-                rdi: ctx.regs.rdi,
-                rsi: ctx.regs.rsi,
-                rdx: ctx.regs.rdx,
-                rcx: ctx.regs.rcx,
-                rbx: ctx.regs.rbx,
-                rax: ctx.regs.rax,
-            },
-            rsp: ctx.frame.rsp as u64,
-            flags: ctx.frame.flags as u64,
-            ret_addr: ctx.frame.rip as u64,
-        };
 
         // Locking the GDB state for the duration of the stop will cause any other
         // APs that hit a breakpoint to busy-wait until the current CPU releases
@@ -150,30 +127,11 @@ pub mod svsm_gdbstub {
                         movq    %rax, %rsp
                     "#,
                     in("rsi") exception_type as u64,
-                    in("rdi") &raw mut task_ctx,
+                    in("rdi") ctx,
                     in("rdx") &raw mut gdb_state,
                     in("rax") GDB_STACK_TOP.expose_provenance(),
                     options(att_syntax));
             }
-
-            ctx.frame.rip = task_ctx.ret_addr as usize;
-            ctx.frame.flags = task_ctx.flags as usize;
-            ctx.frame.rsp = task_ctx.rsp as usize;
-            ctx.regs.rax = task_ctx.regs.rax;
-            ctx.regs.rbx = task_ctx.regs.rbx;
-            ctx.regs.rcx = task_ctx.regs.rcx;
-            ctx.regs.rdx = task_ctx.regs.rdx;
-            ctx.regs.rsi = task_ctx.regs.rsi;
-            ctx.regs.rdi = task_ctx.regs.rdi;
-            ctx.regs.rbp = task_ctx.regs.rbp;
-            ctx.regs.r8 = task_ctx.regs.r8;
-            ctx.regs.r9 = task_ctx.regs.r9;
-            ctx.regs.r10 = task_ctx.regs.r10;
-            ctx.regs.r11 = task_ctx.regs.r11;
-            ctx.regs.r12 = task_ctx.regs.r12;
-            ctx.regs.r13 = task_ctx.regs.r13;
-            ctx.regs.r14 = task_ctx.regs.r14;
-            ctx.regs.r15 = task_ctx.regs.r15;
 
             break;
         }
@@ -272,7 +230,7 @@ pub mod svsm_gdbstub {
 
     #[unsafe(no_mangle)]
     fn handle_stop(
-        ctx: &mut TaskContext,
+        ctx: &mut X86ExceptionContext,
         exception_type: ExceptionType,
         gdb_state: &mut LockGuard<'_, Option<SvsmGdbStub<'_>>>,
     ) {
@@ -281,14 +239,14 @@ pub mod svsm_gdbstub {
         target.set_regs(ctx);
 
         let hardcoded_bp = (exception_type == ExceptionType::SwBreakpoint)
-            && !target.is_breakpoint(ctx.ret_addr as usize - 1);
+            && !target.is_breakpoint(ctx.frame.rip - 1);
 
         // If the current address is on a breakpoint then we need to
         // move the IP back by one byte
         if (exception_type == ExceptionType::SwBreakpoint)
-            && target.is_breakpoint(ctx.ret_addr as usize - 1)
+            && target.is_breakpoint(ctx.frame.rip - 1)
         {
-            ctx.ret_addr -= 1;
+            ctx.frame.rip -= 1;
         }
 
         let tid = Tid::new(this_cpu().runqueue().current_task_id() as usize)
@@ -339,9 +297,9 @@ pub mod svsm_gdbstub {
             };
         }
         if target.is_single_step == tid.get() as u32 {
-            ctx.flags |= 0x100;
+            ctx.frame.flags |= 0x100;
         } else {
-            ctx.flags &= !0x100;
+            ctx.frame.flags &= !0x100;
         }
         **gdb_state = Some(SvsmGdbStub {
             gdb: new_gdb,
@@ -385,7 +343,7 @@ pub mod svsm_gdbstub {
     }
 
     struct GdbStubTarget {
-        ctx: *mut TaskContext,
+        ctx: *mut X86ExceptionContext,
         breakpoints: [GdbStubBreakpoint; MAX_BREAKPOINTS],
         is_single_step: u32,
     }
@@ -409,7 +367,7 @@ pub mod svsm_gdbstub {
             }
         }
 
-        fn ctx(&self) -> Option<&TaskContext> {
+        fn ctx(&self) -> Option<&X86ExceptionContext> {
             // SAFETY: this is a pointer to the exception context on the
             // stack, so it is not aliased from a different task. We trust
             // the debug exception handler to pass a well-aligned pointer
@@ -417,7 +375,7 @@ pub mod svsm_gdbstub {
             unsafe { self.ctx.as_ref() }
         }
 
-        fn ctx_mut(&mut self) -> Option<&mut TaskContext> {
+        fn ctx_mut(&mut self) -> Option<&mut X86ExceptionContext> {
             // SAFETY: this is a pointer to the exception context on the
             // stack, so it is not aliased from a different task. We trust
             // the debug exception handler to pass a well-aligned pointer
@@ -425,7 +383,7 @@ pub mod svsm_gdbstub {
             unsafe { self.ctx.as_mut() }
         }
 
-        fn set_regs(&mut self, ctx: &mut TaskContext) {
+        fn set_regs(&mut self, ctx: &mut X86ExceptionContext) {
             self.ctx = core::ptr::from_mut(ctx)
         }
 
@@ -472,6 +430,33 @@ pub mod svsm_gdbstub {
             &mut self,
         ) -> Option<gdbstub::target::ext::breakpoints::BreakpointsOps<'_, Self>> {
             Some(self)
+        }
+    }
+
+    impl From<&X86ExceptionContext> for X86_64CoreRegs {
+        fn from(value: &X86ExceptionContext) -> Self {
+            let mut regs = X86_64CoreRegs::default();
+            regs.rip = value.frame.rip as u64;
+            regs.regs = [
+                value.regs.rax as u64,
+                value.regs.rbx as u64,
+                value.regs.rcx as u64,
+                value.regs.rdx as u64,
+                value.regs.rsi as u64,
+                value.regs.rdi as u64,
+                value.regs.rbp as u64,
+                value.frame.rsp as u64,
+                value.regs.r8 as u64,
+                value.regs.r9 as u64,
+                value.regs.r10 as u64,
+                value.regs.r11 as u64,
+                value.regs.r12 as u64,
+                value.regs.r13 as u64,
+                value.regs.r14 as u64,
+                value.regs.r15 as u64,
+            ];
+            regs.eflags = value.frame.flags as u32;
+            regs
         }
     }
 
@@ -544,7 +529,7 @@ pub mod svsm_gdbstub {
 
             let context = self.ctx_mut().unwrap();
 
-            context.ret_addr = regs.rip;
+            context.frame.rip = regs.rip as usize;
             context.regs.rax = regs.regs[0] as usize;
             context.regs.rbx = regs.regs[1] as usize;
             context.regs.rcx = regs.regs[2] as usize;
@@ -552,7 +537,7 @@ pub mod svsm_gdbstub {
             context.regs.rsi = regs.regs[4] as usize;
             context.regs.rdi = regs.regs[5] as usize;
             context.regs.rbp = regs.regs[6] as usize;
-            context.rsp = regs.regs[7];
+            context.frame.rsp = regs.regs[7] as usize;
             context.regs.r8 = regs.regs[8] as usize;
             context.regs.r9 = regs.regs[9] as usize;
             context.regs.r10 = regs.regs[10] as usize;
@@ -561,7 +546,7 @@ pub mod svsm_gdbstub {
             context.regs.r13 = regs.regs[13] as usize;
             context.regs.r14 = regs.regs[14] as usize;
             context.regs.r15 = regs.regs[15] as usize;
-            context.flags = regs.eflags as u64;
+            context.frame.flags = regs.eflags as usize;
             Ok(())
         }
 

--- a/kernel/src/mm/ptguards.rs
+++ b/kernel/src/mm/ptguards.rs
@@ -104,7 +104,7 @@ impl PerCPUPageMappingGuard {
         let mapping = VRangeAlloc::new_4k(pages.len() * PAGE_SIZE, 0)?;
         let flags = PTEntryFlags::data();
 
-        let mut pgtable = this_cpu().get_pgtable();
+        let pgtable = this_cpu().get_pgtable();
         for (vaddr, (paddr, shared)) in mapping
             .region()
             .iter_pages(PageSize::Regular)

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -31,6 +31,7 @@
 extern crate alloc;
 
 use super::tasks::TASK_ACTIVE_OFFSET;
+use super::tasks::TASK_CUR_CPU_OFFSET;
 use super::{
     INITIAL_TASK_ID, KernelThreadStartInfo, Task, TaskListAdapter, TaskPointer, TaskRunListAdapter,
 };
@@ -39,7 +40,12 @@ use crate::cpu::IrqGuard;
 use crate::cpu::ipi::{IpiMessage, IpiTarget, send_multicast_ipi};
 use crate::cpu::irq_state::raw_get_tpr;
 use crate::cpu::msr::write_msr;
-use crate::cpu::percpu::{irq_nesting_count, this_cpu};
+use crate::cpu::percpu::PERCPU_CTXT_SWITCH_STACK_OFFSET;
+use crate::cpu::percpu::PERCPU_PAGING_ROOT_OFFSET;
+use crate::cpu::percpu::PERCPU_SHARED_INDEX_OFFSET;
+use crate::cpu::percpu::PERCPU_SHARED_OFFSET;
+use crate::cpu::percpu::irq_nesting_count;
+use crate::cpu::percpu::this_cpu;
 use crate::cpu::shadow_stack::{IS_CET_ENABLED, PL0_SSP, is_cet_ss_enabled};
 use crate::cpu::sse::{sse_restore_context, sse_save_context};
 use crate::error::SvsmError;
@@ -51,6 +57,7 @@ use alloc::string::String;
 use alloc::sync::Arc;
 use core::arch::global_asm;
 use core::mem::offset_of;
+use core::ptr;
 use core::ptr::null_mut;
 use intrusive_collections::LinkedList;
 
@@ -480,18 +487,13 @@ unsafe fn switch_to(prev: *const Task, next: *const Task) {
     unsafe {
         let cr3 = (*next).page_table.lock().cr3_value().bits();
 
-        // The location of a cpu-local stack that's mapped into every set of
-        // page tables for use during context switches.
-        //
-        // If an IRQ is raised after switching the page tables but before
-        // switching to the new stack, the CPU will try to access the old stack
-        // in the new page tables. To protect against this, we switch to another
-        // stack that's mapped into both the old and the new set of page tables.
-        // That way we always have a valid stack to handle exceptions on.
-        let tos_cs = this_cpu().get_top_of_context_switch_stack().unwrap();
-
         // Switch to new task
-        switch_context(prev as usize, next as usize, tos_cs.into(), cr3);
+        switch_context(
+            prev as usize,
+            next as usize,
+            ptr::from_ref(this_cpu()) as usize,
+            cr3,
+        );
     }
 }
 
@@ -534,6 +536,18 @@ fn preemption_checks() {
     assert!(raw_get_tpr() == 0 || !SVSM_PLATFORM.use_interrupts());
 }
 
+/// # Safety
+/// The caller must guarantee that this is only called on a valid task pointer
+/// that is actively scheduled on the current CPU.  Called only from the
+/// task switch code.
+#[unsafe(no_mangle)]
+pub unsafe fn update_task_percpu_page_tables(t: *const Task) {
+    // SAFETY: the caller guarantees the correctness of the task pointer.
+    let task = unsafe { &*t };
+    let mut pt = task.page_table.lock();
+    this_cpu().populate_page_table(&mut pt);
+}
+
 /// Perform a task switch and hand the CPU over to the next task on the
 /// run-list. In case the current task is terminated, it will be destroyed after
 /// the switch to the next task.
@@ -554,16 +568,11 @@ fn select_new_task(reschedule: bool, irq_guard: Option<IrqGuard>) {
 
     let work = this_cpu().schedule_prepare(reschedule);
 
-    // !!! Runqueue lock must be release here !!!
+    // !!! Runqueue lock must be released here !!!
     if let Some((current, next)) = work {
-        // Update per-cpu mappings if needed
-        let cpu_index = this_cpu().get_cpu_index();
-
-        if next.update_cpu(cpu_index) != cpu_index {
-            // Task has changed CPU, update per-cpu mappings
-            let mut pt = next.page_table.lock();
-            this_cpu().populate_page_table(&mut pt);
-        }
+        // Ensure that the current stack bounds of the current CPU are adjusted
+        // to reflect the task being scheduled.
+        this_cpu().set_current_stack(next.stack_bounds());
 
         // SAFETY: ths stack pointer is known to be correct.
         unsafe {
@@ -649,7 +658,7 @@ pub fn schedule_task(task: TaskPointer) {
 }
 
 unsafe extern "C" {
-    fn switch_context(prev: usize, next: usize, tos_cs: usize, cr3: usize);
+    fn switch_context(prev: usize, next: usize, this_cpu: usize, cr3: usize);
 }
 
 global_asm!(
@@ -660,7 +669,7 @@ global_asm!(
         // Arguments:
         // rdi: previous task pointer
         // rsi: new task pointer
-        // rdx: per-CPU global-scope stack pointer
+        // rdx: current per-CPU pointer
         // rcx: paging root of the new task
         //
         // Save the current context. The layout must match the TaskContext
@@ -679,9 +688,14 @@ global_asm!(
         // Save the current stack pointer
         movq    %rsp, {TASK_RSP_OFFSET}(%rdi)
 
-        // Switch to a stack pointer that's valid in both the old and new page tables.
-        mov     %rdx, %rsp
+        // Switch to a stack pointer that's valid in both the old and new page
+        // tables.
+        mov     {CONTEXT_SWITCH_RSP_OFFSET}(%rdx), %rsp
 
+        // Clear the frame pointer since it is no longer meaningful.
+        xorl    %ebp, %ebp
+
+        // Switch shadow stacks if required.
         cmpb    $0, {IS_CET_ENABLED}(%rip)
         je      4f
         // Save the current shadow stack pointer
@@ -695,6 +709,13 @@ global_asm!(
         saveprevssp
 
     4:
+        // Switch to the current CPU's page table to ensure that the page
+        // table remains correct for the current CPU even if the previous task
+        // is scheduled onto another CPU and has its per-CPU address space
+        // updated.
+        movq    {PERCPU_PGTBL_OFFSET}(%rdx), %rax
+        movq    %rax, %cr3
+
         // Mark the previous task as inactive.  This must be done after
         // switching off of its stack because as soon as it is marked as
         // inactive, another processor is free to immediately switch to that
@@ -702,10 +723,7 @@ global_asm!(
         andb    $0, {TASK_STATE_ACTIVE}(%rdi)
 
     1:
-        // Switch to the new task state
-
-        // Switch to the new task page tables
-        mov     %rcx, %cr3
+        // Switch to the new task state.
 
         // Wait until the new task is inactive.  It may still be running
         // on another processor so its stack cannot be consumed until its
@@ -717,15 +735,37 @@ global_asm!(
         testb   %al, %al
         jnz     3b
 
+        // Check to see whether the task is moving across CPUs.  If so, its
+        // per-CPU page table state must be updated.
+        movq    {PERCPU_SHARED_OFFSET}(%rdx), %r8
+        movq    {PERCPU_SHARED_INDEX_OFFSET}(%r8), %rax
+        cmpq    {TASK_CPU_OFFSET}(%rsi), %rax
+        jz      5f
+        movq    %rax, {TASK_CPU_OFFSET}(%rsi)
+
+        // Save local registers before calling out to do the page table update.
+        pushq   %rsi
+        pushq   %rcx
+
+        movq    %rsi, %rdi
+        call    update_task_percpu_page_tables
+
+        popq    %rcx
+        popq    %rsi
+
+    5:
+        // Switch to the new task page tables
+        movq    %rcx, %cr3
+
         cmpb    $0, {IS_CET_ENABLED}(%rip)
         je      2f
         // Switch to the new task shadow stack and move the "shadow stack
         // restore token" back.
-        mov     {TASK_SSP_OFFSET}(%rsi), %rdx
-        rstorssp (%rdx)
+        mov     {TASK_SSP_OFFSET}(%rsi), %rax
+        rstorssp (%rax)
         saveprevssp
-    2:
 
+    2:
         // Switch to the new task stack
         movq    {TASK_RSP_OFFSET}(%rsi), %rsp
 
@@ -741,7 +781,12 @@ global_asm!(
     TASK_RSP_OFFSET = const offset_of!(Task, rsp),
     TASK_SSP_OFFSET = const offset_of!(Task, ssp),
     TASK_STATE_ACTIVE = const TASK_ACTIVE_OFFSET,
+    TASK_CPU_OFFSET = const TASK_CUR_CPU_OFFSET,
     IS_CET_ENABLED = sym IS_CET_ENABLED,
+    CONTEXT_SWITCH_RSP_OFFSET = const PERCPU_CTXT_SWITCH_STACK_OFFSET,
+    PERCPU_SHARED_OFFSET = const PERCPU_SHARED_OFFSET,
+    PERCPU_SHARED_INDEX_OFFSET = const PERCPU_SHARED_INDEX_OFFSET,
+    PERCPU_PGTBL_OFFSET = const PERCPU_PAGING_ROOT_OFFSET,
     CONTEXT_SWITCH_RESTORE_TOKEN = const CONTEXT_SWITCH_RESTORE_TOKEN.as_usize(),
     options(att_syntax)
 );

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -663,24 +663,13 @@ global_asm!(
         // rdx: per-CPU global-scope stack pointer
         // rcx: paging root of the new task
         //
-        // Save the current context. The layout must match the TaskContext structure.
-        pushfq
-        pushq   %rax
-        pushq   %rbx
-        pushq   %rcx
-        pushq   %rdx
-        pushq   %rsi
-        pushq   %rdi
+        // Save the current context. The layout must match the TaskContext
+        // structure.  Only callee-save registers need to be pushed here; the
+        // remainder of the TaskContext frame can simply be allocated on the
+        // stack.
         pushq   %rbp
-        pushq   %r8
-        pushq   %r9
-        pushq   %r10
-        pushq   %r11
-        pushq   %r12
-        pushq   %r13
-        pushq   %r14
-        pushq   %r15
-        pushq   %rsp
+        pushq   %rbx
+        subq    $24, %rsp
 
         // If `prev` is not null...
         testq   %rdi, %rdi
@@ -740,26 +729,12 @@ global_asm!(
         // Switch to the new task stack
         movq    {TASK_RSP_OFFSET}(%rsi), %rsp
 
-        // We've already restored rsp
-        addq    $8, %rsp
-
-        // Restore the task context
-        popq    %r15
-        popq    %r14
-        popq    %r13
-        popq    %r12
-        popq    %r11
-        popq    %r10
-        popq    %r9
-        popq    %r8
-        popq    %rbp
+        // Restore the task state, following the layout of TaskContext.
         popq    %rdi
         popq    %rsi
         popq    %rdx
-        popq    %rcx
         popq    %rbx
-        popq    %rax
-        popfq
+        popq    %rbp
 
         ret
     "#,

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -49,7 +49,7 @@ use crate::mm::SVSM_CONTEXT_SWITCH_SHADOW_STACK;
 use crate::platform::SVSM_PLATFORM;
 use alloc::string::String;
 use alloc::sync::Arc;
-use core::arch::{asm, global_asm};
+use core::arch::global_asm;
 use core::mem::offset_of;
 use core::ptr::null_mut;
 use intrusive_collections::LinkedList;
@@ -478,7 +478,7 @@ unsafe fn switch_to(prev: *const Task, next: *const Task) {
     // the page table and stack information in those tasks are correct and
     // can be used to switch to the correct page table and execution stack.
     unsafe {
-        let cr3 = (*next).page_table.lock().cr3_value().bits() as u64;
+        let cr3 = (*next).page_table.lock().cr3_value().bits();
 
         // The location of a cpu-local stack that's mapped into every set of
         // page tables for use during context switches.
@@ -488,18 +488,10 @@ unsafe fn switch_to(prev: *const Task, next: *const Task) {
         // in the new page tables. To protect against this, we switch to another
         // stack that's mapped into both the old and the new set of page tables.
         // That way we always have a valid stack to handle exceptions on.
-        let tos_cs: u64 = this_cpu().get_top_of_context_switch_stack().unwrap().into();
+        let tos_cs = this_cpu().get_top_of_context_switch_stack().unwrap();
 
         // Switch to new task
-        asm!(
-            r#"
-            call switch_context
-            "#,
-            in("r12") prev as u64,
-            in("r13") next as u64,
-            in("r14") tos_cs,
-            in("r15") cr3,
-            options(att_syntax));
+        switch_context(prev as usize, next as usize, tos_cs.into(), cr3);
     }
 }
 
@@ -656,16 +648,20 @@ pub fn schedule_task(task: TaskPointer) {
     schedule();
 }
 
+unsafe extern "C" {
+    fn switch_context(prev: usize, next: usize, tos_cs: usize, cr3: usize);
+}
+
 global_asm!(
     r#"
         .section .text
 
     switch_context:
         // Arguments:
-        // R12: previous task pointer
-        // R13: new task pointer
-        // R14: per-CPU global-scope stack pointer
-        // R15: paging root of the new task
+        // rdi: previous task pointer
+        // rsi: new task pointer
+        // rdx: per-CPU global-scope stack pointer
+        // rcx: paging root of the new task
         //
         // Save the current context. The layout must match the TaskContext structure.
         pushfq
@@ -687,22 +683,22 @@ global_asm!(
         pushq   %rsp
 
         // If `prev` is not null...
-        testq   %r12, %r12
+        testq   %rdi, %rdi
         // The initial stack is always mapped in the new page table.
         jz      1f
 
         // Save the current stack pointer
-        movq    %rsp, {TASK_RSP_OFFSET}(%r12)
+        movq    %rsp, {TASK_RSP_OFFSET}(%rdi)
 
         // Switch to a stack pointer that's valid in both the old and new page tables.
-        mov     %r14, %rsp
+        mov     %rdx, %rsp
 
         cmpb    $0, {IS_CET_ENABLED}(%rip)
         je      4f
         // Save the current shadow stack pointer
         rdssp   %rax
         sub     $8, %rax
-        movq    %rax, {TASK_SSP_OFFSET}(%r12)
+        movq    %rax, {TASK_SSP_OFFSET}(%rdi)
         // Switch to a shadow stack that's valid in both page tables and move
         // the "shadow stack restore token" to the old shadow stack.
         mov     ${CONTEXT_SWITCH_RESTORE_TOKEN}, %rax
@@ -714,13 +710,13 @@ global_asm!(
         // switching off of its stack because as soon as it is marked as
         // inactive, another processor is free to immediately switch to that
         // thread's stack.
-        andb    $0, {TASK_STATE_ACTIVE}(%r12)
+        andb    $0, {TASK_STATE_ACTIVE}(%rdi)
 
     1:
         // Switch to the new task state
 
         // Switch to the new task page tables
-        mov     %r15, %cr3
+        mov     %rcx, %cr3
 
         // Wait until the new task is inactive.  It may still be running
         // on another processor so its stack cannot be consumed until its
@@ -728,7 +724,7 @@ global_asm!(
     3:
         pause
         movb    $1, %al
-        lock xchgb {TASK_STATE_ACTIVE}(%r13), %al
+        lock xchgb {TASK_STATE_ACTIVE}(%rsi), %al
         testb   %al, %al
         jnz     3b
 
@@ -736,13 +732,13 @@ global_asm!(
         je      2f
         // Switch to the new task shadow stack and move the "shadow stack
         // restore token" back.
-        mov     {TASK_SSP_OFFSET}(%r13), %rdx
+        mov     {TASK_SSP_OFFSET}(%rsi), %rdx
         rstorssp (%rdx)
         saveprevssp
     2:
 
         // Switch to the new task stack
-        movq    {TASK_RSP_OFFSET}(%r13), %rsp
+        movq    {TASK_RSP_OFFSET}(%rsi), %rsp
 
         // We've already restored rsp
         addq    $8, %rsp

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -119,15 +119,17 @@ impl RunQueue {
         }
     }
 
-    /// Initialized the scheduler for this (RunQueue)[RunQueue]. This method is
+    /// Initializes the scheduler for this (RunQueue)[RunQueue]. This method is
     /// called on the very first scheduling event when there is no current task
-    /// yet.
+    /// yet.  For consistency, it will always invoke the idle task using an
+    /// abbreviated task switch flow, and if there is another task that can
+    /// run, a full task switch will then occur.
     ///
     /// # Returns
     ///
     /// [TaskPointer] to the first task to run
     pub fn schedule_init(&mut self) -> TaskPointer {
-        let task = self.get_next_task();
+        let task = self.idle_task.as_ref().unwrap().clone();
         self.current_task = Some(task.clone());
         task
     }
@@ -202,6 +204,15 @@ impl RunQueue {
         TASKLIST.lock().list().push_front(task.clone());
 
         self.idle_task.replace(task);
+    }
+
+    /// Gets a pointer to the idle task
+    ///
+    /// # Panics
+    ///
+    /// Panics if the idle task has not yet been set.
+    pub fn get_idle_task(&self) -> TaskPointer {
+        self.idle_task.as_ref().unwrap().clone()
     }
 
     /// Gets a pointer to the current task

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -251,10 +251,6 @@ impl TaskSchedState {
         }
     }
 
-    fn update_cpu(&self, new_cpu_index: usize) -> usize {
-        self.cpu_index.swap(new_cpu_index, Ordering::Relaxed)
-    }
-
     fn set_state(&self, state: TaskState) {
         self.state.store(state.into(), Ordering::Release);
     }
@@ -310,8 +306,11 @@ pub struct Task {
     objs: Arc<RWLock<BTreeMap<ObjHandle, Arc<dyn Obj>>>>,
 }
 
+// Expose the offsets of critical task fields to assembly.
 pub const TASK_ACTIVE_OFFSET: usize =
     offset_of!(Task, sched_state) + offset_of!(TaskSchedState, active);
+pub const TASK_CUR_CPU_OFFSET: usize =
+    offset_of!(Task, sched_state) + offset_of!(TaskSchedState, cpu_index);
 
 // SAFETY: Send + Sync is required for Arc<Task> to implement Send. All members
 // of  `Task` are Send + Sync except for the intrusive_collection links, which
@@ -593,10 +592,6 @@ impl Task {
 
     pub fn is_idle_task(&self) -> bool {
         self.sched_state.idle_task.load(Ordering::Relaxed)
-    }
-
-    pub fn update_cpu(&self, new_cpu_index: usize) -> usize {
-        self.sched_state.update_cpu(new_cpu_index)
     }
 
     pub fn fault(&self, vaddr: VirtAddr, write: bool) -> Result<(), SvsmError> {

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -19,13 +19,15 @@ use core::sync::atomic::AtomicUsize;
 use core::sync::atomic::Ordering;
 
 use crate::address::{Address, VirtAddr};
+use crate::cpu::ShadowStackInit;
+use crate::cpu::X86ExceptionContext;
 use crate::cpu::features::{Feature, cpu_get_feat, cpu_has_feat};
 use crate::cpu::idt::svsm::return_new_task;
 use crate::cpu::irq_state::EFLAGS_IF;
+use crate::cpu::irqs_enable;
 use crate::cpu::percpu::{PerCpu, current_task};
 use crate::cpu::shadow_stack::init_shadow_stack;
 use crate::cpu::sse::sse_restore_context;
-use crate::cpu::{ShadowStackInit, X86ExceptionContext, X86GeneralRegs, irqs_enable};
 use crate::error::SvsmError;
 use crate::fs::{Directory, FileHandle, opendir, stdout_open};
 use crate::locking::{RWLock, SpinLock};
@@ -187,12 +189,27 @@ impl TaskIDAllocator {
 
 static TASK_ID_ALLOCATOR: TaskIDAllocator = TaskIDAllocator::new();
 
-#[repr(C, packed)]
+#[repr(C)]
+#[derive(Default, Debug, Clone, Copy)]
+pub struct X86TaskSwitchRegs {
+    // The context switch structure only needs to allocate enough space for
+    // callee-save registers and any registers that are used as argument
+    // registers for task start routines (such as for run_kernel_task).
+    //
+    // Argument registers come first.
+    pub rdi: usize,
+    pub rsi: usize,
+    pub rdx: usize,
+
+    // Callee-save registers come next.
+    pub rbx: usize,
+    pub rbp: usize,
+}
+
+#[repr(C)]
 #[derive(Default, Debug, Clone, Copy)]
 pub struct TaskContext {
-    pub rsp: u64,
-    pub regs: X86GeneralRegs,
-    pub flags: u64,
+    pub regs: X86TaskSwitchRegs,
     pub ret_addr: u64,
 }
 
@@ -648,11 +665,6 @@ impl Task {
             let task_context = stack_ptr
                 .sub(size_of::<TaskContext>())
                 .cast::<TaskContext>();
-            // The processor flags must always be in a default state, unrelated
-            // to the flags of the caller.  In particular, interrupts must be
-            // disabled because the task switch code expects to execute a new
-            // task with interrupts disabled.
-            (*task_context).flags = 2;
             // ret_addr
             (*task_context).regs.rdi = entry;
             // xsave area addr
@@ -724,7 +736,7 @@ impl Task {
             *stack_iret_frame = iret_frame;
 
             let task_context = TaskContext {
-                regs: X86GeneralRegs {
+                regs: X86TaskSwitchRegs {
                     rdi: xsa_addr, // XSAVE area addr
                     ..Default::default()
                 },
@@ -732,7 +744,6 @@ impl Task {
                     .bits()
                     .try_into()
                     .unwrap(),
-                ..Default::default()
             };
 
             let stack_task_context = stack_ptr


### PR DESCRIPTION
Task per-CPU state (current CPU index and per-CPU mappings) cannot safely be modified unless the task is active on the CPU performing the modification; otherwise, the information might be changed out from under the task while it is executing on another CPU.  Therefore, defer the per-CPU configuration until the task is running.  However, the new task cannot be selected until its per-CPU environment is correct; otherwise, the task switch code might be running with the wrong per-CPU context, which would cause errors if an exception or unmaskable event is delivered prior to the per-CPU update.  Thus, the CPU must switch to a neutral environment before the new task is selected, so that the new task can be reconfigured if required before it is made active.