### PR TITLE
kernel: cpu/sse: retrieve XSAVE area size from 0xD CPUID subleaves

### DIFF
--- a/cpuarch/src/snp_cpuid.rs
+++ b/cpuarch/src/snp_cpuid.rs
@@ -7,7 +7,7 @@
 const SNP_CPUID_MAX_COUNT: usize = 64;
 
 #[derive(Copy, Clone, Default, Debug)]
-#[repr(C, packed)]
+#[repr(C)]
 pub struct SnpCpuidFn {
     pub eax_in: u32,
     pub ecx_in: u32,
@@ -21,7 +21,7 @@ pub struct SnpCpuidFn {
 }
 
 #[derive(Copy, Clone, Debug)]
-#[repr(C, packed)]
+#[repr(C)]
 pub struct SnpCpuidTable {
     pub count: u32,
     pub reserved_1: u32,

--- a/kernel/src/cpu/cpuid.rs
+++ b/kernel/src/cpu/cpuid.rs
@@ -4,6 +4,7 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
+use super::sse::XSAVE_LEGACY_SIZE;
 use crate::address::VirtAddr;
 use crate::types::PAGE_SIZE;
 use crate::utils::immut_after_init::ImmutAfterInitCell;
@@ -19,6 +20,52 @@ pub fn register_cpuid_table(table: &'static SnpCpuidTable) {
     CPUID_PAGE
         .init(table)
         .expect("Could not initialize CPUID page");
+}
+
+/// Remove XSAVE feature bits from leaf 0xD if the corresponding size
+/// subleaf (2-63) is not present in the CPUID page. This prevents
+/// enabling a feature in XCR0/XSS whose XSAVE area size cannot be
+/// determined.
+///
+/// Updates as well ECX in subleaf 0, which reports maximum XSAVE
+/// area size.
+fn filter_xsave_features(table: &mut SnpCpuidTable) {
+    // Legacy x87 + SSE are always present
+    let mut avail = 3u64;
+    let mut max_size = XSAVE_LEGACY_SIZE;
+
+    // Gather available features from ECX={2-63} subleaves
+    for e in table.entries() {
+        // If the size subleaf is present and reports a non-zero size, the feature
+        // can be enabled.
+        if e.eax_in == 0xd && e.ecx_in >= 2 && e.ecx_in < 64 && e.eax_out != 0 {
+            avail |= 1u64 << e.ecx_in;
+            max_size = max_size.max(e.ebx_out + e.eax_out);
+        }
+    }
+
+    // Now remove the available feature bits from ECX={0,1} subleaves
+    for e in table.entries_mut().iter_mut().filter(|e| e.eax_in == 0xd) {
+        let (hi, lo) = match e.ecx_in {
+            // Subleaf 0: EAX/EDX contain XCR0 features
+            0 => (&mut e.edx_out, &mut e.eax_out),
+            // Subleaf 1: ECX/EDX contain XSS features
+            1 => (&mut e.edx_out, &mut e.ecx_out),
+            _ => continue,
+        };
+        *lo &= avail as u32;
+        *hi &= (avail >> 32) as u32;
+    }
+
+    // ECX in subleaf ECX=0 indicates maximum XSAVE area size, update it
+    // as well
+    if let Some(e) = table
+        .entries_mut()
+        .iter_mut()
+        .find(|e| e.eax_in == 0xd && e.ecx_in == 0)
+    {
+        e.ecx_out = max_size;
+    }
 }
 
 /// # Safety
@@ -42,6 +89,7 @@ pub unsafe fn init_cpuid_table(addr: VirtAddr) {
         }
     }
 
+    filter_xsave_features(table);
     register_cpuid_table(table);
 }
 

--- a/kernel/src/cpu/cpuid.rs
+++ b/kernel/src/cpu/cpuid.rs
@@ -139,21 +139,17 @@ impl CpuidLeaf {
     }
 }
 
-pub fn cpuid_table_raw(eax: u32, ecx: u32, xcr0: u64, xss: u64) -> Option<CpuidResult> {
+pub fn cpuid_table(eax: u32, ecx: u32) -> Option<CpuidResult> {
     CPUID_PAGE
         .entries()
         .iter()
-        .find(|f| eax == f.eax_in && ecx == f.ecx_in && xcr0 == f.xcr0_in && xss == f.xss_in)
+        .find(|f| eax == f.eax_in && ecx == f.ecx_in)
         .map(|f| CpuidResult {
             eax: f.eax_out,
             ebx: f.ebx_out,
             ecx: f.ecx_out,
             edx: f.edx_out,
         })
-}
-
-pub fn cpuid_table(eax: u32, ecx: u32) -> Option<CpuidResult> {
-    cpuid_table_raw(eax, ecx, 0, 0)
 }
 
 pub fn dump_cpuid_table() {

--- a/kernel/src/cpu/features.rs
+++ b/kernel/src/cpu/features.rs
@@ -166,7 +166,6 @@ define_cpu_feats! {
     Xcr0X87 => CpuFeat::new_bit(0x0000_000d, CpuidReg::Eax, 0),
     Xcr0Sse => CpuFeat::new_bit(0x0000_000d, CpuidReg::Eax, 1),
     Xcr0Avx => CpuFeat::new_bit(0x0000_000d, CpuidReg::Eax, 2),
-    XsaveSize => CpuFeat::new_u32(0x0000_000d, CpuidReg::Ecx, 0),
     XsaveOpt => CpuFeat::new_bit(0x0000_000d, CpuidReg::Eax, 0).with_subfn(1),
     HyperV => CpuFeat::new_u32(0x40000001, CpuidReg::Eax, 0x31237648),
     PhysAddrSizes => CpuFeat::new_u32(0x80000008, CpuidReg::Eax, 0),

--- a/kernel/src/cpu/sse.rs
+++ b/kernel/src/cpu/sse.rs
@@ -5,6 +5,7 @@
 // Author: Vasant Karasulli <vkarasulli@suse.de>
 
 use crate::cpu::control_regs::{cr0_sse_enable, cr4_osfxsr_enable, cr4_xsave_enable};
+use crate::platform::cpuid;
 use core::arch::asm;
 use core::arch::x86_64::{_xgetbv, _xsetbv};
 use core::sync::atomic::{AtomicU64, Ordering};
@@ -57,6 +58,34 @@ fn xsave_enable() {
 pub fn sse_init() {
     legacy_sse_enable();
     xsave_enable();
+}
+
+/// Compute the XSAVE area size for the currently enabled features.
+///
+/// Rather than relying on the CPUID page having entries indexed by the
+/// runtime XCR0 value, compute the size from CPUID leaf 0xD subleaves
+/// 2-63, which describe individual XSAVE components independently of
+/// XCR0 (AMD APM Vol. 3, Appendix E.3.10). This avoids needing an entry
+/// in the CPUID page for every potential XCR0 value.
+pub fn xsave_area_size() -> u32 {
+    let xcr0 = SVSM_XCR0.load(Ordering::Relaxed);
+    let mut size = XSAVE_LEGACY_SIZE;
+
+    for bit in 2..64 {
+        if xcr0 & (1u64 << bit) == 0 {
+            continue;
+        }
+        let Some(result) = cpuid(0xd, bit) else {
+            log::warn!("FP feature {bit:#x} enabled but not present in CPUID");
+            continue;
+        };
+        // We only use the non-compacted format for now.
+        // EBX is the offset within the XSAVE area, EAX is the size
+        // starting from the offset.
+        size = size.max(result.ebx + result.eax);
+    }
+
+    size
 }
 
 /// # Safety

--- a/kernel/src/cpu/sse.rs
+++ b/kernel/src/cpu/sse.rs
@@ -15,6 +15,9 @@ const XCR0_X87_ENABLE: u64 = 0x1;
 const XCR0_SSE_ENABLE: u64 = 0x2;
 const XCR0_YMM_ENABLE: u64 = 0x4;
 
+// XSAVE size for x87 + SSE
+pub const XSAVE_LEGACY_SIZE: u32 = 0x240;
+
 static SVSM_XCR0: AtomicU64 = AtomicU64::new(XCR0_X87_ENABLE | XCR0_SSE_ENABLE);
 
 fn legacy_sse_enable() {

--- a/kernel/src/cpu/vc.rs
+++ b/kernel/src/cpu/vc.rs
@@ -6,7 +6,7 @@
 
 use super::idt::common::X86ExceptionContext;
 use crate::address::VirtAddr;
-use crate::cpu::cpuid::cpuid_table_raw;
+use crate::cpu::cpuid::cpuid_table;
 use crate::cpu::percpu::current_ghcb;
 use crate::debug::gdbstub::svsm_gdbstub::handle_debug_exception;
 use crate::error::SvsmError;
@@ -158,13 +158,7 @@ fn handle_cpuid(ctx: &mut X86ExceptionContext) -> Result<(), SvsmError> {
 fn snp_cpuid(ctx: &mut X86ExceptionContext) -> Result<(), SvsmError> {
     let cpuid_fn = ctx.regs.rax as u32;
     let cpuid_subfn = ctx.regs.rcx as u32;
-    let xcr0_in = if cpuid_fn == 0xD && (cpuid_subfn == 1 || cpuid_subfn == 0) {
-        1
-    } else {
-        0
-    };
-
-    let Some(ret) = cpuid_table_raw(cpuid_fn, cpuid_subfn, xcr0_in, 0) else {
+    let Some(ret) = cpuid_table(cpuid_fn, cpuid_subfn) else {
         return Err(VcError::new(ctx, VcErrorType::UnknownCpuidLeaf).into());
     };
 

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -17,7 +17,7 @@ use super::snp_fw::{
 use crate::address::{Address, PhysAddr, VirtAddr};
 use crate::boot_params::BootParams;
 use crate::console::init_svsm_console;
-use crate::cpu::cpuid::cpuid_table_raw;
+use crate::cpu::cpuid::cpuid_table;
 use crate::cpu::cpuid::init_cpuid_table;
 use crate::cpu::features::{Feature, cpu_get_feat};
 use crate::cpu::irq_state::raw_irqs_disable;
@@ -304,12 +304,7 @@ impl SvsmPlatform for SnpPlatform {
         if (eax >> 28) == 4 {
             current_ghcb().cpuid(eax, ecx).ok()
         } else {
-            let xcr0 = if eax == 0xd && (ecx == 1 || ecx == 0) {
-                1
-            } else {
-                0
-            };
-            cpuid_table_raw(eax, ecx, xcr0, 0)
+            cpuid_table(eax, ecx)
         }
     }
 

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -21,13 +21,13 @@ use core::sync::atomic::Ordering;
 use crate::address::{Address, VirtAddr};
 use crate::cpu::ShadowStackInit;
 use crate::cpu::X86ExceptionContext;
-use crate::cpu::features::{Feature, cpu_get_feat, cpu_has_feat};
+use crate::cpu::features::{Feature, cpu_has_feat};
 use crate::cpu::idt::svsm::return_new_task;
 use crate::cpu::irq_state::EFLAGS_IF;
 use crate::cpu::irqs_enable;
 use crate::cpu::percpu::{PerCpu, current_task};
 use crate::cpu::shadow_stack::init_shadow_stack;
-use crate::cpu::sse::sse_restore_context;
+use crate::cpu::sse::{sse_restore_context, xsave_area_size};
 use crate::error::SvsmError;
 use crate::fs::{Directory, FileHandle, opendir, stdout_open};
 use crate::locking::{RWLock, SpinLock};
@@ -751,7 +751,7 @@ impl Task {
     }
 
     fn allocate_xsave_area() -> PageBox<[u8]> {
-        let len = cpu_get_feat(Feature::XsaveSize) as usize;
+        let len = xsave_area_size() as usize;
         let xsa = PageBox::<[u8]>::try_new_slice(0u8, NonZeroUsize::new(len).unwrap());
         if xsa.is_err() {
             panic!("Error while allocating xsave area");

--- a/tools/igvmbuilder/src/cpuid.rs
+++ b/tools/igvmbuilder/src/cpuid.rs
@@ -31,14 +31,10 @@ impl SnpCpuidLeaf {
     }
 
     pub fn new2(eax_in: u32, ecx_in: u32) -> Self {
-        Self::new3(eax_in, ecx_in, 0)
-    }
-
-    pub fn new3(eax_in: u32, ecx_in: u32, xcr0: u64) -> Self {
         Self {
             eax_in,
             ecx_in,
-            xcr0,
+            xcr0: 0,
             xss: 0,
             eax_out: 0,
             ebx_out: 0,
@@ -86,8 +82,8 @@ impl SnpCpuidPage {
         cpuid_page.add(SnpCpuidLeaf::new2(7, 1))?;
         cpuid_page.add(SnpCpuidLeaf::new1(11))?;
         cpuid_page.add(SnpCpuidLeaf::new2(11, 1))?;
-        cpuid_page.add(SnpCpuidLeaf::new3(13, 0, 1))?;
-        cpuid_page.add(SnpCpuidLeaf::new3(13, 1, 1))?;
+        cpuid_page.add(SnpCpuidLeaf::new2(13, 0))?;
+        cpuid_page.add(SnpCpuidLeaf::new2(13, 1))?;
         // XSAVE size for YMM registers
         cpuid_page.add(SnpCpuidLeaf::new2(13, 2))?;
         cpuid_page.add(SnpCpuidLeaf::new1(0x80000000))?;

--- a/tools/igvmbuilder/src/cpuid.rs
+++ b/tools/igvmbuilder/src/cpuid.rs
@@ -88,6 +88,8 @@ impl SnpCpuidPage {
         cpuid_page.add(SnpCpuidLeaf::new2(11, 1))?;
         cpuid_page.add(SnpCpuidLeaf::new3(13, 0, 1))?;
         cpuid_page.add(SnpCpuidLeaf::new3(13, 1, 1))?;
+        // XSAVE size for YMM registers
+        cpuid_page.add(SnpCpuidLeaf::new2(13, 2))?;
         cpuid_page.add(SnpCpuidLeaf::new1(0x80000000))?;
         cpuid_page.add(SnpCpuidLeaf::new1(0x80000001))?;
         cpuid_page.add(SnpCpuidLeaf::new1(0x80000002))?;


### PR DESCRIPTION
The size that needs to be allocated for the XSAVE area can traditionally be computed by querying CPUID with `EAX=0xD` `ECX=0`, which will return the required size based on the currently enabled floating point features (which are stored in XCR0).
    
On SEV-SNP, the CPUID instruction for this particular leaf is emulated by querying the CPUID page. These entries are indexed by the input EAX, ECX and XCR0, meaning that there would need to be a dedicated CPUID page entry for each potential combination of enabled features in XCR0.
    
Instead of modifying igvmbuilder to request each of these entries in the CPUID page, compute the XSAVE area size manually. This can be done by obtaining the size required for each enabled feature, querying CPUID with `EAX=0xD` and setting `ECX` to the corresponding feature bit (in the 2-63 range). This works for all platforms, not just SEV-SNP.

This mimicks what Linux does to compute the XSAVE area size under SEV-SNP as well.

In order for this to work, we need to have the right `EAX=0xD` subfunctions present in the CPUID page, which for now only adds the YMM subfunction.

This addresses #1057, although it does not prevent misuse of the `EAX=0xD` `ECX={0,1}` mechanism to retrieve the XSAVE area size. This can't easily be done because the output registers for these subleaves, besides `ECX`, have legitimate uses and do not depend on XCR0.