### PR TITLE
cpu: Make sure guest's GIF is set

### DIFF
--- a/kernel/src/cpu/vmsa.rs
+++ b/kernel/src/cpu/vmsa.rs
@@ -8,7 +8,7 @@ use crate::hyperv;
 use crate::sev::status::sev_flags;
 use crate::types::{GUEST_VMPL, SVSM_CS, SVSM_CS_ATTRIBUTES, SVSM_DS, SVSM_DS_ATTRIBUTES};
 use cpuarch::sev_status::SEVStatusFlags;
-use cpuarch::vmsa::{VMSA, VMSASegment};
+use cpuarch::vmsa::{VIntrCtrl, VMSA, VMSASegment};
 
 use super::gdt::GLOBAL_GDT;
 use super::idt::GLOBAL_IDT;
@@ -170,6 +170,7 @@ pub fn init_guest_vmsa(v: &mut VMSA, rip: u64, alternate_injection: bool) {
     // Enable alternate injection if requested.
     if alternate_injection {
         sev_status.insert(SEVStatusFlags::ALT_INJ);
+        v.vintr_ctrl = VIntrCtrl::new().with_vgif(true);
     }
 
     v.sev_features = sev_status.as_sev_features();


### PR DESCRIPTION
When the guest's Global Interrupt Flag (GIF) is 0, the virtual interrupt queued in Vintr_Ctrl will never be taken.

In order to be able to inject interrupts with Vintr_Ctrl when Alternate Injection is enabled, set vGIF in Vintr_Ctrl so queued virtual interrupts can be recognized by the guest.