### PR TITLE
error: avoid `SvsmReqError` outside of SVSM-specific paths

### DIFF
--- a/kernel/src/crypto/mod.rs
+++ b/kernel/src/crypto/mod.rs
@@ -9,7 +9,8 @@
 pub mod aead {
     //! API for authentication encryption with associated data
 
-    use crate::{protocols::errors::SvsmReqError, sev::secrets_page::VMPCK_SIZE};
+    use crate::error::SvsmError;
+    use crate::sev::secrets_page::VMPCK_SIZE;
 
     // Message Header Format (AMD SEV-SNP spec. table 98)
 
@@ -38,14 +39,14 @@ pub mod aead {
         /// * Success
         ///     * `usize`: Number of bytes written to `outbuf`
         /// * Error
-        ///     * [SvsmReqError]
+        ///     * [SvsmError]
         fn encrypt(
             iv: &[u8; IV_SIZE],
             key: &[u8; KEY_SIZE],
             aad: &[u8],
             inbuf: &[u8],
             outbuf: &mut [u8],
-        ) -> Result<usize, SvsmReqError>;
+        ) -> Result<usize, SvsmError>;
 
         /// Decrypt the provided buffer using AES-256 GCM
         ///
@@ -62,14 +63,14 @@ pub mod aead {
         /// * Success
         ///     * `usize`: Number of bytes written to `outbuf`
         /// * Error
-        ///     * [SvsmReqError]
+        ///     * [SvsmError]
         fn decrypt(
             iv: &[u8; IV_SIZE],
             key: &[u8; KEY_SIZE],
             aad: &[u8],
             inbuf: &[u8],
             outbuf: &mut [u8],
-        ) -> Result<usize, SvsmReqError>;
+        ) -> Result<usize, SvsmError>;
     }
 
     /// Aes256Gcm type

--- a/kernel/src/crypto/rustcrypto.rs
+++ b/kernel/src/crypto/rustcrypto.rs
@@ -15,12 +15,12 @@ use aes_gcm::{
 use alloc::vec::Vec;
 use sha2::{Digest, Sha512};
 
+use crate::error::SvsmError;
 use crate::{
     crypto::aead::{
         Aes256Gcm as CryptoAes256Gcm, Aes256GcmTrait as CryptoAes256GcmTrait, IV_SIZE, KEY_SIZE,
     },
     crypto::digest::{Algorithm as CryptoHashTrait, Sha512 as CryptoSha512},
-    protocols::errors::SvsmReqError,
 };
 
 #[repr(u64)]
@@ -37,7 +37,7 @@ fn aes_gcm_do(
     aad: &[u8],
     inbuf: &[u8],
     outbuf: &mut [u8],
-) -> Result<usize, SvsmReqError> {
+) -> Result<usize, SvsmError> {
     let payload = Payload { msg: inbuf, aad };
 
     let aes_key = Key::<Aes256Gcm>::from_slice(key);
@@ -49,11 +49,11 @@ fn aes_gcm_do(
     } else {
         gcm.decrypt(nonce, payload)
     };
-    let buffer = result.map_err(|_| SvsmReqError::invalid_format())?;
+    let buffer = result.map_err(|_| SvsmError::InvalidFormat)?;
 
     let outbuf = outbuf
         .get_mut(..buffer.len())
-        .ok_or_else(SvsmReqError::invalid_parameter)?;
+        .ok_or(SvsmError::InvalidParameter)?;
     outbuf.copy_from_slice(&buffer);
 
     Ok(buffer.len())
@@ -66,7 +66,7 @@ impl CryptoAes256GcmTrait for CryptoAes256Gcm {
         aad: &[u8],
         inbuf: &[u8],
         outbuf: &mut [u8],
-    ) -> Result<usize, SvsmReqError> {
+    ) -> Result<usize, SvsmError> {
         aes_gcm_do(AesGcmOperation::Encrypt, iv, key, aad, inbuf, outbuf)
     }
 
@@ -76,7 +76,7 @@ impl CryptoAes256GcmTrait for CryptoAes256Gcm {
         aad: &[u8],
         inbuf: &[u8],
         outbuf: &mut [u8],
-    ) -> Result<usize, SvsmReqError> {
+    ) -> Result<usize, SvsmError> {
         aes_gcm_do(AesGcmOperation::Decrypt, iv, key, aad, inbuf, outbuf)
     }
 }

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -135,6 +135,14 @@ pub enum SvsmError {
     Vc(VcError),
     /// The operation is not supported.
     NotSupported,
+    /// An invalid parameter was specified.
+    InvalidParameter,
+    /// A data object with an invalid format was specified.
+    InvalidFormat,
+    /// An encrypted message could not be decrypted.
+    MessageDecryptionFailure,
+    /// Errors raised following an SNP guest request.
+    SnpGuestRequest(u32),
     /// Generic errors related to APIC emulation.
     Apic(ApicError),
     /// Generic errors related to attestation handling.

--- a/kernel/src/greq/driver.rs
+++ b/kernel/src/greq/driver.rs
@@ -22,7 +22,6 @@ use crate::{
     error::SvsmError,
     greq::msg::{SnpGuestRequestExtData, SnpGuestRequestMsg, SnpGuestRequestMsgType},
     locking::SpinLock,
-    protocols::errors::{SvsmReqError, SvsmResultCode},
     sev::{VMPCK_SIZE, ghcb::GhcbError, secrets_page, secrets_page_mut},
     types::PAGE_SHIFT,
 };
@@ -80,7 +79,7 @@ struct SnpGuestRequestDriver {
 
 impl SnpGuestRequestDriver {
     /// Create a new [`SnpGuestRequestDriver`]
-    pub fn new() -> Result<Self, SvsmReqError> {
+    pub fn new() -> Result<Self, SvsmError> {
         let request = SharedBox::try_new_zeroed()?;
         let response = SharedBox::try_new_zeroed()?;
         let staging = SnpGuestRequestMsg::new_box_zeroed()
@@ -110,10 +109,10 @@ impl SnpGuestRequestDriver {
     }
 
     /// Set the user_extdata_size to `n` and clear the first `n` bytes from `ext_data`
-    pub fn set_user_extdata_size(&mut self, n: usize) -> Result<(), SvsmReqError> {
+    pub fn set_user_extdata_size(&mut self, n: usize) -> Result<(), SvsmError> {
         // At least one page
         if (n >> PAGE_SHIFT) == 0 {
-            return Err(SvsmReqError::invalid_parameter());
+            return Err(SvsmError::InvalidParameter);
         }
         self.ext_data.nclear(n)?;
         self.user_extdata_size = n;
@@ -123,7 +122,7 @@ impl SnpGuestRequestDriver {
 
     /// Call the GHCB layer to send the encrypted SNP_GUEST_REQUEST message
     /// to the PSP.
-    fn send(&mut self, req_class: SnpGuestRequestClass) -> Result<(), SvsmReqError> {
+    fn send(&mut self, req_class: SnpGuestRequestClass) -> Result<(), SvsmError> {
         let req_page = self.request.addr();
         let resp_page = self.response.addr();
         let data_pages = self.ext_data.addr();
@@ -148,13 +147,13 @@ impl SnpGuestRequestDriver {
         msg_seqno: u64,
         buffer: &[u8],
         command_len: usize,
-    ) -> Result<(), SvsmReqError> {
+    ) -> Result<(), SvsmError> {
         // VMPL0 `SNP_GUEST_REQUEST` commands are encrypted with the VMPCK0 key
         let vmpck0: [u8; VMPCK_SIZE] = secrets_page().unwrap().get_vmpck(0);
 
         let inbuf = buffer
             .get(..command_len)
-            .ok_or_else(SvsmReqError::invalid_parameter)?;
+            .ok_or(SvsmError::InvalidParameter)?;
 
         // For security reasons, encrypt the message in protected memory (staging)
         // and then copy the result to shared memory (request)
@@ -170,7 +169,7 @@ impl SnpGuestRequestDriver {
         msg_seqno: u64,
         msg_type: SnpGuestRequestMsgType,
         buffer: &mut [u8],
-    ) -> Result<usize, SvsmReqError> {
+    ) -> Result<usize, SvsmError> {
         let vmpck0: [u8; VMPCK_SIZE] = secrets_page().unwrap().get_vmpck(0);
 
         // For security reasons, decrypt the message in protected memory (staging)
@@ -183,7 +182,7 @@ impl SnpGuestRequestDriver {
             match e {
                 // The buffer provided is too small to store the unwrapped response.
                 // There is no need to clear the VMPCK0, just report it as invalid parameter.
-                SvsmReqError::RequestError(SvsmResultCode::INVALID_PARAMETER) => (),
+                SvsmError::InvalidParameter => (),
                 _ => secrets_page_mut().unwrap().clear_vmpck(0),
             }
         }
@@ -208,16 +207,16 @@ impl SnpGuestRequestDriver {
     /// * Success:
     ///     * `usize`: Size (in bytes) of the response stored in `buffer`
     /// * Error:
-    ///     * [`SvsmReqError`]
+    ///     * [`SvsmError`]
     fn send_request(
         &mut self,
         req_class: SnpGuestRequestClass,
         msg_type: SnpGuestRequestMsgType,
         buffer: &mut [u8],
         command_len: usize,
-    ) -> Result<usize, SvsmReqError> {
+    ) -> Result<usize, SvsmError> {
         if secrets_page().unwrap().is_vmpck_clear(0) {
-            return Err(SvsmReqError::invalid_request());
+            return Err(SvsmError::NotSupported);
         }
 
         // Message sequence number overflow, the driver will not able
@@ -226,15 +225,13 @@ impl SnpGuestRequestDriver {
         let Some(msg_seqno) = self.seqno_last_used().checked_add(1) else {
             log::error!("SNP_GUEST_REQUEST: sequence number overflow");
             secrets_page_mut().unwrap().clear_vmpck(0);
-            return Err(SvsmReqError::invalid_request());
+            return Err(SvsmError::NotSupported);
         };
 
         self.encrypt_request(msg_type, msg_seqno, buffer, command_len)?;
 
         if let Err(e) = self.send(req_class) {
-            if let SvsmReqError::FatalError(SvsmError::Ghcb(GhcbError::VmgexitError(_rbx, info2))) =
-                e
-            {
+            if let SvsmError::Ghcb(GhcbError::VmgexitError(_rbx, info2)) = e {
                 // For some reason the hypervisor did not forward the request to the PSP.
                 //
                 // Because the message sequence number is used as part of the AES-GCM IV, it is important that the
@@ -256,7 +253,7 @@ impl SnpGuestRequestDriver {
                             // We sent a regular SNP_GUEST_REQUEST, but the hypervisor returned
                             // an error code that is exclusive for extended SNP_GUEST_REQUEST
                             secrets_page_mut().unwrap().clear_vmpck(0);
-                            return Err(SvsmReqError::invalid_request());
+                            return Err(SvsmError::NotSupported);
                         }
                     }
                     // The hypervisor is busy.
@@ -291,7 +288,7 @@ impl SnpGuestRequestDriver {
         msg_type: SnpGuestRequestMsgType,
         buffer: &mut [u8],
         command_len: usize,
-    ) -> Result<usize, SvsmReqError> {
+    ) -> Result<usize, SvsmError> {
         self.send_request(SnpGuestRequestClass::Regular, msg_type, buffer, command_len)
     }
 
@@ -302,7 +299,7 @@ impl SnpGuestRequestDriver {
         buffer: &mut [u8],
         command_len: usize,
         certs: &mut [u8],
-    ) -> Result<usize, SvsmReqError> {
+    ) -> Result<usize, SvsmError> {
         self.set_user_extdata_size(certs.len())?;
 
         let outbuf_len: usize = self.send_request(
@@ -343,10 +340,9 @@ pub fn send_regular_guest_request(
     msg_type: SnpGuestRequestMsgType,
     buffer: &mut [u8],
     request_len: usize,
-) -> Result<usize, SvsmReqError> {
+) -> Result<usize, SvsmError> {
     let mut cell = GREQ_DRIVER.lock();
-    let driver: &mut SnpGuestRequestDriver =
-        cell.get_mut().ok_or_else(SvsmReqError::invalid_request)?;
+    let driver: &mut SnpGuestRequestDriver = cell.get_mut().ok_or(SvsmError::NotSupported)?;
     driver.send_regular_guest_request(msg_type, buffer, request_len)
 }
 
@@ -357,9 +353,8 @@ pub fn send_extended_guest_request(
     buffer: &mut [u8],
     request_len: usize,
     certs: &mut [u8],
-) -> Result<usize, SvsmReqError> {
+) -> Result<usize, SvsmError> {
     let mut cell = GREQ_DRIVER.lock();
-    let driver: &mut SnpGuestRequestDriver =
-        cell.get_mut().ok_or_else(SvsmReqError::invalid_request)?;
+    let driver: &mut SnpGuestRequestDriver = cell.get_mut().ok_or(SvsmError::NotSupported)?;
     driver.send_extended_guest_request(msg_type, buffer, request_len, certs)
 }

--- a/kernel/src/greq/msg.rs
+++ b/kernel/src/greq/msg.rs
@@ -8,9 +8,9 @@
 
 use core::mem::{offset_of, size_of};
 
+use crate::error::SvsmError;
 use crate::{
     crypto::aead::{AUTHTAG_SIZE, Aes256Gcm, Aes256GcmTrait, IV_SIZE},
-    protocols::errors::SvsmReqError,
     sev::secrets_page::VMPCK_SIZE,
     types::PAGE_SIZE,
 };
@@ -40,14 +40,14 @@ pub enum SnpGuestRequestMsgType {
 }
 
 impl TryFrom<u8> for SnpGuestRequestMsgType {
-    type Error = SvsmReqError;
+    type Error = SvsmError;
 
     fn try_from(v: u8) -> Result<Self, Self::Error> {
         match v {
             x if x == Self::Invalid as u8 => Ok(Self::Invalid),
             x if x == Self::ReportRequest as u8 => Ok(Self::ReportRequest),
             x if x == Self::ReportResponse as u8 => Ok(Self::ReportResponse),
-            _ => Err(SvsmReqError::invalid_parameter()),
+            _ => Err(SvsmError::InvalidParameter),
         }
     }
 }
@@ -110,20 +110,16 @@ impl SnpGuestRequestMsgHdr {
     }
 
     /// Set the authenticated tag
-    fn set_authtag(&mut self, new_tag: &[u8]) -> Result<(), SvsmReqError> {
+    fn set_authtag(&mut self, new_tag: &[u8]) -> Result<(), SvsmError> {
         self.authtag
             .get_mut(..new_tag.len())
-            .ok_or_else(SvsmReqError::invalid_parameter)?
+            .ok_or(SvsmError::InvalidParameter)?
             .copy_from_slice(new_tag);
         Ok(())
     }
 
     /// Validate the [`SnpGuestRequestMsgHdr`] fields
-    fn validate(
-        &self,
-        msg_type: SnpGuestRequestMsgType,
-        msg_seqno: u64,
-    ) -> Result<(), SvsmReqError> {
+    fn validate(&self, msg_type: SnpGuestRequestMsgType, msg_seqno: u64) -> Result<(), SvsmError> {
         if self.hdr_version != HDR_VERSION
             || self.hdr_sz != MSG_HDR_SIZE as u16
             || self.algo != SnpGuestRequestAead::Aes256Gcm as u8
@@ -131,7 +127,7 @@ impl SnpGuestRequestMsgHdr {
             || self.msg_vmpck != 0
             || self.msg_seqno != msg_seqno
         {
-            return Err(SvsmReqError::invalid_format());
+            return Err(SvsmError::InvalidFormat);
         }
         Ok(())
     }
@@ -194,7 +190,7 @@ impl SnpGuestRequestMsg {
     ///
     /// # Returns
     ///
-    /// () on success and [`SvsmReqError`] on error.
+    /// () on success and [`SvsmError`] on error.
     ///
     /// # Panic
     ///
@@ -206,9 +202,9 @@ impl SnpGuestRequestMsg {
         msg_seqno: u64,
         vmpck0: &[u8; VMPCK_SIZE],
         command: &[u8],
-    ) -> Result<(), SvsmReqError> {
+    ) -> Result<(), SvsmError> {
         let payload_size_u16 =
-            u16::try_from(command.len()).map_err(|_| SvsmReqError::invalid_parameter())?;
+            u16::try_from(command.len()).map_err(|_| SvsmError::InvalidParameter)?;
 
         let mut msg_hdr = SnpGuestRequestMsgHdr::new(payload_size_u16, msg_type, msg_seqno);
         let aad: &[u8] = msg_hdr.get_aad_slice();
@@ -224,7 +220,7 @@ impl SnpGuestRequestMsg {
         let authtag = self
             .pld
             .get_mut(ciphertext_end..authtag_end)
-            .ok_or_else(SvsmReqError::invalid_request)?;
+            .ok_or(SvsmError::InvalidParameter)?;
 
         // The command should have the same size when encrypted and decrypted
         assert_eq!(command.len(), ciphertext_end);
@@ -257,14 +253,14 @@ impl SnpGuestRequestMsg {
     /// * Success
     ///     * usize: Number of bytes written to `outbuf`
     /// * Error
-    ///     * [`SvsmReqError`]
+    ///     * [`SvsmError`]
     pub fn decrypt_get(
         &mut self,
         msg_type: SnpGuestRequestMsgType,
         msg_seqno: u64,
         vmpck0: &[u8; VMPCK_SIZE],
         outbuf: &mut [u8],
-    ) -> Result<usize, SvsmReqError> {
+    ) -> Result<usize, SvsmError> {
         self.hdr.validate(msg_type, msg_seqno)?;
 
         let iv: [u8; IV_SIZE] = build_iv(msg_seqno);
@@ -280,18 +276,18 @@ impl SnpGuestRequestMsg {
             .hdr
             .authtag
             .get(..AUTHTAG_SIZE)
-            .ok_or_else(SvsmReqError::invalid_request)?;
+            .ok_or(SvsmError::MessageDecryptionFailure)?;
         let pld_tag = self
             .pld
             .get_mut(ciphertext_end..tag_end)
-            .ok_or_else(SvsmReqError::invalid_request)?;
+            .ok_or(SvsmError::MessageDecryptionFailure)?;
         pld_tag.copy_from_slice(hdr_tag);
 
         // Payload with postfixed authtag
         let inbuf = self
             .pld
             .get(..tag_end)
-            .ok_or_else(SvsmReqError::invalid_request)?;
+            .ok_or(SvsmError::MessageDecryptionFailure)?;
 
         let outbuf_len: usize = Aes256Gcm::decrypt(&iv, vmpck0, aad, inbuf, outbuf)?;
 

--- a/kernel/src/greq/pld_report.rs
+++ b/kernel/src/greq/pld_report.rs
@@ -10,7 +10,7 @@ use core::mem::{offset_of, size_of};
 
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
-use crate::protocols::errors::SvsmReqError;
+use crate::error::SvsmError;
 
 /// Size of the `SnpReportRequest.user_data`
 pub const USER_DATA_SIZE: usize = 64;
@@ -47,12 +47,12 @@ impl SnpReportRequest {
     }
 
     /// Take a slice and return a reference for Self
-    pub fn try_from_as_ref(buffer: &[u8]) -> Result<&Self, SvsmReqError> {
+    pub fn try_from_as_ref(buffer: &[u8]) -> Result<&Self, SvsmError> {
         Self::ref_from_prefix(buffer)
             .ok()
             .map(|(request, _rest)| request)
             .filter(|request| request.is_reserved_clear())
-            .ok_or_else(SvsmReqError::invalid_parameter)
+            .ok_or(SvsmError::InvalidParameter)
     }
 
     pub fn is_vmpl0(&self) -> bool {
@@ -90,13 +90,13 @@ pub enum SnpReportResponseStatus {
 
 impl SnpReportResponse {
     /// Validate the [SnpReportResponse] fields
-    pub fn validate(&self) -> Result<(), SvsmReqError> {
+    pub fn validate(&self) -> Result<(), SvsmError> {
         if self.status != SnpReportResponseStatus::Success as u32 {
-            return Err(SvsmReqError::invalid_request());
+            return Err(SvsmError::SnpGuestRequest(self.status));
         }
 
         if self.report_size != size_of::<AttestationReport>() as u32 {
-            return Err(SvsmReqError::invalid_format());
+            return Err(SvsmError::InvalidFormat);
         }
 
         Ok(())

--- a/kernel/src/greq/services.rs
+++ b/kernel/src/greq/services.rs
@@ -8,25 +8,23 @@
 
 use zerocopy::FromBytes;
 
-use crate::{
-    greq::{
-        driver::{send_extended_guest_request, send_regular_guest_request},
-        msg::SnpGuestRequestMsgType,
-        pld_report::{SnpReportRequest, SnpReportResponse},
-    },
-    protocols::errors::SvsmReqError,
+use crate::error::SvsmError;
+use crate::greq::{
+    driver::{send_extended_guest_request, send_regular_guest_request},
+    msg::SnpGuestRequestMsgType,
+    pld_report::{SnpReportRequest, SnpReportResponse},
 };
 use core::mem::size_of;
 
 const REPORT_REQUEST_SIZE: usize = size_of::<SnpReportRequest>();
 const REPORT_RESPONSE_SIZE: usize = size_of::<SnpReportResponse>();
 
-fn get_report(buffer: &mut [u8], certs: Option<&mut [u8]>) -> Result<usize, SvsmReqError> {
+fn get_report(buffer: &mut [u8], certs: Option<&mut [u8]>) -> Result<usize, SvsmError> {
     let request: &SnpReportRequest = SnpReportRequest::try_from_as_ref(buffer)?;
     // Non-VMPL0 attestation reports can be requested by the guest kernel
     // directly to the PSP.
     if !request.is_vmpl0() {
-        return Err(SvsmReqError::invalid_parameter());
+        return Err(SvsmError::InvalidParameter);
     }
     let response_len = if certs.is_none() {
         send_regular_guest_request(
@@ -43,10 +41,10 @@ fn get_report(buffer: &mut [u8], certs: Option<&mut [u8]>) -> Result<usize, Svsm
         )?
     };
     if REPORT_RESPONSE_SIZE > response_len {
-        return Err(SvsmReqError::invalid_request());
+        return Err(SvsmError::InvalidParameter);
     }
-    let (response, _rest) = SnpReportResponse::ref_from_prefix(buffer)
-        .map_err(|_| SvsmReqError::invalid_parameter())?;
+    let (response, _rest) =
+        SnpReportResponse::ref_from_prefix(buffer).map_err(|_| SvsmError::InvalidParameter)?;
     response.validate()?;
 
     Ok(response_len)
@@ -72,8 +70,8 @@ fn get_report(buffer: &mut [u8], certs: Option<&mut [u8]>) -> Result<usize, Svsm
 ///     * `usize`: Number of bytes written to `buffer`. It should match the
 ///       [`MSG_REPORT_RESP`](SnpReportResponse) size.
 /// * Error
-///     * [`SvsmReqError`]
-pub fn get_regular_report(buffer: &mut [u8]) -> Result<usize, SvsmReqError> {
+///     * [`SvsmError`]
+pub fn get_regular_report(buffer: &mut [u8]) -> Result<usize, SvsmError> {
     get_report(buffer, None)
 }
 
@@ -99,12 +97,12 @@ pub fn get_regular_report(buffer: &mut [u8]) -> Result<usize, SvsmReqError> {
 ///     * `usize`: Number of bytes written to `buffer`. It should match
 ///       the [`MSG_REPORT_RESP`](SnpReportResponse) size.
 /// * Error
-///     * [`SvsmReqError`]
-///     * `SvsmReqError::FatalError(SvsmError::Ghcb(GhcbError::VmgexitError(certs_buffer_size, psp_rc)))`:
+///     * [`SvsmError`]
+///     * `SvsmError::Ghcb(GhcbError::VmgexitError(certs_buffer_size, psp_rc))`:
 ///         * `certs` is not large enough to hold the certificates.
 ///             * `certs_buffer_size`: number of bytes required.
 ///             * `psp_rc`: PSP return code
-pub fn get_extended_report(buffer: &mut [u8], certs: &mut [u8]) -> Result<usize, SvsmReqError> {
+pub fn get_extended_report(buffer: &mut [u8], certs: &mut [u8]) -> Result<usize, SvsmError> {
     get_report(buffer, Some(certs))
 }
 

--- a/kernel/src/mm/page_visibility.rs
+++ b/kernel/src/mm/page_visibility.rs
@@ -18,7 +18,6 @@ use crate::mm::validate::{
 };
 use crate::mm::{PageBox, virt_to_phys};
 use crate::platform::{PageStateChangeOp, PageValidateOp, SVSM_PLATFORM};
-use crate::protocols::errors::SvsmReqError;
 use crate::types::{PAGE_SIZE, PageSize};
 use crate::utils::MemoryRegion;
 
@@ -190,12 +189,12 @@ impl<T> SharedBox<T> {
 
 impl<T, const N: usize> SharedBox<[T; N]> {
     /// Clear the first `n` elements.
-    pub fn nclear(&mut self, n: usize) -> Result<(), SvsmReqError>
+    pub fn nclear(&mut self, n: usize) -> Result<(), SvsmError>
     where
         T: FromZeros,
     {
         if n > N {
-            return Err(SvsmReqError::invalid_parameter());
+            return Err(SvsmError::InvalidParameter);
         }
 
         // SAFETY: `self.ptr` is valid and we did a bounds check on `n`.
@@ -207,12 +206,12 @@ impl<T, const N: usize> SharedBox<[T; N]> {
     }
 
     /// Fill up the `outbuf` slice provided with bytes from data
-    pub fn copy_to_slice(&self, outbuf: &mut [T]) -> Result<(), SvsmReqError>
+    pub fn copy_to_slice(&self, outbuf: &mut [T]) -> Result<(), SvsmError>
     where
         T: FromBytes + Copy,
     {
         if outbuf.len() > N {
-            return Err(SvsmReqError::invalid_parameter());
+            return Err(SvsmError::InvalidParameter);
         }
 
         // SAFETY: `self.ptr` is valid.

--- a/kernel/src/protocols/errors.rs
+++ b/kernel/src/protocols/errors.rs
@@ -83,6 +83,11 @@ impl From<SvsmError> for SvsmReqError {
                 ApicError::Registration => Self::protocol(SVSM_ERR_APIC_CANNOT_REGISTER),
             },
             SvsmError::Attestation(e) => Self::protocol(e as u64),
+            SvsmError::InvalidParameter => Self::invalid_parameter(),
+            SvsmError::InvalidFormat => Self::invalid_format(),
+            SvsmError::NotSupported
+            | SvsmError::MessageDecryptionFailure
+            | SvsmError::SnpGuestRequest(_) => Self::invalid_request(),
             // Use a fatal error for now
             _ => Self::FatalError(err),
         }


### PR DESCRIPTION
The `SvsmReqError` type is defined based on the SVSM protocol, and its use should only be a part of code paths that specifically support the SVSM protocol.  Common code paths that provide general services should use the system-wide error type `SvsmError`.