### PR TITLE
scripts/launch_guest: remove sudo from QEMU invocation

### DIFF
--- a/.github/workflows/qemu.yml
+++ b/.github/workflows/qemu.yml
@@ -129,6 +129,9 @@ jobs:
       - name: Install netcat used by test-in-svsm for vsock tests
         run: sudo apt install -y ncat
 
+      - name: Set up KVM permissions
+        run: sudo chmod 666 /dev/kvm
+
       - name: Set up vhost-vsock permissions
         run: sudo chmod 666 /dev/vhost-vsock
 

--- a/Documentation/docs/installation/INSTALL.md
+++ b/Documentation/docs/installation/INSTALL.md
@@ -356,19 +356,24 @@ scripts/launch_guest.sh
 ```
 
 The path to QEMU can also be specified either by setting the `QEMU` variable, or
-by passing the path as a parameter:
+by passing the path as a parameter. Both can also include `sudo` to run QEMU
+with elevated privileges:
 
 ```shell
 QEMU=/path/to/qemu-system-x86_64 scripts/launch_guest.sh
 
 scripts/launch_guest.sh --qemu /path/to/qemu-system-x86_64
+
+QEMU="sudo /path/to/qemu-system-x86_64" scripts/launch_guest.sh
+
+scripts/launch_guest.sh --qemu "sudo /path/to/qemu-system-x86_64"
 ```
 
 The script supports a number of other options described in the table below
 
 | Command-line     | Variable | Default               | Description                                                                  |
 | ---------------- | -------- | --------------------- | ---------------------------------------------------------------------------- |
-| `--qemu [path]`  | QEMU     | qemu-system-x86_64    | Path to QEMU binary to use.                                                  |
+| `--qemu [path]`  | QEMU     | qemu-system-x86_64    | Path to QEMU binary to use. Can include `sudo` to run as root.               |
 | `--igvm [path]`  | IGVM     | bin/coconut-qemu.igvm | Path to the IGVM binary to launch.                                           |
 | `--image [path]` | IMAGE    | [None]                | The QEMU disk image to use. If unset then no disk is provided on the guest.  |
 | `--debugserial`  | N/A      | not set               | Define a second serial port that can be used with the COCONUT-SVSM GDB stub. |

--- a/scripts/launch_guest.sh
+++ b/scripts/launch_guest.sh
@@ -161,12 +161,6 @@ if [ ! -z "$IMAGE" ]; then
     -device scsi-hd,drive=disk0"
 fi
 
-if [ "$EUID" -ne 0 ] && [ "$ACCEL" != "tcg" ]; then
-	SUDO_CMD="sudo"
-else
-	SUDO_CMD=""
-fi
-
 echo "============================="
 echo "Launching SVSM guest"
 echo "============================="
@@ -190,8 +184,7 @@ if [ -t 0 ]; then
 fi
 
 # Temporarily use -vga none to avoid IGVM VGA init failure in QEMU 10.1
-$SUDO_CMD \
-  "$QEMU" \
+$QEMU \
     -cpu $CPU \
     -machine $MACHINE \
     -object $MEMORY \


### PR DESCRIPTION
Running QEMU as root via sudo grants unnecessary privileges when the only resource requiring access is /dev/sev. ~Instead, document that the user should be in the `sev` group to access the device.~

Suggested-by: Stefano Garzarella <sgarzare@redhat.com>

Original discussion: https://github.com/coconut-svsm/svsm/pull/1058#discussion_r3225903449