### PR TITLE
kernel: platform: remove trivial FIXME for `SvsmPlatformCell`

### DIFF
--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -296,8 +296,7 @@ pub trait SvsmPlatform: Sync {
         Self: Sized;
 }
 
-//FIXME - remove Copy trait
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub enum SvsmPlatformCell {
     Snp(SnpPlatform),
     Tdp(TdpPlatform),


### PR DESCRIPTION
`SvsmPlatformCell` had a FIXME to remove the `Copy` trait derive from the struct. This trait is no longer needed and no longer required by the repository's clippy rules, so simply remove it.