### PR TITLE
kernel: platform/snp: completely convert to CPU features API

### DIFF
--- a/kernel/src/cpu/features.rs
+++ b/kernel/src/cpu/features.rs
@@ -171,4 +171,5 @@ define_cpu_feats! {
     HyperV => CpuFeat::new_u32(0x40000001, CpuidReg::Eax, 0x31237648),
     PhysAddrSizes => CpuFeat::new_u32(0x80000008, CpuidReg::Eax, 0),
     InvlpgbMax => CpuFeat::new(0x80000008, CpuidReg::Edx, 0, u16::BITS as u8, 0),
+    Cbit => CpuFeat::new(0x8000001f, CpuidReg::Ebx, 0, 6, 0),
 }

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -16,7 +16,6 @@ use super::snp_fw::{
 use crate::address::{Address, PhysAddr, VirtAddr};
 use crate::boot_params::BootParams;
 use crate::console::init_svsm_console;
-use crate::cpu::cpuid::cpuid_table;
 use crate::cpu::cpuid::cpuid_table_raw;
 use crate::cpu::cpuid::init_cpuid_table;
 use crate::cpu::features::{Feature, cpu_get_feat};
@@ -241,15 +240,14 @@ impl SvsmPlatform for SnpPlatform {
 
     fn get_page_encryption_masks(&self) -> PageEncryptionMasks {
         // Find physical address size.
-        let processor_capacity =
-            cpuid_table(0x80000008, 0).expect("Can not get physical address size from CPUID table");
+        let phys_addr_sizes = cpu_get_feat(Feature::PhysAddrSizes);
         if vtom_enabled() {
             let vtom = *VTOM;
             PageEncryptionMasks {
                 private_pte_mask: 0,
                 shared_pte_mask: vtom,
                 addr_mask_width: vtom.leading_zeros(),
-                phys_addr_sizes: processor_capacity.eax,
+                phys_addr_sizes,
             }
         } else {
             // Find C-bit position.
@@ -261,7 +259,7 @@ impl SvsmPlatform for SnpPlatform {
                 private_pte_mask: 1 << c_bit,
                 shared_pte_mask: 0,
                 addr_mask_width: c_bit,
-                phys_addr_sizes: processor_capacity.eax,
+                phys_addr_sizes,
             }
         }
     }

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -19,6 +19,7 @@ use crate::console::init_svsm_console;
 use crate::cpu::cpuid::cpuid_table;
 use crate::cpu::cpuid::cpuid_table_raw;
 use crate::cpu::cpuid::init_cpuid_table;
+use crate::cpu::features::{Feature, cpu_get_feat};
 use crate::cpu::irq_state::raw_irqs_disable;
 use crate::cpu::percpu::{PerCpu, current_ghcb, this_cpu};
 use crate::cpu::tlb::TlbFlushScope;
@@ -252,9 +253,10 @@ impl SvsmPlatform for SnpPlatform {
             }
         } else {
             // Find C-bit position.
-            let sev_capabilities =
-                cpuid_table(0x8000001f, 0).expect("Can not get C-Bit position from CPUID table");
-            let c_bit = sev_capabilities.ebx & 0x3f;
+            let c_bit = cpu_get_feat(Feature::Cbit);
+            if c_bit == 0 {
+                panic!("Cannot get C-Bit position from CPUID");
+            }
             PageEncryptionMasks {
                 private_pte_mask: 1 << c_bit,
                 shared_pte_mask: 0,


### PR DESCRIPTION
Remove a couple of manual CPUID queries that were left over, and use the new CPU features API.