### PR TITLE
kernel: platform: remove `setup_guest_host_comm()`

### DIFF
--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -182,9 +182,6 @@ pub trait SvsmPlatform: Sync {
     /// affect memory safety.
     unsafe fn write_host_msr(&self, msr: u32, value: u64);
 
-    /// Establishes state required for guest/host communication.
-    fn setup_guest_host_comm(&mut self, _cpu: &PerCpu, _is_bsp: bool) {}
-
     /// Obtains a reference to an I/O port implemetation appropriate to the
     /// platform.
     fn get_io_port(&self) -> &'static dyn IOPort;

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -220,7 +220,9 @@ impl SvsmPlatform for SnpPlatform {
     }
 
     fn setup_percpu(&self, cpu: &PerCpu) -> Result<(), SvsmError> {
-        // Setup GHCB
+        if cpu.shared().cpu_index() == 0 {
+            verify_ghcb_version();
+        }
         cpu.setup_ghcb()
     }
 
@@ -310,21 +312,6 @@ impl SvsmPlatform for SnpPlatform {
         current_ghcb()
             .wrmsr(msr, value)
             .expect("Host MSR access failed");
-    }
-
-    fn setup_guest_host_comm(&mut self, cpu: &PerCpu, is_bsp: bool) {
-        if is_bsp {
-            verify_ghcb_version();
-        }
-
-        cpu.setup_ghcb().unwrap_or_else(|_| {
-            if is_bsp {
-                panic!("Failed to setup BSP GHCB");
-            } else {
-                panic!("Failed to setup AP GHCB");
-            }
-        });
-        cpu.register_ghcb().expect("Failed to register GHCB");
     }
 
     fn get_io_port(&self) -> &'static dyn IOPort {


### PR DESCRIPTION
Remove an unused `SvsmPlatform` method, as its last user was stage2, which was removed. The pieces of GHCB initialization that this method used to do on SEV-SNP are done in the SVSM kernel as follows:

    PerCpu::setup()
        SnpPlatform::setup_percpu()
            PerCpu::setup_ghcb()

    PerCpu::setup_on_cpu()
        SnpPlatform::setup_percpu_current()
            PerCpu::register_ghcb()

The method was a no-op on on all other platforms.

The only part that is missing is the call to `verify_ghcb_version()`, so add it right before `SnpPlatform` calls `PerCpu::setup_ghcb()`.