### PR TITLE
virtio-drivers: validate host provided len and token before using them

### DIFF
--- a/virtio-drivers/src/queue/owning.rs
+++ b/virtio-drivers/src/queue/owning.rs
@@ -85,7 +85,12 @@ impl<H: Hal, const SIZE: usize, const BUFFER_SIZE: usize> OwningQueue<H, SIZE, B
 
         // SAFETY: The device has told us it has finished using the buffer, and there are no other
         // references to it.
-        let buffer = unsafe { self.buffers[usize::from(token)].as_mut() };
+        let buffer = unsafe {
+            self.buffers
+                .get_mut(usize::from(token))
+                .ok_or(Error::WrongToken)?
+                .as_mut()
+        };
         // SAFETY: We maintain a consistent mapping of tokens to buffers, so we pass the same buffer
         // to `pop_used` as we previously passed to `add` for the token. Once we add the buffer back
         // to the RX queue then we don't access it again until next time it is popped.

--- a/virtio-drivers/src/queue/owning.rs
+++ b/virtio-drivers/src/queue/owning.rs
@@ -98,6 +98,12 @@ impl<H: Hal, const SIZE: usize, const BUFFER_SIZE: usize> OwningQueue<H, SIZE, B
             .try_into()
             .unwrap();
 
+        // The device reports how many bytes it wrote; reject if it claims more than the buffer
+        // size.
+        if len > BUFFER_SIZE {
+            return Err(Error::IoError);
+        }
+
         Ok(Some((&buffer[0..len], token)))
     }
 


### PR DESCRIPTION
Both `len` and `token` are provided by the device. If the device is misbehaving the driver would panic.
Let's check them before using and return errors instead.

Same changes also posted upstream, see https://github.com/rcore-os/virtio-drivers/pull/245

CC @osteffenrh 