### PR TITLE
kernel/vtpm: fix uninitialized heap bytes returned in TPM failure mode

### DIFF
--- a/kernel/src/vtpm/tcgtpm/mod.rs
+++ b/kernel/src/vtpm/tcgtpm/mod.rs
@@ -120,6 +120,16 @@ impl TcgTpmSimulatorInterface for TcgTpm {
             if response_ffi_size == 0 || response_ffi_size as usize > response_ffi.capacity() {
                 return Err(SvsmReqError::invalid_request());
             }
+            // In TPM failure mode, _plat__RunCommand() redirects the response
+            // pointer to an internal static buffer instead of writing into the
+            // provided one.
+            if response_ffi_p != response_ffi.as_mut_ptr() {
+                core::ptr::copy(
+                    response_ffi_p,
+                    response_ffi.as_mut_ptr(),
+                    response_ffi_size as usize,
+                );
+            }
             response_ffi.set_len(response_ffi_size as usize);
         }
 


### PR DESCRIPTION
_plat__RunCommand() takes a double pointer for the response buffer. In the normal path it writes directly into the caller-provided buffer, but in TPM failure mode TpmFailureMode() redirects *response to an internal static buffer (failure_response_buffer in TpmFail.c).

The Rust code ignores the possibly updated pointer and calls set_len() on the original Vec, whose buffer was never written to in the failure case. This causes uninitialized heap bytes to be returned to the guest.

Fix it by checking whether the response pointer was redirected after the FFI call, and if so, copying from the actual response location into the Vec buffer before setting its length.