### PR TITLE
svsm: detect and display CPU vendor

### DIFF
--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -48,6 +48,13 @@ pub static SVSM_PLATFORM: ImmutAfterInitCell<&dyn SvsmPlatform> = ImmutAfterInit
 pub static CAPS: ImmutAfterInitCell<Caps> = ImmutAfterInitCell::uninit();
 
 #[derive(Clone, Copy, Debug)]
+pub enum CpuVendor {
+    Unknown,
+    Intel,
+    AMD,
+}
+
+#[derive(Clone, Copy, Debug)]
 pub struct PageEncryptionMasks {
     pub private_pte_mask: usize,
     pub shared_pte_mask: usize,
@@ -119,6 +126,9 @@ pub trait SvsmPlatform: Sync {
     /// Performs initialiation of the kernel environment once the boot task
     /// is running.
     fn env_setup_svsm(&self) -> Result<(), SvsmError>;
+
+    /// Determines which CPU vendor is running this SVSM instance.
+    fn get_cpu_vendor(&self) -> CpuVendor;
 
     /// Frees a platforms-specific page if it is not used by the underlying
     /// platform.

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -6,8 +6,13 @@
 // Author: Jon Lange <jlange@microsoft.com>
 // Author: Joerg Roedel <jroedel@suse.de>
 
+use super::CpuVendor;
+use super::PageEncryptionMasks;
+use super::PageStateChangeOp;
+use super::PageValidateOp;
+use super::SvsmPlatform;
 use super::capabilities::Caps;
-use super::{PageEncryptionMasks, PageStateChangeOp, PageValidateOp, SvsmPlatform};
+use super::cpuid;
 use crate::address::{PhysAddr, VirtAddr};
 use crate::console::init_svsm_console;
 use crate::cpu::IrqGuard;
@@ -82,6 +87,18 @@ impl SvsmPlatform for NativePlatform {
 
     fn env_setup_svsm(&self) -> Result<(), SvsmError> {
         Ok(())
+    }
+
+    fn get_cpu_vendor(&self) -> CpuVendor {
+        if let Some(r) = cpuid(0, 0) {
+            match r.edx {
+                0x69746e65 => CpuVendor::AMD,
+                0x49656e69 => CpuVendor::Intel,
+                _ => CpuVendor::Unknown,
+            }
+        } else {
+            CpuVendor::Unknown
+        }
     }
 
     fn setup_percpu(&self, _cpu: &PerCpu) -> Result<(), SvsmError> {

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -4,6 +4,7 @@
 //
 // Author: Jon Lange <jlange@microsoft.com>
 
+use super::CpuVendor;
 use super::PageEncryptionMasks;
 use super::PageStateChangeOp;
 use super::PageValidateOp;
@@ -180,6 +181,10 @@ impl SvsmPlatform for SnpPlatform {
         }
         guest_request_driver_init();
         Ok(())
+    }
+
+    fn get_cpu_vendor(&self) -> CpuVendor {
+        CpuVendor::AMD
     }
 
     /// # Safety

--- a/kernel/src/platform/tdp.rs
+++ b/kernel/src/platform/tdp.rs
@@ -4,8 +4,12 @@
 //
 // Author: Peter Fang <peter.fang@intel.com>
 
+use super::CpuVendor;
+use super::PageEncryptionMasks;
+use super::PageStateChangeOp;
+use super::PageValidateOp;
+use super::SvsmPlatform;
 use super::capabilities::Caps;
-use super::{PageEncryptionMasks, PageStateChangeOp, PageValidateOp, SvsmPlatform};
 use crate::address::{Address, PhysAddr, VirtAddr};
 use crate::console::init_svsm_console;
 use crate::cpu::features::{Feature, cpu_get_feat, cpu_has_feat};
@@ -79,6 +83,10 @@ impl SvsmPlatform for TdpPlatform {
 
     fn env_setup_svsm(&self) -> Result<(), SvsmError> {
         Ok(())
+    }
+
+    fn get_cpu_vendor(&self) -> CpuVendor {
+        CpuVendor::Intel
     }
 
     fn setup_percpu(&self, _cpu: &PerCpu) -> Result<(), SvsmError> {

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -341,6 +341,7 @@ unsafe fn svsm_start(
     platform
         .env_setup(debug_serial_port, launch_info.vtom.try_into().unwrap())
         .expect("Early environment setup failed");
+    log::info!("CPU vendor {:?}", platform.get_cpu_vendor());
 
     // Load symbol info now that there is a console
     // SAFETY: the launch info here is the launch info passed by the boot


### PR DESCRIPTION
During startup, display the CPU vendor for debug logging purposes.