### PR TITLE
github/manual-verify: fix triggering on 'verification' label

### DIFF
--- a/.github/workflows/manual-verify.yml
+++ b/.github/workflows/manual-verify.yml
@@ -5,7 +5,7 @@ name: Verification
 on:
   workflow_dispatch:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, labeled]
 
 env:
   CARGO_TERM_COLOR: always
@@ -17,7 +17,10 @@ jobs:
   check:
     name: Verification Check
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'verification')
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'verification') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'verification'))
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0


### PR DESCRIPTION
The workflow was triggering on every label change (add or remove) as long as the PR had the 'verification' label. This caused unnecessary runs when unrelated labels were added or removed.

Drop the 'unlabeled' event type and refine the condition so that 'labeled' events only trigger the job when the label being added is specifically 'verification'. For non-label events (opened, synchronize, reopened), fall through to checking whether the PR carries the label.