### PR TITLE
scripts/launch_guest: avoid signal remapping

### DIFF
--- a/scripts/launch_guest.sh
+++ b/scripts/launch_guest.sh
@@ -17,7 +17,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # in the guest.
 REDUCED_PHYS_BITS=1
 C_BIT_POS=$(cargo run --package cbit || true)
-COM1_SERIAL="-serial stdio" # console
+COM1_SERIAL="-serial mon:stdio" # console
 COM2_SERIAL="-serial null"  # debug
 COM3_SERIAL="-serial null"  # used by hyper-v
 COM4_SERIAL="-serial null"  # used by in-SVSM tests
@@ -179,19 +179,8 @@ echo "QEMU Version:   ${QEMU_VERSION}"
 echo "IGVM:           ${IGVM}"
 echo "IMAGE:          ${IMAGE}"
 echo "============================="
-
-
-# Remap Ctrl-C to Ctrl-] to allow the guest to handle Ctrl-C,
-# if we are running with a TTY attached.
-if [ -t 0 ]; then
-  echo "Press Ctrl-] to interrupt"
-  echo "============================="
-  # Store original terminal settings and restore it on exit
-  STTY_ORIGINAL=$(stty -g)
-  trap 'stty "$STTY_ORIGINAL"' EXIT
-
-  stty intr ^]
-fi
+echo "Press Ctrl-A to enter in the QEMU monitor, then x to exit"
+echo "============================="
 
 # Temporarily use -vga none to avoid IGVM VGA init failure in QEMU 10.1
 $SUDO_CMD \
@@ -207,7 +196,6 @@ $SUDO_CMD \
     $IMAGE_DISK \
     -nographic \
     -vga none \
-    -monitor none \
     $COM1_SERIAL \
     $COM2_SERIAL \
     $COM3_SERIAL \


### PR DESCRIPTION
The script was remapping Ctrl-C to Ctrl-] using stty to allow the guest to handle Ctrl-C. This approach modifies the terminal settings and requires careful cleanup via a trap on exit.

QEMU already provides this functionality through its monitor multiplexer (mon:stdio), which is the standard and well-documented way to combine serial console and monitor on the same stdio. Ctrl-C is passed through to the guest without any terminal reconfiguration, and the user can press Ctrl-A to enter the QEMU monitor (then 'x' to quit).

Switch to mon:stdio, drop the stty manipulation and the associated EXIT trap, and remove -monitor none since we now want the monitor accessible through the multiplexer.