### PR TITLE
cpuarch: move APIC constants to a common location

### DIFF
--- a/cpuarch/src/lib.rs
+++ b/cpuarch/src/lib.rs
@@ -7,3 +7,4 @@ pub mod sev_status;
 pub mod snp_cpuid;
 pub mod vmsa;
 pub mod x86;
+pub mod x86apic;

--- a/cpuarch/src/x86apic.rs
+++ b/cpuarch/src/x86apic.rs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Jon Lange (jlange@microsoft.com)
+
+use bitfield_struct::bitfield;
+
+pub const APIC_REGISTER_APIC_ID: u64 = 0x802;
+pub const APIC_REGISTER_TPR: u64 = 0x808;
+pub const APIC_REGISTER_PPR: u64 = 0x80A;
+pub const APIC_REGISTER_EOI: u64 = 0x80B;
+pub const APIC_REGISTER_ISR_0: u64 = 0x810;
+pub const APIC_REGISTER_ISR_7: u64 = 0x817;
+pub const APIC_REGISTER_TMR_0: u64 = 0x818;
+pub const APIC_REGISTER_TMR_7: u64 = 0x81F;
+pub const APIC_REGISTER_IRR_0: u64 = 0x820;
+pub const APIC_REGISTER_IRR_7: u64 = 0x827;
+pub const APIC_REGISTER_ICR: u64 = 0x830;
+pub const APIC_REGISTER_SELF_IPI: u64 = 0x83F;
+
+#[derive(Debug, PartialEq)]
+pub enum IcrDestFmt {
+    Dest = 0,
+    OnlySelf = 1,
+    AllWithSelf = 2,
+    AllButSelf = 3,
+}
+
+impl IcrDestFmt {
+    const fn into_bits(self) -> u64 {
+        self as _
+    }
+    const fn from_bits(value: u64) -> Self {
+        match value {
+            3 => Self::AllButSelf,
+            2 => Self::AllWithSelf,
+            1 => Self::OnlySelf,
+            _ => Self::Dest,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum IcrMessageType {
+    Fixed = 0,
+    Unknown = 3,
+    Nmi = 4,
+    Init = 5,
+    Sipi = 6,
+    ExtInt = 7,
+}
+
+impl IcrMessageType {
+    const fn into_bits(self) -> u64 {
+        self as _
+    }
+    const fn from_bits(value: u64) -> Self {
+        match value {
+            7 => Self::ExtInt,
+            6 => Self::Sipi,
+            5 => Self::Init,
+            4 => Self::Nmi,
+            0 => Self::Fixed,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+#[bitfield(u64)]
+pub struct ApicIcr {
+    pub vector: u8,
+    #[bits(3)]
+    pub message_type: IcrMessageType,
+    pub destination_mode: bool,
+    pub delivery_status: bool,
+    rsvd_13: bool,
+    pub assert: bool,
+    pub trigger_mode: bool,
+    #[bits(2)]
+    pub remote_read_status: usize,
+    #[bits(2)]
+    pub destination_shorthand: IcrDestFmt,
+    #[bits(12)]
+    rsvd_31_20: u64,
+    pub destination: u32,
+}

--- a/kernel/src/cpu/apic.rs
+++ b/kernel/src/cpu/apic.rs
@@ -15,89 +15,23 @@ use crate::requests::SvsmCaa;
 use crate::sev::hv_doorbell::HVExtIntStatus;
 use crate::types::GUEST_VMPL;
 
-use bitfield_struct::bitfield;
 use core::ptr::NonNull;
 use core::sync::atomic::Ordering;
-
-const APIC_REGISTER_APIC_ID: u64 = 0x802;
-const APIC_REGISTER_TPR: u64 = 0x808;
-const APIC_REGISTER_PPR: u64 = 0x80A;
-const APIC_REGISTER_EOI: u64 = 0x80B;
-const APIC_REGISTER_ISR_0: u64 = 0x810;
-const APIC_REGISTER_ISR_7: u64 = 0x817;
-const APIC_REGISTER_TMR_0: u64 = 0x818;
-const APIC_REGISTER_TMR_7: u64 = 0x81F;
-const APIC_REGISTER_IRR_0: u64 = 0x820;
-const APIC_REGISTER_IRR_7: u64 = 0x827;
-const APIC_REGISTER_ICR: u64 = 0x830;
-const APIC_REGISTER_SELF_IPI: u64 = 0x83F;
-
-#[derive(Debug, PartialEq)]
-pub enum IcrDestFmt {
-    Dest = 0,
-    OnlySelf = 1,
-    AllWithSelf = 2,
-    AllButSelf = 3,
-}
-
-impl IcrDestFmt {
-    const fn into_bits(self) -> u64 {
-        self as _
-    }
-    const fn from_bits(value: u64) -> Self {
-        match value {
-            3 => Self::AllButSelf,
-            2 => Self::AllWithSelf,
-            1 => Self::OnlySelf,
-            _ => Self::Dest,
-        }
-    }
-}
-
-#[derive(Debug, PartialEq)]
-pub enum IcrMessageType {
-    Fixed = 0,
-    Unknown = 3,
-    Nmi = 4,
-    Init = 5,
-    Sipi = 6,
-    ExtInt = 7,
-}
-
-impl IcrMessageType {
-    const fn into_bits(self) -> u64 {
-        self as _
-    }
-    const fn from_bits(value: u64) -> Self {
-        match value {
-            7 => Self::ExtInt,
-            6 => Self::Sipi,
-            5 => Self::Init,
-            4 => Self::Nmi,
-            0 => Self::Fixed,
-            _ => Self::Unknown,
-        }
-    }
-}
-
-#[bitfield(u64)]
-pub struct ApicIcr {
-    pub vector: u8,
-    #[bits(3)]
-    pub message_type: IcrMessageType,
-    pub destination_mode: bool,
-    pub delivery_status: bool,
-    rsvd_13: bool,
-    pub assert: bool,
-    pub trigger_mode: bool,
-    #[bits(2)]
-    pub remote_read_status: usize,
-    #[bits(2)]
-    pub destination_shorthand: IcrDestFmt,
-    #[bits(12)]
-    rsvd_31_20: u64,
-    pub destination: u32,
-}
+use cpuarch::x86apic::APIC_REGISTER_APIC_ID;
+use cpuarch::x86apic::APIC_REGISTER_EOI;
+use cpuarch::x86apic::APIC_REGISTER_ICR;
+use cpuarch::x86apic::APIC_REGISTER_IRR_0;
+use cpuarch::x86apic::APIC_REGISTER_IRR_7;
+use cpuarch::x86apic::APIC_REGISTER_ISR_0;
+use cpuarch::x86apic::APIC_REGISTER_ISR_7;
+use cpuarch::x86apic::APIC_REGISTER_PPR;
+use cpuarch::x86apic::APIC_REGISTER_SELF_IPI;
+use cpuarch::x86apic::APIC_REGISTER_TMR_0;
+use cpuarch::x86apic::APIC_REGISTER_TMR_7;
+use cpuarch::x86apic::APIC_REGISTER_TPR;
+use cpuarch::x86apic::ApicIcr;
+use cpuarch::x86apic::IcrDestFmt;
+use cpuarch::x86apic::IcrMessageType;
 
 // This structure must never be copied because a silent copy will cause APIC
 // state to be lost.

--- a/kernel/src/cpu/ipi.rs
+++ b/kernel/src/cpu/ipi.rs
@@ -5,7 +5,6 @@
 // Author: Jon Lange (jlange@microsoft.com)
 
 use super::TprGuard;
-use super::apic::{ApicIcr, IcrDestFmt};
 use super::cpuset::{AtomicCpuSet, CpuSet};
 use super::idt::common::IPI_VECTOR;
 use super::percpu::{PERCPU_AREAS, PerCpuShared, this_cpu};
@@ -20,6 +19,8 @@ use core::mem;
 use core::mem::MaybeUninit;
 use core::ptr;
 use core::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
+use cpuarch::x86apic::ApicIcr;
+use cpuarch::x86apic::IcrDestFmt;
 
 /// This module implements inter-processor interrupt support, including the
 /// ability to send and receive messages across CPUs.  Two types of IPI

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -16,7 +16,6 @@ use super::cpuid;
 use crate::address::{PhysAddr, VirtAddr};
 use crate::console::init_svsm_console;
 use crate::cpu::IrqGuard;
-use crate::cpu::apic::{ApicIcr, IcrMessageType};
 use crate::cpu::features::{Feature, cpu_get_feat, cpu_has_feat};
 use crate::cpu::irq_state::raw_irqs_disable;
 use crate::cpu::msr::write_msr;
@@ -35,6 +34,8 @@ use crate::types::PAGE_SIZE;
 #[cfg(debug_assertions)]
 use crate::types::PageSize;
 use crate::utils::MemoryRegion;
+use cpuarch::x86apic::ApicIcr;
+use cpuarch::x86apic::IcrMessageType;
 
 use bootdefs::kernel_launch::ApStartContext;
 use bootdefs::kernel_launch::SIPI_STUB_GPA;

--- a/kernel/src/tdx/apic.rs
+++ b/kernel/src/tdx/apic.rs
@@ -4,7 +4,6 @@
 //
 // Author: Peter Fang <peter.fang@intel.com>
 
-use crate::cpu::apic::{ApicIcr, IcrDestFmt, IcrMessageType};
 use crate::cpu::msr::{read_msr, write_msr};
 use crate::cpu::percpu::this_cpu;
 use crate::cpu::x86::apic::{
@@ -13,6 +12,9 @@ use crate::cpu::x86::apic::{
 use crate::cpu::x86::x2apic::{MSR_X2APIC_BASE, MSR_X2APIC_SELF_IPI};
 use crate::cpu::x86::{ApicAccess, MSR_APIC_BASE};
 use crate::tdx::tdcall;
+use cpuarch::x86apic::ApicIcr;
+use cpuarch::x86apic::IcrDestFmt;
+use cpuarch::x86apic::IcrMessageType;
 
 #[derive(Debug)]
 pub struct TdxApicAccessor {}


### PR DESCRIPTION
APIC constants are an aspect of platform architecture and should not be embedded in guest APIC emulation code.