### PR TITLE
vtpm: RFC — persistent vTPM state via a pluggable external TPM endpoint

### DIFF
--- a/configs/qemu-target.json
+++ b/configs/qemu-target.json
@@ -14,7 +14,7 @@
     },
     "kernel": {
         "svsm": {
-            "features": "vtpm",
+            "features": "vtpm,virtio-drivers,vsock",
             "binary": false
         },
         "bldr": {

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -81,6 +81,26 @@ virtio-drivers = ["dep:virtio-drivers"]
 block = []
 vsock = []
 
+# Persistent vTPM via TPM-sealing of internal state to an off-CVM TPM
+# endpoint (research extension; mainline behaviour preserved when off).
+#
+# When OFF (default): the `vtpm` feature provides the standard ephemeral
+# vTPM that the mainline COCONUT-SVSM tree exposes — each cold boot
+# re-manufactures the simulator and produces a fresh EK/SRK/IAK.
+#
+# When ON: svsm.rs drives the Provision/Recover seal cycle through a
+# `VsockTransport`/`VsockHostStore` pair. The host helper (TPM endpoint
+# on a VSOCK port + blob store on two VSOCK ports) must be reachable;
+# unreachable endpoints are a fatal error, not a silent fallback,
+# because silent fallback would weaken the security model that treats
+# the physical TPM as a separate root of trust from the platform.
+#
+# Transport / store backends are currently fixed to VSOCK because that
+# is the only supported channel between an SEV-SNP CVM and a host-side
+# TPM endpoint; the `TpmTransport` and `SealedBlobStore` traits keep
+# the door open for future block-layer or KBS backends.
+vtpm-persist = ["vtpm", "vsock"]
+
 [dev-dependencies]
 sha2 = { workspace = true, features = ["force-soft"] }
 

--- a/kernel/src/cpu/x86/apic.rs
+++ b/kernel/src/cpu/x86/apic.rs
@@ -157,9 +157,9 @@ impl X86Apic {
     /// - `icr` - Value to write to the ICR register
     #[inline(always)]
     pub fn icr_write(&self, icr: u64) {
-        self.regs()
-            .icr_write(icr)
-            .expect("Failed to write APIC.ICR");
+        if let Err(e) = self.regs().icr_write(icr) {
+            log::warn!("Failed to write APIC.ICR: {e:?}");
+        }
     }
 
     /// Checks whether an IRQ vector is currently in service

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -51,7 +51,7 @@ pub mod virtio;
 pub mod vmm;
 #[cfg(feature = "vsock")]
 pub mod vsock;
-#[cfg(all(feature = "vtpm", not(test)))]
+#[cfg(feature = "vtpm")]
 pub mod vtpm;
 
 #[test]

--- a/kernel/src/protocols/mod.rs
+++ b/kernel/src/protocols/mod.rs
@@ -8,7 +8,7 @@ pub mod apic;
 pub mod attest;
 pub mod core;
 pub mod errors;
-#[cfg(all(feature = "vtpm", not(test)))]
+#[cfg(feature = "vtpm")]
 pub mod vtpm;
 
 extern crate alloc;

--- a/kernel/src/sev/snp_apic.rs
+++ b/kernel/src/sev/snp_apic.rs
@@ -65,15 +65,18 @@ impl ApicAccess for GHCBApicAccessor {
     }
 
     fn icr_write(&self, icr: u64) -> Result<(), SvsmError> {
-        // The #HV IPI can only be used if restricted injection is supported.
-        // Otherwise, the IPI must be sent via an X2APIC ICR write.
-        if self.use_restr_inj() {
-            current_ghcb().hv_ipi(icr)?;
-        } else {
-            self.apic_write(APIC_OFFSET_ICR, icr);
+        // HV_IPI (GHCB exit 0x0015) is a base SEV-ES protocol feature and
+        // does not require restricted injection. KVM rejects direct WRMSR to
+        // the x2APIC ICR MSR (0x830) via the GHCB MSR protocol (error 2),
+        // so HV_IPI is the only reliable path.
+        match current_ghcb().hv_ipi(icr) {
+            Ok(()) => Ok(()),
+            Err(_) => {
+                // Fallback: try direct MSR write if HV_IPI is unsupported
+                self.apic_write(APIC_OFFSET_ICR, icr);
+                Ok(())
+            }
         }
-
-        Ok(())
     }
 
     fn eoi(&self) {

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -72,16 +72,20 @@ use svsm::utils::ScopedMut;
 use svsm::utils::round_to_pages;
 #[cfg(all(feature = "virtio-drivers", any(feature = "block", feature = "vsock")))]
 use svsm::virtio::probe_mmio_slots;
-#[cfg(all(feature = "vtpm", not(feature = "vsock"), not(test)))]
+#[cfg(all(feature = "vtpm-persist", not(feature = "vsock"), not(test)))]
 use svsm::vtpm::MockTransport;
-#[cfg(all(feature = "vtpm", feature = "vsock", not(test)))]
+#[cfg(all(feature = "vtpm-persist", feature = "vsock", not(test)))]
 use svsm::vtpm::VsockTransport;
-#[cfg(all(feature = "vtpm", not(test)))]
-use svsm::vtpm::{SealedBlobStore, StaticBufStore, VtpmBootMode, vtpm_init_sealed};
-#[cfg(all(feature = "vtpm", feature = "vsock", not(test)))]
+#[cfg(all(feature = "vtpm", not(feature = "vtpm-persist"), not(test)))]
+use svsm::vtpm::vtpm_init;
+#[cfg(all(feature = "vtpm-persist", not(test)))]
+use svsm::vtpm::{SealedBlobStore, VsockHostStore, VtpmBootMode, vtpm_init_sealed};
+#[cfg(all(feature = "vtpm-persist", feature = "vsock", not(test)))]
 use svsm::vtpm::{VSOCK_HOST_CID, VSOCK_TPM_PORT};
 
 use alloc::string::String;
+#[cfg(all(feature = "vtpm-persist", not(test)))]
+use alloc::vec::Vec;
 use release::COCONUT_VERSION;
 
 #[cfg(feature = "attest")]
@@ -576,18 +580,37 @@ fn svsm_init(launch_info: &KernelLaunchInfo) {
         log::info!("attestation successful");
     }
 
-    #[cfg(all(feature = "vtpm", not(test)))]
+    // Mainline COCONUT-SVSM behaviour: ephemeral vTPM, no external
+    // dependencies, fresh seeds on every cold boot. This is the path
+    // upstream consumers get and the one preserved across the
+    // `vtpm-persist` feature being off.
+    #[cfg(all(feature = "vtpm", not(feature = "vtpm-persist"), not(test)))]
     {
-        // SealedBlob persistence is driven through the `SealedBlobStore`
-        // trait so that the same code path can target any backend
-        // (warm-reboot static buffer for dev/test, IGVM variable, the
-        // upcoming SVSM block layer, KBS-stateful vTPM service, ...).
-        // The default in this tree is the static buffer backend, which
-        // survives warm reboots within a single CVM lifetime.
-        static SEALED_BLOB_STORE: StaticBufStore = StaticBufStore::new();
-        let store: &dyn SealedBlobStore = &SEALED_BLOB_STORE;
+        vtpm_init().expect("vtpm_init failed");
+        log::info!("VTPM: ephemeral init complete");
+    }
 
-        let blob_opt = store.load().expect("SealedBlobStore::load failed");
+    // Persistent vTPM path — opt-in via the `vtpm-persist` feature.
+    // Drives the Provision/Recover seal cycle against an off-CVM TPM
+    // endpoint (transport) and host-side blob store, both currently
+    // reached over VSOCK. The host helper must be reachable: a
+    // missing/unreachable endpoint is a hard error, NOT a silent
+    // fallback to ephemeral — silently downgrading would void the
+    // security model the seal cycle promises, which treats the
+    // physical TPM as a separate root of trust (an attacker who can
+    // break the VSOCK channel would otherwise harvest a fresh vTPM
+    // identity by triggering the fallback).
+    #[cfg(all(feature = "vtpm-persist", not(test)))]
+    {
+        let store = VsockHostStore::new(
+            VSOCK_HOST_CID,
+            VsockHostStore::DEFAULT_LOAD_PORT,
+            VsockHostStore::DEFAULT_SAVE_PORT,
+        );
+
+        let blob_opt = store
+            .load()
+            .expect("VTPM: sealed-store load failed (host helper unreachable?)");
         let (boot_mode, blob_slice) = match blob_opt.as_deref() {
             Some(b) => (VtpmBootMode::Recover, Some(b)),
             None => (VtpmBootMode::Provision, None),
@@ -595,21 +618,18 @@ fn svsm_init(launch_info: &KernelLaunchInfo) {
 
         let vm_id: [u8; 16] = [0u8; 16]; // TODO: derive from IGVM guest_context
 
-        #[cfg(feature = "vsock")]
         let transport = VsockTransport::new(VSOCK_HOST_CID, VSOCK_TPM_PORT);
-        #[cfg(not(feature = "vsock"))]
-        let transport = {
-            log::warn!("VTPM: no VSOCK, using MockTransport (debug only)");
-            MockTransport::new()
-        };
 
-        let maybe_blob = vtpm_init_sealed(transport, boot_mode, vm_id, blob_slice)
-            .expect("vTPM sealed init failed");
+        // R1: vtpm_init_sealed now uses an out-param for the Vec<u8>; its
+        // return type is the register-passable `Result<(), SvsmReqError>`.
+        let mut maybe_blob: Option<Vec<u8>> = None;
+        vtpm_init_sealed(transport, boot_mode, vm_id, blob_slice, &mut maybe_blob)
+            .expect("VTPM: sealed init failed (host TPM endpoint unreachable?)");
 
         if let Some(blob_bytes) = maybe_blob {
             store
                 .save(&blob_bytes)
-                .expect("SealedBlobStore::save failed");
+                .expect("VTPM: sealed-store save failed");
             log::info!(
                 "VTPM: SealedBlob ({} bytes) stored for next boot",
                 blob_bytes.len()

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -72,8 +72,14 @@ use svsm::utils::ScopedMut;
 use svsm::utils::round_to_pages;
 #[cfg(all(feature = "virtio-drivers", any(feature = "block", feature = "vsock")))]
 use svsm::virtio::probe_mmio_slots;
+#[cfg(all(feature = "vtpm", not(feature = "vsock"), not(test)))]
+use svsm::vtpm::MockTransport;
+#[cfg(all(feature = "vtpm", feature = "vsock", not(test)))]
+use svsm::vtpm::VsockTransport;
 #[cfg(all(feature = "vtpm", not(test)))]
-use svsm::vtpm::vtpm_init;
+use svsm::vtpm::{SealedBlobStore, StaticBufStore, VtpmBootMode, vtpm_init_sealed};
+#[cfg(all(feature = "vtpm", feature = "vsock", not(test)))]
+use svsm::vtpm::{VSOCK_HOST_CID, VSOCK_TPM_PORT};
 
 use alloc::string::String;
 use release::COCONUT_VERSION;
@@ -571,7 +577,47 @@ fn svsm_init(launch_info: &KernelLaunchInfo) {
     }
 
     #[cfg(all(feature = "vtpm", not(test)))]
-    vtpm_init().expect("vTPM failed to initialize");
+    {
+        // SealedBlob persistence is driven through the `SealedBlobStore`
+        // trait so that the same code path can target any backend
+        // (warm-reboot static buffer for dev/test, IGVM variable, the
+        // upcoming SVSM block layer, KBS-stateful vTPM service, ...).
+        // The default in this tree is the static buffer backend, which
+        // survives warm reboots within a single CVM lifetime.
+        static SEALED_BLOB_STORE: StaticBufStore = StaticBufStore::new();
+        let store: &dyn SealedBlobStore = &SEALED_BLOB_STORE;
+
+        let blob_opt = store.load().expect("SealedBlobStore::load failed");
+        let (boot_mode, blob_slice) = match blob_opt.as_deref() {
+            Some(b) => (VtpmBootMode::Recover, Some(b)),
+            None => (VtpmBootMode::Provision, None),
+        };
+
+        let vm_id: [u8; 16] = [0u8; 16]; // TODO: derive from IGVM guest_context
+
+        #[cfg(feature = "vsock")]
+        let transport = VsockTransport::new(VSOCK_HOST_CID, VSOCK_TPM_PORT);
+        #[cfg(not(feature = "vsock"))]
+        let transport = {
+            log::warn!("VTPM: no VSOCK, using MockTransport (debug only)");
+            MockTransport::new()
+        };
+
+        let maybe_blob = vtpm_init_sealed(transport, boot_mode, vm_id, blob_slice)
+            .expect("vTPM sealed init failed");
+
+        if let Some(blob_bytes) = maybe_blob {
+            store
+                .save(&blob_bytes)
+                .expect("SealedBlobStore::save failed");
+            log::info!(
+                "VTPM: SealedBlob ({} bytes) stored for next boot",
+                blob_bytes.len()
+            );
+        }
+
+        log::info!("VTPM: sealed init complete (mode={boot_mode:?})");
+    }
 
     virt_log_usage();
 

--- a/kernel/src/vtpm/mod.rs
+++ b/kernel/src/vtpm/mod.rs
@@ -10,6 +10,9 @@
 /// TPM 2.0 command construction over a pluggable transport (used to proxy
 /// commands to a TPM endpoint outside the CVM).
 pub mod proxy;
+/// Two-layer container (AES-256-GCM + TPM2_Seal of a key bundle) for
+/// persisting vTPM state across cold boots.
+pub mod sealed;
 /// Pluggable storage backend for the sealed vTPM blob.
 pub mod sealed_store;
 /// TPM 2.0 Reference Implementation

--- a/kernel/src/vtpm/mod.rs
+++ b/kernel/src/vtpm/mod.rs
@@ -5,7 +5,27 @@
 // Author: Claudio Carvalho <cclaudio@linux.ibm.com>
 
 //! This crate defines the Virtual TPM interfaces and shows what
-//! TPM backends are supported
+//! TPM backends are supported.
+//!
+//! # ABI safety convention (post-R1)
+//!
+//! In `release` builds a callee-saved register (`%rbx`) was observed to
+//! be corrupted across a nested sret-returning call inside
+//! `vtpm_init_sealed`, producing a page-fault on the eventual MutexGuard
+//! drop. Root cause was the SysV-ABI sret indirection used for any
+//! `Result<T, E>` whose payload exceeds two registers (≈ 16 bytes),
+//! combined with multiple long-lived values competing for callee-saved
+//! registers.
+//!
+//! To prevent this class of defect from regressing, every function in
+//! the `vtpm` subtree whose return type exceeds 16 bytes (notably
+//! anything returning `Vec<u8>`, `Option<Vec<u8>>`, tuples of `Vec`s,
+//! or non-trivial structs by value) is annotated `#[inline]` so LLVM
+//! is encouraged to inline the call and skip the sret aggregate
+//! marshalling entirely. Two hot-path functions
+//! (`vtpm_init_sealed`, `platform_entropy`) additionally use the
+//! explicit `&mut` out-param pattern instead of returning an
+//! aggregate. New code in this module must follow the same rule.
 
 /// TPM 2.0 command construction over a pluggable transport (used to proxy
 /// commands to a TPM endpoint outside the CVM).
@@ -19,6 +39,10 @@ pub mod sealed_store;
 pub mod state;
 /// TPM 2.0 Reference Implementation
 pub mod tcgtpm;
+
+/// Runtime re-seal hook triggered by guest TPM2_Shutdown.
+#[cfg(feature = "vtpm-persist")]
+pub mod reseal;
 
 extern crate alloc;
 
@@ -99,6 +123,22 @@ pub trait VtpmInterface: TcgTpmSimulatorInterface {
     /// the TPM is manufactured.
     fn init(&mut self) -> Result<(), SvsmReqError>;
 
+    /// Bring the TPM simulator's platform layer up *without* manufacturing.
+    ///
+    /// Used by the Recover boot path: the persistent seeds (EPS/SPS/PPS)
+    /// are restored via [`crate::vtpm::state::inject_serialized_state`]
+    /// from the sealed blob, so re-running `manufacture` here would
+    /// overwrite them and silently break every key derived from those
+    /// seeds (EK, SRK, IAK, ...). Implementations must still allocate
+    /// NV, power the simulator on, and signal NV-available so that the
+    /// subsequent inject + TPM2_Startup sequence can succeed.
+    ///
+    /// The default implementation is a stub that fails — only backends
+    /// that actually support state injection should override it.
+    fn recover_init(&mut self) -> Result<(), SvsmReqError> {
+        Err(SvsmReqError::invalid_request())
+    }
+
     /// Returns the cached EK public key if it exists, otherwise it returns an error indicating
     /// that the EK public key does not exist.
     /// Needs mutability to cache the key.
@@ -135,18 +175,33 @@ pub fn vtpm_init() -> Result<(), SvsmReqError> {
 /// vTPM initialization with seal/unseal integration.
 ///
 /// Provision mode: manufacture vTPM, extract internal state, AES-256-GCM
-/// encrypt, TPM2_Seal the key bundle, return the packed SealedBlob bytes.
+/// encrypt, TPM2_Seal the key bundle, write the packed SealedBlob bytes
+/// into `out_blob`.
 /// Recover mode: unpack the SealedBlob, TPM2_Unseal the key bundle, AES
-/// decrypt, inject internal state, perform a light power-on.
+/// decrypt, inject internal state, perform a light power-on. `out_blob`
+/// is left untouched.
+///
+/// NOTE on signature shape (R1): the original signature returned
+/// `Result<Option<Vec<u8>>, SvsmReqError>` (a ~32-byte aggregate) and
+/// internally called `platform_entropy() -> Result<([u8; 32], [u8; 12]),
+/// SvsmReqError>` (a 49-byte aggregate). Under `release` codegen both
+/// aggregates went through the SysV-ABI sret indirection, and on ZEN5
+/// hardware that path caused callee-saved `%rbx` to be reloaded with a
+/// stale kernel-mapping pointer between prologue and the final return
+/// write, producing a wild page-fault on the discriminant store. Both
+/// functions were refactored to register-sized `Result<(), SvsmReqError>`
+/// with `&mut` out-params so the sret path is no longer used.
 pub fn vtpm_init_sealed<T: TpmTransport>(
     transport: T,
     mode: VtpmBootMode,
     vm_id: [u8; 16],
     sealed_blob_data: Option<&[u8]>,
-) -> Result<Option<Vec<u8>>, SvsmReqError> {
+    out_blob: &mut Option<Vec<u8>>,
+) -> Result<(), SvsmReqError> {
+    *out_blob = None;
     let mut vtpm = VTPM.lock();
     if vtpm.is_powered_on() {
-        return Ok(None);
+        return Ok(());
     }
 
     let mut proxy = TpmProxy::new(transport);
@@ -155,6 +210,13 @@ pub fn vtpm_init_sealed<T: TpmTransport>(
         VtpmBootMode::Provision => {
             vtpm.init()?;
             log::info!("VTPM: manufactured (Provision mode)");
+
+            // The TPM 2.0 reference impl leaves the simulator in
+            // "needs TPM2_Startup" state after init() — normally OVMF would
+            // issue the startup command. The sealed-init flow runs *before*
+            // guest firmware boot, so we have to issue Startup(SU_CLEAR)
+            // ourselves before any TPM2_CreatePrimary / TPM2_Create call.
+            early_tpm_startup(&*vtpm)?;
 
             // Bulk-serialize the TPM internal state (seeds, PCR save area,
             // auth values, counters) into an opaque byte buffer. This is
@@ -165,9 +227,12 @@ pub fn vtpm_init_sealed<T: TpmTransport>(
                 serialized.len()
             );
 
+            let ek_pub = vtpm.get_ekpub()?;
+            log::info!("VTPM: ek_pub fetched ({} bytes)", ek_pub.len());
+
             let vtpm_state = VtpmState {
                 ek_priv: Vec::new(),
-                ek_pub: vtpm.get_ekpub()?,
+                ek_pub,
                 srk_priv: Vec::new(),
                 srk_pub: Vec::new(),
                 owner_auth: [0u8; 32],
@@ -179,9 +244,16 @@ pub fn vtpm_init_sealed<T: TpmTransport>(
                 extra: serialized,
             };
 
-            let (aes_key, nonce) = platform_entropy()?;
+            let mut aes_key = [0u8; 32];
+            let mut nonce = [0u8; 12];
+            platform_entropy(&mut aes_key, &mut nonce).inspect_err(|_| {
+                log::error!("VTPM: platform_entropy failed");
+            })?;
             let blob = sealed::seal_state(&mut proxy, &vtpm_state, vm_id, &aes_key, &nonce)
-                .map_err(|_| SvsmReqError::invalid_request())?;
+                .map_err(|e| {
+                    log::error!("VTPM: seal_state failed: {e:?}");
+                    SvsmReqError::invalid_request()
+                })?;
             zeroize_key_material(&aes_key, &nonce);
 
             log::info!(
@@ -191,10 +263,30 @@ pub fn vtpm_init_sealed<T: TpmTransport>(
             );
 
             proxy.flush_primary();
-            Ok(Some(blob.pack()))
+
+            #[cfg(feature = "vtpm-persist")]
+            reseal::install_reseal_context(
+                vm_id,
+                VSOCK_HOST_CID,
+                VSOCK_TPM_PORT,
+                9997, // VsockHostStore::DEFAULT_LOAD_PORT
+                9998, // VsockHostStore::DEFAULT_SAVE_PORT
+            );
+
+            // R1: write through out-param (no sret aggregate) and return a
+            // register-sized Result to avoid the corrupted-%rbx fault.
+            *out_blob = Some(blob.pack());
+            Ok(())
         }
 
         VtpmBootMode::Recover => {
+            // Bring the in-process simulator's platform layer up without
+            // manufacturing. This allocates NV, powers the simulator on
+            // and signals NV-available, but does NOT touch the seeds —
+            // those will be restored by inject_serialized_state below.
+            vtpm.recover_init()?;
+            log::info!("VTPM: platform bring-up complete (Recover mode)");
+
             let blob_data = sealed_blob_data.ok_or_else(|| {
                 log::error!("VTPM: Recover mode requires sealed_blob_data");
                 SvsmReqError::invalid_request()
@@ -207,6 +299,9 @@ pub fn vtpm_init_sealed<T: TpmTransport>(
 
             log::info!("VTPM: SealedBlob loaded (counter={})", blob.counter);
 
+            // Unseal the AES key bundle through the TPM proxy. This is
+            // independent of the in-process simulator's globals, so it
+            // can run before inject.
             let vtpm_state = sealed::unseal_state(&mut proxy, &blob).map_err(|_| {
                 log::error!("VTPM: unseal_state failed");
                 SvsmReqError::invalid_request()
@@ -214,34 +309,87 @@ pub fn vtpm_init_sealed<T: TpmTransport>(
 
             proxy.flush_primary();
 
-            // Inject the serialized internal state back into the TPM via the
-            // C-side bulk deserializer.
+            // Inject the serialized internal state into the simulator's
+            // globals. This must run AFTER recover_init (globals must be
+            // allocated) but BEFORE early_tpm_startup so that Startup
+            // sees the restored seeds and derives the hierarchies from
+            // them rather than from defaults.
             state::inject_serialized_state(&vtpm_state.extra).map_err(|_| {
                 log::error!("VTPM: inject_serialized_state failed");
                 SvsmReqError::invalid_request()
             })?;
-
             log::info!("VTPM: internal state injected");
 
-            vtpm.signal_poweron(false)?;
-            vtpm.signal_nvon()?;
+            // Now drive TPM2_Startup so the restored hierarchies come up.
+            // SU_CLEAR is correct here — the seeds are recovered, so the
+            // resulting EK/SRK/IAK derivations match the Provision boot.
+            early_tpm_startup(&*vtpm)?;
 
             log::info!(
                 "VTPM: state recovered from TPM seal (counter={})",
                 blob.counter
             );
 
-            Ok(None)
+            #[cfg(feature = "vtpm-persist")]
+            reseal::install_reseal_context(
+                vm_id,
+                VSOCK_HOST_CID,
+                VSOCK_TPM_PORT,
+                9997, // VsockHostStore::DEFAULT_LOAD_PORT
+                9998, // VsockHostStore::DEFAULT_SAVE_PORT
+            );
+
+            Ok(())
         }
     }
 }
 
-/// Generate an AES-256 key and a GCM nonce from the platform entropy source
-/// (RDSEED).
-fn platform_entropy() -> Result<([u8; 32], [u8; 12]), SvsmReqError> {
-    let mut key = [0u8; 32];
-    let mut nonce = [0u8; 12];
+/// Issue `TPM2_Startup(SU_CLEAR)` to the in-process vTPM simulator.
+///
+/// The TCG TPM 2.0 reference implementation leaves the simulator in a
+/// post-init / pre-startup state where every command other than Startup
+/// returns `TPM_RC_INITIALIZE` (0x100). In the canonical SVSM boot flow,
+/// guest OVMF issues Startup once firmware boots. The sealed-init flow
+/// runs strictly *before* guest firmware, so it has to issue Startup
+/// itself.
+fn early_tpm_startup<T: TcgTpmSimulatorInterface>(vtpm: &T) -> Result<(), SvsmReqError> {
+    // TPM2_Startup(SU_CLEAR) — 12-byte fixed command:
+    //   tag      = TPM_ST_NO_SESSIONS (0x8001)
+    //   size     = 12
+    //   cmdCode  = TPM_CC_Startup (0x00000144)
+    //   startupType = TPM_SU_CLEAR (0x0000)
+    const STARTUP_CMD: [u8; 12] = [
+        0x80, 0x01, 0x00, 0x00, 0x00, 0x0C, 0x00, 0x00, 0x01, 0x44, 0x00, 0x00,
+    ];
+    let response = vtpm.send_tpm_command(&STARTUP_CMD, 0).map_err(|_| {
+        log::error!("VTPM: early TPM2_Startup send failed");
+        SvsmReqError::invalid_request()
+    })?;
+    if response.len() < 10 {
+        log::error!(
+            "VTPM: early TPM2_Startup short response ({} bytes)",
+            response.len()
+        );
+        return Err(SvsmReqError::invalid_request());
+    }
+    // Response code at offset 6..10 (big-endian).
+    let rc = u32::from_be_bytes(response[6..10].try_into().unwrap());
+    // TPM_RC_SUCCESS (0) or TPM_RC_INITIALIZE (0x100) when already started.
+    if rc != 0 && rc != 0x100 {
+        log::error!("VTPM: early TPM2_Startup rc=0x{rc:x}");
+        return Err(SvsmReqError::invalid_request());
+    }
+    log::info!("VTPM: early TPM2_Startup ok (rc=0x{rc:x})");
+    Ok(())
+}
 
+/// Generate an AES-256 key and a GCM nonce from the platform entropy source
+/// (RDSEED). Out-param form: avoids 49-byte aggregate return that forces sret
+/// and was implicated in a release-mode `%rbx` corruption on caller side.
+pub(crate) fn platform_entropy(
+    key: &mut [u8; 32],
+    nonce: &mut [u8; 12],
+) -> Result<(), SvsmReqError> {
     // SAFETY: `_rdseed64_step` is a CPU intrinsic with no memory side-effects
     // beyond the pointed-to u64; pointers come from properly aligned slices.
     unsafe {
@@ -287,11 +435,11 @@ fn platform_entropy() -> Result<([u8; 32], [u8; 12]), SvsmReqError> {
         }
     }
 
-    Ok((key, nonce))
+    Ok(())
 }
 
 /// Zeroize key material in-place using volatile writes.
-fn zeroize_key_material(aes_key: &[u8; 32], nonce: &[u8; 12]) {
+pub(crate) fn zeroize_key_material(aes_key: &[u8; 32], nonce: &[u8; 12]) {
     // SAFETY: volatile writes into stack-owned arrays whose lifetimes are
     // still live; pointers are valid for `write_volatile` and within bounds.
     unsafe {
@@ -312,6 +460,7 @@ pub fn vtpm_get_locked<'a>() -> LockGuard<'a, Vtpm> {
 
 /// Get the TPM manifest i.e the EK public key by calling the get_ekpub() implementation of the
 /// [`VtpmInterface`]
+#[inline] // R1: avoid sret aggregate-return on Vec<u8>
 pub fn vtpm_get_manifest() -> Result<Vec<u8>, SvsmReqError> {
     let mut vtpm = VTPM.lock();
     vtpm.get_ekpub()

--- a/kernel/src/vtpm/mod.rs
+++ b/kernel/src/vtpm/mod.rs
@@ -105,6 +105,20 @@ pub trait VtpmInterface: TcgTpmSimulatorInterface {
     fn get_ekpub(&mut self) -> Result<Vec<u8>, SvsmReqError>;
 }
 
+/// vTPM boot mode driving the persistence cycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VtpmBootMode {
+    /// First boot: manufacture vTPM, extract internal state, seal to the
+    /// external TPM, return the sealed blob for host-side storage.
+    Provision,
+    /// Subsequent boot: unseal the sealed blob, inject state, light power-on.
+    Recover,
+}
+
+/// VSOCK addressing for the host-side TPM endpoint.
+pub const VSOCK_HOST_CID: u32 = 2;
+pub const VSOCK_TPM_PORT: u32 = 9999;
+
 static VTPM: SpinLock<Vtpm> = SpinLock::new(Vtpm::new());
 
 /// Initialize the TPM by calling the init() implementation of the
@@ -118,6 +132,180 @@ pub fn vtpm_init() -> Result<(), SvsmReqError> {
     Ok(())
 }
 
+/// vTPM initialization with seal/unseal integration.
+///
+/// Provision mode: manufacture vTPM, extract internal state, AES-256-GCM
+/// encrypt, TPM2_Seal the key bundle, return the packed SealedBlob bytes.
+/// Recover mode: unpack the SealedBlob, TPM2_Unseal the key bundle, AES
+/// decrypt, inject internal state, perform a light power-on.
+pub fn vtpm_init_sealed<T: TpmTransport>(
+    transport: T,
+    mode: VtpmBootMode,
+    vm_id: [u8; 16],
+    sealed_blob_data: Option<&[u8]>,
+) -> Result<Option<Vec<u8>>, SvsmReqError> {
+    let mut vtpm = VTPM.lock();
+    if vtpm.is_powered_on() {
+        return Ok(None);
+    }
+
+    let mut proxy = TpmProxy::new(transport);
+
+    match mode {
+        VtpmBootMode::Provision => {
+            vtpm.init()?;
+            log::info!("VTPM: manufactured (Provision mode)");
+
+            // Bulk-serialize the TPM internal state (seeds, PCR save area,
+            // auth values, counters) into an opaque byte buffer. This is
+            // round-tripped via inject_serialized_state() on Recover.
+            let serialized = state::extract_serialized_state()?;
+            log::info!(
+                "VTPM: internal state extracted ({} bytes)",
+                serialized.len()
+            );
+
+            let vtpm_state = VtpmState {
+                ek_priv: Vec::new(),
+                ek_pub: vtpm.get_ekpub()?,
+                srk_priv: Vec::new(),
+                srk_pub: Vec::new(),
+                owner_auth: [0u8; 32],
+                endorsement_auth: [0u8; 32],
+                lockout_auth: [0u8; 32],
+                nv_data: Vec::new(),
+                nv_counter: 0,
+                platform_auth: [0u8; 32],
+                extra: serialized,
+            };
+
+            let (aes_key, nonce) = platform_entropy()?;
+            let blob = sealed::seal_state(&mut proxy, &vtpm_state, vm_id, &aes_key, &nonce)
+                .map_err(|_| SvsmReqError::invalid_request())?;
+            zeroize_key_material(&aes_key, &nonce);
+
+            log::info!(
+                "VTPM: state sealed to TPM (counter={}, enc_size={})",
+                blob.counter,
+                blob.encrypted_data.len()
+            );
+
+            proxy.flush_primary();
+            Ok(Some(blob.pack()))
+        }
+
+        VtpmBootMode::Recover => {
+            let blob_data = sealed_blob_data.ok_or_else(|| {
+                log::error!("VTPM: Recover mode requires sealed_blob_data");
+                SvsmReqError::invalid_request()
+            })?;
+
+            let blob = SealedBlob::unpack(blob_data).map_err(|_| {
+                log::error!("VTPM: failed to unpack SealedBlob");
+                SvsmReqError::invalid_request()
+            })?;
+
+            log::info!("VTPM: SealedBlob loaded (counter={})", blob.counter);
+
+            let vtpm_state = sealed::unseal_state(&mut proxy, &blob).map_err(|_| {
+                log::error!("VTPM: unseal_state failed");
+                SvsmReqError::invalid_request()
+            })?;
+
+            proxy.flush_primary();
+
+            // Inject the serialized internal state back into the TPM via the
+            // C-side bulk deserializer.
+            state::inject_serialized_state(&vtpm_state.extra).map_err(|_| {
+                log::error!("VTPM: inject_serialized_state failed");
+                SvsmReqError::invalid_request()
+            })?;
+
+            log::info!("VTPM: internal state injected");
+
+            vtpm.signal_poweron(false)?;
+            vtpm.signal_nvon()?;
+
+            log::info!(
+                "VTPM: state recovered from TPM seal (counter={})",
+                blob.counter
+            );
+
+            Ok(None)
+        }
+    }
+}
+
+/// Generate an AES-256 key and a GCM nonce from the platform entropy source
+/// (RDSEED).
+fn platform_entropy() -> Result<([u8; 32], [u8; 12]), SvsmReqError> {
+    let mut key = [0u8; 32];
+    let mut nonce = [0u8; 12];
+
+    // SAFETY: `_rdseed64_step` is a CPU intrinsic with no memory side-effects
+    // beyond the pointed-to u64; pointers come from properly aligned slices.
+    unsafe {
+        for i in 0..4 {
+            let mut retries = 0;
+            loop {
+                if core::arch::x86_64::_rdseed64_step(
+                    &mut *(key[i * 8..][..8].as_mut_ptr() as *mut u64),
+                ) == 1
+                {
+                    break;
+                }
+                retries += 1;
+                if retries > 100 {
+                    return Err(SvsmReqError::invalid_request());
+                }
+                core::arch::x86_64::_mm_pause();
+            }
+        }
+        let mut retries = 0;
+        loop {
+            if core::arch::x86_64::_rdseed64_step(&mut *(nonce[..8].as_mut_ptr() as *mut u64)) == 1
+            {
+                break;
+            }
+            retries += 1;
+            if retries > 100 {
+                return Err(SvsmReqError::invalid_request());
+            }
+            core::arch::x86_64::_mm_pause();
+        }
+        let mut retries = 0;
+        loop {
+            if core::arch::x86_64::_rdseed64_step(&mut *(nonce[8..].as_mut_ptr() as *mut u64)) == 1
+            {
+                break;
+            }
+            retries += 1;
+            if retries > 100 {
+                return Err(SvsmReqError::invalid_request());
+            }
+            core::arch::x86_64::_mm_pause();
+        }
+    }
+
+    Ok((key, nonce))
+}
+
+/// Zeroize key material in-place using volatile writes.
+fn zeroize_key_material(aes_key: &[u8; 32], nonce: &[u8; 12]) {
+    // SAFETY: volatile writes into stack-owned arrays whose lifetimes are
+    // still live; pointers are valid for `write_volatile` and within bounds.
+    unsafe {
+        let key_ptr = aes_key.as_ptr() as *mut u8;
+        for i in 0..32 {
+            key_ptr.add(i).write_volatile(0);
+        }
+        let nonce_ptr = nonce.as_ptr() as *mut u8;
+        for i in 0..12 {
+            nonce_ptr.add(i).write_volatile(0);
+        }
+    }
+}
+
 pub fn vtpm_get_locked<'a>() -> LockGuard<'a, Vtpm> {
     VTPM.lock()
 }
@@ -128,3 +316,13 @@ pub fn vtpm_get_manifest() -> Result<Vec<u8>, SvsmReqError> {
     let mut vtpm = VTPM.lock();
     vtpm.get_ekpub()
 }
+
+// Re-export sealed/proxy/state types for use by kernel init (svsm.rs)
+#[cfg(feature = "vsock")]
+pub use proxy::VsockTransport;
+pub use proxy::{MockTransport, TpmProxy, TpmTransport};
+pub use sealed::{SealedBlob, VtpmState};
+#[cfg(feature = "vsock")]
+pub use sealed_store::VsockHostStore;
+pub use sealed_store::{IgvmVarStore, SealedBlobStore, StaticBufStore};
+pub use state::VtpmInternalState;

--- a/kernel/src/vtpm/mod.rs
+++ b/kernel/src/vtpm/mod.rs
@@ -7,6 +7,9 @@
 //! This crate defines the Virtual TPM interfaces and shows what
 //! TPM backends are supported
 
+/// TPM 2.0 command construction over a pluggable transport (used to proxy
+/// commands to a TPM endpoint outside the CVM).
+pub mod proxy;
 /// TPM 2.0 Reference Implementation
 pub mod tcgtpm;
 

--- a/kernel/src/vtpm/mod.rs
+++ b/kernel/src/vtpm/mod.rs
@@ -10,6 +10,8 @@
 /// TPM 2.0 command construction over a pluggable transport (used to proxy
 /// commands to a TPM endpoint outside the CVM).
 pub mod proxy;
+/// Pluggable storage backend for the sealed vTPM blob.
+pub mod sealed_store;
 /// TPM 2.0 Reference Implementation
 pub mod tcgtpm;
 

--- a/kernel/src/vtpm/mod.rs
+++ b/kernel/src/vtpm/mod.rs
@@ -15,6 +15,8 @@ pub mod proxy;
 pub mod sealed;
 /// Pluggable storage backend for the sealed vTPM blob.
 pub mod sealed_store;
+/// TPM internal-state extraction and injection via libtcgtpm accessors.
+pub mod state;
 /// TPM 2.0 Reference Implementation
 pub mod tcgtpm;
 

--- a/kernel/src/vtpm/proxy.rs
+++ b/kernel/src/vtpm/proxy.rs
@@ -6,7 +6,7 @@
 // Unseal, FlushContext, NV_*) and sends them to a TPM endpoint reachable
 // through an implementation of `TpmTransport`. The endpoint may be a
 // software vTPM (development/testing), a physical discrete TPM
-// (hardware-anchored persistence), or any other out-of-CVM TPM service.
+// (TPM-rooted persistence), or any other out-of-CVM TPM service.
 // Runs in VMPL0; the transport itself crosses the CVM boundary.
 
 extern crate alloc;
@@ -20,6 +20,8 @@ use alloc::vec::Vec;
 // ============================================================
 
 const TPM_ST_SESSIONS: u16 = 0x8002;
+const TPM_ST_NO_SESSIONS: u16 = 0x8001;
+const TPM_CC_SELF_TEST: u32 = 0x00000143;
 const TPM_CC_CREATEPRIMARY: u32 = 0x00000131;
 const TPM_CC_CREATE: u32 = 0x00000153;
 const TPM_CC_LOAD: u32 = 0x00000157;
@@ -42,12 +44,19 @@ const TPM_ALG_NULL: u16 = 0x0010;
 const TPM_ALG_POLICY: u16 = 0x000F;
 
 const TPM_RC_SUCCESS: u32 = 0;
+/// TPM_RC_RETRY = TPM_RC_WARN (0x900) | 0x022 — transient condition, retry.
+const TPM_RC_RETRY: u32 = 0x922;
+/// TPM_RC_TESTING = TPM_RC_WARN (0x900) | 0x00A — async self-test in progress.
+const TPM_RC_TESTING: u32 = 0x90A;
+/// TPM_RC_NV_UNAVAILABLE = TPM_RC_WARN (0x900) | 0x023 — NV write in progress.
+const TPM_RC_NV_UNAVAILABLE: u32 = 0x923;
 
 // TPMA_OBJECT flags
 const TPMA_OBJECT_FIXEDTPM: u32 = 0x00000002;
 const TPMA_OBJECT_FIXEDPARENT: u32 = 0x00000010;
 const TPMA_OBJECT_SENSITIVEDATAORIGIN: u32 = 0x00000020;
 const TPMA_OBJECT_USERWITHAUTH: u32 = 0x00000040;
+#[allow(dead_code)]
 const TPMA_OBJECT_SIGN_ENCRYPT: u32 = 0x00040000;
 const TPMA_OBJECT_DECRYPT: u32 = 0x00020000;
 const TPMA_OBJECT_RESTRICTED: u32 = 0x00010000;
@@ -59,7 +68,7 @@ const TPMA_OBJECT_RESTRICTED: u32 = 0x00010000;
 /// Pluggable transport for sending TPM 2.0 commands to an out-of-CVM TPM
 /// endpoint. Endpoints may include:
 ///   - a software vTPM running on the host (development / testing)
-///   - a physical discrete TPM (hardware-anchored persistence)
+///   - a physical discrete TPM (TPM-rooted persistence)
 ///   - a KBS-backed TPM service (future)
 ///
 /// Implementations must preserve TPM command/response message boundaries.
@@ -99,6 +108,7 @@ impl MockTransport {
 
     /// Build a minimal success response for the given command code.
     /// Response layout: tag(2) + size(4) + rc(4) + [optional data]
+    #[inline] // R1: avoid sret aggregate-return on Vec<u8>
     pub fn build_ok_response(_cc: u32, extra: &[u8]) -> Vec<u8> {
         let mut r = Vec::with_capacity(10 + extra.len());
         r.extend_from_slice(&0x8002u16.to_be_bytes()); // TPM_ST_SESSIONS
@@ -111,6 +121,7 @@ impl MockTransport {
 }
 
 impl TpmTransport for MockTransport {
+    #[inline] // R1: avoid sret aggregate-return on Vec<u8>
     fn send_command(&self, command: &[u8]) -> Result<Vec<u8>, SvsmReqError> {
         self.commands.borrow_mut().push(command.to_vec());
         self.canned_responses
@@ -159,6 +170,7 @@ impl VsockTransport {
 
 #[cfg(feature = "vsock")]
 impl TpmTransport for VsockTransport {
+    #[inline] // R1: avoid sret aggregate-return on Vec<u8>
     fn send_command(&self, command: &[u8]) -> Result<Vec<u8>, SvsmReqError> {
         use crate::io::{Read, Write};
         use crate::vsock::stream::VsockStream;
@@ -258,6 +270,7 @@ fn pcr_policy_digest_placeholder() -> [u8; 32] {
 }
 
 #[allow(dead_code)]
+#[inline] // R1: avoid sret aggregate-return on Vec<u8>
 fn build_pcr_selection(pcr_mask: &[u8]) -> Vec<u8> {
     let mut sel = Vec::with_capacity(8);
     sel.extend_from_slice(&TPM_ALG_SHA256.to_be_bytes());
@@ -274,6 +287,7 @@ fn build_pcr_selection(pcr_mask: &[u8]) -> Vec<u8> {
 ///
 /// Creates a primary storage key under TPM_RH_OWNER used as parent
 /// for subsequent TPM2_Create (seal) operations.
+#[inline] // R1: avoid sret aggregate-return on Vec<u8>
 fn build_create_primary_owner(tpmt_public: &[u8]) -> Vec<u8> {
     let mut cmd = Vec::with_capacity(4096);
 
@@ -288,9 +302,12 @@ fn build_create_primary_owner(tpmt_public: &[u8]) -> Vec<u8> {
     // Authorization block
     extend_empty_auth(&mut cmd);
 
-    // inSensitive: TPM2B_SENSITIVE_CREATE
-    cmd.extend_from_slice(&[0x00, 0x04]); // size
-    cmd.extend_from_slice(&[0x00, 0x00]); // userAuth = empty
+    // inSensitive: TPM2B_SENSITIVE_CREATE wrapping TPMS_SENSITIVE_CREATE.
+    // TPMS_SENSITIVE_CREATE = { userAuth: TPM2B_AUTH, data: TPM2B_SENSITIVE_DATA }.
+    // Both empty → 2 (userAuth.size) + 2 (data.size) = 4 content bytes.
+    cmd.extend_from_slice(&[0x00, 0x04]); // outer TPM2B size = 4
+    cmd.extend_from_slice(&[0x00, 0x00]); // userAuth.size = 0 (empty)
+    cmd.extend_from_slice(&[0x00, 0x00]); // data.size = 0 (empty)
 
     // inPublic: TPM2B_PUBLIC
     cmd.extend_from_slice(&(tpmt_public.len() as u16).to_be_bytes());
@@ -318,6 +335,7 @@ fn build_create_primary_owner(tpmt_public: &[u8]) -> Vec<u8> {
 /// `parent_handle` — handle from CreatePrimary
 /// `data` — the data to seal (≤256 bytes for RSA-2048 parent)
 /// `policy_digest` — 32-byte PCR policy digest
+#[inline] // R1: avoid sret aggregate-return on Vec<u8>
 fn build_create(parent_handle: u32, data: &[u8], policy_digest: &[u8; 32]) -> Vec<u8> {
     let mut cmd = Vec::with_capacity(4096);
 
@@ -357,6 +375,7 @@ fn build_create(parent_handle: u32, data: &[u8], policy_digest: &[u8; 32]) -> Ve
     cmd
 }
 
+#[inline] // R1: avoid sret aggregate-return on Vec<u8>
 fn build_keyedhash_public(policy_digest: &[u8; 32]) -> Vec<u8> {
     let mut p = Vec::with_capacity(64);
 
@@ -365,23 +384,22 @@ fn build_keyedhash_public(policy_digest: &[u8; 32]) -> Vec<u8> {
     p.extend_from_slice(&TPM_ALG_KEYEDHASH.to_be_bytes());
     //   nameAlg: TPM_ALG_SHA256
     p.extend_from_slice(&TPM_ALG_SHA256.to_be_bytes());
-    //   objectAttributes: fixedTPM | fixedParent | userWithAuth | signEncrypt
-    let attrs = TPMA_OBJECT_FIXEDTPM
-        | TPMA_OBJECT_FIXEDPARENT
-        | TPMA_OBJECT_USERWITHAUTH
-        | TPMA_OBJECT_SIGN_ENCRYPT;
+    //   objectAttributes: fixedTPM | fixedParent | userWithAuth.
+    //   Sealed-data objects (KEYEDHASH + scheme=NULL + externally-provided data)
+    //   MUST NOT have sign/decrypt/restricted/sensitiveDataOrigin set per TCG
+    //   Part 2 §11.2.4.10 — otherwise the TPM treats this as an HMAC key with
+    //   a contradictory NULL scheme, which IBM TPM2 ref impl rejects.
+    let attrs = TPMA_OBJECT_FIXEDTPM | TPMA_OBJECT_FIXEDPARENT | TPMA_OBJECT_USERWITHAUTH;
     p.extend_from_slice(&attrs.to_be_bytes());
 
     //   authPolicy: 32-byte policy digest
     p.extend_from_slice(&(32u16).to_be_bytes());
     p.extend_from_slice(policy_digest);
 
-    //   parameters (keyedhash union):
-    //     scheme: TPM_ALG_NULL (sealed data, not a signing key)
+    //   parameters (TPMS_KEYEDHASH_PARMS):
+    //     scheme: TPM_ALG_NULL (sealed data, not a signing/HMAC key).
+    //     TPMU_SCHEME_KEYEDHASH for ALG_NULL is empty per TCG Part 2 §11.1.20.
     p.extend_from_slice(&TPM_ALG_NULL.to_be_bytes());
-    //     scheme detail: keyedHashScheme (empty for NULL)
-    p.extend_from_slice(&[0x00, 0x00]); // TPM_ALG_NULL
-    p.extend_from_slice(&TPM_ALG_SHA256.to_be_bytes()); // hashAlg
 
     //   unique (keyedhash union):
     p.extend_from_slice(&[0x00, 0x00]); // zero-length unique
@@ -389,12 +407,14 @@ fn build_keyedhash_public(policy_digest: &[u8; 32]) -> Vec<u8> {
     p
 }
 
+#[inline] // R1: avoid sret aggregate-return on Vec<u8>
 fn build_sensitive_create(data: &[u8]) -> Vec<u8> {
     let mut s = Vec::with_capacity(data.len() + 8);
-    // TPM2B_SENSITIVE_CREATE outer size
-    let inner_size = 2 + data.len(); // auth(2) + data(size+data)
+    // TPM2B_SENSITIVE_CREATE wrapping TPMS_SENSITIVE_CREATE.
+    // Inner = userAuth (TPM2B_AUTH: 2-byte size, empty) + data (TPM2B_SENSITIVE_DATA: 2-byte size + payload).
+    let inner_size = 2 + 2 + data.len();
     s.extend_from_slice(&(inner_size as u16).to_be_bytes());
-    // userAuth = empty
+    // userAuth.size = 0 (empty)
     s.extend_from_slice(&[0x00, 0x00]);
     // data: TPM2B_SENSITIVE_DATA
     s.extend_from_slice(&(data.len() as u16).to_be_bytes());
@@ -407,6 +427,7 @@ fn build_sensitive_create(data: &[u8]) -> Vec<u8> {
 // ============================================================
 
 /// Build TPM2_Load command to load a sealed object into the TPM.
+#[inline] // R1: avoid sret aggregate-return on Vec<u8>
 fn build_load(parent_handle: u32, sealed_priv: &[u8], sealed_pub: &[u8]) -> Vec<u8> {
     let mut cmd = Vec::with_capacity(4096);
 
@@ -448,6 +469,7 @@ fn parse_load_handle(response: &[u8]) -> Result<u32, SvsmReqError> {
 // ============================================================
 
 /// Build TPM2_Unseal command.
+#[inline] // R1: avoid sret aggregate-return on Vec<u8>
 fn build_unseal(item_handle: u32) -> Vec<u8> {
     let mut cmd = Vec::with_capacity(256);
 
@@ -477,6 +499,7 @@ fn build_unseal(item_handle: u32) -> Vec<u8> {
 
 /// Extract unsealed data from TPM2_Unseal response.
 /// Response: tag(2) + size(4) + rc(4) + paramSize(4) + TPM2B_SENSITIVE_DATA
+#[inline] // R1: avoid sret aggregate-return on Vec<u8>
 fn parse_unseal_data(response: &[u8]) -> Result<Vec<u8>, SvsmReqError> {
     if response.len() < 16 {
         return Err(SvsmReqError::invalid_request());
@@ -493,6 +516,7 @@ fn parse_unseal_data(response: &[u8]) -> Result<Vec<u8>, SvsmReqError> {
 // TPM2_FlushContext
 // ============================================================
 
+#[inline] // R1: avoid sret aggregate-return on Vec<u8>
 fn build_flushcontext(handle: u32) -> Vec<u8> {
     let mut cmd = Vec::with_capacity(32);
 
@@ -515,6 +539,7 @@ fn build_flushcontext(handle: u32) -> Vec<u8> {
 ///
 /// This is a restricted decryption key used as parent for sealed objects.
 /// Matches tpm2-tools `tpm2_createprimary -C o -G rsa2048` behavior.
+#[inline] // R1: avoid sret aggregate-return on Vec<u8>
 fn build_rsa2048_storage_template() -> Vec<u8> {
     let mut t = Vec::with_capacity(64);
 
@@ -540,11 +565,9 @@ fn build_rsa2048_storage_template() -> Vec<u8> {
     t.extend_from_slice(&TPM_ALG_AES.to_be_bytes());
     t.extend_from_slice(&128u16.to_be_bytes()); // keyBits
     t.extend_from_slice(&TPM_ALG_CFB.to_be_bytes()); // mode
-    //   scheme: TPM_ALG_NULL (decrypt-only, not signing)
+    //   scheme: TPM_ALG_NULL (decrypt-only, not signing).
+    //   TPMU_ASYM_SCHEME for ALG_NULL is empty per TCG Part 2 §11.2.4.2.
     t.extend_from_slice(&TPM_ALG_NULL.to_be_bytes());
-    //   scheme detail
-    t.extend_from_slice(&[0x00, 0x00]); // TPM_ALG_NULL
-    t.extend_from_slice(&TPM_ALG_SHA256.to_be_bytes()); // hashAlg
     //   keyBits: 2048
     t.extend_from_slice(&2048u16.to_be_bytes());
     //   exponent: 0 (default = 65537)
@@ -570,6 +593,7 @@ pub struct TpmProxy<T: TpmTransport> {
     primary_handle: Option<u32>,
     pcr_policy_digest: [u8; 32],
     seal_counter: u64,
+    self_tested: bool,
 }
 
 impl<T: TpmTransport> TpmProxy<T> {
@@ -579,6 +603,7 @@ impl<T: TpmTransport> TpmProxy<T> {
             primary_handle: None,
             pcr_policy_digest: pcr_policy_digest_placeholder(),
             seal_counter: 0,
+            self_tested: false,
         }
     }
 
@@ -586,23 +611,73 @@ impl<T: TpmTransport> TpmProxy<T> {
         self.pcr_policy_digest = digest;
     }
 
+    /// Send a TPM command, automatically retrying on transient warnings
+    /// (`TPM_RC_RETRY` / `TPM_RC_TESTING` / `TPM_RC_NV_UNAVAILABLE`) per
+    /// TCG TPM 2.0 Part 1 §29.6.1 recommendation.
+    #[inline] // R1: avoid sret aggregate-return on Vec<u8>
+    fn send_with_retry(&self, cmd: &[u8]) -> Result<Vec<u8>, SvsmReqError> {
+        const MAX_RETRIES: usize = 8;
+        for attempt in 0..MAX_RETRIES {
+            let response = self.transport.send_command(cmd)?;
+            if response.len() < 10 {
+                return Ok(response);
+            }
+            let rc = tpm_cmd_rc(&response);
+            if rc != TPM_RC_RETRY && rc != TPM_RC_TESTING && rc != TPM_RC_NV_UNAVAILABLE {
+                return Ok(response);
+            }
+            log::warn!(
+                "TPM transient rc=0x{rc:x}, retry {}/{}",
+                attempt + 1,
+                MAX_RETRIES
+            );
+        }
+        log::error!("TPM exceeded {MAX_RETRIES} retries on transient rc");
+        Err(SvsmReqError::invalid_request())
+    }
+
+    /// Send TPM2_SelfTest(fullTest=YES) once, before the first key operation.
+    ///
+    /// IBM TPM 2.0 reference impl (used by swtpm) returns TPM_RC_RETRY (0x922)
+    /// when an algorithm is first exercised without prior self-test. Pre-testing
+    /// all algorithms avoids stalling the first TPM2_Create / keyedhash op.
+    fn ensure_self_tested(&mut self) -> Result<(), SvsmReqError> {
+        if self.self_tested {
+            return Ok(());
+        }
+        // TPM2_SelfTest: tag NO_SESSIONS | size 11 | cc 0x143 | fullTest=YES (0x01)
+        let mut cmd = Vec::with_capacity(11);
+        cmd.extend_from_slice(&TPM_ST_NO_SESSIONS.to_be_bytes());
+        cmd.extend_from_slice(&11u32.to_be_bytes());
+        cmd.extend_from_slice(&TPM_CC_SELF_TEST.to_be_bytes());
+        cmd.push(0x01); // fullTest = YES
+        let response = self.send_with_retry(&cmd)?;
+        let rc = tpm_cmd_rc(&response);
+        // Accept SUCCESS, INITIALIZE (0x100), or TESTING (0x90A — async self-test in progress).
+        if rc != TPM_RC_SUCCESS && rc != 0x100 && rc != 0x90A {
+            log::error!("TPM2_SelfTest failed rc=0x{rc:x}");
+            return Err(SvsmReqError::invalid_request());
+        }
+        log::info!("TPM2_SelfTest ok (rc=0x{rc:x})");
+        self.self_tested = true;
+        Ok(())
+    }
+
     /// Ensure primary storage key exists under Owner hierarchy.
     pub fn ensure_primary(&mut self) -> Result<u32, SvsmReqError> {
         if let Some(handle) = self.primary_handle {
             return Ok(handle);
         }
+        self.ensure_self_tested()?;
 
         let template = build_rsa2048_storage_template();
         let cmd = build_create_primary_owner(&template);
-        let response = self.transport.send_command(&cmd)?;
+        let response = self.send_with_retry(&cmd)?;
 
         let rc = tpm_cmd_rc(&response);
         if rc != TPM_RC_SUCCESS {
-            // TPM_RC_INITIALIZE (0x100) if TPM not started — that's ok,
-            // the handle from the command response may still be valid
-            if rc != 0x100 {
-                log::warn!("CreatePrimary returned rc=0x{rc:x}");
-            }
+            log::error!("CreatePrimary failed rc=0x{rc:x}");
+            return Err(SvsmReqError::invalid_request());
         }
 
         // Object handle is at offset 10 in response
@@ -622,12 +697,13 @@ impl<T: TpmTransport> TpmProxy<T> {
     ///
     /// This seals only the AES key (60 bytes in practice), not bulk data.
     /// Bulk data is AES-256-GCM encrypted separately by the caller.
+    #[inline] // R1: avoid sret aggregate-return on (Vec<u8>, Vec<u8>)
     pub fn seal_payload(&mut self, payload: &[u8]) -> Result<(Vec<u8>, Vec<u8>), SvsmReqError> {
         let parent_handle = self.ensure_primary()?;
         self.seal_counter += 1;
 
         let cmd = build_create(parent_handle, payload, &self.pcr_policy_digest);
-        let response = self.transport.send_command(&cmd)?;
+        let response = self.send_with_retry(&cmd)?;
 
         let rc = tpm_cmd_rc(&response);
         if rc != TPM_RC_SUCCESS {
@@ -667,6 +743,7 @@ impl<T: TpmTransport> TpmProxy<T> {
     ///
     /// Loads the sealed object via TPM2_Load, then unseals via TPM2_Unseal.
     /// Returns the recovered plaintext payload (the AES key).
+    #[inline] // R1: avoid sret aggregate-return on Vec<u8>
     pub fn unseal_payload(
         &mut self,
         sealed_priv: &[u8],
@@ -676,7 +753,7 @@ impl<T: TpmTransport> TpmProxy<T> {
 
         // Step 1: Load
         let load_cmd = build_load(parent_handle, sealed_priv, sealed_pub);
-        let load_response = self.transport.send_command(&load_cmd)?;
+        let load_response = self.send_with_retry(&load_cmd)?;
 
         let rc = tpm_cmd_rc(&load_response);
         if rc != TPM_RC_SUCCESS {
@@ -688,7 +765,7 @@ impl<T: TpmTransport> TpmProxy<T> {
 
         // Step 2: Unseal
         let unseal_cmd = build_unseal(item_handle);
-        let unseal_response = self.transport.send_command(&unseal_cmd)?;
+        let unseal_response = self.send_with_retry(&unseal_cmd)?;
 
         let rc = tpm_cmd_rc(&unseal_response);
         if rc != TPM_RC_SUCCESS {

--- a/kernel/src/vtpm/proxy.rs
+++ b/kernel/src/vtpm/proxy.rs
@@ -65,6 +65,7 @@ const TPMA_OBJECT_RESTRICTED: u32 = 0x00010000;
 /// Implementations must preserve TPM command/response message boundaries.
 ///
 /// Bundled implementations:
+/// - `VsockTransport`  — AF_VSOCK to the host (feature-gated `vsock`)
 /// - `MockTransport`   — records commands for unit testing
 pub trait TpmTransport {
     fn send_command(&self, command: &[u8]) -> Result<Vec<u8>, SvsmReqError>;
@@ -116,6 +117,119 @@ impl TpmTransport for MockTransport {
             .borrow_mut()
             .pop_front()
             .ok_or(SvsmReqError::invalid_request())
+    }
+}
+
+// ============================================================
+// VsockTransport — AF_VSOCK to a host-side TPM forwarder
+// ============================================================
+
+/// AF_VSOCK transport to a host-side TPM endpoint.
+///
+/// On each `send_command`:
+/// 1. Opens a VSOCK connection to host (CID=2) on the configured port
+/// 2. Sends the raw TPM command buffer
+/// 3. Reads the TPM response (header first to get total size, then body)
+/// 4. Closes the connection
+///
+/// This one-command-per-connection model avoids TPM session state issues.
+/// The host side needs a lightweight forwarder such as:
+///   `socat VSOCK-LISTEN:9999,fork OPEN:/dev/tpm0`
+#[cfg(feature = "vsock")]
+#[derive(Debug)]
+pub struct VsockTransport {
+    remote_cid: u32,
+    remote_port: u32,
+}
+
+#[cfg(feature = "vsock")]
+impl VsockTransport {
+    /// Default VSOCK port for TPM forwarding.
+    pub const DEFAULT_TPM_PORT: u32 = 9999;
+    /// Host CID (always 2 in VSOCK).
+    pub const HOST_CID: u32 = 2;
+
+    pub fn new(remote_cid: u32, remote_port: u32) -> Self {
+        Self {
+            remote_cid,
+            remote_port,
+        }
+    }
+}
+
+#[cfg(feature = "vsock")]
+impl TpmTransport for VsockTransport {
+    fn send_command(&self, command: &[u8]) -> Result<Vec<u8>, SvsmReqError> {
+        use crate::io::{Read, Write};
+        use crate::vsock::stream::VsockStream;
+
+        // Open fresh connection for each command
+        let mut stream = VsockStream::connect(self.remote_port, self.remote_cid).map_err(|_| {
+            log::error!(
+                "VsockTransport: failed to connect to {}:{}",
+                self.remote_cid,
+                self.remote_port
+            );
+            SvsmReqError::invalid_request()
+        })?;
+
+        // Send TPM command
+        let written = stream.write(command).map_err(|_| {
+            log::error!("VsockTransport: write failed");
+            SvsmReqError::invalid_request()
+        })?;
+        if written != command.len() {
+            log::error!("VsockTransport: short write {}/{}", written, command.len());
+            return Err(SvsmReqError::invalid_request());
+        }
+
+        // Read TPM response header: tag(2) + size(4) + rc(4) = 10 bytes minimum
+        let mut header = [0u8; 10];
+        let n = stream.read(&mut header).map_err(|_| {
+            log::error!("VsockTransport: header read failed");
+            SvsmReqError::invalid_request()
+        })?;
+        if n < 10 {
+            log::error!("VsockTransport: short header read {n}/10");
+            return Err(SvsmReqError::invalid_request());
+        }
+
+        // Parse total response size from bytes 2..6 (big-endian u32)
+        let resp_size = u32::from_be_bytes(header[2..6].try_into().unwrap()) as usize;
+
+        if !(10..=4096).contains(&resp_size) {
+            log::error!("VsockTransport: invalid response size {resp_size}");
+            return Err(SvsmReqError::invalid_request());
+        }
+
+        let mut response = Vec::with_capacity(resp_size);
+        response.extend_from_slice(&header);
+
+        // Read remaining response body
+        let remaining = resp_size - 10;
+        if remaining > 0 {
+            let mut buf = alloc::vec![0u8; remaining];
+            let mut total_read = 0usize;
+            while total_read < remaining {
+                let n = stream.read(&mut buf[total_read..]).map_err(|_| {
+                    log::error!("VsockTransport: body read failed at {total_read}/{remaining}");
+                    SvsmReqError::invalid_request()
+                })?;
+                if n == 0 {
+                    // Peer closed — partial read is an error if we expected more
+                    break;
+                }
+                total_read += n;
+            }
+            if total_read < remaining {
+                log::error!("VsockTransport: short body read {total_read}/{remaining}");
+                return Err(SvsmReqError::invalid_request());
+            }
+            response.extend_from_slice(&buf);
+        }
+
+        // stream dropped → connection shutdown
+        Ok(response)
     }
 }
 

--- a/kernel/src/vtpm/proxy.rs
+++ b/kernel/src/vtpm/proxy.rs
@@ -1,0 +1,836 @@
+// SPDX-License-Identifier: MIT
+//
+// vTPM proxy: TPM 2.0 command construction over a pluggable transport.
+//
+// Constructs raw TPM 2.0 command buffers (CreatePrimary, Create, Load,
+// Unseal, FlushContext, NV_*) and sends them to a TPM endpoint reachable
+// through an implementation of `TpmTransport`. The endpoint may be a
+// software vTPM (development/testing), a physical discrete TPM
+// (hardware-anchored persistence), or any other out-of-CVM TPM service.
+// Runs in VMPL0; the transport itself crosses the CVM boundary.
+
+extern crate alloc;
+
+use crate::protocols::errors::SvsmReqError;
+use alloc::collections::VecDeque;
+use alloc::vec::Vec;
+
+// ============================================================
+// TPM 2.0 Constants
+// ============================================================
+
+const TPM_ST_SESSIONS: u16 = 0x8002;
+const TPM_CC_CREATEPRIMARY: u32 = 0x00000131;
+const TPM_CC_CREATE: u32 = 0x00000153;
+const TPM_CC_LOAD: u32 = 0x00000157;
+const TPM_CC_UNSEAL: u32 = 0x0000015E;
+const TPM_CC_FLUSHCONTEXT: u32 = 0x00000165;
+
+const TPM_RH_OWNER: u32 = 0x40000001;
+#[allow(dead_code)]
+const TPM_RH_NULL: u32 = 0x40000007;
+#[allow(dead_code)]
+const TPM_RS_PW: u32 = 0x40000009;
+
+const TPM_ALG_SHA256: u16 = 0x000B;
+const TPM_ALG_RSA: u16 = 0x0001;
+const TPM_ALG_AES: u16 = 0x0006;
+const TPM_ALG_CFB: u16 = 0x0043;
+const TPM_ALG_KEYEDHASH: u16 = 0x0008;
+const TPM_ALG_NULL: u16 = 0x0010;
+#[allow(dead_code)]
+const TPM_ALG_POLICY: u16 = 0x000F;
+
+const TPM_RC_SUCCESS: u32 = 0;
+
+// TPMA_OBJECT flags
+const TPMA_OBJECT_FIXEDTPM: u32 = 0x00000002;
+const TPMA_OBJECT_FIXEDPARENT: u32 = 0x00000010;
+const TPMA_OBJECT_SENSITIVEDATAORIGIN: u32 = 0x00000020;
+const TPMA_OBJECT_USERWITHAUTH: u32 = 0x00000040;
+const TPMA_OBJECT_SIGN_ENCRYPT: u32 = 0x00040000;
+const TPMA_OBJECT_DECRYPT: u32 = 0x00020000;
+const TPMA_OBJECT_RESTRICTED: u32 = 0x00010000;
+
+// ============================================================
+// Transport Abstraction
+// ============================================================
+
+/// Pluggable transport for sending TPM 2.0 commands to an out-of-CVM TPM
+/// endpoint. Endpoints may include:
+///   - a software vTPM running on the host (development / testing)
+///   - a physical discrete TPM (hardware-anchored persistence)
+///   - a KBS-backed TPM service (future)
+///
+/// Implementations must preserve TPM command/response message boundaries.
+///
+/// Bundled implementations:
+/// - `MockTransport`   — records commands for unit testing
+pub trait TpmTransport {
+    fn send_command(&self, command: &[u8]) -> Result<Vec<u8>, SvsmReqError>;
+}
+
+// ============================================================
+// MockTransport — for unit testing without real TPM
+// ============================================================
+
+/// A mock transport that records commands and returns canned responses.
+/// Useful for unit tests of TpmProxy logic without requiring a real TPM.
+#[derive(Debug, Default)]
+pub struct MockTransport {
+    pub commands: core::cell::RefCell<Vec<Vec<u8>>>,
+    canned_responses: core::cell::RefCell<VecDeque<Vec<u8>>>,
+}
+
+impl MockTransport {
+    pub fn new() -> Self {
+        Self {
+            commands: core::cell::RefCell::new(Vec::new()),
+            canned_responses: core::cell::RefCell::new(VecDeque::new()),
+        }
+    }
+
+    /// Enqueue a response to be returned by the next pending
+    /// `send_command` call. Multiple calls form a FIFO queue.
+    pub fn set_response(&self, response: Vec<u8>) {
+        self.canned_responses.borrow_mut().push_back(response);
+    }
+
+    /// Build a minimal success response for the given command code.
+    /// Response layout: tag(2) + size(4) + rc(4) + [optional data]
+    pub fn build_ok_response(_cc: u32, extra: &[u8]) -> Vec<u8> {
+        let mut r = Vec::with_capacity(10 + extra.len());
+        r.extend_from_slice(&0x8002u16.to_be_bytes()); // TPM_ST_SESSIONS
+        let size = (10 + extra.len()) as u32;
+        r.extend_from_slice(&size.to_be_bytes());
+        r.extend_from_slice(&0u32.to_be_bytes()); // TPM_RC_SUCCESS
+        r.extend_from_slice(extra);
+        r
+    }
+}
+
+impl TpmTransport for MockTransport {
+    fn send_command(&self, command: &[u8]) -> Result<Vec<u8>, SvsmReqError> {
+        self.commands.borrow_mut().push(command.to_vec());
+        self.canned_responses
+            .borrow_mut()
+            .pop_front()
+            .ok_or(SvsmReqError::invalid_request())
+    }
+}
+
+// ============================================================
+// TPM Command Builder Helpers
+// ============================================================
+
+fn extend_empty_auth(buf: &mut Vec<u8>) {
+    buf.extend_from_slice(&[
+        0x00, 0x00, 0x00, 0x09, // auth size
+        0x40, 0x00, 0x00, 0x09, // session handle = TPM_RS_PW
+        0x00, 0x00, // nonce = empty
+        0x01, // sessionAttributes = continueSession
+        0x00, 0x00, // password = empty
+    ]);
+}
+
+fn tpm_cmd_rc(cmd: &[u8]) -> u32 {
+    u32::from_be_bytes(cmd[6..10].try_into().unwrap())
+}
+
+fn pcr_policy_digest_placeholder() -> [u8; 32] {
+    // Zero digest: "seal to any PCR state" for prototype.
+    // Production: derive from actual PCR policy via TPM2_PolicyPCR.
+    [0u8; 32]
+}
+
+#[allow(dead_code)]
+fn build_pcr_selection(pcr_mask: &[u8]) -> Vec<u8> {
+    let mut sel = Vec::with_capacity(8);
+    sel.extend_from_slice(&TPM_ALG_SHA256.to_be_bytes());
+    sel.push(pcr_mask.len() as u8);
+    sel.extend_from_slice(pcr_mask);
+    sel
+}
+
+// ============================================================
+// TPM2_CreatePrimary (Owner Hierarchy)
+// ============================================================
+
+/// Build TPM2_CreatePrimary command for Owner hierarchy.
+///
+/// Creates a primary storage key under TPM_RH_OWNER used as parent
+/// for subsequent TPM2_Create (seal) operations.
+fn build_create_primary_owner(tpmt_public: &[u8]) -> Vec<u8> {
+    let mut cmd = Vec::with_capacity(4096);
+
+    // Command header
+    cmd.extend_from_slice(&TPM_ST_SESSIONS.to_be_bytes());
+    cmd.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // size placeholder
+    cmd.extend_from_slice(&TPM_CC_CREATEPRIMARY.to_be_bytes());
+
+    // Handle: TPM_RH_OWNER
+    cmd.extend_from_slice(&TPM_RH_OWNER.to_be_bytes());
+
+    // Authorization block
+    extend_empty_auth(&mut cmd);
+
+    // inSensitive: TPM2B_SENSITIVE_CREATE
+    cmd.extend_from_slice(&[0x00, 0x04]); // size
+    cmd.extend_from_slice(&[0x00, 0x00]); // userAuth = empty
+
+    // inPublic: TPM2B_PUBLIC
+    cmd.extend_from_slice(&(tpmt_public.len() as u16).to_be_bytes());
+    cmd.extend_from_slice(tpmt_public);
+
+    // outsideInfo
+    cmd.extend_from_slice(&[0x00, 0x00]);
+
+    // creationPCR
+    cmd.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
+
+    // Patch size
+    let sz = cmd.len() as u32;
+    cmd[2..6].copy_from_slice(&sz.to_be_bytes());
+
+    cmd
+}
+
+// ============================================================
+// TPM2_Create (Seal)
+// ============================================================
+
+/// Build TPM2_Create command to seal data under a parent key.
+///
+/// `parent_handle` — handle from CreatePrimary
+/// `data` — the data to seal (≤256 bytes for RSA-2048 parent)
+/// `policy_digest` — 32-byte PCR policy digest
+fn build_create(parent_handle: u32, data: &[u8], policy_digest: &[u8; 32]) -> Vec<u8> {
+    let mut cmd = Vec::with_capacity(4096);
+
+    // Build TPMT_PUBLIC for a keyedhash (sealed data) object
+    let tpmt_public = build_keyedhash_public(policy_digest);
+
+    let in_sensitive_data = build_sensitive_create(data);
+
+    // Command header
+    cmd.extend_from_slice(&TPM_ST_SESSIONS.to_be_bytes());
+    cmd.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // size placeholder
+    cmd.extend_from_slice(&TPM_CC_CREATE.to_be_bytes());
+
+    // Handle: parent key
+    cmd.extend_from_slice(&parent_handle.to_be_bytes());
+
+    // Authorization block
+    extend_empty_auth(&mut cmd);
+
+    // inSensitive
+    cmd.extend_from_slice(&in_sensitive_data);
+
+    // inPublic
+    cmd.extend_from_slice(&(tpmt_public.len() as u16).to_be_bytes());
+    cmd.extend_from_slice(&tpmt_public);
+
+    // outsideInfo
+    cmd.extend_from_slice(&[0x00, 0x00]);
+
+    // creationPCR
+    cmd.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
+
+    // Patch size
+    let sz = cmd.len() as u32;
+    cmd[2..6].copy_from_slice(&sz.to_be_bytes());
+
+    cmd
+}
+
+fn build_keyedhash_public(policy_digest: &[u8; 32]) -> Vec<u8> {
+    let mut p = Vec::with_capacity(64);
+
+    // TPMT_PUBLIC:
+    //   type: TPM_ALG_KEYEDHASH
+    p.extend_from_slice(&TPM_ALG_KEYEDHASH.to_be_bytes());
+    //   nameAlg: TPM_ALG_SHA256
+    p.extend_from_slice(&TPM_ALG_SHA256.to_be_bytes());
+    //   objectAttributes: fixedTPM | fixedParent | userWithAuth | signEncrypt
+    let attrs = TPMA_OBJECT_FIXEDTPM
+        | TPMA_OBJECT_FIXEDPARENT
+        | TPMA_OBJECT_USERWITHAUTH
+        | TPMA_OBJECT_SIGN_ENCRYPT;
+    p.extend_from_slice(&attrs.to_be_bytes());
+
+    //   authPolicy: 32-byte policy digest
+    p.extend_from_slice(&(32u16).to_be_bytes());
+    p.extend_from_slice(policy_digest);
+
+    //   parameters (keyedhash union):
+    //     scheme: TPM_ALG_NULL (sealed data, not a signing key)
+    p.extend_from_slice(&TPM_ALG_NULL.to_be_bytes());
+    //     scheme detail: keyedHashScheme (empty for NULL)
+    p.extend_from_slice(&[0x00, 0x00]); // TPM_ALG_NULL
+    p.extend_from_slice(&TPM_ALG_SHA256.to_be_bytes()); // hashAlg
+
+    //   unique (keyedhash union):
+    p.extend_from_slice(&[0x00, 0x00]); // zero-length unique
+
+    p
+}
+
+fn build_sensitive_create(data: &[u8]) -> Vec<u8> {
+    let mut s = Vec::with_capacity(data.len() + 8);
+    // TPM2B_SENSITIVE_CREATE outer size
+    let inner_size = 2 + data.len(); // auth(2) + data(size+data)
+    s.extend_from_slice(&(inner_size as u16).to_be_bytes());
+    // userAuth = empty
+    s.extend_from_slice(&[0x00, 0x00]);
+    // data: TPM2B_SENSITIVE_DATA
+    s.extend_from_slice(&(data.len() as u16).to_be_bytes());
+    s.extend_from_slice(data);
+    s
+}
+
+// ============================================================
+// TPM2_Load
+// ============================================================
+
+/// Build TPM2_Load command to load a sealed object into the TPM.
+fn build_load(parent_handle: u32, sealed_priv: &[u8], sealed_pub: &[u8]) -> Vec<u8> {
+    let mut cmd = Vec::with_capacity(4096);
+
+    cmd.extend_from_slice(&TPM_ST_SESSIONS.to_be_bytes());
+    cmd.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // size placeholder
+    cmd.extend_from_slice(&TPM_CC_LOAD.to_be_bytes());
+
+    // Handle: parent key
+    cmd.extend_from_slice(&parent_handle.to_be_bytes());
+
+    // Authorization block
+    extend_empty_auth(&mut cmd);
+
+    // inPrivate: TPM2B_PRIVATE
+    cmd.extend_from_slice(&(sealed_priv.len() as u16).to_be_bytes());
+    cmd.extend_from_slice(sealed_priv);
+
+    // inPublic: TPM2B_PUBLIC
+    cmd.extend_from_slice(&(sealed_pub.len() as u16).to_be_bytes());
+    cmd.extend_from_slice(sealed_pub);
+
+    // Patch size
+    let sz = cmd.len() as u32;
+    cmd[2..6].copy_from_slice(&sz.to_be_bytes());
+
+    cmd
+}
+
+/// Extract object handle from TPM2_Load response (offset 10, u32).
+fn parse_load_handle(response: &[u8]) -> Result<u32, SvsmReqError> {
+    if response.len() < 14 {
+        return Err(SvsmReqError::invalid_request());
+    }
+    Ok(u32::from_be_bytes(response[10..14].try_into().unwrap()))
+}
+
+// ============================================================
+// TPM2_Unseal
+// ============================================================
+
+/// Build TPM2_Unseal command.
+fn build_unseal(item_handle: u32) -> Vec<u8> {
+    let mut cmd = Vec::with_capacity(256);
+
+    cmd.extend_from_slice(&TPM_ST_SESSIONS.to_be_bytes());
+    cmd.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // size placeholder
+    cmd.extend_from_slice(&TPM_CC_UNSEAL.to_be_bytes());
+
+    // Handle: loaded object
+    cmd.extend_from_slice(&item_handle.to_be_bytes());
+
+    // Authorization: password session with empty password
+    // TPM_RS_PW session
+    cmd.extend_from_slice(&[
+        0x00, 0x00, 0x00, 0x09, // auth size
+        0x40, 0x00, 0x00, 0x09, // session handle = TPM_RS_PW
+        0x00, 0x00, // nonce = empty
+        0x01, // continueSession
+        0x00, 0x00, // password = empty
+    ]);
+
+    // Patch size
+    let sz = cmd.len() as u32;
+    cmd[2..6].copy_from_slice(&sz.to_be_bytes());
+
+    cmd
+}
+
+/// Extract unsealed data from TPM2_Unseal response.
+/// Response: tag(2) + size(4) + rc(4) + paramSize(4) + TPM2B_SENSITIVE_DATA
+fn parse_unseal_data(response: &[u8]) -> Result<Vec<u8>, SvsmReqError> {
+    if response.len() < 16 {
+        return Err(SvsmReqError::invalid_request());
+    }
+    // outData: TPM2B_SENSITIVE_DATA at offset 14
+    let data_size = u16::from_be_bytes(response[14..16].try_into().unwrap()) as usize;
+    if response.len() < 16 + data_size {
+        return Err(SvsmReqError::invalid_request());
+    }
+    Ok(response[16..16 + data_size].to_vec())
+}
+
+// ============================================================
+// TPM2_FlushContext
+// ============================================================
+
+fn build_flushcontext(handle: u32) -> Vec<u8> {
+    let mut cmd = Vec::with_capacity(32);
+
+    cmd.extend_from_slice(&[0x80, 0x01]); // TPM_ST_NO_SESSIONS
+    cmd.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // size placeholder
+    cmd.extend_from_slice(&TPM_CC_FLUSHCONTEXT.to_be_bytes());
+    cmd.extend_from_slice(&handle.to_be_bytes());
+
+    let sz = cmd.len() as u32;
+    cmd[2..6].copy_from_slice(&sz.to_be_bytes());
+
+    cmd
+}
+
+// ============================================================
+// Default RSA 2048 Primary Key Template (Owner Hierarchy)
+// ============================================================
+
+/// Build TPMT_PUBLIC for an RSA-2048 storage key under Owner hierarchy.
+///
+/// This is a restricted decryption key used as parent for sealed objects.
+/// Matches tpm2-tools `tpm2_createprimary -C o -G rsa2048` behavior.
+fn build_rsa2048_storage_template() -> Vec<u8> {
+    let mut t = Vec::with_capacity(64);
+
+    // type: TPM_ALG_RSA
+    t.extend_from_slice(&TPM_ALG_RSA.to_be_bytes());
+    // nameAlg: TPM_ALG_SHA256
+    t.extend_from_slice(&TPM_ALG_SHA256.to_be_bytes());
+    // objectAttributes: restricted | decrypt | fixedTPM | fixedParent
+    //   | sensitiveDataOrigin | userWithAuth
+    let attrs = TPMA_OBJECT_RESTRICTED
+        | TPMA_OBJECT_DECRYPT
+        | TPMA_OBJECT_FIXEDTPM
+        | TPMA_OBJECT_FIXEDPARENT
+        | TPMA_OBJECT_SENSITIVEDATAORIGIN
+        | TPMA_OBJECT_USERWITHAUTH;
+    t.extend_from_slice(&attrs.to_be_bytes());
+
+    // authPolicy: empty
+    t.extend_from_slice(&[0x00, 0x00]);
+
+    // parameters (RSA union):
+    //   symmetric: TPM_ALG_AES + 128 + CFB
+    t.extend_from_slice(&TPM_ALG_AES.to_be_bytes());
+    t.extend_from_slice(&128u16.to_be_bytes()); // keyBits
+    t.extend_from_slice(&TPM_ALG_CFB.to_be_bytes()); // mode
+    //   scheme: TPM_ALG_NULL (decrypt-only, not signing)
+    t.extend_from_slice(&TPM_ALG_NULL.to_be_bytes());
+    //   scheme detail
+    t.extend_from_slice(&[0x00, 0x00]); // TPM_ALG_NULL
+    t.extend_from_slice(&TPM_ALG_SHA256.to_be_bytes()); // hashAlg
+    //   keyBits: 2048
+    t.extend_from_slice(&2048u16.to_be_bytes());
+    //   exponent: 0 (default = 65537)
+    t.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
+
+    // unique (RSA union): zero-length
+    t.extend_from_slice(&[0x00, 0x00]);
+
+    t
+}
+
+// ============================================================
+// TpmProxy
+// ============================================================
+
+/// Proxy that constructs TPM seal/unseal commands and sends them
+/// to the physical TPM via a transport.
+///
+/// Operates entirely within VMPL0 — no sockets, no JSON, no separate process.
+#[derive(Debug)]
+pub struct TpmProxy<T: TpmTransport> {
+    transport: T,
+    primary_handle: Option<u32>,
+    pcr_policy_digest: [u8; 32],
+    seal_counter: u64,
+}
+
+impl<T: TpmTransport> TpmProxy<T> {
+    pub fn new(transport: T) -> Self {
+        Self {
+            transport,
+            primary_handle: None,
+            pcr_policy_digest: pcr_policy_digest_placeholder(),
+            seal_counter: 0,
+        }
+    }
+
+    pub fn set_pcr_policy(&mut self, digest: [u8; 32]) {
+        self.pcr_policy_digest = digest;
+    }
+
+    /// Ensure primary storage key exists under Owner hierarchy.
+    pub fn ensure_primary(&mut self) -> Result<u32, SvsmReqError> {
+        if let Some(handle) = self.primary_handle {
+            return Ok(handle);
+        }
+
+        let template = build_rsa2048_storage_template();
+        let cmd = build_create_primary_owner(&template);
+        let response = self.transport.send_command(&cmd)?;
+
+        let rc = tpm_cmd_rc(&response);
+        if rc != TPM_RC_SUCCESS {
+            // TPM_RC_INITIALIZE (0x100) if TPM not started — that's ok,
+            // the handle from the command response may still be valid
+            if rc != 0x100 {
+                log::warn!("CreatePrimary returned rc=0x{rc:x}");
+            }
+        }
+
+        // Object handle is at offset 10 in response
+        if response.len() < 14 {
+            return Err(SvsmReqError::invalid_request());
+        }
+        let handle = u32::from_be_bytes(response[10..14].try_into().unwrap());
+        self.primary_handle = Some(handle);
+        Ok(handle)
+    }
+
+    /// Seal a payload (≤256 bytes) under the physical TPM.
+    ///
+    /// Returns (sealed_private, sealed_public) — the TPM2B_PRIVATE and
+    /// TPM2B_PUBLIC from the TPM2_Create response, which together form
+    /// the sealed object stored to disk.
+    ///
+    /// This seals only the AES key (60 bytes in practice), not bulk data.
+    /// Bulk data is AES-256-GCM encrypted separately by the caller.
+    pub fn seal_payload(&mut self, payload: &[u8]) -> Result<(Vec<u8>, Vec<u8>), SvsmReqError> {
+        let parent_handle = self.ensure_primary()?;
+        self.seal_counter += 1;
+
+        let cmd = build_create(parent_handle, payload, &self.pcr_policy_digest);
+        let response = self.transport.send_command(&cmd)?;
+
+        let rc = tpm_cmd_rc(&response);
+        if rc != TPM_RC_SUCCESS {
+            log::error!("TPM2_Create failed rc=0x{rc:x}");
+            return Err(SvsmReqError::invalid_request());
+        }
+
+        // Parse TPM2_Create response:
+        // tag(2) + size(4) + rc(4) + paramSize(4)
+        // + outPrivate: TPM2B_PRIVATE  (offset 14)
+        // + outPublic: TPM2B_PUBLIC
+        let mut offset = 14;
+
+        // outPrivate
+        if response.len() < offset + 2 {
+            return Err(SvsmReqError::invalid_request());
+        }
+        let priv_size =
+            u16::from_be_bytes(response[offset..offset + 2].try_into().unwrap()) as usize;
+        offset += 2;
+        let sealed_priv = response[offset..offset + priv_size].to_vec();
+        offset += priv_size;
+
+        // outPublic
+        if response.len() < offset + 2 {
+            return Err(SvsmReqError::invalid_request());
+        }
+        let pub_size =
+            u16::from_be_bytes(response[offset..offset + 2].try_into().unwrap()) as usize;
+        offset += 2;
+        let sealed_pub = response[offset..offset + pub_size].to_vec();
+
+        Ok((sealed_priv, sealed_pub))
+    }
+
+    /// Unseal a previously sealed payload.
+    ///
+    /// Loads the sealed object via TPM2_Load, then unseals via TPM2_Unseal.
+    /// Returns the recovered plaintext payload (the AES key).
+    pub fn unseal_payload(
+        &mut self,
+        sealed_priv: &[u8],
+        sealed_pub: &[u8],
+    ) -> Result<Vec<u8>, SvsmReqError> {
+        let parent_handle = self.ensure_primary()?;
+
+        // Step 1: Load
+        let load_cmd = build_load(parent_handle, sealed_priv, sealed_pub);
+        let load_response = self.transport.send_command(&load_cmd)?;
+
+        let rc = tpm_cmd_rc(&load_response);
+        if rc != TPM_RC_SUCCESS {
+            log::error!("TPM2_Load failed rc=0x{rc:x}");
+            return Err(SvsmReqError::invalid_request());
+        }
+
+        let item_handle = parse_load_handle(&load_response)?;
+
+        // Step 2: Unseal
+        let unseal_cmd = build_unseal(item_handle);
+        let unseal_response = self.transport.send_command(&unseal_cmd)?;
+
+        let rc = tpm_cmd_rc(&unseal_response);
+        if rc != TPM_RC_SUCCESS {
+            log::error!("TPM2_Unseal failed rc=0x{rc:x}");
+            return Err(SvsmReqError::invalid_request());
+        }
+
+        let data = parse_unseal_data(&unseal_response)?;
+
+        // Step 3: Flush loaded object
+        let flush_cmd = build_flushcontext(item_handle);
+        let _ = self.transport.send_command(&flush_cmd);
+
+        Ok(data)
+    }
+
+    /// Flush the primary key handle (call before shutdown).
+    pub fn flush_primary(&mut self) {
+        if let Some(handle) = self.primary_handle.take() {
+            let cmd = build_flushcontext(handle);
+            let _ = self.transport.send_command(&cmd);
+        }
+    }
+
+    pub fn seal_counter(&self) -> u64 {
+        self.seal_counter
+    }
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a minimal CreatePrimary success response.
+    /// Returns a fake object handle (0x81000000).
+    fn fake_create_primary_response() -> Vec<u8> {
+        let handle: u32 = 0x81000000;
+        let extra = handle.to_be_bytes().to_vec();
+        MockTransport::build_ok_response(TPM_CC_CREATEPRIMARY, &extra)
+    }
+
+    /// Build a minimal Create success response.
+    /// Returns outPrivate = b"sealed_priv_data" + outPublic = b"sealed_pub_data".
+    fn fake_create_response() -> Vec<u8> {
+        let priv_data = b"sealed_priv_data";
+        let pub_data = b"sealed_pub_data";
+        let payload_size = 2 + priv_data.len() + 2 + pub_data.len();
+        let mut extra = Vec::new();
+        // paramSize (TPM_ST_SESSIONS response carries a 4-byte parameter
+        // size before the response parameters).
+        extra.extend_from_slice(&(payload_size as u32).to_be_bytes());
+        extra.extend_from_slice(&(priv_data.len() as u16).to_be_bytes());
+        extra.extend_from_slice(priv_data);
+        extra.extend_from_slice(&(pub_data.len() as u16).to_be_bytes());
+        extra.extend_from_slice(pub_data);
+        MockTransport::build_ok_response(TPM_CC_CREATE, &extra)
+    }
+
+    /// Build a minimal Load success response.
+    fn fake_load_response() -> Vec<u8> {
+        let handle: u32 = 0x81000001;
+        let extra = handle.to_be_bytes().to_vec();
+        MockTransport::build_ok_response(TPM_CC_LOAD, &extra)
+    }
+
+    /// Build a minimal Unseal success response.
+    fn fake_unseal_response(data: &[u8]) -> Vec<u8> {
+        let mut extra = Vec::new();
+        // paramSize (4 bytes)
+        extra.extend_from_slice(&(data.len() as u32 + 2).to_be_bytes());
+        // TPM2B_SENSITIVE_DATA: size(2) + data
+        extra.extend_from_slice(&(data.len() as u16).to_be_bytes());
+        extra.extend_from_slice(data);
+        MockTransport::build_ok_response(TPM_CC_UNSEAL, &extra)
+    }
+
+    fn fake_flush_response() -> Vec<u8> {
+        // FlushContext response has no extra data
+        MockTransport::build_ok_response(TPM_CC_FLUSHCONTEXT, &[])
+    }
+
+    #[test]
+    fn test_create_primary_command_structure() {
+        let transport = MockTransport::new();
+        transport.set_response(fake_create_primary_response());
+
+        let mut proxy = TpmProxy::new(transport);
+        let handle = proxy.ensure_primary().unwrap();
+
+        assert_eq!(handle, 0x81000000);
+        assert_eq!(proxy.seal_counter(), 0);
+
+        // Verify the recorded command
+        let cmds = proxy.transport.commands.borrow();
+        let cmd = &cmds[0];
+        // tag = TPM_ST_SESSIONS (0x8002)
+        assert_eq!(u16::from_be_bytes(cmd[0..2].try_into().unwrap()), 0x8002);
+        // command code = TPM_CC_CREATEPRIMARY
+        assert_eq!(
+            u32::from_be_bytes(cmd[6..10].try_into().unwrap()),
+            TPM_CC_CREATEPRIMARY
+        );
+        // handle area starts at offset 10 = TPM_RH_OWNER
+        assert_eq!(
+            u32::from_be_bytes(cmd[10..14].try_into().unwrap()),
+            TPM_RH_OWNER
+        );
+    }
+
+    #[test]
+    fn test_seal_payload_command() {
+        let transport = MockTransport::new();
+        transport.set_response(fake_create_primary_response());
+        transport.set_response(fake_create_response());
+
+        let mut proxy = TpmProxy::new(transport);
+        let payload = b"test_payload_60_bytes_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+
+        let (sealed_priv, sealed_pub) = proxy.seal_payload(payload).unwrap();
+
+        assert_eq!(sealed_priv, b"sealed_priv_data");
+        assert_eq!(sealed_pub, b"sealed_pub_data");
+        assert_eq!(proxy.seal_counter(), 1);
+
+        // Verify Create command was sent
+        let cmds = proxy.transport.commands.borrow();
+        assert_eq!(cmds.len(), 2); // CreatePrimary + Create
+        let create_cmd = &cmds[1];
+        assert_eq!(
+            u32::from_be_bytes(create_cmd[6..10].try_into().unwrap()),
+            TPM_CC_CREATE
+        );
+    }
+
+    #[test]
+    fn test_unseal_payload_roundtrip() {
+        let transport = MockTransport::new();
+        let original_payload = b"test_payload_60_bytes_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+
+        // Set up canned responses for the full sequence:
+        // CreatePrimary → Create → (stash priv/pub) → CreatePrimary → Load → Unseal → Flush
+        transport.set_response(fake_create_primary_response());
+        transport.set_response(fake_create_response());
+
+        let mut proxy = TpmProxy::new(transport);
+        let (sealed_priv, sealed_pub) = proxy.seal_payload(original_payload).unwrap();
+
+        // Now for unseal: CreatePrimary → Load → Unseal → Flush
+        let transport2 = MockTransport::new();
+        transport2.set_response(fake_create_primary_response());
+        transport2.set_response(fake_load_response());
+        // unseal must return EXACTLY the original 60-byte payload
+        transport2.set_response(fake_unseal_response(original_payload));
+        transport2.set_response(fake_flush_response());
+
+        let mut proxy2 = TpmProxy::new(transport2);
+        let recovered = proxy2.unseal_payload(&sealed_priv, &sealed_pub).unwrap();
+
+        assert_eq!(recovered, original_payload);
+    }
+
+    #[test]
+    fn test_primary_handle_cached() {
+        let transport = MockTransport::new();
+        transport.set_response(fake_create_primary_response());
+        transport.set_response(fake_create_response());
+        transport.set_response(fake_create_response());
+
+        let mut proxy = TpmProxy::new(transport);
+
+        // First call: creates primary + creates sealed
+        proxy
+            .seal_payload(b"payload_1_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+            .unwrap();
+
+        // Second call: uses cached handle, only sends Create
+        proxy
+            .seal_payload(b"payload_2_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+            .unwrap();
+
+        let cmds = proxy.transport.commands.borrow();
+        // CreatePrimary should only appear once
+        let cp_count = cmds
+            .iter()
+            .filter(|c| {
+                c.len() >= 10
+                    && u32::from_be_bytes(c[6..10].try_into().unwrap()) == TPM_CC_CREATEPRIMARY
+            })
+            .count();
+        assert_eq!(
+            cp_count, 1,
+            "CreatePrimary should be cached after first call"
+        );
+    }
+
+    #[test]
+    fn test_flush_primary() {
+        let transport = MockTransport::new();
+        transport.set_response(fake_create_primary_response());
+        transport.set_response(fake_flush_response());
+
+        let mut proxy = TpmProxy::new(transport);
+        proxy.ensure_primary().unwrap();
+        assert!(proxy.primary_handle.is_some());
+
+        proxy.flush_primary();
+        assert!(proxy.primary_handle.is_none());
+
+        // Verify FlushContext was sent
+        let cmds = proxy.transport.commands.borrow();
+        let flush_cmd = &cmds[1];
+        assert_eq!(
+            u32::from_be_bytes(flush_cmd[6..10].try_into().unwrap()),
+            TPM_CC_FLUSHCONTEXT
+        );
+    }
+
+    #[test]
+    fn test_build_rsa2048_template_valid() {
+        let template = build_rsa2048_storage_template();
+        // Must start with TPM_ALG_RSA
+        assert_eq!(
+            u16::from_be_bytes(template[0..2].try_into().unwrap()),
+            TPM_ALG_RSA
+        );
+        // The TPMT_PUBLIC body (excluding outer u16 size) is fixed-length
+        // for this template; cross-check exact layout to guard accidental
+        // field reordering.
+        assert_eq!(
+            template.len(),
+            30,
+            "Unexpected template size: {}",
+            template.len()
+        );
+        // Verify keyBits = 2048 lives at the known offset
+        // (type(2)+nameAlg(2)+attrs(4)+authPolicy(2)+sym(6)+scheme(2)
+        //  +scheme_detail(4) = 22).
+        assert_eq!(
+            u16::from_be_bytes(template[22..24].try_into().unwrap()),
+            2048
+        );
+    }
+
+    #[test]
+    fn test_build_keyedhash_public() {
+        let policy = [0xAAu8; 32];
+        let pub_area = build_keyedhash_public(&policy);
+        assert_eq!(
+            u16::from_be_bytes(pub_area[0..2].try_into().unwrap()),
+            TPM_ALG_KEYEDHASH
+        );
+        // The policy digest should be in the output
+        assert!(pub_area.windows(32).any(|w| w == policy));
+    }
+}

--- a/kernel/src/vtpm/reseal.rs
+++ b/kernel/src/vtpm/reseal.rs
@@ -1,0 +1,310 @@
+// SPDX-License-Identifier: MIT
+//
+// Runtime re-seal hook for the persistent vTPM.
+//
+// # Why this exists (Tier-B L5-R root cause)
+//
+// `vtpm_init_sealed` seals vTPM state at Provision/Recover time — before the
+// guest OS boots. Guest-runtime NV writes (e.g. `tpm2_nvdefine 0x1500016` +
+// `tpm2_nvwrite ...`) live only in the simulator's RAM `s_NV[]` and are never
+// serialised, encrypted, or pushed to the host. A cold boot unseals the
+// Provision-time snapshot, so `tpm2_nvread 0x1500016` returns garbage.
+//
+// # Trigger selection
+//
+// We sniff `TPM2_Shutdown(SU_STATE)` (cmdCode 0x00000145). TCG semantics say
+// the guest OS is about to lose volatile TPM state — exactly the right moment
+// to persist g* + s_NV into a fresh SealedBlob.
+//
+// # What is / is not cached
+//
+// Only stable addressing parameters are cached in `ResealContext`:
+// `vm_id`, host CID, and VSOCK ports. The AES-256 key and GCM nonce are
+// **freshly derived from `platform_entropy()` on every re-seal** (CR-I2).
+// Sensitive key material is zeroized before this function returns.
+//
+// # Lock ordering
+//
+// `trigger_if_shutdown` is called from `TcgTpm::send_tpm_command` while the
+// outer `VTPM` SpinLock is held. `do_reseal` MUST NOT re-acquire `VTPM` —
+// it talks to the physical TPM through a separate `TpmProxy<VsockTransport>`
+// and reads vTPM internal state through C FFI
+// (`state::extract_serialized_state`), neither of which touches the Rust
+// `VTPM` lock.
+//
+// # Failure semantics
+//
+// Re-seal is best-effort. On failure we log the error and let the guest see
+// its real `TPM2_Shutdown` success response. `RESEAL_CTX` is left unchanged
+// (the old SealedBlob on the host is retained). Fail-closed enforcement is
+// on the next cold boot's unseal path (NV-counter check + AES-GCM tag verify).
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+use crate::locking::SpinLock;
+use crate::protocols::errors::SvsmReqError;
+use crate::vtpm::proxy::{TpmProxy, VsockTransport};
+use crate::vtpm::sealed::{self, VtpmState};
+use crate::vtpm::sealed_store::{SealedBlobStore, VsockHostStore};
+use crate::vtpm::state;
+
+// ---------------------------------------------------------------------------
+// ResealContext — stable parameters cached across the instance lifetime
+// ---------------------------------------------------------------------------
+
+struct ResealContext {
+    vm_id: [u8; 16],
+    host_cid: u32,
+    tpm_port: u32,
+    store_load_port: u32,
+    store_save_port: u32,
+}
+
+static RESEAL_CTX: SpinLock<Option<ResealContext>> = SpinLock::new(None);
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Register the parameters needed for a future runtime re-seal.
+///
+/// Called at the tail of both the Provision and Recover branches in
+/// `vtpm_init_sealed`. Safe to call more than once — a double-install logs a
+/// warning and overwrites the old context (Recover re-registration is
+/// expected).
+pub fn install_reseal_context(
+    vm_id: [u8; 16],
+    host_cid: u32,
+    tpm_port: u32,
+    store_load_port: u32,
+    store_save_port: u32,
+) {
+    let mut guard = RESEAL_CTX.lock();
+    if guard.is_some() {
+        log::warn!("VTPM: reseal context overwritten (double-install)");
+    }
+    *guard = Some(ResealContext {
+        vm_id,
+        host_cid,
+        tpm_port,
+        store_load_port,
+        store_save_port,
+    });
+}
+
+/// Sniff a TPM command/response pair. If the command is a successful
+/// `TPM2_Shutdown`, trigger a runtime re-seal.
+///
+/// MUST be called from outside the VTPM SpinLock (see module-level lock
+/// ordering doc). The hook never propagates errors — failures are logged
+/// and the guest sees its real Shutdown rc.
+pub fn trigger_if_shutdown(command: &[u8], response: &[u8]) {
+    // Command header minimum: tag(2) + size(4) + cmdCode(4) = 10 bytes.
+    if command.len() < 10 {
+        return;
+    }
+
+    let cmd_code = u32::from_be_bytes(command[6..10].try_into().unwrap());
+    if cmd_code != 0x0000_0145 {
+        // TPM_CC_Shutdown
+        return;
+    }
+
+    // Response header minimum: tag(2) + size(4) + rc(4) = 10 bytes.
+    if response.len() < 10 {
+        return;
+    }
+
+    let rc = u32::from_be_bytes(response[6..10].try_into().unwrap());
+    if rc != 0 {
+        // TPM_RC_SUCCESS
+        log::debug!("VTPM: TPM2_Shutdown returned non-zero rc=0x{rc:x}, skipping re-seal");
+        return;
+    }
+
+    match do_reseal() {
+        Ok(counter) => log::info!("VTPM: runtime re-seal commit (counter={counter})"),
+        Err(e) => log::error!("VTPM: re-seal failed: {e:?}; old blob retained"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal re-seal logic
+// ---------------------------------------------------------------------------
+
+/// Execute a full persistence cycle: extract vTPM state → fresh encrypt →
+/// seal to TPM → save blob to host.
+///
+/// Returns the NV counter of the newly sealed blob on success.
+///
+/// # Known risk: NV-counter / blob-save ordering
+///
+/// `sealed::seal_state` increments the TPM NV counter *before* this
+/// function saves the packed blob to the host via VSOCK. If
+/// `VsockHostStore::save` fails after a successful `nv_increment`, the old
+/// blob's counter is now stale and will be rejected on the next cold-boot
+/// unseal by the NV-counter check. Mitigation (save-first-then-increment)
+/// is deferred to a follow-up optimisation and is not part of this change.
+fn do_reseal() -> Result<u64, SvsmReqError> {
+    // 1. Snapshot the reseal context (release lock quickly).
+    let ctx = {
+        let guard = RESEAL_CTX.lock();
+        guard.as_ref().map(|c| ResealContext {
+            vm_id: c.vm_id,
+            host_cid: c.host_cid,
+            tpm_port: c.tpm_port,
+            store_load_port: c.store_load_port,
+            store_save_port: c.store_save_port,
+        })
+    };
+    let ctx = ctx.ok_or_else(|| {
+        log::warn!("VTPM: re-seal triggered but RESEAL_CTX is None — persist not enabled?");
+        SvsmReqError::invalid_request()
+    })?;
+
+    // 2. Extract current vTPM internal state (C FFI, no VTPM lock).
+    let serialized = state::extract_serialized_state().map_err(|e| {
+        log::error!("VTPM: re-seal extract_serialized_state failed: {e:?}");
+        SvsmReqError::invalid_request()
+    })?;
+    log::info!(
+        "VTPM: re-seal extracted internal state ({} bytes)",
+        serialized.len()
+    );
+
+    // 3. Build VtpmState. Only `extra` (serialized g* + s_NV) is populated;
+    //    ek_pub is left empty — sealed.rs does not require it, and we cannot
+    //    access TcgTpm.ekpub without the VTPM lock (see Lock ordering above).
+    let vtpm_state = VtpmState {
+        ek_priv: Vec::new(),
+        ek_pub: Vec::new(),
+        srk_priv: Vec::new(),
+        srk_pub: Vec::new(),
+        owner_auth: [0u8; 32],
+        endorsement_auth: [0u8; 32],
+        lockout_auth: [0u8; 32],
+        nv_data: Vec::new(),
+        nv_counter: 0,
+        platform_auth: [0u8; 32],
+        extra: serialized,
+    };
+
+    // 4. Fresh key material (CR-I2: every re-seal derives new keys).
+    let mut aes_key = [0u8; 32];
+    let mut nonce = [0u8; 12];
+    crate::vtpm::platform_entropy(&mut aes_key, &mut nonce).map_err(|e| {
+        log::error!("VTPM: re-seal platform_entropy failed: {e:?}");
+        SvsmReqError::invalid_request()
+    })?;
+
+    // 5. Proxy to the TPM via VSOCK.
+    let transport = VsockTransport::new(ctx.host_cid, ctx.tpm_port);
+    let mut proxy = TpmProxy::new(transport);
+
+    // 6. Seal state to TPM (nv_increment + TPM2_Seal).
+    let blob =
+        sealed::seal_state(&mut proxy, &vtpm_state, ctx.vm_id, &aes_key, &nonce).map_err(|e| {
+            log::error!("VTPM: re-seal seal_state failed: {e:?}");
+            SvsmReqError::invalid_request()
+        })?;
+
+    // 7. Flush the primary handle cached in the proxy.
+    proxy.flush_primary();
+
+    // 8. Pack the blob for host storage.
+    let packed = blob.pack();
+    let counter = blob.counter;
+
+    // 9. Save to host via VSOCK.
+    let store = VsockHostStore::new(ctx.host_cid, ctx.store_load_port, ctx.store_save_port);
+    store.save(&packed).map_err(|e| {
+        log::error!("VTPM: re-seal host save failed: {e:?}");
+        SvsmReqError::invalid_request()
+    })?;
+
+    // 10. Zeroize key material.
+    crate::vtpm::zeroize_key_material(&aes_key, &nonce);
+
+    Ok(counter)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a minimal TPM command header (big-endian).
+    fn tpm_cmd(cmd_code: u32, extra: &[u8]) -> Vec<u8> {
+        let size = (10 + extra.len()) as u32;
+        let mut cmd = Vec::with_capacity(size as usize);
+        cmd.extend_from_slice(&0x8001u16.to_be_bytes()); // tag
+        cmd.extend_from_slice(&size.to_be_bytes()); // size
+        cmd.extend_from_slice(&cmd_code.to_be_bytes()); // commandCode
+        cmd.extend_from_slice(extra);
+        cmd
+    }
+
+    /// Build a minimal TPM success response (rc = 0).
+    fn tpm_success_resp() -> Vec<u8> {
+        let mut resp = Vec::with_capacity(10);
+        resp.extend_from_slice(&0x8001u16.to_be_bytes()); // tag
+        resp.extend_from_slice(&10u32.to_be_bytes()); // size
+        resp.extend_from_slice(&0u32.to_be_bytes()); // rc = SUCCESS
+        resp
+    }
+
+    /// Build a minimal TPM error response (rc != 0).
+    fn tpm_error_resp(rc: u32) -> Vec<u8> {
+        let mut resp = Vec::with_capacity(10);
+        resp.extend_from_slice(&0x8001u16.to_be_bytes()); // tag
+        resp.extend_from_slice(&10u32.to_be_bytes()); // size
+        resp.extend_from_slice(&rc.to_be_bytes());
+        resp
+    }
+
+    #[test]
+    fn test_trigger_ignores_non_shutdown() {
+        // Install a context so the filter has something to forward to.
+        install_reseal_context([0u8; 16], 2, 9999, 9997, 9998);
+
+        // TPM2_GetRandom (cmdCode = 0x0000017B)
+        let cmd = tpm_cmd(0x0000_017B, &[0x00, 0x04]); // 4 random bytes
+        let resp = tpm_success_resp();
+
+        // Must not panic, must not call do_reseal (cmdCode filter).
+        trigger_if_shutdown(&cmd, &resp);
+    }
+
+    #[test]
+    fn test_trigger_ignores_failed_shutdown() {
+        install_reseal_context([0u8; 16], 2, 9999, 9997, 9998);
+
+        // TPM2_Shutdown (cmdCode = 0x00000145) with SU_STATE
+        let cmd = tpm_cmd(0x0000_0145, &[0x00, 0x01]);
+        // Non-zero rc → must not trigger re-seal.
+        let resp = tpm_error_resp(0x0000_0100); // TPM_RC_INITIALIZE
+
+        trigger_if_shutdown(&cmd, &resp);
+    }
+
+    #[test]
+    fn test_short_command_ignored() {
+        install_reseal_context([0u8; 16], 2, 9999, 9997, 9998);
+        let short_cmd = [0x80u8, 0x01]; // 2 bytes < 10
+        let resp = tpm_success_resp();
+        trigger_if_shutdown(&short_cmd, &resp);
+    }
+
+    #[test]
+    fn test_short_response_ignored() {
+        install_reseal_context([0u8; 16], 2, 9999, 9997, 9998);
+        let cmd = tpm_cmd(0x0000_0145, &[0x00, 0x01]);
+        let short_resp = [0x80u8, 0x01]; // 2 bytes < 10
+        trigger_if_shutdown(&cmd, &short_resp);
+    }
+}

--- a/kernel/src/vtpm/sealed.rs
+++ b/kernel/src/vtpm/sealed.rs
@@ -1,0 +1,609 @@
+// SPDX-License-Identifier: MIT
+//
+// Two-layer sealed container for vTPM persistent state.
+//
+// Architecture:
+//   1. AES-256-GCM encrypts the full VtpmState (bulk data).
+//   2. The 60-byte key bundle (aes_key || gcm_tag || nonce) is sealed by
+//      the external TPM via TpmProxy.
+//
+// The TPM-sealed payload is kept small (60 bytes) to fit within the
+// RSA-2048 / ECC seal size limit imposed by typical TPM sealing parents,
+// while the bulk state travels under AES-GCM authenticated encryption.
+
+extern crate alloc;
+
+use crate::protocols::errors::SvsmReqError;
+use crate::vtpm::proxy::{TpmProxy, TpmTransport};
+use aes_gcm::{Aes256Gcm, Key, KeyInit, Nonce, aead::Aead};
+use alloc::vec::Vec;
+use sha2::{Digest, Sha256};
+
+// ============================================================
+// Constants
+// ============================================================
+
+/// Size of the TPM seal payload: aes_key(32) + gcm_tag(16) + nonce(12) = 60 bytes
+pub const SEAL_PAYLOAD_SIZE: usize = 60;
+const GCM_TAG_SIZE: usize = 16;
+
+/// Current SealedBlob format version
+const BLOB_VERSION: u16 = 1;
+
+// ============================================================
+// VtpmState — Serializable vTPM Persistent State
+// ============================================================
+
+/// Serializable representation of vTPM persistent state.
+///
+/// Captures everything needed to restore vTPM identity across reboots:
+/// EK, SRK, and persistent NV indices.
+#[derive(Debug, Clone)]
+pub struct VtpmState {
+    /// Endorsement Key private (TPM2B_SENSITIVE)
+    pub ek_priv: Vec<u8>,
+    /// Endorsement Key public (TPM2B_PUBLIC / TPMT_PUBLIC)
+    pub ek_pub: Vec<u8>,
+    /// Storage Root Key private
+    pub srk_priv: Vec<u8>,
+    /// Storage Root Key public
+    pub srk_pub: Vec<u8>,
+    /// Owner hierarchy auth value
+    pub owner_auth: [u8; 32],
+    /// Endorsement hierarchy auth value
+    pub endorsement_auth: [u8; 32],
+    /// Lockout auth value
+    pub lockout_auth: [u8; 32],
+    /// Persistent NV data (concatenated NV indices)
+    pub nv_data: Vec<u8>,
+    /// Counter for persistent NV indices
+    pub nv_counter: u32,
+    /// Platform auth value
+    pub platform_auth: [u8; 32],
+    /// Opaque extra data
+    pub extra: Vec<u8>,
+}
+
+impl VtpmState {
+    /// Serialize VtpmState to a byte vector.
+    pub fn serialize(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(1024);
+
+        out.extend_from_slice(&(self.ek_priv.len() as u32).to_le_bytes());
+        out.extend_from_slice(&self.ek_priv);
+
+        out.extend_from_slice(&(self.ek_pub.len() as u32).to_le_bytes());
+        out.extend_from_slice(&self.ek_pub);
+
+        out.extend_from_slice(&(self.srk_priv.len() as u32).to_le_bytes());
+        out.extend_from_slice(&self.srk_priv);
+
+        out.extend_from_slice(&(self.srk_pub.len() as u32).to_le_bytes());
+        out.extend_from_slice(&self.srk_pub);
+
+        out.extend_from_slice(&self.owner_auth);
+        out.extend_from_slice(&self.endorsement_auth);
+        out.extend_from_slice(&self.lockout_auth);
+
+        out.extend_from_slice(&self.nv_counter.to_le_bytes());
+
+        out.extend_from_slice(&(self.nv_data.len() as u32).to_le_bytes());
+        out.extend_from_slice(&self.nv_data);
+
+        out.extend_from_slice(&self.platform_auth);
+
+        out.extend_from_slice(&(self.extra.len() as u32).to_le_bytes());
+        out.extend_from_slice(&self.extra);
+
+        out
+    }
+
+    /// Deserialize VtpmState from bytes.
+    pub fn deserialize(data: &[u8]) -> Result<Self, &'static str> {
+        let (ek_priv, offset) = read_len_prefixed(data, 0)?;
+        let (ek_pub, offset) = read_len_prefixed(data, offset)?;
+        let (srk_priv, offset) = read_len_prefixed(data, offset)?;
+        let (srk_pub, offset) = read_len_prefixed(data, offset)?;
+
+        if offset + 96 > data.len() {
+            return Err("buffer underrun at auth fields");
+        }
+        let owner_auth: [u8; 32] = data[offset..offset + 32].try_into().unwrap();
+        let endorsement_auth: [u8; 32] = data[offset + 32..offset + 64].try_into().unwrap();
+        let lockout_auth: [u8; 32] = data[offset + 64..offset + 96].try_into().unwrap();
+        let mut offset = offset + 96;
+
+        if offset + 4 > data.len() {
+            return Err("buffer underrun at nv_counter");
+        }
+        let nv_counter = u32::from_le_bytes(data[offset..offset + 4].try_into().unwrap());
+        offset += 4;
+
+        let (nv_data, offset) = read_len_prefixed(data, offset)?;
+
+        if offset + 32 > data.len() {
+            return Err("buffer underrun at platform_auth");
+        }
+        let platform_auth: [u8; 32] = data[offset..offset + 32].try_into().unwrap();
+        let offset = offset + 32;
+
+        let (extra, _offset) = read_len_prefixed(data, offset)?;
+
+        Ok(VtpmState {
+            ek_priv,
+            ek_pub,
+            srk_priv,
+            srk_pub,
+            owner_auth,
+            endorsement_auth,
+            lockout_auth,
+            nv_data,
+            nv_counter,
+            platform_auth,
+            extra,
+        })
+    }
+
+    /// Minimum empty state for bootstrap (first boot).
+    pub fn empty() -> Self {
+        Self {
+            ek_priv: Vec::new(),
+            ek_pub: Vec::new(),
+            srk_priv: Vec::new(),
+            srk_pub: Vec::new(),
+            owner_auth: [0u8; 32],
+            endorsement_auth: [0u8; 32],
+            lockout_auth: [0u8; 32],
+            nv_data: Vec::new(),
+            nv_counter: 0,
+            platform_auth: [0u8; 32],
+            extra: Vec::new(),
+        }
+    }
+}
+
+fn read_len_prefixed(data: &[u8], offset: usize) -> Result<(Vec<u8>, usize), &'static str> {
+    if offset + 4 > data.len() {
+        return Err("buffer underrun at length prefix");
+    }
+    let len = u32::from_le_bytes(data[offset..offset + 4].try_into().unwrap()) as usize;
+    if offset + 4 + len > data.len() {
+        return Err("buffer underrun at data field");
+    }
+    Ok((
+        data[offset + 4..offset + 4 + len].to_vec(),
+        offset + 4 + len,
+    ))
+}
+
+// ============================================================
+// SealedBlob — On-disk Format (protocol_spec.md §3.2)
+// ============================================================
+
+/// The on-disk sealed blob format.
+///
+/// Stored on public disk; integrity protected by TPM seal and AES-GCM tag.
+#[derive(Debug, Clone)]
+pub struct SealedBlob {
+    pub version: u16,
+    pub counter: u64,
+    pub pcr_policy_digest: [u8; 32],
+    pub sealed_priv: Vec<u8>,
+    pub sealed_pub: Vec<u8>,
+    pub encrypted_data: Vec<u8>,
+    pub vm_id: [u8; 16],
+    pub created_at: u64,
+}
+
+impl SealedBlob {
+    pub fn pack(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(512);
+
+        out.extend_from_slice(&self.version.to_le_bytes());
+        out.extend_from_slice(&self.counter.to_le_bytes());
+        out.extend_from_slice(&self.pcr_policy_digest);
+
+        out.extend_from_slice(&(self.sealed_priv.len() as u32).to_le_bytes());
+        out.extend_from_slice(&self.sealed_priv);
+
+        out.extend_from_slice(&(self.sealed_pub.len() as u32).to_le_bytes());
+        out.extend_from_slice(&self.sealed_pub);
+
+        out.extend_from_slice(&(self.encrypted_data.len() as u32).to_le_bytes());
+        out.extend_from_slice(&self.encrypted_data);
+
+        out.extend_from_slice(&self.vm_id);
+        out.extend_from_slice(&self.created_at.to_le_bytes());
+
+        out
+    }
+
+    pub fn unpack(data: &[u8]) -> Result<Self, &'static str> {
+        if data.len() < 42 {
+            return Err("SealedBlob too short");
+        }
+
+        let version = u16::from_le_bytes(data[0..2].try_into().unwrap());
+        let counter = u64::from_le_bytes(data[2..10].try_into().unwrap());
+        let pcr_policy_digest: [u8; 32] = data[10..42].try_into().unwrap();
+        let mut offset = 42;
+
+        let priv_len = u32::from_le_bytes(data[offset..offset + 4].try_into().unwrap()) as usize;
+        offset += 4;
+        let sealed_priv = data[offset..offset + priv_len].to_vec();
+        offset += priv_len;
+
+        let pub_len = u32::from_le_bytes(data[offset..offset + 4].try_into().unwrap()) as usize;
+        offset += 4;
+        let sealed_pub = data[offset..offset + pub_len].to_vec();
+        offset += pub_len;
+
+        let enc_len = u32::from_le_bytes(data[offset..offset + 4].try_into().unwrap()) as usize;
+        offset += 4;
+        let encrypted_data = data[offset..offset + enc_len].to_vec();
+        offset += enc_len;
+
+        let vm_id: [u8; 16] = data[offset..offset + 16].try_into().unwrap();
+        offset += 16;
+
+        let created_at = u64::from_le_bytes(data[offset..offset + 8].try_into().unwrap());
+
+        Ok(SealedBlob {
+            version,
+            counter,
+            pcr_policy_digest,
+            sealed_priv,
+            sealed_pub,
+            encrypted_data,
+            vm_id,
+            created_at,
+        })
+    }
+}
+
+// ============================================================
+// AES-256-GCM Helpers
+// ============================================================
+
+/// Encrypt plaintext with AES-256-GCM using caller-provided key material.
+///
+/// The caller is responsible for generating `aes_key` (32 bytes) and
+/// `nonce` (12 bytes) from a cryptographically secure RNG.
+/// In production: rdseed instruction via cocoon-tpm-crypto.
+/// In prototype: OsRng from rand crate.
+///
+/// Returns (ciphertext, tag) where the GCM authentication tag is 16 bytes.
+pub fn aes_gcm_encrypt(
+    plaintext: &[u8],
+    aes_key: &[u8; 32],
+    nonce: &[u8; 12],
+) -> Result<(Vec<u8>, [u8; 16]), SvsmReqError> {
+    let key = Key::<Aes256Gcm>::from_slice(aes_key);
+    let nonce_obj = Nonce::from_slice(nonce);
+    let cipher = Aes256Gcm::new(key);
+
+    let ciphertext = cipher
+        .encrypt(nonce_obj, plaintext)
+        .map_err(|_| SvsmReqError::invalid_request())?;
+
+    let ct_len = ciphertext.len() - GCM_TAG_SIZE;
+    let (ct, tag_slice) = ciphertext.split_at(ct_len);
+    let tag: [u8; 16] = tag_slice.try_into().unwrap();
+
+    Ok((ct.to_vec(), tag))
+}
+
+/// Decrypt ciphertext with AES-256-GCM.
+pub fn aes_gcm_decrypt(
+    ciphertext: &[u8],
+    aes_key: &[u8; 32],
+    nonce: &[u8; 12],
+    tag: &[u8; 16],
+) -> Result<Vec<u8>, SvsmReqError> {
+    let key = Key::<Aes256Gcm>::from_slice(aes_key);
+    let nonce_obj = Nonce::from_slice(nonce);
+    let cipher = Aes256Gcm::new(key);
+
+    let mut combined = Vec::with_capacity(ciphertext.len() + GCM_TAG_SIZE);
+    combined.extend_from_slice(ciphertext);
+    combined.extend_from_slice(tag);
+
+    cipher
+        .decrypt(nonce_obj, combined.as_slice())
+        .map_err(|_| SvsmReqError::invalid_request())
+}
+
+// ============================================================
+// Seal/Unseal Orchestration
+// ============================================================
+
+/// Seal vTPM state to a SealedBlob.
+///
+/// Flow:
+///   1. Serialize VtpmState
+///   2. AES-256-GCM encrypt serialized state (key/nonce from caller)
+///   3. TPM seal the 60-byte (key+tag+nonce) payload
+///   4. Pack everything into SealedBlob
+pub fn seal_state<T: TpmTransport>(
+    proxy: &mut TpmProxy<T>,
+    state: &VtpmState,
+    vm_id: [u8; 16],
+    aes_key: &[u8; 32],
+    nonce: &[u8; 12],
+) -> Result<SealedBlob, SvsmReqError> {
+    let serialized = state.serialize();
+
+    // Step 1: AES-256-GCM encrypt
+    let (ciphertext, tag) = aes_gcm_encrypt(&serialized, aes_key, nonce)?;
+
+    // Step 2: Assemble seal payload: key(32) + tag(16) + nonce(12) = 60 bytes
+    let mut seal_payload = Vec::with_capacity(SEAL_PAYLOAD_SIZE);
+    seal_payload.extend_from_slice(aes_key);
+    seal_payload.extend_from_slice(&tag);
+    seal_payload.extend_from_slice(nonce);
+
+    // Step 3: TPM seal the 60-byte payload
+    let (sealed_priv, sealed_pub) = proxy.seal_payload(&seal_payload)?;
+
+    // Step 4: Pack into SealedBlob
+    let counter = proxy.seal_counter();
+    let created_at = monotonic_timestamp();
+
+    Ok(SealedBlob {
+        version: BLOB_VERSION,
+        counter,
+        pcr_policy_digest: [0u8; 32], // placeholder; production: derive from PCR policy
+        sealed_priv,
+        sealed_pub,
+        encrypted_data: ciphertext,
+        vm_id,
+        created_at,
+    })
+}
+
+/// Unseal a SealedBlob to recover vTPM state.
+///
+/// Flow:
+///   1. TPM unseal the 60-byte payload → recover (aes_key, tag, nonce)
+///   2. AES-256-GCM decrypt the encrypted data
+///   3. Deserialize VtpmState
+pub fn unseal_state<T: TpmTransport>(
+    proxy: &mut TpmProxy<T>,
+    blob: &SealedBlob,
+) -> Result<VtpmState, SvsmReqError> {
+    // Step 1: TPM unseal
+    let seal_payload = proxy.unseal_payload(&blob.sealed_priv, &blob.sealed_pub)?;
+
+    if seal_payload.len() < SEAL_PAYLOAD_SIZE {
+        log::error!(
+            "Unsealed payload too short: {} bytes (expected {})",
+            seal_payload.len(),
+            SEAL_PAYLOAD_SIZE
+        );
+        return Err(SvsmReqError::invalid_request());
+    }
+
+    // Step 2: Extract AES key, tag, nonce
+    let aes_key: [u8; 32] = seal_payload[0..32].try_into().unwrap();
+    let tag: [u8; 16] = seal_payload[32..48].try_into().unwrap();
+    let nonce: [u8; 12] = seal_payload[48..60].try_into().unwrap();
+
+    // Step 3: AES-256-GCM decrypt
+    let plaintext = aes_gcm_decrypt(&blob.encrypted_data, &aes_key, &nonce, &tag)?;
+
+    // Step 4: Deserialize
+    VtpmState::deserialize(&plaintext).map_err(|e| {
+        log::error!("VtpmState deserialization failed: {e}");
+        SvsmReqError::invalid_request()
+    })
+}
+
+/// Compute SHA-256 hash of VtpmState serialization (for integrity check).
+pub fn state_hash(state: &VtpmState) -> [u8; 32] {
+    Sha256::digest(state.serialize()).into()
+}
+
+// ============================================================
+// Utility
+// ============================================================
+
+/// Monotonic timestamp. In production, read from SEV-SNP attestation clock.
+/// Here: simple incrementing counter (single-threaded VMPL0 context).
+fn monotonic_timestamp() -> u64 {
+    static mut COUNTER: u64 = 0;
+    // SAFETY: VMPL0 is strictly single-threaded at initialization, so the
+    // mutable static is accessed without races.
+    unsafe {
+        COUNTER = COUNTER.wrapping_add(1);
+        COUNTER
+    }
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_state() -> VtpmState {
+        VtpmState {
+            ek_priv: b"ek-private-bytes".to_vec(),
+            ek_pub: b"ek-public-bytes-xx".to_vec(),
+            srk_priv: b"srk-private".to_vec(),
+            srk_pub: b"srk-public".to_vec(),
+            owner_auth: [0x11u8; 32],
+            endorsement_auth: [0x22u8; 32],
+            lockout_auth: [0x33u8; 32],
+            nv_data: b"nv-blob-contents".to_vec(),
+            nv_counter: 0xDEAD_BEEF,
+            platform_auth: [0x44u8; 32],
+            extra: b"opaque-tail".to_vec(),
+        }
+    }
+
+    fn assert_state_eq(a: &VtpmState, b: &VtpmState) {
+        assert_eq!(a.ek_priv, b.ek_priv);
+        assert_eq!(a.ek_pub, b.ek_pub);
+        assert_eq!(a.srk_priv, b.srk_priv);
+        assert_eq!(a.srk_pub, b.srk_pub);
+        assert_eq!(a.owner_auth, b.owner_auth);
+        assert_eq!(a.endorsement_auth, b.endorsement_auth);
+        assert_eq!(a.lockout_auth, b.lockout_auth);
+        assert_eq!(a.nv_data, b.nv_data);
+        assert_eq!(a.nv_counter, b.nv_counter);
+        assert_eq!(a.platform_auth, b.platform_auth);
+        assert_eq!(a.extra, b.extra);
+    }
+
+    #[test]
+    fn vtpmstate_serialize_roundtrip_full() {
+        let s = sample_state();
+        let bytes = s.serialize();
+        let parsed = VtpmState::deserialize(&bytes).expect("deserialize");
+        assert_state_eq(&s, &parsed);
+    }
+
+    #[test]
+    fn vtpmstate_serialize_roundtrip_empty() {
+        let s = VtpmState::empty();
+        let bytes = s.serialize();
+        let parsed = VtpmState::deserialize(&bytes).expect("deserialize empty");
+        assert_state_eq(&s, &parsed);
+        assert_eq!(parsed.nv_counter, 0);
+        assert!(parsed.ek_priv.is_empty());
+        assert!(parsed.extra.is_empty());
+    }
+
+    #[test]
+    fn vtpmstate_deserialize_rejects_truncated() {
+        let bytes = sample_state().serialize();
+        // Truncate just before the trailing extra field's length prefix.
+        let cut = bytes.len() - 8;
+        let err = VtpmState::deserialize(&bytes[..cut]);
+        assert!(err.is_err(), "expected truncation error, got {err:?}");
+    }
+
+    #[test]
+    fn vtpmstate_deserialize_rejects_oversized_length() {
+        // First field is ek_priv with a u32 LE length prefix. Forge a length
+        // that exceeds the remaining buffer.
+        let mut bytes = alloc::vec![0u8; 8];
+        bytes[..4].copy_from_slice(&0xFFFF_FFFFu32.to_le_bytes());
+        let err = VtpmState::deserialize(&bytes);
+        assert!(err.is_err(), "expected oversize error, got {err:?}");
+    }
+
+    #[test]
+    fn sealed_blob_pack_unpack_roundtrip() {
+        let blob = SealedBlob {
+            version: BLOB_VERSION,
+            counter: 0x0102_0304_0506_0708,
+            pcr_policy_digest: [0xAAu8; 32],
+            sealed_priv: b"priv-area".to_vec(),
+            sealed_pub: b"pub-area-bytes".to_vec(),
+            encrypted_data: b"ciphertext-tail".to_vec(),
+            vm_id: [0xBBu8; 16],
+            created_at: 0x9988_7766_5544_3322,
+        };
+        let packed = blob.pack();
+        let parsed = SealedBlob::unpack(&packed).expect("unpack");
+        assert_eq!(parsed.version, blob.version);
+        assert_eq!(parsed.counter, blob.counter);
+        assert_eq!(parsed.pcr_policy_digest, blob.pcr_policy_digest);
+        assert_eq!(parsed.sealed_priv, blob.sealed_priv);
+        assert_eq!(parsed.sealed_pub, blob.sealed_pub);
+        assert_eq!(parsed.encrypted_data, blob.encrypted_data);
+        assert_eq!(parsed.vm_id, blob.vm_id);
+        assert_eq!(parsed.created_at, blob.created_at);
+    }
+
+    #[test]
+    fn sealed_blob_unpack_rejects_too_short() {
+        let err = SealedBlob::unpack(&[0u8; 10]);
+        assert!(err.is_err(), "expected too-short error, got {err:?}");
+    }
+
+    #[test]
+    fn sealed_blob_unpack_preserves_empty_fields() {
+        let blob = SealedBlob {
+            version: BLOB_VERSION,
+            counter: 0,
+            pcr_policy_digest: [0u8; 32],
+            sealed_priv: Vec::new(),
+            sealed_pub: Vec::new(),
+            encrypted_data: Vec::new(),
+            vm_id: [0u8; 16],
+            created_at: 0,
+        };
+        let parsed = SealedBlob::unpack(&blob.pack()).expect("unpack empty");
+        assert!(parsed.sealed_priv.is_empty());
+        assert!(parsed.sealed_pub.is_empty());
+        assert!(parsed.encrypted_data.is_empty());
+    }
+
+    #[test]
+    fn aes_gcm_roundtrip() {
+        let key = [0x5Au8; 32];
+        let nonce = [0xA5u8; 12];
+        let plaintext = b"the quick brown fox jumps over 13 lazy dogs ----------";
+
+        let (ct, tag) = aes_gcm_encrypt(plaintext, &key, &nonce).expect("encrypt");
+        assert_eq!(ct.len(), plaintext.len());
+
+        let recovered = aes_gcm_decrypt(&ct, &key, &nonce, &tag).expect("decrypt");
+        assert_eq!(recovered, plaintext);
+    }
+
+    #[test]
+    fn aes_gcm_detects_ciphertext_tamper() {
+        let key = [0x5Au8; 32];
+        let nonce = [0xA5u8; 12];
+        let plaintext = b"sensitive vtpm key bundle bytes ......";
+
+        let (mut ct, tag) = aes_gcm_encrypt(plaintext, &key, &nonce).expect("encrypt");
+        // Flip a bit in the ciphertext; GCM tag check must reject.
+        ct[0] ^= 0x01;
+        let err = aes_gcm_decrypt(&ct, &key, &nonce, &tag);
+        assert!(err.is_err(), "tampered ciphertext must fail decrypt");
+    }
+
+    #[test]
+    fn aes_gcm_detects_tag_tamper() {
+        let key = [0x5Au8; 32];
+        let nonce = [0xA5u8; 12];
+        let plaintext = b"sensitive vtpm key bundle bytes ......";
+
+        let (ct, mut tag) = aes_gcm_encrypt(plaintext, &key, &nonce).expect("encrypt");
+        tag[0] ^= 0x80;
+        let err = aes_gcm_decrypt(&ct, &key, &nonce, &tag);
+        assert!(err.is_err(), "tampered tag must fail decrypt");
+    }
+
+    #[test]
+    fn aes_gcm_detects_wrong_key() {
+        let key = [0x5Au8; 32];
+        let mut wrong = key;
+        wrong[31] ^= 0xFF;
+        let nonce = [0xA5u8; 12];
+        let plaintext = b"sensitive vtpm key bundle bytes ......";
+
+        let (ct, tag) = aes_gcm_encrypt(plaintext, &key, &nonce).expect("encrypt");
+        let err = aes_gcm_decrypt(&ct, &wrong, &nonce, &tag);
+        assert!(err.is_err(), "wrong key must fail decrypt");
+    }
+
+    #[test]
+    fn state_hash_stable_and_sensitive() {
+        let s1 = sample_state();
+        let mut s2 = s1.clone();
+        let h1 = state_hash(&s1);
+        let h1b = state_hash(&s1);
+        assert_eq!(h1, h1b, "hash must be deterministic");
+
+        s2.nv_counter ^= 1;
+        let h2 = state_hash(&s2);
+        assert_ne!(h1, h2, "hash must change on field flip");
+    }
+}

--- a/kernel/src/vtpm/sealed.rs
+++ b/kernel/src/vtpm/sealed.rs
@@ -66,6 +66,7 @@ pub struct VtpmState {
 
 impl VtpmState {
     /// Serialize VtpmState to a byte vector.
+    #[inline] // R1: avoid sret aggregate-return on Vec<u8>
     pub fn serialize(&self) -> Vec<u8> {
         let mut out = Vec::with_capacity(1024);
 
@@ -99,6 +100,7 @@ impl VtpmState {
     }
 
     /// Deserialize VtpmState from bytes.
+    #[inline] // R1: avoid sret aggregate-return on VtpmState
     pub fn deserialize(data: &[u8]) -> Result<Self, &'static str> {
         let (ek_priv, offset) = read_len_prefixed(data, 0)?;
         let (ek_pub, offset) = read_len_prefixed(data, offset)?;
@@ -162,6 +164,7 @@ impl VtpmState {
     }
 }
 
+#[inline] // R1: avoid sret aggregate-return on (Vec<u8>, usize)
 fn read_len_prefixed(data: &[u8], offset: usize) -> Result<(Vec<u8>, usize), &'static str> {
     if offset + 4 > data.len() {
         return Err("buffer underrun at length prefix");
@@ -177,7 +180,7 @@ fn read_len_prefixed(data: &[u8], offset: usize) -> Result<(Vec<u8>, usize), &'s
 }
 
 // ============================================================
-// SealedBlob — On-disk Format (protocol_spec.md §3.2)
+// SealedBlob — On-disk Format
 // ============================================================
 
 /// The on-disk sealed blob format.
@@ -196,6 +199,7 @@ pub struct SealedBlob {
 }
 
 impl SealedBlob {
+    #[inline] // R1: avoid sret aggregate-return on Vec<u8>
     pub fn pack(&self) -> Vec<u8> {
         let mut out = Vec::with_capacity(512);
 
@@ -218,6 +222,7 @@ impl SealedBlob {
         out
     }
 
+    #[inline] // R1: avoid sret aggregate-return on SealedBlob
     pub fn unpack(data: &[u8]) -> Result<Self, &'static str> {
         if data.len() < 42 {
             return Err("SealedBlob too short");
@@ -273,6 +278,7 @@ impl SealedBlob {
 /// In prototype: OsRng from rand crate.
 ///
 /// Returns (ciphertext, tag) where the GCM authentication tag is 16 bytes.
+#[inline] // R1: avoid sret aggregate-return on (Vec<u8>, [u8; 16])
 pub fn aes_gcm_encrypt(
     plaintext: &[u8],
     aes_key: &[u8; 32],
@@ -294,6 +300,7 @@ pub fn aes_gcm_encrypt(
 }
 
 /// Decrypt ciphertext with AES-256-GCM.
+#[inline] // R1: avoid sret aggregate-return on Vec<u8>
 pub fn aes_gcm_decrypt(
     ciphertext: &[u8],
     aes_key: &[u8; 32],
@@ -324,6 +331,7 @@ pub fn aes_gcm_decrypt(
 ///   2. AES-256-GCM encrypt serialized state (key/nonce from caller)
 ///   3. TPM seal the 60-byte (key+tag+nonce) payload
 ///   4. Pack everything into SealedBlob
+#[inline] // R1: avoid sret aggregate-return on SealedBlob
 pub fn seal_state<T: TpmTransport>(
     proxy: &mut TpmProxy<T>,
     state: &VtpmState,
@@ -367,6 +375,7 @@ pub fn seal_state<T: TpmTransport>(
 ///   1. TPM unseal the 60-byte payload → recover (aes_key, tag, nonce)
 ///   2. AES-256-GCM decrypt the encrypted data
 ///   3. Deserialize VtpmState
+#[inline] // R1: avoid sret aggregate-return on VtpmState
 pub fn unseal_state<T: TpmTransport>(
     proxy: &mut TpmProxy<T>,
     blob: &SealedBlob,

--- a/kernel/src/vtpm/sealed_store.rs
+++ b/kernel/src/vtpm/sealed_store.rs
@@ -90,6 +90,7 @@ impl Default for StaticBufStore {
 }
 
 impl SealedBlobStore for StaticBufStore {
+    #[inline] // R1: avoid sret aggregate-return on Option<Vec<u8>>
     fn load(&self) -> Result<Option<Vec<u8>>, SvsmReqError> {
         let g = self.inner.lock();
         if g.valid && g.len > 0 {
@@ -139,6 +140,7 @@ impl Default for IgvmVarStore {
 }
 
 impl SealedBlobStore for IgvmVarStore {
+    #[inline] // R1: avoid sret aggregate-return on Option<Vec<u8>>
     fn load(&self) -> Result<Option<Vec<u8>>, SvsmReqError> {
         log::debug!("IgvmVarStore::load — not yet implemented, returning empty");
         Ok(None)
@@ -183,20 +185,124 @@ impl VsockHostStore {
 
 #[cfg(feature = "vsock")]
 impl SealedBlobStore for VsockHostStore {
+    /// Wire format: the host helper hands the raw blob bytes as a single
+    /// stream — no framing header. The guest reads until peer-EOF and
+    /// returns whatever it got. `Ok(None)` is reserved for two cases:
+    ///
+    ///   1. The helper is not running (connect refused) — interpreted as
+    ///      a cold boot with no prior state.
+    ///   2. The helper accepted the connection but produced 0 bytes —
+    ///      same interpretation.
+    ///
+    /// This matches a `socat VSOCK-LISTEN:<port> OPEN:<file>,rdonly`
+    /// helper that exits with EOF once the file is fully drained.
+    #[inline] // R1: avoid sret aggregate-return on Option<Vec<u8>>
     fn load(&self) -> Result<Option<Vec<u8>>, SvsmReqError> {
-        // TODO: open AF_VSOCK(cid, load_port), read framed blob.
-        log::debug!(
-            "VsockHostStore::load(cid={}, port={}) — not yet wired",
+        use crate::io::Read;
+        use crate::vsock::stream::VsockStream;
+
+        let mut stream = match VsockStream::connect(self.load_port, self.cid) {
+            Ok(s) => s,
+            Err(e) => {
+                log::debug!(
+                    "VsockHostStore::load(cid={}, port={}) — connect failed ({:?}); treating as cold boot",
+                    self.cid,
+                    self.load_port,
+                    e
+                );
+                return Ok(None);
+            }
+        };
+
+        let mut out = Vec::new();
+        let mut chunk = [0u8; 1024];
+        loop {
+            match stream.read(&mut chunk) {
+                Ok(0) => break,
+                Ok(n) => out.extend_from_slice(&chunk[..n]),
+                Err(e) => {
+                    log::error!(
+                        "VsockHostStore::load(cid={}, port={}) — read error: {:?}",
+                        self.cid,
+                        self.load_port,
+                        e
+                    );
+                    return Err(SvsmReqError::invalid_request());
+                }
+            }
+        }
+
+        if out.is_empty() {
+            log::debug!(
+                "VsockHostStore::load(cid={}, port={}) — peer returned 0 bytes",
+                self.cid,
+                self.load_port
+            );
+            return Ok(None);
+        }
+
+        log::info!(
+            "VsockHostStore::load(cid={}, port={}) — got {} bytes",
             self.cid,
-            self.load_port
+            self.load_port,
+            out.len()
         );
-        Ok(None)
+        Ok(Some(out))
     }
 
+    /// Open a fresh connection to the save port, write the blob in full,
+    /// and let `Drop` shut the stream down — the host helper sees EOF
+    /// and commits the file. Atomicity is the helper's responsibility
+    /// (a `socat OPEN:<file>,creat,trunc` pattern truncates on accept
+    /// and writes the new payload before close).
     fn save(&self, blob: &[u8]) -> Result<(), SvsmReqError> {
-        // TODO: open AF_VSOCK(cid, save_port), write framed blob.
-        log::debug!(
-            "VsockHostStore::save(cid={}, port={}, {} bytes) — not yet wired",
+        use crate::io::Write;
+        use crate::vsock::stream::VsockStream;
+
+        let mut stream = VsockStream::connect(self.save_port, self.cid).map_err(|e| {
+            log::error!(
+                "VsockHostStore::save(cid={}, port={}) — connect failed: {:?}",
+                self.cid,
+                self.save_port,
+                e
+            );
+            SvsmReqError::invalid_request()
+        })?;
+
+        // virtio-vsock under SVSM's HAL requires each `share`d buffer be
+        // <= PAGE_SIZE (see kernel/src/virtio/hal.rs). Pre-Tier-B blobs were
+        // ~2.7 KB so the single-shot write worked; the 16 KB s_NV section now
+        // pushes the blob past 4 KB, so we must chunk explicitly here.
+        const SAVE_CHUNK: usize = 2048;
+        let mut written = 0usize;
+        while written < blob.len() {
+            let end = core::cmp::min(blob.len(), written + SAVE_CHUNK);
+            let n = stream.write(&blob[written..end]).map_err(|e| {
+                log::error!(
+                    "VsockHostStore::save(cid={}, port={}) — write error at {}/{}: {:?}",
+                    self.cid,
+                    self.save_port,
+                    written,
+                    blob.len(),
+                    e
+                );
+                SvsmReqError::invalid_request()
+            })?;
+            if n == 0 {
+                log::error!(
+                    "VsockHostStore::save(cid={}, port={}) — write returned 0 at {}/{}",
+                    self.cid,
+                    self.save_port,
+                    written,
+                    blob.len()
+                );
+                return Err(SvsmReqError::invalid_request());
+            }
+            written += n;
+        }
+
+        log::info!(
+            "VsockHostStore::save(cid={}, port={}) — wrote {} bytes",
             self.cid,
             self.save_port,
             blob.len()

--- a/kernel/src/vtpm/sealed_store.rs
+++ b/kernel/src/vtpm/sealed_store.rs
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: MIT
+//
+// Pluggable storage backend for the sealed vTPM blob.
+//
+// The vTPM persistence cycle (`Provision` → seal → store, store → load →
+// `Recover`) is intentionally decoupled from the underlying durable medium
+// so that the same crypto path can be paired with different host-side
+// storage strategies. Three backends are bundled:
+//
+//   * `StaticBufStore`  — in-CVM static buffer, survives warm reboots
+//                         within the lifetime of the CVM (test / dev).
+//   * `IgvmVarStore`    — IGVM variable interface (stubbed, TODO).
+//   * `VsockHostStore`  — AF_VSOCK to a host-side helper that persists
+//                         the blob on the host filesystem
+//                         (feature-gated `vsock`).
+//
+// The trait is intentionally backend-agnostic so that it can be paired
+// with the upcoming SVSM block-layer abstraction or with a KBS-backed
+// stateful vTPM service without changing the persistence logic itself.
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+use crate::locking::SpinLock;
+use crate::protocols::errors::SvsmReqError;
+
+/// Persistent storage backend for the sealed vTPM blob.
+///
+/// Implementations must be safe to share across CPUs (`Send + Sync`);
+/// concurrency control is the implementation's responsibility.
+pub trait SealedBlobStore: Send + Sync {
+    /// Return the previously saved blob, if any.
+    ///
+    /// `Ok(None)` indicates a cold boot or an empty backend; the caller
+    /// should fall back to `VtpmBootMode::Provision`. A backend error is
+    /// distinct from an empty backend and is reported via `Err`.
+    fn load(&self) -> Result<Option<Vec<u8>>, SvsmReqError>;
+
+    /// Persist the given blob.
+    ///
+    /// Implementations should overwrite any prior content atomically when
+    /// the backend supports it.
+    fn save(&self, blob: &[u8]) -> Result<(), SvsmReqError>;
+}
+
+// ============================================================
+// StaticBufStore — in-CVM static buffer
+// ============================================================
+
+const STATIC_BUF_CAPACITY: usize = 4096;
+
+#[derive(Debug)]
+struct StaticBuf {
+    buf: [u8; STATIC_BUF_CAPACITY],
+    len: usize,
+    valid: bool,
+}
+
+/// In-CVM static buffer. Survives warm reboots within a single CVM
+/// lifetime; zeroed on cold boot. Intended for development, testing,
+/// and bring-up scenarios where no durable backing store is available.
+#[derive(Debug)]
+pub struct StaticBufStore {
+    inner: SpinLock<StaticBuf>,
+}
+
+impl StaticBufStore {
+    /// Create an empty store. Suitable for declaring as a `static`.
+    pub const fn new() -> Self {
+        Self {
+            inner: SpinLock::new(StaticBuf {
+                buf: [0u8; STATIC_BUF_CAPACITY],
+                len: 0,
+                valid: false,
+            }),
+        }
+    }
+
+    /// Storage capacity in bytes.
+    pub const fn capacity(&self) -> usize {
+        STATIC_BUF_CAPACITY
+    }
+}
+
+impl Default for StaticBufStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SealedBlobStore for StaticBufStore {
+    fn load(&self) -> Result<Option<Vec<u8>>, SvsmReqError> {
+        let g = self.inner.lock();
+        if g.valid && g.len > 0 {
+            Ok(Some(g.buf[..g.len].to_vec()))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn save(&self, blob: &[u8]) -> Result<(), SvsmReqError> {
+        if blob.len() > STATIC_BUF_CAPACITY {
+            log::error!(
+                "StaticBufStore::save — blob {} exceeds capacity {}",
+                blob.len(),
+                STATIC_BUF_CAPACITY
+            );
+            return Err(SvsmReqError::invalid_request());
+        }
+        let mut g = self.inner.lock();
+        g.buf[..blob.len()].copy_from_slice(blob);
+        g.len = blob.len();
+        g.valid = true;
+        Ok(())
+    }
+}
+
+// ============================================================
+// IgvmVarStore — stub for future IGVM variable backend
+// ============================================================
+
+/// IGVM variable-backed store. Reserved for the production path; the
+/// load/save plumbing through the IGVM variable interface is not yet
+/// implemented in this tree.
+#[derive(Debug)]
+pub struct IgvmVarStore;
+
+impl IgvmVarStore {
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for IgvmVarStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SealedBlobStore for IgvmVarStore {
+    fn load(&self) -> Result<Option<Vec<u8>>, SvsmReqError> {
+        log::debug!("IgvmVarStore::load — not yet implemented, returning empty");
+        Ok(None)
+    }
+
+    fn save(&self, _blob: &[u8]) -> Result<(), SvsmReqError> {
+        log::warn!("IgvmVarStore::save — not yet implemented, silently dropped");
+        Ok(())
+    }
+}
+
+// ============================================================
+// VsockHostStore — AF_VSOCK to a host-side persistence helper
+// ============================================================
+
+/// VSOCK-backed store. Persists the sealed blob via a host-side helper
+/// reachable over AF_VSOCK. The two ports separate the load and save
+/// directions so that the helper can implement them as independent
+/// services if desired.
+#[cfg(feature = "vsock")]
+#[derive(Debug)]
+pub struct VsockHostStore {
+    pub cid: u32,
+    pub load_port: u32,
+    pub save_port: u32,
+}
+
+#[cfg(feature = "vsock")]
+impl VsockHostStore {
+    /// Default VSOCK ports: 9997 for load, 9998 for save.
+    pub const DEFAULT_LOAD_PORT: u32 = 9997;
+    pub const DEFAULT_SAVE_PORT: u32 = 9998;
+
+    pub const fn new(cid: u32, load_port: u32, save_port: u32) -> Self {
+        Self {
+            cid,
+            load_port,
+            save_port,
+        }
+    }
+}
+
+#[cfg(feature = "vsock")]
+impl SealedBlobStore for VsockHostStore {
+    fn load(&self) -> Result<Option<Vec<u8>>, SvsmReqError> {
+        // TODO: open AF_VSOCK(cid, load_port), read framed blob.
+        log::debug!(
+            "VsockHostStore::load(cid={}, port={}) — not yet wired",
+            self.cid,
+            self.load_port
+        );
+        Ok(None)
+    }
+
+    fn save(&self, blob: &[u8]) -> Result<(), SvsmReqError> {
+        // TODO: open AF_VSOCK(cid, save_port), write framed blob.
+        log::debug!(
+            "VsockHostStore::save(cid={}, port={}, {} bytes) — not yet wired",
+            self.cid,
+            self.save_port,
+            blob.len()
+        );
+        Ok(())
+    }
+}

--- a/kernel/src/vtpm/state.rs
+++ b/kernel/src/vtpm/state.rs
@@ -1,0 +1,319 @@
+// SPDX-License-Identifier: MIT
+//
+// TPM internal-state extraction and injection.
+//
+// Provides `extract_vtpm_state()` / `inject_vtpm_state()` via FFI into the
+// `state_accessor.{c,h}` getter/setter functions, which directly access
+// the TPM 2.0 Reference Implementation's internal globals (gp, gc, gr).
+// A command-based fallback (`extract_vtpm_state_via_commands`) is sketched
+// for environments where the direct accessors are unavailable.
+
+extern crate alloc;
+
+use alloc::vec;
+use alloc::vec::Vec;
+
+use crate::protocols::errors::SvsmReqError;
+
+// ============================================================
+// FFI Declarations — direct extern "C" (no bindgen needed)
+// ============================================================
+
+unsafe extern "C" {
+    // Seed accessors
+    fn get_ep_seed(out: *mut u8);
+    fn set_ep_seed(in_: *const u8);
+    fn get_sp_seed(out: *mut u8);
+    fn set_sp_seed(in_: *const u8);
+    fn get_pp_seed(out: *mut u8);
+    fn set_pp_seed(in_: *const u8);
+
+    // Auth value accessors (return actual size written)
+    fn get_owner_auth(out_buf: *mut u8, buf_size: usize) -> usize;
+    fn set_owner_auth(in_: *const u8, len: usize);
+    fn get_endorsement_auth(out_buf: *mut u8, buf_size: usize) -> usize;
+    fn set_endorsement_auth(in_: *const u8, len: usize);
+    fn get_lockout_auth(out_buf: *mut u8, buf_size: usize) -> usize;
+    fn set_lockout_auth(in_: *const u8, len: usize);
+    fn get_platform_auth(out_buf: *mut u8, buf_size: usize) -> usize;
+    fn set_platform_auth(in_: *const u8, len: usize);
+
+    // Counter accessors
+    fn get_total_reset_count() -> u64;
+    fn set_total_reset_count(val: u64);
+    fn get_reset_count() -> u32;
+    fn set_reset_count(val: u32);
+    fn get_clear_count() -> u32;
+    fn set_clear_count(val: u32);
+    #[allow(dead_code)]
+    fn get_object_context_id() -> u64;
+    #[allow(dead_code)]
+    fn set_object_context_id(val: u64);
+
+    // PCR save accessors
+    fn get_pcr_save(out_buf: *mut u8, buf_size: usize) -> usize;
+    fn set_pcr_save(in_: *const u8, len: usize);
+
+    // Bulk serialization
+    fn serialize_vtpm_state(out_buf: *mut u8, buf_size: usize) -> usize;
+    fn deserialize_vtpm_state(in_: *const u8, len: usize) -> i32;
+}
+
+// ============================================================
+// Constants
+// ============================================================
+
+/// Primary seed size in bytes (SHA-256 → 32 bytes)
+pub const PRIMARY_SEED_SIZE: usize = 32;
+
+/// Maximum auth value buffer size
+const MAX_AUTH_SIZE: usize = 64;
+
+/// Maximum PCR save area size (worst case: SHA-256 + SHA-384 + SHA-512 banks)
+const MAX_PCR_SAVE_SIZE: usize = 4096;
+
+/// Maximum serialized state buffer size
+const MAX_SERIALIZED_SIZE: usize = 8192;
+
+// ============================================================
+// VtpmInternalState — Mirror of TPM Internal Globals
+// ============================================================
+
+/// Complete dump of seal-relevant TPM internal state.
+///
+/// Covers Persistent (gp), State Clear (gc), and State Reset (gr) data.
+#[derive(Debug, Clone)]
+pub struct VtpmInternalState {
+    /// Endorsement Primary Seed (32 bytes)
+    pub ep_seed: [u8; 32],
+    /// Storage Primary Seed (32 bytes) — the SRK seed
+    pub sp_seed: [u8; 32],
+    /// Platform Primary Seed (32 bytes)
+    pub pp_seed: [u8; 32],
+    /// Owner hierarchy auth value
+    pub owner_auth: Vec<u8>,
+    /// Endorsement hierarchy auth value
+    pub endorsement_auth: Vec<u8>,
+    /// Lockout auth value
+    pub lockout_auth: Vec<u8>,
+    /// Platform auth value
+    pub platform_auth: Vec<u8>,
+    /// PCR save area (raw binary dump of PCR_SAVE struct)
+    pub pcr_save: Vec<u8>,
+    /// Total reset counter (monotonic across TPM lifetime)
+    pub total_reset_count: u64,
+    /// Reset counter (reset by TPM2_Clear)
+    pub reset_count: u32,
+    /// Clear count (incremented on TPM Resume)
+    pub clear_count: u32,
+}
+
+impl VtpmInternalState {
+    /// Create an empty (all-zeros) state for bootstrap.
+    pub fn empty() -> Self {
+        Self {
+            ep_seed: [0u8; 32],
+            sp_seed: [0u8; 32],
+            pp_seed: [0u8; 32],
+            owner_auth: Vec::new(),
+            endorsement_auth: Vec::new(),
+            lockout_auth: Vec::new(),
+            platform_auth: Vec::new(),
+            pcr_save: Vec::new(),
+            total_reset_count: 0,
+            reset_count: 0,
+            clear_count: 0,
+        }
+    }
+}
+
+// ============================================================
+// Direct global access via libtcgtpm accessors (FFI)
+// ============================================================
+
+/// Extract all seal-relevant TPM internal state via direct C global access.
+///
+/// Calls the state_accessor.c getter functions, which read gp, gc, gr
+/// directly. This is the fastest path but requires libtcgtpm to be
+/// compiled with state_accessor.c.
+pub fn extract_vtpm_state() -> Result<VtpmInternalState, SvsmReqError> {
+    let mut ep_seed = [0u8; 32];
+    let mut sp_seed = [0u8; 32];
+    let mut pp_seed = [0u8; 32];
+
+    // SAFETY: FFI calls into state_accessor.c. Buffer pointers and sizes are correct.
+    unsafe {
+        get_ep_seed(ep_seed.as_mut_ptr());
+        get_sp_seed(sp_seed.as_mut_ptr());
+        get_pp_seed(pp_seed.as_mut_ptr());
+    }
+
+    let owner_auth = get_auth_value(get_owner_auth)?;
+    let endorsement_auth = get_auth_value(get_endorsement_auth)?;
+    let lockout_auth = get_auth_value(get_lockout_auth)?;
+    let platform_auth = get_auth_value(get_platform_auth)?;
+
+    let mut pcr_buf = vec![0u8; MAX_PCR_SAVE_SIZE];
+    let pcr_len;
+    // SAFETY: FFI call with correct buffer size.
+    unsafe {
+        pcr_len = get_pcr_save(pcr_buf.as_mut_ptr(), pcr_buf.len());
+    }
+    pcr_buf.truncate(pcr_len);
+
+    let total_reset_count;
+    let reset_count;
+    let clear_count;
+    // SAFETY: FFI calls returning scalar values.
+    unsafe {
+        total_reset_count = get_total_reset_count();
+        reset_count = get_reset_count();
+        clear_count = get_clear_count();
+    }
+
+    Ok(VtpmInternalState {
+        ep_seed,
+        sp_seed,
+        pp_seed,
+        owner_auth,
+        endorsement_auth,
+        lockout_auth,
+        platform_auth,
+        pcr_save: pcr_buf,
+        total_reset_count,
+        reset_count,
+        clear_count,
+    })
+}
+
+/// Inject TPM internal state via direct C global write.
+///
+/// Writes all seal-relevant fields back into gp, gc, gr. This must be
+/// called before any TPM operation that depends on the restored state
+/// (e.g., before creating the SRK or loading persistent objects).
+pub fn inject_vtpm_state(state: &VtpmInternalState) -> Result<(), SvsmReqError> {
+    // SAFETY: FFI calls into state_accessor.c. All pointers and lengths are valid.
+    unsafe {
+        set_ep_seed(state.ep_seed.as_ptr());
+        set_sp_seed(state.sp_seed.as_ptr());
+        set_pp_seed(state.pp_seed.as_ptr());
+
+        set_owner_auth(state.owner_auth.as_ptr(), state.owner_auth.len());
+        set_endorsement_auth(
+            state.endorsement_auth.as_ptr(),
+            state.endorsement_auth.len(),
+        );
+        set_lockout_auth(state.lockout_auth.as_ptr(), state.lockout_auth.len());
+        set_platform_auth(state.platform_auth.as_ptr(), state.platform_auth.len());
+
+        set_pcr_save(state.pcr_save.as_ptr(), state.pcr_save.len());
+
+        set_total_reset_count(state.total_reset_count);
+        set_reset_count(state.reset_count);
+        set_clear_count(state.clear_count);
+    }
+
+    Ok(())
+}
+
+// ============================================================
+// Bulk Serialization (C-backed)
+// ============================================================
+
+/// Serialize all seal-relevant state into a flat binary buffer using
+/// the C `serialize_vtpm_state()` function.
+///
+/// Returns the serialized bytes. This is the recommended path for
+/// state extraction before sealing, as the C function knows the exact
+/// struct layouts.
+pub fn extract_serialized_state() -> Result<Vec<u8>, SvsmReqError> {
+    let mut buf = vec![0u8; MAX_SERIALIZED_SIZE];
+    let written;
+    // SAFETY: FFI call with correctly sized buffer.
+    unsafe {
+        written = serialize_vtpm_state(buf.as_mut_ptr(), buf.len());
+    }
+    if written == 0 || written > buf.len() {
+        log::error!("serialize_vtpm_state failed: buffer too small or error");
+        return Err(SvsmReqError::invalid_request());
+    }
+    buf.truncate(written);
+    Ok(buf)
+}
+
+/// Deserialize state from the C `serialize_vtpm_state()` format back
+/// into TPM globals.
+pub fn inject_serialized_state(data: &[u8]) -> Result<(), SvsmReqError> {
+    let ret;
+    // SAFETY: FFI call with valid buffer pointer and length.
+    unsafe {
+        ret = deserialize_vtpm_state(data.as_ptr(), data.len());
+    }
+    if ret != 0 {
+        log::error!("deserialize_vtpm_state failed: error code {ret}");
+        return Err(SvsmReqError::invalid_request());
+    }
+    Ok(())
+}
+
+// ============================================================
+// Command-based fallback path (skeleton)
+// ============================================================
+
+/// Extract vTPM state using standard TPM 2.0 commands.
+///
+/// This path uses:
+///   - TPM2_NV_Read for persistent NV indices (auth values, counters)
+///   - TPM2_ContextSave for loaded objects (EK, SRK)
+///   - TPM2_GetCapability for PCR allocation and algorithm info
+///
+/// This is specification-compliant and works with any TPM (real or
+/// simulated), but requires the TPM to be fully initialized and the
+/// target objects to be loaded.
+///
+/// NOT YET IMPLEMENTED — placeholder for environments where the direct
+/// libtcgtpm accessors are unavailable.
+#[allow(dead_code)]
+pub fn extract_vtpm_state_via_commands() -> Result<Vec<u8>, SvsmReqError> {
+    // A command-based extraction path would:
+    // 1. TPM2_HierarchyChangeAuth(TPM_RH_OWNER) — read ownerAuth
+    //    (can't actually read it; would need prior knowledge or use Policy)
+    // 2. TPM2_NV_Read for NV indices 0x01c00000–0x01c00003 (EK, SRK templates)
+    // 3. TPM2_ContextSave for the SRK handle (if loaded)
+    // 4. TPM2_ContextSave for the EK handle (if loaded)
+    // 5. TPM2_GetCapability(TPM_CAP_TPM_PROPERTIES, TPM_PT_RESET_COUNT, ...)
+    // 6. TPM2_GetCapability(TPM_CAP_PCR, ...)
+    //
+    // Limitation: auth values cannot be read via TPM commands by design.
+    // This path therefore requires the provisioner to have set known auth
+    // values during manufacturing, or to use policy-based access.
+    log::warn!("Command-based state extraction not yet implemented");
+    Err(SvsmReqError::invalid_request())
+}
+
+// ============================================================
+// Helpers
+// ============================================================
+
+/// Read an auth value via the C getter, which returns the actual
+/// length and copies data into a caller-provided buffer.
+fn get_auth_value(
+    getter: unsafe extern "C" fn(*mut u8, usize) -> usize,
+) -> Result<Vec<u8>, SvsmReqError> {
+    let mut buf = vec![0u8; MAX_AUTH_SIZE];
+    let len;
+    // SAFETY: FFI call into state_accessor.c. Buffer pointer and size are valid.
+    unsafe {
+        len = getter(buf.as_mut_ptr(), buf.len());
+    }
+    if len > buf.len() {
+        log::error!(
+            "Auth value getter returned length {} > buffer {}",
+            len,
+            buf.len()
+        );
+        return Err(SvsmReqError::invalid_request());
+    }
+    buf.truncate(len);
+    Ok(buf)
+}

--- a/kernel/src/vtpm/state.rs
+++ b/kernel/src/vtpm/state.rs
@@ -72,8 +72,12 @@ const MAX_AUTH_SIZE: usize = 64;
 /// Maximum PCR save area size (worst case: SHA-256 + SHA-384 + SHA-512 banks)
 const MAX_PCR_SAVE_SIZE: usize = 4096;
 
-/// Maximum serialized state buffer size
-const MAX_SERIALIZED_SIZE: usize = 8192;
+/// Maximum serialized state buffer size.
+///
+/// Sized for the Tier-A field set (DA + PCR alloc, blob ~3 KB) with
+/// headroom for an upcoming Tier-B section that dumps the full 16 KB
+/// `s_NV[]` platform NV memory.
+const MAX_SERIALIZED_SIZE: usize = 32768;
 
 // ============================================================
 // VtpmInternalState — Mirror of TPM Internal Globals
@@ -136,6 +140,7 @@ impl VtpmInternalState {
 /// Calls the state_accessor.c getter functions, which read gp, gc, gr
 /// directly. This is the fastest path but requires libtcgtpm to be
 /// compiled with state_accessor.c.
+#[inline] // R1: avoid sret aggregate-return on VtpmInternalState
 pub fn extract_vtpm_state() -> Result<VtpmInternalState, SvsmReqError> {
     let mut ep_seed = [0u8; 32];
     let mut sp_seed = [0u8; 32];
@@ -226,6 +231,7 @@ pub fn inject_vtpm_state(state: &VtpmInternalState) -> Result<(), SvsmReqError> 
 /// Returns the serialized bytes. This is the recommended path for
 /// state extraction before sealing, as the C function knows the exact
 /// struct layouts.
+#[inline] // R1: avoid sret aggregate-return on Vec<u8>
 pub fn extract_serialized_state() -> Result<Vec<u8>, SvsmReqError> {
     let mut buf = vec![0u8; MAX_SERIALIZED_SIZE];
     let written;
@@ -274,6 +280,7 @@ pub fn inject_serialized_state(data: &[u8]) -> Result<(), SvsmReqError> {
 /// NOT YET IMPLEMENTED — placeholder for environments where the direct
 /// libtcgtpm accessors are unavailable.
 #[allow(dead_code)]
+#[inline] // R1: avoid sret aggregate-return on Vec<u8>
 pub fn extract_vtpm_state_via_commands() -> Result<Vec<u8>, SvsmReqError> {
     // A command-based extraction path would:
     // 1. TPM2_HierarchyChangeAuth(TPM_RH_OWNER) — read ownerAuth

--- a/kernel/src/vtpm/tcgtpm/mod.rs
+++ b/kernel/src/vtpm/tcgtpm/mod.rs
@@ -88,6 +88,7 @@ impl VtpmProtocolInterface for TcgTpm {
 pub const TPM_BUFFER_MAX_SIZE: usize = PAGE_SIZE;
 
 impl TcgTpmSimulatorInterface for TcgTpm {
+    #[inline] // R1: avoid sret aggregate-return on Vec<u8>
     fn send_tpm_command(&self, command: &[u8], locality: u8) -> Result<Vec<u8>, SvsmReqError> {
         if !self.is_powered_on {
             return Err(SvsmReqError::invalid_request());
@@ -133,6 +134,24 @@ impl TcgTpmSimulatorInterface for TcgTpm {
             response_ffi.set_len(response_ffi_size as usize);
         }
 
+        // A3 — runtime re-seal hook.
+        //
+        // The vTPM persistence cycle seals at Provision/Recover time but never
+        // commits guest-runtime NV writes (e.g. `tpm2_nvwrite` between boots).
+        // Sniff TPM2_Shutdown(SU_STATE) as a natural re-seal trigger: TCG
+        // semantics say the OS is about to lose volatile state, which is exactly
+        // the moment we need to persist g* + s_NV into a fresh SealedBlob.
+        //
+        // The hook is a no-op when:
+        //   - the command is not TPM2_Shutdown (cmdCode != 0x00000145), or
+        //   - Shutdown itself returned non-success (avoid re-sealing inconsistent state).
+        //
+        // The hook never propagates failure — re-seal errors are logged; the
+        // guest still sees its real Shutdown rc. fail-closed is enforced on the
+        // next cold boot's unseal path (NV-counter check + AES-GCM tag verify).
+        #[cfg(feature = "vtpm-persist")]
+        crate::vtpm::reseal::trigger_if_shutdown(command, &response_ffi);
+
         Ok(response_ffi)
     }
 
@@ -175,6 +194,7 @@ impl TcgTpmSimulatorInterface for TcgTpm {
 }
 
 impl VtpmInterface for TcgTpm {
+    #[inline] // R1: avoid sret aggregate-return on Vec<u8>
     fn get_ekpub(&mut self) -> Result<Vec<u8>, SvsmReqError> {
         if self.ekpub.is_none() {
             self.ekpub = Some(tss::create_ek(self, &DEFAULT_PUBLIC_AREA[..])?);
@@ -225,6 +245,30 @@ impl VtpmInterface for TcgTpm {
         self.signal_nvon()?;
 
         log::info!("VTPM: TPM 2.0 Reference Implementation initialized");
+
+        Ok(())
+    }
+
+    fn recover_init(&mut self) -> Result<(), SvsmReqError> {
+        // Recover path: bring the platform layer up but DO NOT manufacture.
+        // Manufacturing would re-seed EPS/SPS/PPS, destroying the
+        // correspondence between the in-memory hierarchies and the keys
+        // sealed in the SealedBlob. We need NVEnable so the simulator's
+        // NV region is mapped, signal_poweron(false) so PowerOn+Reset
+        // bring the globals up into a "needs TPM2_Startup" state, and
+        // signal_nvon so NV-backed operations work.
+
+        // SAFETY: FFI call. Parameters and return values are checked.
+        let rc = unsafe { _plat__NVEnable(VirtAddr::null().as_mut_ptr::<c_void>(), 0) };
+        if rc != 0 {
+            log::error!("_plat__NVEnable (recover) failed rc={rc}");
+            return Err(SvsmReqError::incomplete());
+        }
+
+        self.signal_poweron(false)?;
+        self.signal_nvon()?;
+
+        log::info!("VTPM: TPM 2.0 Reference Implementation initialized (Recover)");
 
         Ok(())
     }

--- a/kernel/src/vtpm/tcgtpm/tss.rs
+++ b/kernel/src/vtpm/tcgtpm/tss.rs
@@ -42,6 +42,7 @@ fn extend_empty_auth(buf: &mut Vec<u8>) {
     ]);
 }
 
+#[inline] // R1: avoid sret aggregate-return on Vec<u8>
 fn create_mtauth_ek_cmd(tpmt_public: &[u8]) -> Vec<u8> {
     let mut cmd = Vec::<u8>::with_capacity(TPM_BUFFER_MAX_SIZE);
 

--- a/libtcgtpm/Makefile
+++ b/libtcgtpm/Makefile
@@ -72,7 +72,33 @@ endif
 # Parallel builds are still used inside the sub-targets (-j flag)
 .NOTPARALLEL:
 
-all: $(LIBCRT) $(LIBCRYPTO) $(LIBBNMATH) $(LIBTPMBIGNUM) $(LIBTPM) $(LIBPLATFORM)
+# State accessor: direct TPM global state access (gp, gc, gr)
+STATE_ACCESSOR_SRC = $(ROOT_DIR)/state_accessor.c
+STATE_ACCESSOR_OBJ = $(OUT_DIR)/state_accessor.o
+STATE_ACCESSOR_LIB = $(OUT_DIR)/libStateAccessor.a
+STATE_ACCESSOR_CFLAGS = $(TCGTPM_CFLAGS) \
+	-DSYM_LIB=Ossl \
+	-DHASH_LIB=Ossl \
+	-DMATH_LIB=TpmBigNum \
+	-DBN_MATH_LIB=Ossl \
+	-I$(TCGTPM_SRC_DIR)/tpm/include \
+	-I$(TCGTPM_SRC_DIR)/tpm/include/private \
+	-I$(TCGTPM_SRC_DIR)/tpm/include/private/prototypes \
+	-I$(TCGTPM_SRC_DIR)/tpm/include/platform_interface/Tpm_Platform_Interface \
+	-I$(TCGTPM_SRC_DIR)/tpm/include/platform_interface/Tpm_Platform_Interface/prototypes \
+	-I$(TCGTPM_SRC_DIR)/Platform/include \
+	-I$(TCGTPM_SRC_DIR)/tpm/cryptolibs/Ossl/include \
+	-I$(TCGTPM_SRC_DIR)/tpm/cryptolibs/TpmBigNum/include \
+	-I$(TCGTPM_SRC_DIR)/tpm/cryptolibs/common/include \
+	-I$(DEPS_DIR)/TpmConfiguration
+
+all: $(LIBCRT) $(LIBCRYPTO) $(LIBBNMATH) $(LIBTPMBIGNUM) $(LIBTPM) $(LIBPLATFORM) $(STATE_ACCESSOR_LIB)
+
+$(STATE_ACCESSOR_OBJ): $(STATE_ACCESSOR_SRC) $(LIBTPM) $(LIBPLATFORM)
+	$(CC) -c $(STATE_ACCESSOR_CFLAGS) -o $@ $<
+
+$(STATE_ACCESSOR_LIB): $(STATE_ACCESSOR_OBJ)
+	$(AR) rcs $@ $<
 
 .PHONY: $(LIBCRT)
 

--- a/libtcgtpm/build.rs
+++ b/libtcgtpm/build.rs
@@ -38,6 +38,32 @@ fn main() {
         .allowlist_function("_plat__NVEnable")
         .allowlist_function("TPM_Manufacture")
         .allowlist_function("TPM_TearDown")
+        .allowlist_function("get_ep_seed")
+        .allowlist_function("set_ep_seed")
+        .allowlist_function("get_sp_seed")
+        .allowlist_function("set_sp_seed")
+        .allowlist_function("get_pp_seed")
+        .allowlist_function("set_pp_seed")
+        .allowlist_function("get_owner_auth")
+        .allowlist_function("set_owner_auth")
+        .allowlist_function("get_endorsement_auth")
+        .allowlist_function("set_endorsement_auth")
+        .allowlist_function("get_lockout_auth")
+        .allowlist_function("set_lockout_auth")
+        .allowlist_function("get_platform_auth")
+        .allowlist_function("set_platform_auth")
+        .allowlist_function("get_total_reset_count")
+        .allowlist_function("set_total_reset_count")
+        .allowlist_function("get_reset_count")
+        .allowlist_function("set_reset_count")
+        .allowlist_function("get_pcr_save")
+        .allowlist_function("set_pcr_save")
+        .allowlist_function("get_clear_count")
+        .allowlist_function("set_clear_count")
+        .allowlist_function("get_object_context_id")
+        .allowlist_function("set_object_context_id")
+        .allowlist_function("serialize_vtpm_state")
+        .allowlist_function("deserialize_vtpm_state")
         .use_core()
         .clang_arg("-Wno-incompatible-library-redeclaration")
         .clang_arg("-nostdinc")
@@ -52,6 +78,10 @@ fn main() {
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .unwrap_or_else(|_| panic!("Unable to write bindings.rs"));
+
+    // State accessor library (direct TPM global state access)
+    println!("cargo:rustc-link-search={out_dir}");
+    println!("cargo:rustc-link-lib=static=StateAccessor");
 
     // 'static=...' is needed because core lib + platform lib have
     // circular dependencies.

--- a/libtcgtpm/state_accessor.c
+++ b/libtcgtpm/state_accessor.c
@@ -183,6 +183,106 @@ void set_object_context_id(uint64_t val)
 }
 
 /* ============================================================
+ * Persistent Data (gp) — Dictionary Attack tracking
+ * ============================================================ */
+
+uint32_t get_failed_tries(void)            { return gp.failedTries; }
+void     set_failed_tries(uint32_t val)    { gp.failedTries = val; }
+uint32_t get_max_tries(void)               { return gp.maxTries; }
+void     set_max_tries(uint32_t val)       { gp.maxTries = val; }
+uint32_t get_recovery_time(void)           { return gp.recoveryTime; }
+void     set_recovery_time(uint32_t val)   { gp.recoveryTime = val; }
+uint32_t get_lockout_recovery(void)        { return gp.lockoutRecovery; }
+void     set_lockout_recovery(uint32_t val){ gp.lockoutRecovery = val; }
+
+uint8_t get_lockout_auth_enabled(void)
+{
+    return gp.lockOutAuthEnabled ? 1 : 0;
+}
+
+void set_lockout_auth_enabled(uint8_t val)
+{
+    gp.lockOutAuthEnabled = val ? TRUE : FALSE;
+}
+
+/* ============================================================
+ * Persistent Data (gp) — Orderly shutdown state
+ * ============================================================ */
+
+uint16_t get_orderly_state(void)
+{
+    return (uint16_t)gp.orderlyState;
+}
+
+void set_orderly_state(uint16_t val)
+{
+    gp.orderlyState = (TPM_SU)val;
+}
+
+/* ============================================================
+ * Persistent Data (gp) — PCR allocation
+ * ============================================================ */
+
+size_t get_pcr_allocated(uint8_t *out_buf, size_t buf_size)
+{
+    size_t copy_len = sizeof(gp.pcrAllocated);
+    if (copy_len > buf_size) copy_len = buf_size;
+    memcpy(out_buf, &gp.pcrAllocated, copy_len);
+    return copy_len;
+}
+
+void set_pcr_allocated(const uint8_t *in, size_t len)
+{
+    size_t copy_len = sizeof(gp.pcrAllocated);
+    if (len < copy_len) copy_len = len;
+    memcpy(&gp.pcrAllocated, in, copy_len);
+}
+
+/* ============================================================
+ * Platform NV memory blob (Tier-B)
+ * ============================================================
+ *
+ * The simulator's `s_NV[NV_MEMORY_SIZE]` flat buffer holds, in order:
+ *   [0 .. sizeof(gp))                       PERSISTENT_DATA (mirror of gp)
+ *   [sizeof(gp) .. NV_USER_DYNAMIC)         STATE_RESET / STATE_CLEAR /
+ *                                           index-orderly RAM mirror
+ *   [NV_USER_DYNAMIC .. NV_MEMORY_SIZE)     dynamic area: user NV indices
+ *                                           and evict objects + list end
+ *
+ * NV-index lookup (`NvNext` in NvDynamic.c) walks this byte layout directly
+ * via `_plat__NvMemoryRead`, so there is no separate in-memory index cache to
+ * rebuild — restoring the 16 KB bytes is sufficient for `tpm2_nvread` of a
+ * user index to resolve after cold-boot Recover.
+ */
+
+extern int  _plat__NvMemoryRead(unsigned int startOffset, unsigned int size, void *data);
+extern int  _plat__NvMemoryWrite(unsigned int startOffset, unsigned int size, void *data);
+extern void NvReadPersistent(void);
+
+#define STATE_NV_BACKUP_SIZE 16384u  /* matches TpmProfile_Misc.h NV_MEMORY_SIZE */
+
+size_t get_nv_blob(uint8_t *out_buf, size_t buf_size)
+{
+    if (buf_size < STATE_NV_BACKUP_SIZE) return 0;
+    /* Force RAM gp into s_NV[NV_PERSISTENT_DATA=0] so the dumped blob
+     * reflects the latest in-memory persistent state, not the last NvCommit. */
+    _plat__NvMemoryWrite(0, (unsigned int)sizeof(gp), &gp);
+    _plat__NvMemoryRead(0, STATE_NV_BACKUP_SIZE, out_buf);
+    return STATE_NV_BACKUP_SIZE;
+}
+
+void set_nv_blob(const uint8_t *in, size_t len)
+{
+    unsigned int n = (len < STATE_NV_BACKUP_SIZE) ? (unsigned int)len : STATE_NV_BACKUP_SIZE;
+    /* Cast away const for the platform API; it does a memcpy and never writes
+     * through the pointer. */
+    _plat__NvMemoryWrite(0, n, (void *)(uintptr_t)in);
+    /* Sync the freshly-written s_NV[NV_PERSISTENT_DATA] back into RAM gp.
+     * Subsequent 0x01-0x19 sections will overlay individual fields on top. */
+    NvReadPersistent();
+}
+
+/* ============================================================
  * Bulk Serialization
  * ============================================================
  *
@@ -218,6 +318,30 @@ size_t serialize_vtpm_state(uint8_t *out_buf, size_t buf_size)
 {
     size_t offset = 4; /* reserve 4 bytes for total size */
     size_t written;
+
+    /* 0x1A: platform NV blob (16384B).
+     *
+     * IMPORTANT: emitted FIRST so the deserializer applies it before the
+     * 0x01-0x19 setters. Otherwise `NvReadPersistent()` inside `set_nv_blob`
+     * would clobber the previously-restored RAM gp fields.
+     *
+     * Dumped directly into out_buf to avoid a 16 KB intermediate stack buffer
+     * in the SVSM kernel context (where stack is more constrained than in a
+     * userspace swtpm process). */
+    {
+        size_t needed = offset + 5 + STATE_NV_BACKUP_SIZE;
+        if (needed > buf_size) return 0;
+        /* Force RAM gp into s_NV[NV_PERSISTENT_DATA=0] so the dumped blob
+         * reflects the latest in-memory persistent state. */
+        _plat__NvMemoryWrite(0, (unsigned int)sizeof(gp), &gp);
+        out_buf[offset]     = 0x1A;
+        out_buf[offset + 1] = (uint8_t)(STATE_NV_BACKUP_SIZE & 0xFFu);
+        out_buf[offset + 2] = (uint8_t)((STATE_NV_BACKUP_SIZE >> 8) & 0xFFu);
+        out_buf[offset + 3] = (uint8_t)((STATE_NV_BACKUP_SIZE >> 16) & 0xFFu);
+        out_buf[offset + 4] = (uint8_t)((STATE_NV_BACKUP_SIZE >> 24) & 0xFFu);
+        _plat__NvMemoryRead(0, STATE_NV_BACKUP_SIZE, out_buf + offset + 5);
+        offset += 5 + STATE_NV_BACKUP_SIZE;
+    }
 
     /* 0x01: EP Seed (32B) */
     written = write_section_val(out_buf, buf_size, offset, 0x01,
@@ -306,6 +430,53 @@ size_t serialize_vtpm_state(uint8_t *out_buf, size_t buf_size)
         if (!written) return 0;
         offset += written;
     }
+
+    /* 0x13..0x16: DA UINT32 fields (failedTries, maxTries, recoveryTime, lockoutRecovery) */
+    {
+        const uint32_t da_vals[4] = {
+            gp.failedTries,
+            gp.maxTries,
+            gp.recoveryTime,
+            gp.lockoutRecovery,
+        };
+        const uint8_t  da_ids[4] = { 0x13, 0x14, 0x15, 0x16 };
+        for (int i = 0; i < 4; ++i) {
+            uint8_t v[4];
+            v[0] = (uint8_t)(da_vals[i] & 0xFF);
+            v[1] = (uint8_t)((da_vals[i] >> 8) & 0xFF);
+            v[2] = (uint8_t)((da_vals[i] >> 16) & 0xFF);
+            v[3] = (uint8_t)((da_vals[i] >> 24) & 0xFF);
+            written = write_section_val(out_buf, buf_size, offset, da_ids[i], v, 4);
+            if (!written) return 0;
+            offset += written;
+        }
+    }
+
+    /* 0x17: lockOutAuthEnabled (1B) */
+    {
+        uint8_t lae = gp.lockOutAuthEnabled ? 1 : 0;
+        written = write_section_val(out_buf, buf_size, offset, 0x17, &lae, 1);
+        if (!written) return 0;
+        offset += written;
+    }
+
+    /* 0x18: orderlyState (2B, TPM_SU = UINT16) */
+    {
+        uint8_t os[2];
+        uint16_t v = (uint16_t)gp.orderlyState;
+        os[0] = (uint8_t)(v & 0xFF);
+        os[1] = (uint8_t)((v >> 8) & 0xFF);
+        written = write_section_val(out_buf, buf_size, offset, 0x18, os, 2);
+        if (!written) return 0;
+        offset += written;
+    }
+
+    /* 0x19: pcrAllocated (TPML_PCR_SELECTION, raw struct dump) */
+    written = write_section(out_buf, buf_size, offset, 0x19,
+                            (const uint8_t *)&gp.pcrAllocated,
+                            sizeof(gp.pcrAllocated));
+    if (!written) return 0;
+    offset += written;
 
     /* Write total size at the beginning */
     out_buf[0] = (uint8_t)(offset & 0xFF);
@@ -404,6 +575,54 @@ int deserialize_vtpm_state(const uint8_t *in, size_t len)
                           | ((uint32_t)data[1] << 8)
                           | ((uint32_t)data[2] << 16)
                           | ((uint32_t)data[3] << 24);
+            break;
+        case 0x13: /* failedTries */
+            if (data_len < 4) return -4;
+            gp.failedTries = (uint32_t)data[0]
+                           | ((uint32_t)data[1] << 8)
+                           | ((uint32_t)data[2] << 16)
+                           | ((uint32_t)data[3] << 24);
+            break;
+        case 0x14: /* maxTries */
+            if (data_len < 4) return -4;
+            gp.maxTries = (uint32_t)data[0]
+                        | ((uint32_t)data[1] << 8)
+                        | ((uint32_t)data[2] << 16)
+                        | ((uint32_t)data[3] << 24);
+            break;
+        case 0x15: /* recoveryTime */
+            if (data_len < 4) return -4;
+            gp.recoveryTime = (uint32_t)data[0]
+                            | ((uint32_t)data[1] << 8)
+                            | ((uint32_t)data[2] << 16)
+                            | ((uint32_t)data[3] << 24);
+            break;
+        case 0x16: /* lockoutRecovery */
+            if (data_len < 4) return -4;
+            gp.lockoutRecovery = (uint32_t)data[0]
+                               | ((uint32_t)data[1] << 8)
+                               | ((uint32_t)data[2] << 16)
+                               | ((uint32_t)data[3] << 24);
+            break;
+        case 0x17: /* lockOutAuthEnabled */
+            if (data_len < 1) return -4;
+            gp.lockOutAuthEnabled = data[0] ? TRUE : FALSE;
+            break;
+        case 0x18: /* orderlyState (TPM_SU = UINT16) */
+            if (data_len < 2) return -4;
+            gp.orderlyState = (TPM_SU)((uint16_t)data[0]
+                                     | ((uint16_t)data[1] << 8));
+            break;
+        case 0x19: /* pcrAllocated (TPML_PCR_SELECTION) */
+            if (data_len > sizeof(gp.pcrAllocated)) return -4;
+            memcpy(&gp.pcrAllocated, data, data_len);
+            break;
+        case 0x1A: /* platform NV blob (16384B s_NV[]) — Tier-B */
+            if (data_len != STATE_NV_BACKUP_SIZE) return -4;
+            /* set_nv_blob() writes s_NV[] then re-syncs RAM gp from
+             * s_NV[NV_PERSISTENT_DATA=0]. Subsequent 0x01-0x19 cases will
+             * overwrite individual gp fields with the per-section copies. */
+            set_nv_blob(data, data_len);
             break;
         default:
             /* Unknown section — skip */

--- a/libtcgtpm/state_accessor.c
+++ b/libtcgtpm/state_accessor.c
@@ -1,0 +1,415 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * TPM internal state accessor — implementation.
+ *
+ * Provides getter/setter functions that directly read/write the TPM 2.0
+ * Reference Implementation internal global state variables (gp, gc, gr).
+ */
+
+#include "Tpm.h"
+
+#include <string.h>
+
+/* ============================================================
+ * Persistent Data (gp) — Seed Accessors
+ * ============================================================ */
+
+void get_ep_seed(uint8_t *out)
+{
+    memcpy(out, gp.EPSeed.t.buffer, sizeof(gp.EPSeed.t.buffer));
+}
+
+void set_ep_seed(const uint8_t *in)
+{
+    memcpy(gp.EPSeed.t.buffer, in, sizeof(gp.EPSeed.t.buffer));
+    gp.EPSeed.t.size = sizeof(gp.EPSeed.t.buffer);
+}
+
+void get_sp_seed(uint8_t *out)
+{
+    memcpy(out, gp.SPSeed.t.buffer, sizeof(gp.SPSeed.t.buffer));
+}
+
+void set_sp_seed(const uint8_t *in)
+{
+    memcpy(gp.SPSeed.t.buffer, in, sizeof(gp.SPSeed.t.buffer));
+    gp.SPSeed.t.size = sizeof(gp.SPSeed.t.buffer);
+}
+
+void get_pp_seed(uint8_t *out)
+{
+    memcpy(out, gp.PPSeed.t.buffer, sizeof(gp.PPSeed.t.buffer));
+}
+
+void set_pp_seed(const uint8_t *in)
+{
+    memcpy(gp.PPSeed.t.buffer, in, sizeof(gp.PPSeed.t.buffer));
+    gp.PPSeed.t.size = sizeof(gp.PPSeed.t.buffer);
+}
+
+/* ============================================================
+ * Persistent Data (gp) — Auth Value Accessors
+ * ============================================================ */
+
+size_t get_owner_auth(uint8_t *out_buf, size_t buf_size)
+{
+    size_t copy_len = gp.ownerAuth.t.size;
+    if (copy_len > buf_size) copy_len = buf_size;
+    memcpy(out_buf, gp.ownerAuth.t.buffer, copy_len);
+    return copy_len;
+}
+
+void set_owner_auth(const uint8_t *in, size_t len)
+{
+    if (len > sizeof(gp.ownerAuth.t.buffer)) len = sizeof(gp.ownerAuth.t.buffer);
+    memcpy(gp.ownerAuth.t.buffer, in, len);
+    gp.ownerAuth.t.size = (UINT16)len;
+}
+
+size_t get_endorsement_auth(uint8_t *out_buf, size_t buf_size)
+{
+    size_t copy_len = gp.endorsementAuth.t.size;
+    if (copy_len > buf_size) copy_len = buf_size;
+    memcpy(out_buf, gp.endorsementAuth.t.buffer, copy_len);
+    return copy_len;
+}
+
+void set_endorsement_auth(const uint8_t *in, size_t len)
+{
+    if (len > sizeof(gp.endorsementAuth.t.buffer)) len = sizeof(gp.endorsementAuth.t.buffer);
+    memcpy(gp.endorsementAuth.t.buffer, in, len);
+    gp.endorsementAuth.t.size = (UINT16)len;
+}
+
+size_t get_lockout_auth(uint8_t *out_buf, size_t buf_size)
+{
+    size_t copy_len = gp.lockoutAuth.t.size;
+    if (copy_len > buf_size) copy_len = buf_size;
+    memcpy(out_buf, gp.lockoutAuth.t.buffer, copy_len);
+    return copy_len;
+}
+
+void set_lockout_auth(const uint8_t *in, size_t len)
+{
+    if (len > sizeof(gp.lockoutAuth.t.buffer)) len = sizeof(gp.lockoutAuth.t.buffer);
+    memcpy(gp.lockoutAuth.t.buffer, in, len);
+    gp.lockoutAuth.t.size = (UINT16)len;
+}
+
+/* ============================================================
+ * Persistent Data (gp) — Counter Accessors
+ * ============================================================ */
+
+uint64_t get_total_reset_count(void)
+{
+    return gp.totalResetCount;
+}
+
+void set_total_reset_count(uint64_t val)
+{
+    gp.totalResetCount = val;
+}
+
+uint32_t get_reset_count(void)
+{
+    return gp.resetCount;
+}
+
+void set_reset_count(uint32_t val)
+{
+    gp.resetCount = val;
+}
+
+/* ============================================================
+ * State Clear Data (gc) — PCR Save
+ * ============================================================ */
+
+size_t get_pcr_save(uint8_t *out_buf, size_t buf_size)
+{
+    size_t copy_len = sizeof(gc.pcrSave);
+    if (copy_len > buf_size) copy_len = buf_size;
+    memcpy(out_buf, &gc.pcrSave, copy_len);
+    return copy_len;
+}
+
+void set_pcr_save(const uint8_t *in, size_t len)
+{
+    size_t copy_len = sizeof(gc.pcrSave);
+    if (len < copy_len) copy_len = len;
+    memcpy(&gc.pcrSave, in, copy_len);
+}
+
+/* ============================================================
+ * State Clear Data (gc) — Platform Auth
+ * ============================================================ */
+
+size_t get_platform_auth(uint8_t *out_buf, size_t buf_size)
+{
+    size_t copy_len = gc.platformAuth.t.size;
+    if (copy_len > buf_size) copy_len = buf_size;
+    memcpy(out_buf, gc.platformAuth.t.buffer, copy_len);
+    return copy_len;
+}
+
+void set_platform_auth(const uint8_t *in, size_t len)
+{
+    if (len > sizeof(gc.platformAuth.t.buffer)) len = sizeof(gc.platformAuth.t.buffer);
+    memcpy(gc.platformAuth.t.buffer, in, len);
+    gc.platformAuth.t.size = (UINT16)len;
+}
+
+/* ============================================================
+ * State Reset Data (gr) — Counter Accessors
+ * ============================================================ */
+
+uint32_t get_clear_count(void)
+{
+    return gr.clearCount;
+}
+
+void set_clear_count(uint32_t val)
+{
+    gr.clearCount = val;
+}
+
+uint64_t get_object_context_id(void)
+{
+    return gr.objectContextID;
+}
+
+void set_object_context_id(uint64_t val)
+{
+    gr.objectContextID = val;
+}
+
+/* ============================================================
+ * Bulk Serialization
+ * ============================================================
+ *
+ * Layout: [4B total_size] [section...]
+ * Each section: [1B section_id] [4B len] [data]
+ */
+
+/* Helper: write a section into buf at offset. Returns bytes written, 0 on overflow. */
+static size_t write_section(uint8_t *buf, size_t buf_size, size_t offset,
+                            uint8_t section_id, const uint8_t *data, size_t data_len)
+{
+    size_t needed = offset + 5 + data_len;
+    if (needed > buf_size) return 0;
+
+    buf[offset]     = section_id;
+    buf[offset + 1] = (uint8_t)(data_len & 0xFF);
+    buf[offset + 2] = (uint8_t)((data_len >> 8) & 0xFF);
+    buf[offset + 3] = (uint8_t)((data_len >> 16) & 0xFF);
+    buf[offset + 4] = (uint8_t)((data_len >> 24) & 0xFF);
+    memcpy(buf + offset + 5, data, data_len);
+
+    return 5 + data_len;
+}
+
+/* Helper: write a fixed-size value as a section */
+static size_t write_section_val(uint8_t *buf, size_t buf_size, size_t offset,
+                                uint8_t section_id, const uint8_t *val, size_t val_len)
+{
+    return write_section(buf, buf_size, offset, section_id, val, val_len);
+}
+
+size_t serialize_vtpm_state(uint8_t *out_buf, size_t buf_size)
+{
+    size_t offset = 4; /* reserve 4 bytes for total size */
+    size_t written;
+
+    /* 0x01: EP Seed (32B) */
+    written = write_section_val(out_buf, buf_size, offset, 0x01,
+                                gp.EPSeed.t.buffer, sizeof(gp.EPSeed.t.buffer));
+    if (!written) return 0;
+    offset += written;
+
+    /* 0x02: SP Seed (32B) */
+    written = write_section_val(out_buf, buf_size, offset, 0x02,
+                                gp.SPSeed.t.buffer, sizeof(gp.SPSeed.t.buffer));
+    if (!written) return 0;
+    offset += written;
+
+    /* 0x03: PP Seed (32B) */
+    written = write_section_val(out_buf, buf_size, offset, 0x03,
+                                gp.PPSeed.t.buffer, sizeof(gp.PPSeed.t.buffer));
+    if (!written) return 0;
+    offset += written;
+
+    /* 0x04: ownerAuth */
+    written = write_section(out_buf, buf_size, offset, 0x04,
+                            gp.ownerAuth.t.buffer, gp.ownerAuth.t.size);
+    if (!written) return 0;
+    offset += written;
+
+    /* 0x05: endorsementAuth */
+    written = write_section(out_buf, buf_size, offset, 0x05,
+                            gp.endorsementAuth.t.buffer, gp.endorsementAuth.t.size);
+    if (!written) return 0;
+    offset += written;
+
+    /* 0x06: lockoutAuth */
+    written = write_section(out_buf, buf_size, offset, 0x06,
+                            gp.lockoutAuth.t.buffer, gp.lockoutAuth.t.size);
+    if (!written) return 0;
+    offset += written;
+
+    /* 0x07: platformAuth */
+    written = write_section(out_buf, buf_size, offset, 0x07,
+                            gc.platformAuth.t.buffer, gc.platformAuth.t.size);
+    if (!written) return 0;
+    offset += written;
+
+    /* 0x08: PCR save area */
+    written = write_section(out_buf, buf_size, offset, 0x08,
+                            (const uint8_t *)&gc.pcrSave, sizeof(gc.pcrSave));
+    if (!written) return 0;
+    offset += written;
+
+    /* 0x10: totalResetCount (8B) */
+    {
+        uint8_t trc[8];
+        trc[0] = (uint8_t)(gp.totalResetCount & 0xFF);
+        trc[1] = (uint8_t)((gp.totalResetCount >> 8) & 0xFF);
+        trc[2] = (uint8_t)((gp.totalResetCount >> 16) & 0xFF);
+        trc[3] = (uint8_t)((gp.totalResetCount >> 24) & 0xFF);
+        trc[4] = (uint8_t)((gp.totalResetCount >> 32) & 0xFF);
+        trc[5] = (uint8_t)((gp.totalResetCount >> 40) & 0xFF);
+        trc[6] = (uint8_t)((gp.totalResetCount >> 48) & 0xFF);
+        trc[7] = (uint8_t)((gp.totalResetCount >> 56) & 0xFF);
+        written = write_section_val(out_buf, buf_size, offset, 0x10, trc, 8);
+        if (!written) return 0;
+        offset += written;
+    }
+
+    /* 0x11: resetCount (4B) */
+    {
+        uint8_t rc[4];
+        rc[0] = (uint8_t)(gp.resetCount & 0xFF);
+        rc[1] = (uint8_t)((gp.resetCount >> 8) & 0xFF);
+        rc[2] = (uint8_t)((gp.resetCount >> 16) & 0xFF);
+        rc[3] = (uint8_t)((gp.resetCount >> 24) & 0xFF);
+        written = write_section_val(out_buf, buf_size, offset, 0x11, rc, 4);
+        if (!written) return 0;
+        offset += written;
+    }
+
+    /* 0x12: clearCount (4B) */
+    {
+        uint8_t cc[4];
+        cc[0] = (uint8_t)(gr.clearCount & 0xFF);
+        cc[1] = (uint8_t)((gr.clearCount >> 8) & 0xFF);
+        cc[2] = (uint8_t)((gr.clearCount >> 16) & 0xFF);
+        cc[3] = (uint8_t)((gr.clearCount >> 24) & 0xFF);
+        written = write_section_val(out_buf, buf_size, offset, 0x12, cc, 4);
+        if (!written) return 0;
+        offset += written;
+    }
+
+    /* Write total size at the beginning */
+    out_buf[0] = (uint8_t)(offset & 0xFF);
+    out_buf[1] = (uint8_t)((offset >> 8) & 0xFF);
+    out_buf[2] = (uint8_t)((offset >> 16) & 0xFF);
+    out_buf[3] = (uint8_t)((offset >> 24) & 0xFF);
+
+    return offset;
+}
+
+int deserialize_vtpm_state(const uint8_t *in, size_t len)
+{
+    if (len < 4) return -1;
+
+    uint32_t total_size = (uint32_t)in[0]
+                        | ((uint32_t)in[1] << 8)
+                        | ((uint32_t)in[2] << 16)
+                        | ((uint32_t)in[3] << 24);
+    if (total_size > len) return -2;
+
+    size_t offset = 4;
+    while (offset + 5 <= total_size) {
+        uint8_t section_id = in[offset];
+        uint32_t data_len = (uint32_t)in[offset + 1]
+                          | ((uint32_t)in[offset + 2] << 8)
+                          | ((uint32_t)in[offset + 3] << 16)
+                          | ((uint32_t)in[offset + 4] << 24);
+        offset += 5;
+
+        if (offset + data_len > total_size) return -3;
+
+        const uint8_t *data = in + offset;
+        offset += data_len;
+
+        switch (section_id) {
+        case 0x01: /* EPSeed */
+            if (data_len > sizeof(gp.EPSeed.t.buffer)) return -4;
+            memcpy(gp.EPSeed.t.buffer, data, data_len);
+            gp.EPSeed.t.size = sizeof(gp.EPSeed.t.buffer);
+            break;
+        case 0x02: /* SPSeed */
+            if (data_len > sizeof(gp.SPSeed.t.buffer)) return -4;
+            memcpy(gp.SPSeed.t.buffer, data, data_len);
+            gp.SPSeed.t.size = sizeof(gp.SPSeed.t.buffer);
+            break;
+        case 0x03: /* PPSeed */
+            if (data_len > sizeof(gp.PPSeed.t.buffer)) return -4;
+            memcpy(gp.PPSeed.t.buffer, data, data_len);
+            gp.PPSeed.t.size = sizeof(gp.PPSeed.t.buffer);
+            break;
+        case 0x04: /* ownerAuth */
+            if (data_len > sizeof(gp.ownerAuth.t.buffer)) return -4;
+            memcpy(gp.ownerAuth.t.buffer, data, data_len);
+            gp.ownerAuth.t.size = (UINT16)data_len;
+            break;
+        case 0x05: /* endorsementAuth */
+            if (data_len > sizeof(gp.endorsementAuth.t.buffer)) return -4;
+            memcpy(gp.endorsementAuth.t.buffer, data, data_len);
+            gp.endorsementAuth.t.size = (UINT16)data_len;
+            break;
+        case 0x06: /* lockoutAuth */
+            if (data_len > sizeof(gp.lockoutAuth.t.buffer)) return -4;
+            memcpy(gp.lockoutAuth.t.buffer, data, data_len);
+            gp.lockoutAuth.t.size = (UINT16)data_len;
+            break;
+        case 0x07: /* platformAuth */
+            if (data_len > sizeof(gc.platformAuth.t.buffer)) return -4;
+            memcpy(gc.platformAuth.t.buffer, data, data_len);
+            gc.platformAuth.t.size = (UINT16)data_len;
+            break;
+        case 0x08: /* PCR save */
+            if (data_len > sizeof(gc.pcrSave)) return -4;
+            memcpy(&gc.pcrSave, data, data_len);
+            break;
+        case 0x10: /* totalResetCount */
+            if (data_len < 8) return -4;
+            gp.totalResetCount = (uint64_t)data[0]
+                               | ((uint64_t)data[1] << 8)
+                               | ((uint64_t)data[2] << 16)
+                               | ((uint64_t)data[3] << 24)
+                               | ((uint64_t)data[4] << 32)
+                               | ((uint64_t)data[5] << 40)
+                               | ((uint64_t)data[6] << 48)
+                               | ((uint64_t)data[7] << 56);
+            break;
+        case 0x11: /* resetCount */
+            if (data_len < 4) return -4;
+            gp.resetCount = (uint32_t)data[0]
+                          | ((uint32_t)data[1] << 8)
+                          | ((uint32_t)data[2] << 16)
+                          | ((uint32_t)data[3] << 24);
+            break;
+        case 0x12: /* clearCount */
+            if (data_len < 4) return -4;
+            gr.clearCount = (uint32_t)data[0]
+                          | ((uint32_t)data[1] << 8)
+                          | ((uint32_t)data[2] << 16)
+                          | ((uint32_t)data[3] << 24);
+            break;
+        default:
+            /* Unknown section — skip */
+            break;
+        }
+    }
+
+    return 0;
+}

--- a/libtcgtpm/state_accessor.h
+++ b/libtcgtpm/state_accessor.h
@@ -76,6 +76,48 @@ void     set_clear_count(uint32_t val);
 uint64_t get_object_context_id(void);
 void     set_object_context_id(uint64_t val);
 
+/* --- Persistent Data (gp) — Dictionary Attack tracking ---
+ *
+ * Without these the post-Recover guest hits TPM_RC_LOCKOUT (0x921) on the
+ * first auth-bearing command because the simulator re-initializes DA state
+ * to default after deserialize, mismatching the previously-stored
+ * hierarchy auth values. */
+uint32_t get_failed_tries(void);
+void     set_failed_tries(uint32_t val);
+uint32_t get_max_tries(void);
+void     set_max_tries(uint32_t val);
+uint32_t get_recovery_time(void);
+void     set_recovery_time(uint32_t val);
+uint32_t get_lockout_recovery(void);
+void     set_lockout_recovery(uint32_t val);
+/* gp.lockOutAuthEnabled is BOOL (int); marshalled as a single byte (0/1). */
+uint8_t  get_lockout_auth_enabled(void);
+void     set_lockout_auth_enabled(uint8_t val);
+
+/* --- Persistent Data (gp) — Orderly shutdown state ---
+ * TPM_SU is a UINT16. Used by Startup to decide between TPM_SU_CLEAR /
+ * TPM_SU_STATE branches; if missing, NV reload and PCR alloc behave as if
+ * we suffered an unexpected shutdown. */
+uint16_t get_orderly_state(void);
+void     set_orderly_state(uint16_t val);
+
+/* --- Persistent Data (gp) — PCR allocation ---
+ * gp.pcrAllocated is a TPML_PCR_SELECTION (small variable-size struct,
+ * ≤ ~130 B). Without it, the simulator forgets which PCR banks (sha1 /
+ * sha256 / sha384 / sha512) are active and tpm2_pcrread rejects them as
+ * "unsupported bank/algorithm". */
+size_t get_pcr_allocated(uint8_t *out_buf, size_t buf_size);
+void   set_pcr_allocated(const uint8_t *in, size_t len);
+
+/* --- Platform NV memory blob (Tier-B) ---
+ * The TPM Reference Implementation keeps user-defined NV indices and evict
+ * objects inside a flat 16 KB `s_NV[]` buffer. Without restoring this buffer
+ * across cold boot, `tpm2_nvread 0x1500016` after Recover fails with
+ * "handle does not exist" — the simulator scans s_NV at command time, and
+ * the freshly-initialized buffer contains no user indices. */
+size_t get_nv_blob(uint8_t *out_buf, size_t buf_size);
+void   set_nv_blob(const uint8_t *in, size_t len);
+
 /* --- Bulk serialization helpers --- */
 
 /* Serialize all seal-relevant state into a flat buffer.
@@ -93,6 +135,19 @@ void     set_object_context_id(uint64_t val);
  *   0x10 = totalResetCount (8B)
  *   0x11 = resetCount (4B)
  *   0x12 = clearCount (4B)
+ *   0x13 = failedTries (4B)          [Tier-A: DA persistence]
+ *   0x14 = maxTries (4B)
+ *   0x15 = recoveryTime (4B)
+ *   0x16 = lockoutRecovery (4B)
+ *   0x17 = lockOutAuthEnabled (1B)
+ *   0x18 = orderlyState (2B, TPM_SU)
+ *   0x19 = pcrAllocated (TPML_PCR_SELECTION, ≤ ~130B)
+ *   0x1A = platform NV blob (16384B s_NV[]) [Tier-B: user NV index/evict object
+ *          persistence]. MUST be emitted FIRST in the blob so deserialize
+ *          applies it before 0x01-0x19 setters overwrite RAM gp fields.
+ *
+ * Old blobs (without 0x13-0x1A) deserialize fine — unknown sections are
+ * skipped, simulator-default values stay in place for those fields.
  *
  * Returns: number of bytes written, or 0 on buffer too small. */
 size_t serialize_vtpm_state(uint8_t *out_buf, size_t buf_size);

--- a/libtcgtpm/state_accessor.h
+++ b/libtcgtpm/state_accessor.h
@@ -1,0 +1,104 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * TPM internal state accessors for libtcgtpm.
+ *
+ * Exposes getter/setter functions for the TPM 2.0 Reference Implementation
+ * internal global state variables (gp, gc, gr, go). Useful for callers that
+ * need to dump or restore the persistent vTPM state (for example, when
+ * relocating, snapshotting, or sealing the state to an external root).
+ *
+ * Integration into the libtcgtpm build:
+ *   1. Place this file and state_accessor.c under libtcgtpm/.
+ *   2. Add state_accessor.o to the Makefile OBJS list.
+ *   3. Add the accessor symbols to the bindgen allowlist in build.rs.
+ *
+ * A command-based alternative (TPM2_NV_Read, TPM2_ContextSave,
+ * TPM2_GetCapability) is specification-compliant but cannot retrieve
+ * auth values and seeds, so it is more limited than the direct accessors.
+ */
+
+#ifndef STATE_ACCESSOR_H
+#define STATE_ACCESSOR_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+/* --- Persistent Data (gp) --- */
+
+/* Copy Endorsement Primary Seed (32 bytes) */
+void get_ep_seed(uint8_t *out);
+void set_ep_seed(const uint8_t *in);
+
+/* Copy Storage Primary Seed (32 bytes) — the SRK seed */
+void get_sp_seed(uint8_t *out);
+void set_sp_seed(const uint8_t *in);
+
+/* Copy Platform Primary Seed (32 bytes) */
+void get_pp_seed(uint8_t *out);
+void set_pp_seed(const uint8_t *in);
+
+/* Copy Owner hierarchy auth value (variable, header(2B) + data) */
+size_t get_owner_auth(uint8_t *out_buf, size_t buf_size);
+void   set_owner_auth(const uint8_t *in, size_t len);
+
+/* Copy Endorsement hierarchy auth value */
+size_t get_endorsement_auth(uint8_t *out_buf, size_t buf_size);
+void   set_endorsement_auth(const uint8_t *in, size_t len);
+
+/* Copy Lockout auth value */
+size_t get_lockout_auth(uint8_t *out_buf, size_t buf_size);
+void   set_lockout_auth(const uint8_t *in, size_t len);
+
+/* Total reset counter (u64) — monotonic across TPM lifetime */
+uint64_t get_total_reset_count(void);
+void     set_total_reset_count(uint64_t val);
+
+/* Reset counter (u32) — reset by TPM2_Clear */
+uint32_t get_reset_count(void);
+void     set_reset_count(uint32_t val);
+
+/* --- State Clear Data (gc) --- */
+
+/* Copy PCR save area: per-algorithm bank of 24 static PCRs.
+ * Returns number of bytes written. */
+size_t get_pcr_save(uint8_t *out_buf, size_t buf_size);
+void   set_pcr_save(const uint8_t *in, size_t len);
+
+/* Copy platform auth value */
+size_t get_platform_auth(uint8_t *out_buf, size_t buf_size);
+void   set_platform_auth(const uint8_t *in, size_t len);
+
+/* --- State Reset Data (gr) --- */
+
+uint32_t get_clear_count(void);
+void     set_clear_count(uint32_t val);
+
+uint64_t get_object_context_id(void);
+void     set_object_context_id(uint64_t val);
+
+/* --- Bulk serialization helpers --- */
+
+/* Serialize all seal-relevant state into a flat buffer.
+ * Layout: [4B total_size] [section...]
+ * Each section: [1B section_id] [4B len] [data]
+ * Section IDs:
+ *   0x01 = EPSeed (32B)
+ *   0x02 = SPSeed (32B)
+ *   0x03 = PPSeed (32B)
+ *   0x04 = ownerAuth
+ *   0x05 = endorsementAuth
+ *   0x06 = lockoutAuth
+ *   0x07 = platformAuth
+ *   0x08 = PCR save
+ *   0x10 = totalResetCount (8B)
+ *   0x11 = resetCount (4B)
+ *   0x12 = clearCount (4B)
+ *
+ * Returns: number of bytes written, or 0 on buffer too small. */
+size_t serialize_vtpm_state(uint8_t *out_buf, size_t buf_size);
+
+/* Deserialize state back into TPM globals.
+ * Returns: 0 on success, nonzero on error. */
+int deserialize_vtpm_state(const uint8_t *in, size_t len);
+
+#endif /* STATE_ACCESSOR_H */


### PR DESCRIPTION
[Draft PR — RFC for design feedback, not requesting merge.]

## Background

SEV-SNP does not currently provide trusted access from a CVM to
platform devices, including a physical TPM (discrete, firmware, or
otherwise). As a result, the in-CVM vTPM at VMPL0 cannot use a
physical TPM as a backing root of trust and cannot cross a cold boot
on its own. Today, the upstream path being developed by Stefano
Garzarella and others addresses this with encrypted-block + KBS:
durable storage for the vTPM blob plus a remote attestation-gated
key release for decryption. That path fits cloud deployments where
a KBS is already part of the trust infrastructure.

This RFC explores a **complementary** path for deployments where an
online KBS is unavailable, not a fit for the deployment model, or
overkill for the workload:

- on-prem / private cloud where a TPM is already the platform root of
  trust
- disconnected, long-running, or independent-audit workloads
- bring-up / development environments where setting up a KBS is
  disproportionate to the task

The approach: keep the vTPM in-CVM at VMPL0 (no change to today's
attestation surface), but route only its persistent state through a
seal/unseal cycle against an **external TPM 2.0 endpoint** reached
over an adversarial host channel. The endpoint is intentionally
abstract: a TPM 2.0 command/response pair is all the proxy assumes,
so the same code path can target:

- a software vTPM (`swtpm`) for development and CI
- a host-side firmware TPM (AMD-SP fTPM, Intel PTT) where one already
  exists on the platform
- a physical discrete TPM for deployments that want a hardware-rooted
  persistence anchor maintained outside the CVM
- a TPM-as-a-service endpoint where the operator wants centralized
  key custody without a full KBS stack

The choice is a deployment decision; the SVSM code is the same.

This is not a replacement for the KBS-stateful vTPM work. The two
approaches target different deployment regimes and can coexist on the
same SVSM build via different backends behind the `SealedBlobStore`
trait introduced here.

## What this RFC adds

- **libtcgtpm** (`d62abbb`): getter/setter accessors for TPM 2.0
  reference globals (`gp`, `gc`, `gr`) plus a bulk serialize/deserialize
  pair. Useful for any path that needs to lift the reference
  implementation's persistent state out of the in-CVM binary, not just
  this RFC.
- **vtpm/proxy.rs** (`48abdc3`, `6c08cd2`): a small `TpmTransport`
  trait with a `MockTransport` for unit tests and a VSOCK
  implementation (feature-gated). The TPM2 command builder
  (`build_get_random`, `build_nv_define_space`, `build_nv_increment`,
  `build_nv_read`, `build_create_primary`, `build_create`, `build_load`,
  `build_seal`, `build_unseal`, `build_flush_context`) is generic over
  the transport, so the proxy makes no assumption about which TPM 2.0
  endpoint is on the other side.
- **vtpm/sealed_store.rs** (`0bdc9df`): a `SealedBlobStore` trait with
  `StaticBufStore` (in-memory, test-only), a stubbed `IgvmVarStore`,
  and a VSOCK-backed `VsockHostStore` (feature-gated). Intent is to
  align with the upcoming block-layer abstraction so the same trait
  can later wrap a block device, and to leave room for a KBS-backed
  implementation to drop in as a peer backend.
- **vtpm/sealed.rs** (`72f12ef`): two-layer container.
  AES-256-GCM-encrypt the state payload (~1 KB at Tier-1.5, growing
  to ~19 KB once Tier-2 NV-block persistence is enabled), then
  TPM2_Seal only the 60-byte key bundle
  (`aes_key[32] || gcm_tag[16] || nonce[12]`). Keeps the TPM-sealed
  payload well under RSA-2048 size limits regardless of the
  underlying state size. The blob format is documented in
  `kernel/src/vtpm/sealed.rs` and is versioned. The current revision
  carries only the AES-256-GCM payload and the TPM-sealed key bundle;
  a counter-binding field for cross-tenant replay isolation on a
  shared NV counter backend is a planned format addition, not part of
  this revision (see open questions 5 and 8).
- **vtpm/state.rs** (`143ab03`): Rust wrappers around the new
  libtcgtpm accessors, plus a bulk serialize/deserialize path that
  matches the C-side layout.
- **vtpm boot integration** (`6f5db7b`): two boot modes plumbed
  through `kernel/src/svsm.rs`:
  - `Provision` — manufacture vTPM, extract state, seal via the
    configured TPM endpoint, persist the blob.
  - `Recover` — load the blob, unseal via the configured TPM endpoint,
    inject state, signal NV-on + light power-on.
- **vtpm/reseal.rs + Tier-2 persistence** (`b1fbbd1`): full
  guest-state persistence path covering DA lockout, PCR allocation,
  orderly-shutdown state, and the platform NV memory (TPM reference
  implementation's flat 16 KB `s_NV[]` buffer that backs every user NV
  index, evict object, and DA bookkeeping field). The libtcgtpm
  accessors gain section 0x1A (s_NV dump); the SVSM kernel gains
  `kernel/src/vtpm/reseal.rs` registering a runtime hook in the
  command path that, on a successful guest-side
  `TPM2_Shutdown(SU_STATE)`, re-extracts internal state, freshly
  re-encrypts under a new AES key + nonce (no key material is cached
  across calls), and pushes a new SealedBlob via `VsockHostStore`.
  Sealed blob grows from ~2.7 KB (Tier-1.5) to ~19 KB (Tier-2). The
  hook is feature-gated behind `vtpm-persist`; the previous Tier-1.5
  build path is unchanged when the feature is off.

## Known limitations / open questions

1. **Storage backend**: ships with `StaticBufStore` (test-only) and
   stubbed `IgvmVarStore`. Production needs either an IGVM-variable
   path, integration with the upcoming SVSM block layer, or a
   KBS-backed implementation. I deferred picking one so the trait
   shape can be reviewed first.
2. **vm_id**: currently zero in the boot wiring; should derive from
   IGVM `guest_context` once that surface stabilizes.
3. **Transport**: VSOCK implementation is feature-gated; the
   `TpmTransport` trait is intentionally minimal so alternative
   transports (virtio-serial, MMIO, in-process for `swtpm` co-tenants,
   etc.) are welcome.
4. **State extraction**: reaches into the Microsoft TPM reference
   globals via the libtcgtpm accessors added in commit 1. A
   TPM2_ContextSave-based path was considered but cannot reach
   hierarchy seeds and auth values by design. Would appreciate
   guidance on whether the maintainers prefer the direct-accessor
   approach or want a higher-level abstraction.
5. **HMAC channel auth**: the transport layer assumes an adversarial
   host channel, but per-session HMAC binding is only sketched.
   Enforcement would need a session-key provisioning path, which I
   left out of this RFC to keep the diff small.
6. **vTPM in user-mode**: per `DEVELOPMENT-PLAN.md`, the vTPM is
   slated to move to a user-mode task. The boot integration in commit
   7 is intentionally a thin shim (`vtpm_init_sealed`) so it can be
   re-targeted to a user-mode init task. Happy to refactor if there
   is a preferred timeline for that move.
7. **Tier-2 re-seal trigger boundary**: runtime re-seal fires on
   `TPM2_Shutdown(SU_STATE)` only. A guest that does not issue
   Shutdown (forced poweroff, hypervisor-side kill, guest crash,
   sudden power loss) loses that session's NV writes. This matches
   TCG semantics for ungraceful power loss but is worth flagging as
   an API contract.
8. **Tier-2 NV-counter / blob-save ordering**: rollback/replay
   resistance is sketched, not wired in this revision. The intended
   shape is to bind a monotonic counter from the external endpoint's
   NV into the blob and check it on unseal, so a stale or rolled-back
   blob fails closed. With that in place, the ordering matters: if the
   NV counter is advanced inside `seal_state` before the new SealedBlob
   is committed via the configured `SealedBlobStore` backend and the
   store-side write then fails, a later cold boot would see a counter
   ahead of the persisted blob and fall back to Provision instead of
   recovering. A save-then-commit ordering (defer `nv_increment` until
   the store has acknowledged the new blob) avoids that window. This is
   noted now so the counter-check and the commit ordering land
   together; both are tracked as follow-up alongside open question 5.

Seeking feedback on overall direction, whether `SealedBlobStore`
should live alongside the block-layer abstraction, the
`TpmTransport` shape (and whether keeping it endpoint-agnostic is
the right call), the libtcgtpm accessor surface, and whether the
Tier-2 runtime re-seal hook belongs in the kernel command path or
should be lifted to the planned user-mode vTPM task.

## Commit series

```
d62abbb libtcgtpm: Expose direct accessors for TPM persistent globals
48abdc3 vtpm: Add pluggable transport trait with mock implementation
6c08cd2 vtpm: Add VSOCK transport for TPM proxying
0bdc9df vtpm: Add pluggable storage trait for sealed vTPM state
72f12ef vtpm: Add two-layer SealedBlob (AES-256-GCM + TPM2_Seal)
143ab03 vtpm: Add TPM internal state extract/inject via libtcgtpm accessors
6f5db7b vtpm/svsm: Wire TPM-rooted persistence boot mode
b1fbbd1 vtpm: Add runtime re-seal hook and NV-block persistence
```

Each commit compiles and passes `cargo clippy --features vtpm` (and
`--features vtpm,vsock`, `--features vtpm,vtpm-persist` where
relevant) on its own. `make igvm` produces the three IGVM binaries
(`coconut-qemu.igvm`, `coconut-hyperv.igvm`, `coconut-vanadium.igvm`)
at HEAD with both `FEATURES=vtpm` and
`FEATURES=vtpm,vtpm-persist`.

End-to-end validated on an AMD EPYC server with SEV-SNP enabled,
against two TPM 2.0 endpoints sharing the same IGVM binary
(SHA-256 `6c1b09cd...`):

1. **swtpm as the endpoint** (software reference, via
   VSOCK→socat→TCP:2321): functional correctness baseline.
2. **Physical discrete TPM** — Infineon SLB 9672 SPI module
   (vendor "IFX"/"SLB9672", fw 1.84) on a Gigabyte CTM012 carrier,
   reached via `/dev/tpmrm0` and a host-side TPM-over-VSOCK bridge
   daemon that replaces socat/swtpm on the host side.

Both runs exercise the same L0–L5 guest validation suite and the
same Provision → cold-boot → Recover sequence:

- vTPM identity preserved across cold boot: EK name and EK
  qualified name are **byte-identical** between Provision and
  Recover (`000bdb93ab66...` / `000b0ae7f061...` on SLB 9672;
  `000b92934628...` / `000bfca90d16...` on swtpm).
- Guest-runtime NV writes persist: a user NV index at
  `0x1500016` written under Provision is readable after a
  cold reboot under Recover (Tier-2 / A3 path).
- The A3 runtime re-seal hook fires on guest-side
  `TPM2_Shutdown(SU_STATE)` and commits a fresh SealedBlob
  before SVSM exits (observed in serial log on both endpoints).

Sealed-blob sizes match across backends (~19.1 KB Provision,
~18.8 KB Recover; the observed sub-kilobyte delta between the two
cold-boot samples is consistent with an NV-section repack and is
not endpoint-specific). On SLB 9672 the external-TPM-side latency
is dominated by RSA-2048 `TPM2_CreatePrimary` (~6.6 s per call on
this device); the critical unseal step itself measures ~126 ms.
Per-command latency CSV (bridge-side wall clock) is included in
the artifact dump.

Reproduction artifacts (IGVM SHA-256, Launch Digest, boot/validate
logs, sealed blobs, TPM-endpoint latency CSV) available on request.

All commits are DCO-signed.

