### PR TITLE
Use TOML formatter

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,16 +2,18 @@
 
 [target.x86_64-unknown-none]
 rustflags = [
-	"-C", "force-frame-pointers",
-	"--cfg", "aes_force_soft",
-	"--cfg", 'aes_backend="soft"',
-	"--cfg", "polyval_force_soft",
+    "-C",
+    "force-frame-pointers",
+    "--cfg",
+    "aes_force_soft",
+    "--cfg",
+    'aes_backend="soft"',
+    "--cfg",
+    "polyval_force_soft",
 ]
 
 [target.x86_64-unknown-linux-gnu]
-rustflags = [
-       "-C", "code-model=kernel",
-]
+rustflags = ["-C", "code-model=kernel"]
 
 [alias]
 verify = "verus focus --features verus"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ aes-gcm = { version = "0.10.3", default-features = false }
 aes-kw = { version = "0.3.1", default-features = false }
 arbitrary = "1.3.0"
 base64 = { version = "0.22.1", default-features = false }
-bindgen = {version = "0.71.0", default-features = false }
+bindgen = { version = "0.71.0", default-features = false }
 bitfield-struct = "0.6.2"
 bitflags = "2.6"
 clap = { version = "4.4.14", default-features = false }
@@ -108,13 +108,18 @@ zeroize = { version = "1.8.2", default-features = false }
 
 # Verus repos
 verus_builtin = { version = "=0.0.0-2026-05-17-0151", default-features = false }
-verus_builtin_macros = { version = "=0.0.0-2026-07-12-0122", features = ["vpanic"], default-features = false }
+verus_builtin_macros = { version = "=0.0.0-2026-07-12-0122", features = [
+    "vpanic",
+], default-features = false }
 verus_state_machines_macros = { version = "=0.0.0-2026-06-14-0213", default-features = false }
-vstd = { version = "=0.0.0-2026-07-12-0122", features = ["alloc", "allow_panic"], default-features = false }
+vstd = { version = "=0.0.0-2026-07-12-0122", features = [
+    "alloc",
+    "allow_panic",
+], default-features = false }
 
 # Verification libs
-verify_proof = { path = "verification/verify_proof", default-features = false  }
-verify_external = { path = "verification/verify_external", default-features = false  }
+verify_proof = { path = "verification/verify_proof", default-features = false }
+verify_external = { path = "verification/verify_external", default-features = false }
 
 [patch.crates-io]
 # Force all dependencies to use the same version of safe-mmio, which has

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -25,15 +25,24 @@ aes-kw = { workspace = true, features = ["zeroize"], optional = true }
 bitfield-struct.workspace = true
 bitflags.workspace = true
 cocoon-tpm-crypto = { workspace = true, features = [
-    "enable_arch_math_asm", "zeroize",
+    "enable_arch_math_asm",
+    "zeroize",
     # Enable x86 rdseed based rng.
     "enable_x86_64_rdseed",
     # At least one of block cipher, mode and hash is needed,
     # otherwise compilation will fail due to empty enums.
-    "aes", "cfb", "sha256", "sha384", "sha512",
-    "ecc", "ecdh", "ecdsa",
-    "ecc_nist_p224", "ecc_nist_p256",
-    "ecc_nist_p384", "ecc_nist_p521",
+    "aes",
+    "cfb",
+    "sha256",
+    "sha384",
+    "sha512",
+    "ecc",
+    "ecdh",
+    "ecdsa",
+    "ecc_nist_p224",
+    "ecc_nist_p256",
+    "ecc_nist_p384",
+    "ecc_nist_p521",
 ], optional = true }
 cocoon-tpm-tpm2-interface = { workspace = true, optional = true }
 cocoon-tpm-utils-common = { workspace = true, optional = true }
@@ -61,9 +70,9 @@ virtfw-varstore = { workspace = true, optional = true }
 
 verus_builtin = { workspace = true, optional = true }
 verus_builtin_macros = { workspace = true, optional = true }
-vstd = { workspace = true, optional = true}
-verify_proof = { workspace = true, optional = true}
-verify_external = { workspace = true, optional = true}
+vstd = { workspace = true, optional = true }
+verify_proof = { workspace = true, optional = true }
+verify_external = { workspace = true, optional = true }
 verus_stub = { workspace = true }
 zeroize = { workspace = true, features = ["alloc", "derive"] }
 
@@ -71,7 +80,18 @@ zeroize = { workspace = true, features = ["alloc", "derive"] }
 test.workspace = true
 
 [features]
-attest = ["vsock", "dep:aes-kw", "dep:cocoon-tpm-crypto", "dep:cocoon-tpm-tpm2-interface", "dep:cocoon-tpm-utils-common", "dep:concat-kdf", "dep:kbs-types", "dep:libaproxy", "dep:serde", "dep:serde_json"]
+attest = [
+    "vsock",
+    "dep:aes-kw",
+    "dep:cocoon-tpm-crypto",
+    "dep:cocoon-tpm-tpm2-interface",
+    "dep:cocoon-tpm-utils-common",
+    "dep:concat-kdf",
+    "dep:kbs-types",
+    "dep:libaproxy",
+    "dep:serde",
+    "dep:serde_json",
+]
 attest-serial = ["attest"]
 
 default = []
@@ -79,7 +99,14 @@ enable-gdb = ["dep:gdbstub", "dep:gdbstub_arch"]
 vtpm = ["dep:libtcgtpm"]
 nosmep = []
 nosmap = []
-verus_all = ["verus_builtin", "verus_builtin_macros", "vstd", "verify_proof/verus", "verify_external/verus", "verus_stub/disable"]
+verus_all = [
+    "verus_builtin",
+    "verus_builtin_macros",
+    "vstd",
+    "verify_proof/verus",
+    "verify_external/verus",
+    "verus_stub/disable",
+]
 verus = ["verus_all", "verify_proof/noverify", "verify_external/noverify"]
 noverify = []
 virtio-drivers = ["dep:virtio-drivers", "dep:safe-mmio"]

--- a/libaproxy/Cargo.toml
+++ b/libaproxy/Cargo.toml
@@ -6,16 +6,26 @@ edition.workspace = true
 [dependencies]
 base64 = { workspace = true, features = ["alloc"] }
 cocoon-tpm-crypto = { workspace = true, features = [
-    "enable_arch_math_asm", "zeroize",
+    "enable_arch_math_asm",
+    "zeroize",
     # Enable x86 rdseed based rng.
     "enable_x86_64_rdseed",
     # At least one of block cipher, mode and hash is needed,
     # otherwise compilation will fail due to empty enums.
-    "aes", "cbc", "cfb", "sha256", "sha384", "sha512",
-    "ecc", "ecdh", "ecdsa",
-    "ecc_nist_p224", "ecc_nist_p256",
-    "ecc_nist_p384", "ecc_nist_p521",
-]}
+    "aes",
+    "cbc",
+    "cfb",
+    "sha256",
+    "sha384",
+    "sha512",
+    "ecc",
+    "ecdh",
+    "ecdsa",
+    "ecc_nist_p224",
+    "ecc_nist_p256",
+    "ecc_nist_p384",
+    "ecc_nist_p521",
+] }
 cocoon-tpm-tpm2-interface.workspace = true
 kbs-types = { workspace = true, features = ["alloc"] }
 serde.workspace = true

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.88.0"
-targets = [ "x86_64-unknown-none" ]
+targets = ["x86_64-unknown-none"]

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,0 +1,19 @@
+# Exclude all git submodules
+exclude = ["libtcgtpm/deps/openssl/**", "libtcgtpm/deps/tpm-20-ref/**", "packit/**"]
+
+[formatting]
+
+# Use same indentation as Rust code = 4 spaces
+indent_string = "    "
+
+# Alphabetize dependencies.
+# Not enabling, to preserve grouping
+reorder_keys = false
+
+# No space after/before [ / ]
+compact_arrays = true
+
+# Keep arrays in one line if they fit
+array_auto_collapse = true
+
+column_width = 100

--- a/tools/aproxy/Cargo.toml
+++ b/tools/aproxy/Cargo.toml
@@ -4,7 +4,11 @@ version = "0.1.0"
 edition.workspace = true
 
 [target.'cfg(all(target_os = "linux"))'.dependencies]
-reqwest = { version = "0.12.9", default-features = false, features = ["blocking", "cookies", "json"] }
+reqwest = { version = "0.12.9", default-features = false, features = [
+    "blocking",
+    "cookies",
+    "json",
+] }
 kbs-types.workspace = true
 
 [dependencies]


### PR DESCRIPTION
Add a style for the TOML formatter `Taplo`, explain how
to use in in the docs, and reformat all `.toml` files
with it.

The style is what seems to be the most common standard in
the Rust ecosystem, Taplo default, 4 spaces indentaton,
comact arrays.

I hope to establish this as the default for all TOML files
here, which have very inconsistent formatting.

I did not add Taplo to the CI since it has a surprising
amount of dependencies and takes too long to install IMO.
(Maybe with some cargo caching?)