### PR TITLE
kernel/attest: disable default fallback on serial port

### DIFF
--- a/Documentation/docs/developer/ATTESTATION.md
+++ b/Documentation/docs/developer/ATTESTATION.md
@@ -247,10 +247,12 @@ launching the proxy. The supported backend attestation protocols include:
 
 SVSM communicates with the attestation proxy using one of two transport methods:
 
-- **vsock**: When the `vsock` feature is enabled, SVSM will first try to use vsock for communication with the host proxy
-  using port `1995`. If it fails, SVSM will try again using the serial port.
+- **vsock** (default): SVSM uses vsock for communication with the host proxy on
+  port `1995`.
 
-- **Serial port**: If vsock is not available, SVSM uses the COM3 serial port for communication with the attestation proxy.
+- **Serial port** (testing only): When the `attest-serial` feature is enabled,
+  SVSM falls back to the COM3 serial port if the vsock connection fails. This
+  is intended for testing purposes only.
 
 ## Try for yourself
 
@@ -267,8 +269,8 @@ SEV-SNP machine with an SVSM-enabled kernel.
     ```shell
     git clone https://github.com/coconut-svsm/svsm.git
     # ... build OVMF, qemu, SVSM IGVM, etc...
-    FW_FILE=... make FEATURES=attest                       # serial transport
-    FW_FILE=... make FEATURES=attest,vsock,virtio-drivers  # vsock transport (with serial fallback)
+    FW_FILE=... make FEATURES=attest,vsock,virtio-drivers                # vsock transport (default)
+    FW_FILE=... make FEATURES=attest,vsock,attest-serial,virtio-drivers  # vsock with serial fallback (testing)
     ```
 
 2. Clone and run the `kbs-test` server used for testing. Supply the following
@@ -327,10 +329,11 @@ SEV-SNP machine with an SVSM-enabled kernel.
 
 4. Run a guest with SVSM
 
-    SVSM will use vsock for communication if the feature is enabled, otherwise it
-    falls back to the COM3 serial port (see [Transport Methods](#transport-methods)).
-    The attestation proxy will need to be configured correctly to ensure proper communication
-    according to the transport used.
+    SVSM uses vsock for communication by default. If the `attest-serial` feature
+    is enabled, it falls back to the COM3 serial port when vsock fails (see
+    [Transport Methods](#transport-methods)). The attestation proxy will need to
+    be configured correctly to ensure proper communication according to the
+    transport used.
 
     * **vsock**
       ```shell

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -71,7 +71,8 @@ zeroize = { workspace = true, features = ["alloc", "derive"] }
 test.workspace = true
 
 [features]
-attest = ["dep:aes-kw", "dep:cocoon-tpm-crypto", "dep:cocoon-tpm-tpm2-interface", "dep:cocoon-tpm-utils-common", "dep:concat-kdf", "dep:kbs-types", "dep:libaproxy", "dep:serde", "dep:serde_json"]
+attest = ["vsock", "dep:aes-kw", "dep:cocoon-tpm-crypto", "dep:cocoon-tpm-tpm2-interface", "dep:cocoon-tpm-utils-common", "dep:concat-kdf", "dep:kbs-types", "dep:libaproxy", "dep:serde", "dep:serde_json"]
+attest-serial = ["attest"]
 
 default = []
 enable-gdb = ["dep:gdbstub", "dep:gdbstub_arch"]

--- a/kernel/src/attest.rs
+++ b/kernel/src/attest.rs
@@ -39,13 +39,13 @@ use zerocopy::{FromBytes, IntoBytes};
 // TODO: Make the IO port configurable/discoverable or drop the support entirely.
 const ATTEST_DEFAULT_SERIAL_IO_ADDR: u16 = 0x3e8; // COM3
 
-enum Transport<'a> {
+enum Transport {
     #[cfg(feature = "vsock")]
     Vsock(VsockStream),
-    Serial(SerialPort<'a>),
+    Serial(SerialPort<'static>),
 }
 
-impl Read for Transport<'_> {
+impl Read for Transport {
     type Err = SvsmError;
 
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Err> {
@@ -57,7 +57,7 @@ impl Read for Transport<'_> {
     }
 }
 
-impl Write for Transport<'_> {
+impl Write for Transport {
     type Err = SvsmError;
 
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Err> {
@@ -69,7 +69,7 @@ impl Write for Transport<'_> {
     }
 }
 
-impl Transport<'_> {
+impl Transport {
     #[cfg(feature = "vsock")]
     fn new() -> Self {
         match VsockStream::connect(ATTEST_DEFAULT_VSOCK_PORT, VMADDR_CID_HOST) {
@@ -91,7 +91,7 @@ impl Transport<'_> {
     }
 }
 
-fn create_serial_transport<'a>() -> Transport<'a> {
+fn create_serial_transport() -> Transport {
     let sp = SerialPort::new(&DEFAULT_IO_DRIVER, ATTEST_DEFAULT_SERIAL_IO_ADDR);
     sp.init();
     Transport::Serial(sp)
@@ -100,13 +100,13 @@ fn create_serial_transport<'a>() -> Transport<'a> {
 /// The attestation driver that communicates with the proxy via some communication channel (serial
 /// port, virtio-vsock, etc...).
 #[allow(missing_debug_implementations)]
-pub struct AttestationDriver<'a> {
-    transport: Transport<'a>,
+pub struct AttestationDriver {
+    transport: Transport,
     tee: Tee,
     ecc: EccKey,
 }
 
-impl TryFrom<Tee> for AttestationDriver<'_> {
+impl TryFrom<Tee> for AttestationDriver {
     type Error = SvsmError;
 
     fn try_from(tee: Tee) -> Result<Self, Self::Error> {
@@ -127,7 +127,7 @@ impl TryFrom<Tee> for AttestationDriver<'_> {
     }
 }
 
-impl AttestationDriver<'_> {
+impl AttestationDriver {
     /// Attest SVSM's launch state by communicating with the attestation proxy.
     pub fn attest(&mut self) -> Result<SecretSlice, SvsmError> {
         let negotiation = self.negotiation()?;

--- a/kernel/src/attest.rs
+++ b/kernel/src/attest.rs
@@ -11,11 +11,11 @@ use crate::{
     crypto::SecretSlice,
     error::SvsmError,
     greq::{pld_report::*, services::get_regular_report},
-    io::{DEFAULT_IO_DRIVER, Read, Write},
-    serial::SerialPort,
+    io::{Read, Write},
     utils::vec::{try_to_vec, vec_sized},
 };
-#[cfg(feature = "vsock")]
+#[cfg(feature = "attest-serial")]
+use crate::{io::DEFAULT_IO_DRIVER, serial::SerialPort};
 use crate::{vsock::VMADDR_CID_HOST, vsock::stream::VsockStream};
 use aes_gcm::{AeadInPlace, Aes256Gcm, KeyInit, Nonce, aead::generic_array::GenericArray};
 use aes_kw::{KeyInit as _, KwAes256};
@@ -36,12 +36,13 @@ use serde::Serialize;
 use sha2::{Digest, Sha512};
 use zerocopy::{FromBytes, IntoBytes};
 
+#[cfg(feature = "attest-serial")]
 // TODO: Make the IO port configurable/discoverable or drop the support entirely.
 const ATTEST_DEFAULT_SERIAL_IO_ADDR: u16 = 0x3e8; // COM3
 
 enum Transport {
-    #[cfg(feature = "vsock")]
     Vsock(VsockStream),
+    #[cfg(feature = "attest-serial")]
     Serial(SerialPort<'static>),
 }
 
@@ -50,8 +51,8 @@ impl Read for Transport {
 
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Err> {
         match self {
-            #[cfg(feature = "vsock")]
             Transport::Vsock(vsock) => vsock.read(buf),
+            #[cfg(feature = "attest-serial")]
             Transport::Serial(serial) => serial.read(buf),
         }
     }
@@ -62,35 +63,36 @@ impl Write for Transport {
 
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Err> {
         match self {
-            #[cfg(feature = "vsock")]
             Transport::Vsock(vsock) => vsock.write(buf),
+            #[cfg(feature = "attest-serial")]
             Transport::Serial(serial) => serial.write(buf),
         }
     }
 }
 
 impl Transport {
-    #[cfg(feature = "vsock")]
     fn new() -> Result<Self, SvsmError> {
         match VsockStream::connect(ATTEST_DEFAULT_VSOCK_PORT, VMADDR_CID_HOST) {
             Ok(value) => Ok(Transport::Vsock(value)),
             Err(e) => {
                 log::warn!(
                     "Failed to connect to attestation proxy on vsock port \
-                     {ATTEST_DEFAULT_VSOCK_PORT}: {e:?}. \
-                     Falling back to serial port transport.",
+                     {ATTEST_DEFAULT_VSOCK_PORT}: {e:?}."
                 );
-                create_serial_transport()
+
+                #[cfg(feature = "attest-serial")]
+                {
+                    log::warn!("Falling back to serial port transport.");
+                    create_serial_transport()
+                }
+                #[cfg(not(feature = "attest-serial"))]
+                Err(e)
             }
         }
     }
-
-    #[cfg(not(feature = "vsock"))]
-    fn new() -> Result<Self, SvsmError> {
-        create_serial_transport()
-    }
 }
 
+#[cfg(feature = "attest-serial")]
 fn create_serial_transport() -> Result<Transport, SvsmError> {
     let sp = SerialPort::new(&DEFAULT_IO_DRIVER, ATTEST_DEFAULT_SERIAL_IO_ADDR);
     sp.init();

--- a/kernel/src/attest.rs
+++ b/kernel/src/attest.rs
@@ -71,9 +71,9 @@ impl Write for Transport {
 
 impl Transport {
     #[cfg(feature = "vsock")]
-    fn new() -> Self {
+    fn new() -> Result<Self, SvsmError> {
         match VsockStream::connect(ATTEST_DEFAULT_VSOCK_PORT, VMADDR_CID_HOST) {
-            Ok(value) => Transport::Vsock(value),
+            Ok(value) => Ok(Transport::Vsock(value)),
             Err(e) => {
                 log::warn!(
                     "Failed to connect to attestation proxy on vsock port \
@@ -86,15 +86,15 @@ impl Transport {
     }
 
     #[cfg(not(feature = "vsock"))]
-    fn new() -> Self {
+    fn new() -> Result<Self, SvsmError> {
         create_serial_transport()
     }
 }
 
-fn create_serial_transport() -> Transport {
+fn create_serial_transport() -> Result<Transport, SvsmError> {
     let sp = SerialPort::new(&DEFAULT_IO_DRIVER, ATTEST_DEFAULT_SERIAL_IO_ADDR);
     sp.init();
-    Transport::Serial(sp)
+    Ok(Transport::Serial(sp))
 }
 
 /// The attestation driver that communicates with the proxy via some communication channel (serial
@@ -118,7 +118,7 @@ impl TryFrom<Tee> for AttestationDriver {
         let curve = Curve::new(TpmEccCurve::NistP521).map_err(AttestationError::Crypto)?;
         let ecc = sc_key_generate(&curve).map_err(AttestationError::Crypto)?;
 
-        let transport = Transport::new();
+        let transport = Transport::new()?;
         Ok(Self {
             transport,
             tee,


### PR DESCRIPTION
This PR makes vsock the default transport mechanism for attestation and makes the serial fallback as an opt-in feature behind the `attest-serial` rust feature.

To summarize:
`make FEATURES=attest,virtio-drivers` will try to use vsock as a transport, if it's not available it will fail.
`make FEATURES=attest,virtio-drivers,attest-serial` will try to use vsock as a transport first, if it's not available it will fallback using the serial port.