### PR TITLE
igvmbuilder: specify a single VTL for native IGVM platforms

### DIFF
--- a/tools/igvmbuilder/src/igvm_builder.rs
+++ b/tools/igvmbuilder/src/igvm_builder.rs
@@ -327,7 +327,9 @@ impl IgvmBuilder {
             self.platforms.push(IgvmPlatformHeader::SupportedPlatform(
                 IGVM_VHS_SUPPORTED_PLATFORM {
                     compatibility_mask: NATIVE_COMPATIBILITY_MASK,
-                    highest_vtl,
+                    // The native platform only suports a single VTL, so
+                    // specify zero regardless of whether firmware is included.
+                    highest_vtl: 0,
                     platform_type: IgvmPlatformType::NATIVE,
                     platform_version: 1,
                     shared_gpa_boundary: 0,


### PR DESCRIPTION
The native platform does not support multiple VTLs, so it should specify VTL 0 as the highest enabled VTL regardless of whether guest firmware is included in the image.

This was supposed to be included in #1085 but I failed to push properly before the PR merged.