### PR TITLE
kernel/attest: add SecretSlice for zeroed attestation secrets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1968,6 +1968,7 @@ dependencies = [
  "virtio-drivers",
  "vstd",
  "zerocopy",
+ "zeroize",
 ]
 
 [[package]]
@@ -2648,6 +2649,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ sha2 = { version = "0.10.8", default-features = false }
 uuid = { version = "1.6.1", default-features = false }
 # Add the derive feature by default because all crates use it.
 zerocopy = { version = "0.8.2", features = ["derive"] }
+zeroize = { version = "1.8.2", default-features = false }
 embedded-io = { version = "0.6.1" }
 
 # Verus repos

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -62,6 +62,7 @@ vstd = { workspace = true, optional = true}
 verify_proof = { workspace = true, optional = true}
 verify_external = { workspace = true, optional = true}
 verus_stub = { workspace = true }
+zeroize = { workspace = true, features = ["alloc", "derive"] }
 
 [target."x86_64-unknown-none".dev-dependencies]
 test.workspace = true

--- a/kernel/src/attest.rs
+++ b/kernel/src/attest.rs
@@ -8,6 +8,7 @@
 extern crate alloc;
 
 use crate::{
+    crypto::SecretSlice,
     error::SvsmError,
     greq::{pld_report::*, services::get_regular_report},
     io::{DEFAULT_IO_DRIVER, Read, Write},
@@ -128,7 +129,7 @@ impl TryFrom<Tee> for AttestationDriver<'_> {
 
 impl AttestationDriver<'_> {
     /// Attest SVSM's launch state by communicating with the attestation proxy.
-    pub fn attest(&mut self) -> Result<Vec<u8>, SvsmError> {
+    pub fn attest(&mut self) -> Result<SecretSlice, SvsmError> {
         let negotiation = self.negotiation()?;
 
         Ok(self.attestation(negotiation)?)
@@ -152,7 +153,7 @@ impl AttestationDriver<'_> {
     /// Send an attestation request to the proxy. Proxy should reply with attestation response
     /// containing the status (success/fail) and an optional secret returned from the server upon
     /// successful attestation.
-    fn attestation(&mut self, n: NegotiationResponse) -> Result<Vec<u8>, AttestationError> {
+    fn attestation(&mut self, n: NegotiationResponse) -> Result<SecretSlice, AttestationError> {
         let curve =
             Curve::new(self.ecc.pub_key().get_curve_id()).map_err(AttestationError::Crypto)?;
 
@@ -185,13 +186,18 @@ impl AttestationDriver<'_> {
             return Err(AttestationError::PublicKeyMissing)?;
         };
 
-        let Some(mut secret) = response.secret else {
+        let Some(secret_enc) = response.secret else {
             return Err(AttestationError::SecretMissing);
         };
 
-        self.decrypt(&mut secret, decryption)?;
+        // `secret_enc` holds ciphertext from the attestation server. Move it
+        // into `SecretSlice` before decryption so the same buffer is decrypted
+        // in-place and zeroed on drop.
+        let mut secret_slice = SecretSlice::from(secret_enc.into_boxed_slice());
 
-        Ok(secret)
+        self.decrypt(&mut secret_slice, decryption)?;
+
+        Ok(secret_slice)
     }
 
     /// Decrypt a secret from the attestation server with the TEE private key. Secrets are

--- a/kernel/src/crypto/mod.rs
+++ b/kernel/src/crypto/mod.rs
@@ -6,6 +6,47 @@
 
 //! SVSM kernel crypto API
 
+extern crate alloc;
+
+use alloc::boxed::Box;
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+/// Container for sensitive byte data.
+///
+/// The owned buffer is zeroed when the `SecretSlice` is dropped or explicitly
+/// [`zeroize`](Zeroize::zeroize)d.
+#[derive(Zeroize, ZeroizeOnDrop)]
+pub struct SecretSlice(Box<[u8]>);
+
+impl From<Box<[u8]>> for SecretSlice {
+    fn from(data: Box<[u8]>) -> Self {
+        Self(data)
+    }
+}
+
+impl core::ops::Deref for SecretSlice {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl core::ops::DerefMut for SecretSlice {
+    fn deref_mut(&mut self) -> &mut [u8] {
+        &mut self.0
+    }
+}
+
+impl core::fmt::Debug for SecretSlice {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SecretSlice")
+            .field("len", &self.0.len())
+            .field("data", &"[REDACTED]")
+            .finish()
+    }
+}
+
 pub mod aead {
     //! API for authentication encryption with associated data
 
@@ -102,3 +143,40 @@ pub mod digest {
 // Crypto implementations supported. Only one of them must be compiled-in.
 
 pub mod rustcrypto;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec::Vec;
+    use zeroize::Zeroize;
+
+    #[test]
+    fn secretslice_stores_secret() {
+        let b: SecretSlice = Vec::from([1u8, 2, 3, 4, 5]).into_boxed_slice().into();
+        assert_eq!(b.len(), 5);
+        assert_eq!(&*b, &[1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn secretslice_empty_ok() {
+        let b: SecretSlice = Vec::new().into_boxed_slice().into();
+        assert_eq!(b.len(), 0);
+        assert!(b.is_empty());
+    }
+
+    #[test]
+    fn secretslice_deref_mut_mutates() {
+        let mut b: SecretSlice = Vec::from([1u8, 2, 3, 4]).into_boxed_slice().into();
+        b[0] = 42;
+        assert_eq!(&*b, &[42, 2, 3, 4]);
+    }
+
+    #[test]
+    fn secretslice_zeroize_wipes_data() {
+        let mut b: SecretSlice = Vec::from([1u8, 2, 3, 4, 5, 6, 7, 8])
+            .into_boxed_slice()
+            .into();
+        b.zeroize();
+        assert!(b.iter().all(|&byte| byte == 0));
+    }
+}


### PR DESCRIPTION
Introduce SecretSlice, a Box<[u8]> wrapper that zeroes its backing memory on drop, and use it to hold the secret returned from the attestation proxy in place of a plain Vec. This ensures the decrypted key material released after a successful attestation is wiped from memory once it goes out of scope.

SecretSlice takes ownership of an existing heap buffer via a From<Box<[u8]>> impl without copying, relies on zeroize's ZeroizeOnDrop derive for drop-time clearing, and implements Debug by hand to redact its contents. The attestation path moves the ciphertext into the SecretSlice and decrypts in place, reusing the same allocation. Unit tests cover construction, slice access and zeroization.