### PR TITLE
Pgtable: expose map_xx_with_parent_flags to add flexibility for other systems && enforce dirty bit in default parent flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1583,6 +1583,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "paging"
+version = "0.1.0"
+dependencies = [
+ "bitflags",
+ "verify_external",
+ "verify_proof",
+ "verus_stub",
+ "vstd",
+ "zerocopy",
+]
+
+[[package]]
 name = "pastey"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2092,6 +2104,7 @@ dependencies = [
  "libtcgtpm",
  "log",
  "packit",
+ "paging",
  "release",
  "rustc-demangle",
  "rustc_version",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "boot/bootimg",
     "boot/defs",
     "cpuarch",
+    "paging",
     # binary targets
     "stage1",
     "kernel",
@@ -55,6 +56,7 @@ bldr = { path = "boot/bldr" }
 bootdefs = { path = "boot/defs" }
 bootimg = { path = "boot/bootimg" }
 cpuarch = { path = "cpuarch" }
+paging = { path = "paging" }
 test = { path = "test" }
 svsm = { path = "kernel" }
 elf = { path = "elf" }
@@ -139,6 +141,7 @@ missing_debug_implementations = { level = "deny", priority = 50 }
 single_use_lifetimes = { level = "warn", priority = 125 }
 trivial-numeric-casts = { level = "deny", priority = 10 }
 unsafe_op_in_unsafe_fn = { level = "deny", priority = 2 }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(verus_only)'] }
 
 [workspace.lints.clippy]
 await_holding_lock = "warn"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -16,6 +16,8 @@ doctest = true
 bootdefs.workspace = true
 bootimg.workspace = true
 cpuarch.workspace = true
+paging.workspace = true
+
 libaproxy = { workspace = true, optional = true }
 elf.workspace = true
 syscall.workspace = true
@@ -78,7 +80,7 @@ enable-gdb = ["dep:gdbstub", "dep:gdbstub_arch"]
 vtpm = ["dep:libtcgtpm"]
 nosmep = []
 nosmap = []
-verus_all = ["verus_builtin", "verus_builtin_macros", "vstd", "verify_proof/verus", "verify_external/verus", "verus_stub/disable"]
+verus_all = ["verus_builtin", "verus_builtin_macros", "vstd", "verify_proof/verus", "verify_external/verus", "verus_stub/disable", "paging/verus"]
 verus = ["verus_all", "verify_proof/noverify", "verify_external/noverify"]
 noverify = []
 virtio-drivers = ["dep:virtio-drivers", "dep:safe-mmio"]

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -32,7 +32,7 @@ use crate::locking::{
     WriteLockGuard, WriteLockGuardIrqSafe,
 };
 use crate::mm::page_visibility::SharedBox;
-use crate::mm::pagetable::{PTEntryFlags, PageTable};
+use crate::mm::pagetable::{PTEntryFlags, PageTable, SvsmMayNeedFlush};
 use crate::mm::virtualrange::VirtualRange;
 use crate::mm::vm::{Mapping, VMKernelStack, VMPhysMem, VMR, VMRMapping, VMReserved};
 use crate::mm::{
@@ -819,7 +819,7 @@ impl PerCpu {
 
     fn finish_page_table(&self) {
         let pgtable = self.get_pgtable();
-        self.vm_range.populate(pgtable);
+        self.vm_range.populate(pgtable).expect_no_flush();
     }
 
     pub fn dump_vm_ranges(&self) {
@@ -1200,8 +1200,8 @@ impl PerCpu {
     /// # Arguments
     ///
     /// * `pt` - The page table to populate the the PerCpu range into
-    pub fn populate_page_table(&self, pt: &mut PageTable) {
-        self.vm_range.populate(pt);
+    pub fn populate_page_table(&self, pt: &mut PageTable) -> SvsmMayNeedFlush {
+        self.vm_range.populate(pt)
     }
 
     pub fn handle_pf(&self, vaddr: VirtAddr, write: bool) -> Result<(), SvsmError> {

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -38,6 +38,7 @@ use crate::virtio::VirtioError;
 #[cfg(feature = "vsock")]
 use crate::vsock::VsockError;
 use elf::ElfError;
+use paging::traits::PagingError;
 use syscall::SysCallError;
 
 /// Errors related to I/O operations.
@@ -142,6 +143,8 @@ pub enum SvsmError {
     TeeAttestation(AttestationError),
     /// Errors related to ImmutAfterInitCell
     ImmutAfterInit(ImmutAfterInitError),
+    /// Errors from the paging crate
+    Paging(PagingError),
     /// Errors related to vsock.
     #[cfg(feature = "vsock")]
     Vsock(VsockError),
@@ -160,6 +163,12 @@ impl From<IoError> for SvsmError {
 impl From<ElfError> for SvsmError {
     fn from(err: ElfError) -> Self {
         Self::Elf(err)
+    }
+}
+
+impl From<PagingError> for SvsmError {
+    fn from(err: PagingError) -> Self {
+        Self::Paging(err)
     }
 }
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -20,7 +20,7 @@
 )]
 
 pub mod acpi;
-pub mod address;
+pub use paging::address;
 #[cfg(feature = "attest")]
 pub mod attest;
 #[cfg(feature = "block")]

--- a/kernel/src/mm/alloc.rs
+++ b/kernel/src/mm/alloc.rs
@@ -1127,7 +1127,7 @@ impl HeapMemoryRegion {
     }
 
     /// Merges two pages of the same order into a new compound page.
-    #[verus_verify(spinoff_prover, rlimit(2))]
+    #[verus_verify(spinoff_prover, rlimit(3))]
     #[verus_spec(ret =>
         with Tracked(perm): Tracked<&mut PgUnitPerm<DeallocUnit>>, Tracked(p2): Tracked<PgUnitPerm<DeallocUnit>>
         requires

--- a/kernel/src/mm/global_memory.rs
+++ b/kernel/src/mm/global_memory.rs
@@ -5,14 +5,13 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 
 use crate::address::{Address, PhysAddr, VirtAddr};
-use crate::cpu::flush_tlb_global_sync_range;
 use crate::cpu::percpu::this_cpu;
 use crate::error::SvsmError;
 use crate::locking::SpinLock;
-use crate::mm::pagetable::PTEntryFlags;
+use crate::mm::pagetable::{PTEntryFlags, SvsmMayNeedFlush};
 use crate::mm::virtualrange::VirtualRange;
 use crate::mm::{SIZE_LEVEL1, SVSM_GLOBAL_MAPPING_BASE, SVSM_GLOBAL_MAPPING_END};
-use crate::types::{PAGE_SHIFT, PAGE_SHIFT_2M, PAGE_SIZE, PAGE_SIZE_2M, PageSize};
+use crate::types::{PAGE_SHIFT, PAGE_SHIFT_2M, PAGE_SIZE, PAGE_SIZE_2M};
 use crate::utils::{MemoryRegion, align_up};
 
 struct GlobalRanges {
@@ -126,11 +125,11 @@ impl GlobalRangeGuard {
         }
     }
 
-    fn unmap(&self) {
+    fn unmap(&self) -> SvsmMayNeedFlush {
         if self.huge {
-            this_cpu().get_pgtable().unmap_region_2m(self.region());
+            this_cpu().get_pgtable().unmap_region_2m(self.region())
         } else {
-            this_cpu().get_pgtable().unmap_region_4k(self.region());
+            this_cpu().get_pgtable().unmap_region_4k(self.region())
         }
     }
 
@@ -147,14 +146,9 @@ impl GlobalRangeGuard {
 
 impl Drop for GlobalRangeGuard {
     fn drop(&mut self) {
-        self.unmap();
+        let flush = self.unmap();
         // Flush TLB before allowing to re-use addresses
-        let pgsize = if self.huge {
-            PageSize::Huge
-        } else {
-            PageSize::Regular
-        };
-        flush_tlb_global_sync_range(self.region(), pgsize);
+        flush.flush_tlb_global_sync();
         GLOBAL_RANGES
             .lock()
             .free(self.vstart, self.pages, self.huge);

--- a/kernel/src/mm/page_visibility.rs
+++ b/kernel/src/mm/page_visibility.rs
@@ -9,7 +9,6 @@ use core::ops::Deref;
 use core::ptr::NonNull;
 
 use crate::address::VirtAddr;
-use crate::cpu::flush_tlb_global_sync_page;
 use crate::cpu::mem::{unsafe_copy_bytes, write_bytes};
 use crate::cpu::percpu::this_cpu;
 use crate::error::SvsmError;
@@ -18,7 +17,7 @@ use crate::mm::validate::{
 };
 use crate::mm::{PageBox, virt_to_phys};
 use crate::platform::{PageStateChangeOp, PageValidateOp, SVSM_PLATFORM};
-use crate::types::{PAGE_SIZE, PageSize};
+use crate::types::PAGE_SIZE;
 use crate::utils::MemoryRegion;
 
 use zerocopy::{FromBytes, FromZeros, Immutable, IntoBytes};
@@ -60,8 +59,8 @@ pub unsafe fn make_page_shared(vaddr: VirtAddr) -> Result<(), SvsmError> {
     this_cpu()
         .get_pgtable()
         .set_shared_4k(vaddr)
-        .expect("Failed to remap shared page in page tables");
-    flush_tlb_global_sync_page(vaddr, PageSize::Regular);
+        .expect("Failed to remap shared page in page tables")
+        .flush_tlb_global_sync();
 
     Ok(())
 }
@@ -79,8 +78,10 @@ pub unsafe fn make_page_shared(vaddr: VirtAddr) -> Result<(), SvsmError> {
 /// No outstanding references to the page may exist.
 pub unsafe fn make_page_private(vaddr: VirtAddr) -> Result<(), SvsmError> {
     // Update the page tables to map the page as private.
-    this_cpu().get_pgtable().set_encrypted_4k(vaddr)?;
-    flush_tlb_global_sync_page(vaddr, PageSize::Regular);
+    this_cpu()
+        .get_pgtable()
+        .set_encrypted_4k(vaddr)?
+        .flush_tlb_global_sync();
 
     // Ask the hypervisor to make the page private.
     let paddr = virt_to_phys(vaddr);

--- a/kernel/src/mm/pagetable.rs
+++ b/kernel/src/mm/pagetable.rs
@@ -7,9 +7,9 @@
 use crate::BIT_MASK;
 use crate::address::{PhysAddr, VirtAddr};
 use crate::cpu::control_regs::write_cr3;
-use crate::cpu::flush_tlb_global_sync;
 use crate::cpu::idt::common::PageFaultError;
 use crate::cpu::registers::RFlags;
+use crate::cpu::{TlbFlushRange, TlbFlushScope};
 use crate::error::SvsmError;
 use crate::mm::{
     PGTABLE_LVL3_IDX_PTE_SELFMAP, PGTABLE_LVL3_IDX_SHARED, PageBox, phys_to_virt, virt_to_phys,
@@ -28,6 +28,7 @@ use cpuarch::x86::EFERFlags;
 use paging::pagetable::{
     ArchPagingMeta, GenericPageTable, PageLevel, PagingError, PagingHandler, SelfMap,
 };
+use paging::tlb::MayNeedFlush;
 use zerocopy::FromBytes;
 use zerocopy::FromZeros;
 
@@ -118,6 +119,7 @@ pub struct SvsmPaging;
 
 impl ArchPagingMeta for SvsmPaging {
     type PTFlags = PTEntryFlags;
+    type TlbFlushTok = TlbFlushScope;
 
     fn private_pte_mask() -> usize {
         private_pte_mask()
@@ -131,12 +133,63 @@ impl ArchPagingMeta for SvsmPaging {
         0x000f_ffff_ffff_f000
     }
 
-    fn flush_tlb_global() {
-        flush_tlb_global_sync();
-    }
-
     fn supported_flags() -> PTEntryFlags {
         *FEATURE_MASK
+    }
+}
+
+impl paging::tlb::TlbFlush for TlbFlushScope {
+    fn range(start: VirtAddr, end: VirtAddr, level: PageLevel) -> Self {
+        let page_size = match level {
+            PageLevel::Level0 => PageSize::Regular,
+            PageLevel::Level1 => PageSize::Huge,
+            _ => return TlbFlushScope::all(),
+        };
+        TlbFlushScope::range(MemoryRegion::new(start, end - start), page_size)
+    }
+
+    fn all() -> Self {
+        TlbFlushScope::all()
+    }
+
+    fn and(self, other: Self) -> Self {
+        match (self.range, other.range) {
+            (TlbFlushRange::All, _) | (_, TlbFlushRange::All) => TlbFlushScope::all(),
+            (
+                TlbFlushRange::Range {
+                    region: self_region,
+                    pgsize: self_pgsize,
+                },
+                TlbFlushRange::Range {
+                    region: other_region,
+                    pgsize: other_pgsize,
+                },
+            ) => {
+                let range = self_region.merge(&other_region);
+                let pgsize = if self_pgsize == PageSize::Regular && self_pgsize == other_pgsize {
+                    self_pgsize
+                } else {
+                    PageSize::Huge
+                };
+                TlbFlushScope::range(range, pgsize)
+            }
+        }
+    }
+
+    fn flush_tlb_global_sync(self) {
+        self.with_global(true).flush_all_cpus();
+    }
+
+    fn flush_tlb_ignore_global_sync(self) {
+        self.with_global(false).flush_all_cpus();
+    }
+
+    fn flush_tlb_global_percpu(self) {
+        self.with_global(true).flush_percpu();
+    }
+
+    fn flush_tlb_ignore_global_percpu(self) {
+        self.with_global(false).flush_percpu();
     }
 }
 
@@ -217,6 +270,8 @@ pub type Mapping<'a> = paging::pagetable::Mapping<'a, SvsmPaging>;
 
 /// A physical address within a page frame
 pub type PageFrame = paging::pagetable::PageFrame<SvsmPaging>;
+
+pub type SvsmMayNeedFlush = MayNeedFlush<TlbFlushScope>;
 
 trait PTEntryExt {
     /// Check if the page table entry has reserved bits set.
@@ -412,18 +467,6 @@ impl PageTable {
         Ok(pgtable)
     }
 
-    /// Splits a page into 4KB pages if it is part of a larger mapping.
-    ///
-    /// # Parameters
-    /// - `mapping`: The mapping to split.
-    ///
-    /// # Returns
-    /// A result indicating success or an error [`SvsmError`].
-    pub fn split_4k(mapping: Mapping<'_>) -> Result<(), SvsmError> {
-        SvsmPageTable::split_4k(mapping)?;
-        Ok(())
-    }
-
     /// Gets the physical address for a mapped `vaddr` or `None` if
     /// no such mapping exists.
     pub fn check_mapping(&mut self, vaddr: VirtAddr) -> Option<PhysAddr> {
@@ -481,9 +524,13 @@ impl PageTable {
     ///
     /// # Parameters
     /// - `vregion`: The virtual memory region to unmap.
-    pub fn unmap_region_4k(&mut self, vregion: MemoryRegion<VirtAddr>) {
+    pub fn unmap_region_4k(&mut self, vregion: MemoryRegion<VirtAddr>) -> SvsmMayNeedFlush {
         let (start, end) = (vregion.start(), vregion.end());
-        self.0.unmap_region_4k(start, end);
+        let flush = self.0.unmap_region_4k(start, end);
+        if let TlbFlushRange::Range { region, pgsize } = flush.scope().unwrap().range {
+            assert!(region.start() == start && region.end() == end && pgsize == PageSize::Regular);
+        }
+        flush
     }
 
     /// Maps a region of memory using 2MB pages.
@@ -510,9 +557,13 @@ impl PageTable {
 
     /// Unmaps a region `vregion` of 2MB pages. The region must be
     /// 2MB-aligned and correspond to a set of huge mappings.
-    pub fn unmap_region_2m(&mut self, vregion: MemoryRegion<VirtAddr>) {
+    pub fn unmap_region_2m(&mut self, vregion: MemoryRegion<VirtAddr>) -> SvsmMayNeedFlush {
         let (start, end) = (vregion.start(), vregion.end());
-        self.0.unmap_region_2m(start, end);
+        let flush = self.0.unmap_region_2m(start, end);
+        if let TlbFlushRange::Range { region, pgsize } = flush.scope().unwrap().range {
+            assert!(region.start() == start && region.end() == end && pgsize == PageSize::Huge);
+        }
+        flush
     }
 
     /// Maps a memory region to physical memory with specified flags.
@@ -536,23 +587,25 @@ impl PageTable {
     }
 
     /// Unmaps the virtual memory region `vregion`.
-    pub fn unmap_region(&mut self, vregion: MemoryRegion<VirtAddr>) {
-        if !self.0.unmap_region(vregion.start(), vregion.end()) {
+    pub fn unmap_region(&mut self, vregion: MemoryRegion<VirtAddr>) -> SvsmMayNeedFlush {
+        let (was_mapped, flush) = self.0.unmap_region(vregion.start(), vregion.end());
+        if !was_mapped {
             log::error!(
                 "Can't unmap - address not mapped in region {:#x}-{:#x}",
                 vregion.start(),
                 vregion.end()
             );
         }
+        flush
     }
 
     /// Populates this page table with the contents of the given subtree
     /// in `part`.
     ///
     /// Returns `true` if the PTE contents were updated.
-    pub fn populate_pgtbl_part(&mut self, part: &PageTablePart) -> bool {
+    pub fn populate_pgtbl_part(&mut self, part: &PageTablePart) -> (bool, SvsmMayNeedFlush) {
         let Some(paddr) = part.address() else {
-            return false;
+            return (false, SvsmMayNeedFlush::none());
         };
         let idx = part.index();
         let flags = PTEntryFlags::PRESENT
@@ -572,10 +625,14 @@ impl PageTable {
     /// expected.
     /// The caller must also ensure that the region start and size are 4k
     /// aligned.
+    ///
+    /// # Returns
+    /// The [`SvsmMayNeedFlush`] TLB-flush obligation for the now-stale
+    /// translations on success, or a [`SvsmError`] on failure.
     pub unsafe fn make_region_ro_4k(
         &mut self,
         region: MemoryRegion<VirtAddr>,
-    ) -> Result<(), SvsmError> {
+    ) -> Result<SvsmMayNeedFlush, SvsmError> {
         for page in region.iter_pages(PageSize::Regular) {
             match self.walk_addr(page) {
                 Mapping {
@@ -605,7 +662,11 @@ impl PageTable {
             }
         }
 
-        Ok(())
+        Ok(SvsmMayNeedFlush::new_range(
+            region.start(),
+            region.end(),
+            PageLevel::Level0,
+        ))
     }
 }
 
@@ -722,14 +783,17 @@ impl PageTablePart {
     ///
     /// # Returns
     ///
-    /// Returns a copy of the PTEntry that mapped the virtual address, if any.
+    /// A copy of the [`PTEntry`] that mapped the virtual address together with
+    /// the [`SvsmMayNeedFlush`] TLB-flush obligation for the now-stale translation,
+    /// or [`None`] if no leaf was mapped.
     ///
     /// # Panics
     ///
     /// This method panics when `vaddr` is not aligned to 4KiB.
-    pub fn unmap_4k(&mut self, vaddr: VirtAddr) -> Option<PTEntry> {
+    pub fn unmap_4k(&mut self, vaddr: VirtAddr) -> (Option<PTEntry>, SvsmMayNeedFlush) {
         assert!(PageTable::index::<3>(vaddr) == self.idx);
-        self.get_mut()?.unmap_4k(vaddr)
+        self.get_mut()
+            .map_or((None, SvsmMayNeedFlush::none()), |pt| pt.unmap_4k(vaddr))
     }
 
     /// Map a 2MiB page in the page table sub-tree
@@ -772,14 +836,17 @@ impl PageTablePart {
     ///
     /// # Returns
     ///
-    /// Returns a copy of the PTEntry that mapped the virtual address, if any.
+    /// A copy of the [`PTEntry`] that mapped the virtual address together with
+    /// the [`SvsmMayNeedFlush`] TLB-flush obligation for the now-stale translation,
+    /// or [`None`] if no huge leaf was mapped.
     ///
     /// # Panics
     ///
     /// This method panics when `vaddr` is not aligned to 2MiB.
-    pub fn unmap_2m(&mut self, vaddr: VirtAddr) -> Option<PTEntry> {
+    pub fn unmap_2m(&mut self, vaddr: VirtAddr) -> (Option<PTEntry>, SvsmMayNeedFlush) {
         assert!(PageTable::index::<3>(vaddr) == self.idx);
-        self.get_mut()?.unmap_2m(vaddr)
+        self.get_mut()
+            .map_or((None, SvsmMayNeedFlush::none()), |pt| pt.unmap_2m(vaddr))
     }
 }
 

--- a/kernel/src/mm/pagetable.rs
+++ b/kernel/src/mm/pagetable.rs
@@ -5,7 +5,7 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 
 use crate::BIT_MASK;
-use crate::address::{Address, PhysAddr, VirtAddr};
+use crate::address::{PhysAddr, VirtAddr};
 use crate::cpu::control_regs::write_cr3;
 use crate::cpu::flush_tlb_global_sync;
 use crate::cpu::idt::common::PageFaultError;
@@ -15,7 +15,7 @@ use crate::mm::{
     PGTABLE_LVL3_IDX_PTE_SELFMAP, PGTABLE_LVL3_IDX_SHARED, PageBox, phys_to_virt, virt_to_phys,
 };
 use crate::platform::SvsmPlatform;
-use crate::types::{PAGE_SIZE, PAGE_SIZE_2M, PageSize};
+use crate::types::PageSize;
 use crate::utils::MemoryRegion;
 use crate::utils::immut_after_init::{ImmutAfterInitCell, ImmutAfterInitResult};
 use bitflags::bitflags;
@@ -472,10 +472,8 @@ impl PageTable {
         flags: PTEntryFlags,
         shared: bool,
     ) -> Result<(), SvsmError> {
-        for addr in vregion.iter_pages(PageSize::Regular) {
-            let offset = addr - vregion.start();
-            self.map_4k(addr, phys + offset, flags, shared)?;
-        }
+        let (start, end) = (vregion.start(), vregion.end());
+        self.0.map_region_4k(start, end, phys, flags, shared)?;
         Ok(())
     }
 
@@ -484,9 +482,8 @@ impl PageTable {
     /// # Parameters
     /// - `vregion`: The virtual memory region to unmap.
     pub fn unmap_region_4k(&mut self, vregion: MemoryRegion<VirtAddr>) {
-        for addr in vregion.iter_pages(PageSize::Regular) {
-            self.unmap_4k(addr);
-        }
+        let (start, end) = (vregion.start(), vregion.end());
+        self.0.unmap_region_4k(start, end);
     }
 
     /// Maps a region of memory using 2MB pages.
@@ -506,19 +503,16 @@ impl PageTable {
         flags: PTEntryFlags,
         shared: bool,
     ) -> Result<(), SvsmError> {
-        for addr in vregion.iter_pages(PageSize::Huge) {
-            let offset = addr - vregion.start();
-            self.map_2m(addr, phys + offset, flags, shared)?;
-        }
+        let (start, end) = (vregion.start(), vregion.end());
+        self.0.map_region_2m(start, end, phys, flags, shared)?;
         Ok(())
     }
 
     /// Unmaps a region `vregion` of 2MB pages. The region must be
     /// 2MB-aligned and correspond to a set of huge mappings.
     pub fn unmap_region_2m(&mut self, vregion: MemoryRegion<VirtAddr>) {
-        for addr in vregion.iter_pages(PageSize::Huge) {
-            self.unmap_2m(addr);
-        }
+        let (start, end) = (vregion.start(), vregion.end());
+        self.0.unmap_region_2m(start, end);
     }
 
     /// Maps a memory region to physical memory with specified flags.
@@ -536,51 +530,19 @@ impl PageTable {
         phys: PhysAddr,
         flags: PTEntryFlags,
     ) -> Result<(), SvsmError> {
-        let mut vaddr = region.start();
-        let end = region.end();
-        let mut paddr = phys;
-
-        while vaddr < end {
-            if vaddr.is_aligned(PAGE_SIZE_2M)
-                && paddr.is_aligned(PAGE_SIZE_2M)
-                && vaddr + PAGE_SIZE_2M <= end
-                && self.map_2m(vaddr, paddr, flags, false).is_ok()
-            {
-                vaddr = vaddr + PAGE_SIZE_2M;
-                paddr = paddr + PAGE_SIZE_2M;
-                continue;
-            }
-
-            self.map_4k(vaddr, paddr, flags, false)?;
-            vaddr = vaddr + PAGE_SIZE;
-            paddr = paddr + PAGE_SIZE;
-        }
-
+        let (start, end) = (region.start(), region.end());
+        self.0.map_region(start, end, phys, flags)?;
         Ok(())
     }
 
     /// Unmaps the virtual memory region `vregion`.
     pub fn unmap_region(&mut self, vregion: MemoryRegion<VirtAddr>) {
-        let mut vaddr = vregion.start();
-        let end = vregion.end();
-
-        while vaddr < end {
-            let mapping = self.walk_addr(vaddr);
-
-            match mapping.level {
-                PageLevel::Level0 => {
-                    mapping.entry.clear();
-                    vaddr = vaddr + PAGE_SIZE;
-                }
-                PageLevel::Level1 => {
-                    mapping.entry.clear();
-                    vaddr = vaddr + PAGE_SIZE_2M;
-                }
-                _ => {
-                    log::error!("Can't unmap - address not mapped {vaddr:#x}");
-                    vaddr = vaddr + PAGE_SIZE;
-                }
-            }
+        if !self.0.unmap_region(vregion.start(), vregion.end()) {
+            log::error!(
+                "Can't unmap - address not mapped in region {:#x}-{:#x}",
+                vregion.start(),
+                vregion.end()
+            );
         }
     }
 

--- a/kernel/src/mm/pagetable.rs
+++ b/kernel/src/mm/pagetable.rs
@@ -12,25 +12,27 @@ use crate::cpu::idt::common::PageFaultError;
 use crate::cpu::registers::RFlags;
 use crate::error::SvsmError;
 use crate::mm::{
-    PGTABLE_LVL3_IDX_PTE_SELFMAP, PGTABLE_LVL3_IDX_SHARED, PageBox, SVSM_PTE_BASE, phys_to_virt,
-    virt_to_phys,
+    PGTABLE_LVL3_IDX_PTE_SELFMAP, PGTABLE_LVL3_IDX_SHARED, PageBox, phys_to_virt, virt_to_phys,
 };
 use crate::platform::SvsmPlatform;
-use crate::types::{PAGE_SIZE, PAGE_SIZE_1G, PAGE_SIZE_2M, PageSize};
+use crate::types::{PAGE_SIZE, PAGE_SIZE_2M, PageSize};
 use crate::utils::MemoryRegion;
 use crate::utils::immut_after_init::{ImmutAfterInitCell, ImmutAfterInitResult};
 use bitflags::bitflags;
 use core::cmp;
-use core::ops::{Index, IndexMut};
+use core::ops::{Deref, DerefMut};
 use core::ptr::NonNull;
 use cpuarch::x86::CR0Flags;
 use cpuarch::x86::CR4Flags;
 use cpuarch::x86::EFERFlags;
+use paging::pagetable::{
+    ArchPagingMeta, GenericPageTable, PageLevel, PagingError, PagingHandler, SelfMap,
+};
 use zerocopy::FromBytes;
 use zerocopy::FromZeros;
 
-/// Number of entries in a page table (4KB/8B).
-pub const ENTRY_COUNT: usize = 512;
+/// Re-export types from the paging crate.
+pub use paging::x86_64::{PTEntryFlags, PdptLevel, Pml4Level};
 
 /// Mask for private page table entry.
 static PRIVATE_PTE_MASK: ImmutAfterInitCell<usize> = ImmutAfterInitCell::uninit();
@@ -105,72 +107,66 @@ pub fn max_phys_addr() -> PhysAddr {
     PhysAddr::from(*MAX_PHYS_ADDR)
 }
 
-/// Returns the supported flags considering the feature mask.
-fn supported_flags(flags: PTEntryFlags) -> PTEntryFlags {
-    flags & *FEATURE_MASK
-}
-
-/// Set address as shared via mask.
-fn make_shared_address(paddr: PhysAddr) -> PhysAddr {
-    (strip_confidentiality_bits(paddr).bits() | shared_pte_mask()).into()
-}
-
 /// Set address as private via mask.
 pub fn make_private_address(paddr: PhysAddr) -> PhysAddr {
-    (strip_shared_address_bits(paddr).bits() | private_pte_mask()).into()
+    SvsmPaging::make_private_address(paddr)
 }
 
-// Returns true if the address is shared.
-fn is_shared(paddr: PhysAddr) -> bool {
-    paddr == make_shared_address(paddr)
-}
+/// The SVSM page table provider: frame mapping, allocation, and encryption masks.
+#[derive(Debug, Clone, Copy, FromBytes)]
+pub struct SvsmPaging;
 
-fn strip_confidentiality_bits(paddr: PhysAddr) -> PhysAddr {
-    (paddr.bits() & !private_pte_mask()).into()
-}
+impl ArchPagingMeta for SvsmPaging {
+    type PTFlags = PTEntryFlags;
 
-fn strip_shared_address_bits(paddr: PhysAddr) -> PhysAddr {
-    (paddr.bits() & !shared_pte_mask()).into()
-}
+    fn private_pte_mask() -> usize {
+        private_pte_mask()
+    }
 
-bitflags! {
-    #[derive(Copy, Clone, Debug, Default)]
-    pub struct PTEntryFlags: u64 {
-        const PRESENT       = 1 << 0;
-        const WRITABLE      = 1 << 1;
-        const USER      = 1 << 2;
-        const ACCESSED      = 1 << 5;
-        const DIRTY     = 1 << 6;
-        const HUGE      = 1 << 7;
-        const GLOBAL        = 1 << 8;
-        const NX        = 1 << 63;
+    fn shared_pte_mask() -> usize {
+        shared_pte_mask()
+    }
+
+    fn address_mask() -> usize {
+        0x000f_ffff_ffff_f000
+    }
+
+    fn flush_tlb_global() {
+        flush_tlb_global_sync();
+    }
+
+    fn supported_flags() -> PTEntryFlags {
+        *FEATURE_MASK
     }
 }
 
-impl PTEntryFlags {
-    pub fn exec() -> Self {
-        Self::PRESENT | Self::GLOBAL | Self::ACCESSED
+// SAFETY: paddr_to_vaddr correctly maps physical addresses via phys_to_virt,
+// and allocate_physical_page returns unique zeroed frames via PageBox.
+unsafe impl PagingHandler for SvsmPaging {
+    fn paddr_to_vaddr(paddr: PhysAddr) -> VirtAddr {
+        phys_to_virt(paddr)
     }
 
-    pub fn data() -> Self {
-        Self::PRESENT | Self::GLOBAL | Self::WRITABLE | Self::NX | Self::ACCESSED | Self::DIRTY
+    fn allocate_physical_page() -> Result<PhysAddr, PagingError> {
+        let page = pt_page_alloc_box().map_err(|_| PagingError::AllocFrame)?;
+        let paddr = virt_to_phys(page.vaddr());
+        let _ = PageBox::leak(page);
+        Ok(paddr)
     }
 
-    pub fn data_ro() -> Self {
-        Self::PRESENT | Self::GLOBAL | Self::NX | Self::ACCESSED
+    unsafe fn deallocate_physical_page(paddr: PhysAddr) {
+        let vaddr = phys_to_virt(paddr);
+        // SAFETY: paddr was returned by allocate_physical_page (via PageBox::leak),
+        // so reconstructing the PageBox from the same pointer is valid.
+        unsafe {
+            let ptr = NonNull::new(vaddr.as_mut_ptr::<PTPage>()).unwrap();
+            let _ = PageBox::from_raw(ptr);
+        }
     }
+}
 
-    pub fn task_exec() -> Self {
-        Self::PRESENT | Self::ACCESSED
-    }
-
-    pub fn task_data() -> Self {
-        Self::PRESENT | Self::WRITABLE | Self::NX | Self::ACCESSED | Self::DIRTY
-    }
-
-    pub fn task_data_ro() -> Self {
-        Self::PRESENT | Self::NX | Self::ACCESSED
-    }
+impl SelfMap for SvsmPaging {
+    const SELFMAP_IDX: usize = PGTABLE_LVL3_IDX_PTE_SELFMAP;
 }
 
 /// Represents paging mode.
@@ -211,53 +207,24 @@ impl PagingMode {
 }
 
 /// Represents a page table entry.
-#[repr(C)]
-#[derive(Copy, Clone, Debug, FromBytes)]
-pub struct PTEntry(PhysAddr);
+pub type PTEntry = paging::pagetable::PTEntry<SvsmPaging>;
 
-impl PTEntry {
-    /// Check if the page table entry is clear (null).
-    pub fn is_clear(&self) -> bool {
-        self.0.is_null()
-    }
+/// A pagetable page with multiple entries.
+pub type PTPage = paging::pagetable::PTPage<SvsmPaging, SvsmPaging>;
 
-    /// Clear the page table entry.
-    pub fn clear(&mut self) {
-        self.0 = PhysAddr::null();
-    }
+/// Mapping levels of page table entries.
+pub type Mapping<'a> = paging::pagetable::Mapping<'a, SvsmPaging>;
 
-    /// Check if the page table entry is present.
-    pub fn present(&self) -> bool {
-        self.flags().contains(PTEntryFlags::PRESENT)
-    }
+/// A physical address within a page frame
+pub type PageFrame = paging::pagetable::PageFrame<SvsmPaging>;
 
-    /// Check if the page table entry is huge.
-    pub fn huge(&self) -> bool {
-        self.flags().contains(PTEntryFlags::HUGE)
-    }
-
-    /// Check if the page table entry is writable.
-    pub fn writable(&self) -> bool {
-        self.flags().contains(PTEntryFlags::WRITABLE)
-    }
-
-    /// Check if the page table entry is NX (no-execute).
-    pub fn nx(&self) -> bool {
-        self.flags().contains(PTEntryFlags::NX)
-    }
-
-    /// Check if the page table entry is user-accessible.
-    pub fn user(&self) -> bool {
-        self.flags().contains(PTEntryFlags::USER)
-    }
-
-    /// Check if the page table entry is global.
-    pub fn global(&self) -> bool {
-        self.flags().contains(PTEntryFlags::GLOBAL)
-    }
-
+trait PTEntryExt {
     /// Check if the page table entry has reserved bits set.
-    pub fn has_reserved_bits(&self, pm: PagingMode, level: usize) -> bool {
+    fn has_reserved_bits(&self, pm: PagingMode, level: usize) -> bool;
+}
+
+impl PTEntryExt for PTEntry {
+    fn has_reserved_bits(&self, pm: PagingMode, level: usize) -> bool {
         let reserved_mask = match pm {
             PagingMode::NoPaging => unreachable!("NoPaging does not have page table"),
             PagingMode::NonPAE => {
@@ -345,204 +312,36 @@ impl PTEntry {
             }
         };
 
-        self.raw() & reserved_mask != 0
-    }
-
-    /// Get the raw bits (`u64`) of the page table entry.
-    pub fn raw(&self) -> u64 {
-        self.0.bits() as u64
-    }
-
-    /// Get the flags of the page table entry.
-    pub fn flags(&self) -> PTEntryFlags {
-        PTEntryFlags::from_bits_truncate(self.0.bits() as u64)
-    }
-
-    /// Set the page table entry with the specified address and flags.
-    pub fn set_unrestricted(&mut self, addr: PhysAddr, flags: PTEntryFlags) {
-        let addr = addr.bits() as u64;
-        assert_eq!(addr & !0x000f_ffff_ffff_f000, 0);
-        self.0 = PhysAddr::from(addr | flags.bits());
-    }
-
-    /// Set the page table entry with the specified address, with flags
-    /// constrained to the supported feature flags.
-    pub fn set(&mut self, addr: PhysAddr, flags: PTEntryFlags) {
-        self.set_unrestricted(addr, supported_flags(flags));
-    }
-
-    /// Inserts the private address mask if the page is present.
-    pub fn make_private_if_present(&mut self) {
-        if self.flags().contains(PTEntryFlags::PRESENT) {
-            self.0 = make_private_address(self.0);
-        }
-    }
-
-    /// Get the address from the page table entry, including the shared bit.
-    pub fn page_frame(&self) -> PhysAddr {
-        let addr = PhysAddr::from(self.0.bits() & 0x000f_ffff_ffff_f000);
-        strip_confidentiality_bits(addr)
-    }
-
-    /// Get the address from the page table entry, excluding the C/shared bit.
-    pub fn address(&self) -> PhysAddr {
-        strip_shared_address_bits(self.page_frame())
-    }
-
-    /// Read a page table entry from the specified virtual address.
-    ///
-    /// # Safety
-    ///
-    /// Reads from an arbitrary virtual address, making this essentially a
-    /// raw pointer read.  The caller must be certain to calculate the correct
-    /// address.
-    pub unsafe fn read_pte(vaddr: VirtAddr) -> Self {
-        // SAFETY: When the methods safety requirements are met, the raw
-        // pointer read is safe.
-        unsafe { *vaddr.as_ptr::<Self>() }
+        self.raw() & reserved_mask as usize != 0
     }
 }
 
-/// A pagetable page with multiple entries.
-#[repr(C)]
-#[derive(Debug, FromBytes)]
-pub struct PTPage {
-    entries: [PTEntry; ENTRY_COUNT],
+fn pt_page_alloc_box() -> Result<PageBox<PTPage>, SvsmError> {
+    PageBox::try_new_zeroed()
 }
 
-impl PTPage {
-    /// Allocates a zeroed pagetable page and returns a `PageBox` containing
-    /// the allocation.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`SvsmError`] if the page cannot be allocated.
-    pub fn alloc_box() -> Result<PageBox<Self>, SvsmError> {
-        PageBox::try_new_zeroed()
-    }
+/// Inner type alias to simplify references to the fully-parameterized generic page table.
+type SvsmPageTable = GenericPageTable<SvsmPaging, SvsmPaging, Pml4Level>;
 
-    /// Allocates a zeroed pagetable page and returns a mutable reference to
-    /// it, plus its physical address.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`SvsmError`] if the page cannot be allocated.
-    fn alloc() -> Result<(&'static mut Self, PhysAddr), SvsmError> {
-        let page = Self::alloc_box()?;
-        let paddr = virt_to_phys(page.vaddr());
-        Ok((PageBox::leak(page), paddr))
-    }
-
-    /// Frees a pagetable page.
-    ///
-    /// # Safety
-    ///
-    /// The given reference must correspond to a valid previously allocated
-    /// page table page.
-    unsafe fn free(page: &'static Self) {
-        // SAFETY: The page put into the PageBox is a previously allocated
-        // page table page.
-        unsafe {
-            let _ = PageBox::from_raw(NonNull::from(page));
-        }
-    }
-
-    /// Converts a pagetable entry to a mutable reference to a [`PTPage`],
-    /// if the entry is present and not huge.
-    fn from_entry(entry: PTEntry) -> Option<&'static mut Self> {
-        let flags = entry.flags();
-        if !flags.contains(PTEntryFlags::PRESENT) || flags.contains(PTEntryFlags::HUGE) {
-            return None;
-        }
-
-        let address = phys_to_virt(entry.address());
-        // SAFETY: Every PTEntry points to a previously allocated page-table
-        // page, so this pointer dereference is safe.
-        Some(unsafe { Self::from_vaddr(address) })
-    }
-
-    /// Generates a `PTPage` from a virtual address.
-    /// # Safety
-    /// The caller must ensure that the virtual address is a valid page table.
-    pub unsafe fn from_vaddr(vaddr: VirtAddr) -> &'static mut Self {
-        // SAFETY: the caller guarantees the correctness of the virtual
-        // address.
-        unsafe { &mut *vaddr.as_mut_ptr::<PTPage>() }
-    }
-}
-
-/// Can be used to access page table entries by index.
-impl Index<usize> for PTPage {
-    type Output = PTEntry;
-
-    fn index(&self, index: usize) -> &PTEntry {
-        &self.entries[index]
-    }
-}
-
-/// Can be used to modify page table entries by index.
-impl IndexMut<usize> for PTPage {
-    fn index_mut(&mut self, index: usize) -> &mut PTEntry {
-        &mut self.entries[index]
-    }
-}
-
-/// Mapping levels of page table entries.
-#[derive(Debug)]
-pub enum Mapping<'a> {
-    Level3(&'a mut PTEntry),
-    Level2(&'a mut PTEntry),
-    Level1(&'a mut PTEntry),
-    Level0(&'a mut PTEntry),
-}
-
-/// A physical address within a page frame
-#[derive(Clone, Copy, Debug)]
-pub enum PageFrame {
-    Size4K(PhysAddr),
-    Size2M(PhysAddr),
-    Size1G(PhysAddr),
-}
-
-impl PageFrame {
-    /// Get the address from the page frame, including the shared bit.
-    pub fn page_frame(&self) -> PhysAddr {
-        let paddr = match *self {
-            Self::Size4K(pa) => pa,
-            Self::Size2M(pa) => pa,
-            Self::Size1G(pa) => pa,
-        };
-        strip_confidentiality_bits(paddr)
-    }
-
-    /// Get the address from the page frame, excluding the C/shared bit.
-    pub fn address(&self) -> PhysAddr {
-        strip_shared_address_bits(self.page_frame())
-    }
-
-    pub fn size(&self) -> usize {
-        match self {
-            Self::Size4K(_) => PAGE_SIZE,
-            Self::Size2M(_) => PAGE_SIZE_2M,
-            Self::Size1G(_) => PAGE_SIZE_1G,
-        }
-    }
-
-    pub fn start(&self) -> PhysAddr {
-        let end = self.address().bits() & !(self.size() - 1);
-        end.into()
-    }
-
-    pub fn end(&self) -> PhysAddr {
-        self.start() + self.size()
-    }
-}
+/// Represents a sub-tree of a page-table which can be mapped at a top-level index
+type RawPageTablePart = GenericPageTable<SvsmPaging, SvsmPaging, PdptLevel>;
 
 /// Page table structure containing a root page with multiple entries.
 #[repr(C)]
 #[derive(Debug, FromZeros)]
-pub struct PageTable {
-    root: PTPage,
+pub struct PageTable(SvsmPageTable);
+
+impl Deref for PageTable {
+    type Target = SvsmPageTable;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for PageTable {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
 }
 
 impl PageTable {
@@ -565,42 +364,6 @@ impl PageTable {
         virt_to_phys(pgtable)
     }
 
-    /// Allocate a new page table root.
-    ///
-    /// # Errors
-    /// Returns [`SvsmError`] if the page cannot be allocated.
-    pub fn allocate_new() -> Result<PageBox<Self>, SvsmError> {
-        let mut pgtable: PageBox<Self> = PageBox::try_new_zeroed()?;
-        let paddr = virt_to_phys(pgtable.vaddr());
-
-        // Set the self-map entry.
-        let entry = &mut pgtable.root[PGTABLE_LVL3_IDX_PTE_SELFMAP];
-        let flags = PTEntryFlags::PRESENT
-            | PTEntryFlags::WRITABLE
-            | PTEntryFlags::ACCESSED
-            | PTEntryFlags::DIRTY
-            | PTEntryFlags::NX;
-        entry.set(make_private_address(paddr), flags);
-
-        Ok(pgtable)
-    }
-
-    /// Clone the shared part of the page table; excluding the private
-    /// parts.
-    ///
-    /// # Errors
-    /// Returns [`SvsmError`] if the page cannot be allocated.
-    pub fn clone_shared(&self) -> Result<PageBox<PageTable>, SvsmError> {
-        let mut pgtable = Self::allocate_new()?;
-        pgtable.root.entries[PGTABLE_LVL3_IDX_SHARED] = self.root.entries[PGTABLE_LVL3_IDX_SHARED];
-        Ok(pgtable)
-    }
-
-    /// Copy an entry `entry` from another [`PageTable`].
-    pub fn copy_entry(&mut self, other: &Self, entry: usize) {
-        self.root.entries[entry] = other.root.entries[entry];
-    }
-
     /// Computes the index within a page table at the given level for a
     /// virtual address `vaddr`.
     ///
@@ -609,96 +372,9 @@ impl PageTable {
     ///
     /// # Returns
     /// The index within the page table.
+    #[inline]
     pub fn index<const L: usize>(vaddr: VirtAddr) -> usize {
-        vaddr.to_pgtbl_idx::<L>()
-        //vaddr.bits() >> (12 + L * 9) & 0x1ff
-    }
-
-    /// Walks a page table at level 0 to find a mapping.
-    ///
-    /// # Parameters
-    /// - `page`: A mutable reference to the root page table.
-    /// - `vaddr`: The virtual address to find a mapping for.
-    ///
-    /// # Returns
-    /// A `Mapping` representing the found mapping.
-    fn walk_addr_lvl0(page: &mut PTPage, vaddr: VirtAddr) -> Mapping<'_> {
-        let idx = Self::index::<0>(vaddr);
-        Mapping::Level0(&mut page[idx])
-    }
-
-    /// Walks a page table at level 1 to find a mapping.
-    ///
-    /// # Parameters
-    /// - `page`: A mutable reference to the root page table.
-    /// - `vaddr`: The virtual address to find a mapping for.
-    ///
-    /// # Returns
-    /// A `Mapping` representing the found mapping.
-    fn walk_addr_lvl1(page: &mut PTPage, vaddr: VirtAddr) -> Mapping<'_> {
-        let idx = Self::index::<1>(vaddr);
-        let entry = page[idx];
-        match PTPage::from_entry(entry) {
-            Some(page) => Self::walk_addr_lvl0(page, vaddr),
-            None => Mapping::Level1(&mut page[idx]),
-        }
-    }
-
-    /// Walks a page table at level 2 to find a mapping.
-    ///
-    /// # Parameters
-    /// - `page`: A mutable reference to the root page table.
-    /// - `vaddr`: The virtual address to find a mapping for.
-    ///
-    /// # Returns
-    /// A `Mapping` representing the found mapping.
-    fn walk_addr_lvl2(page: &mut PTPage, vaddr: VirtAddr) -> Mapping<'_> {
-        let idx = Self::index::<2>(vaddr);
-        let entry = page[idx];
-        match PTPage::from_entry(entry) {
-            Some(page) => Self::walk_addr_lvl1(page, vaddr),
-            None => Mapping::Level2(&mut page[idx]),
-        }
-    }
-
-    /// Walks the page table to find a mapping for a given virtual address.
-    ///
-    /// # Parameters
-    /// - `page`: A mutable reference to the root page table.
-    /// - `vaddr`: The virtual address to find a mapping for.
-    ///
-    /// # Returns
-    /// A `Mapping` representing the found mapping.
-    fn walk_addr_lvl3(page: &mut PTPage, vaddr: VirtAddr) -> Mapping<'_> {
-        let idx = Self::index::<3>(vaddr);
-        let entry = page[idx];
-        match PTPage::from_entry(entry) {
-            Some(page) => Self::walk_addr_lvl2(page, vaddr),
-            None => Mapping::Level3(&mut page[idx]),
-        }
-    }
-
-    /// Walk the virtual address and return the corresponding mapping.
-    ///
-    /// # Parameters
-    /// - `vaddr`: The virtual address to find a mapping for.
-    ///
-    /// # Returns
-    /// A `Mapping` representing the found mapping.
-    fn walk_addr(&mut self, vaddr: VirtAddr) -> Mapping<'_> {
-        Self::walk_addr_lvl3(&mut self.root, vaddr)
-    }
-
-    /// Calculate the virtual address of a PTE in the self-map, which maps a
-    /// specified virtual address.
-    ///
-    /// # Parameters
-    /// - `vaddr': The virtual address whose PTE should be located.
-    ///
-    /// # Returns
-    /// The virtual address of the PTE.
-    fn get_pte_address(vaddr: VirtAddr) -> VirtAddr {
-        SVSM_PTE_BASE + ((usize::from(vaddr) & 0x0000_FFFF_FFFF_F000) >> 9)
+        SvsmPageTable::index::<L>(vaddr)
     }
 
     /// Perform a virtual to physical translation using the self-map.
@@ -709,190 +385,31 @@ impl PageTable {
     /// # Returns
     /// Some(PageFrame) if the virtual address is valid.
     /// None if the virtual address is not valid.
+    #[inline]
     pub fn virt_to_frame(vaddr: VirtAddr) -> Option<PageFrame> {
-        // Calculate the virtual addresses of each level of the paging
-        // hierarchy in the self-map.
-        let pte_addr = Self::get_pte_address(vaddr);
-        let pde_addr = Self::get_pte_address(pte_addr);
-        let pdpe_addr = Self::get_pte_address(pde_addr);
-        let pml4e_addr = Self::get_pte_address(pdpe_addr);
-
-        // SAFETY: Check each entry in the paging hierarchy to determine
-        // whether this address is mapped.  Because the hierarchy is read from
-        // the top down using self-map addresses that were calculated
-        // correctly, the reads are safe to perform.
-        let pml4e = unsafe { PTEntry::read_pte(pml4e_addr) };
-        if !pml4e.present() {
-            return None;
-        }
-
-        // There is no need to check for a large page in the PML4E because
-        // the architecture does not support the large bit at the top-level
-        // entry.  If a large page is detected at a lower level of the
-        // hierarchy, the low bits from the virtual address must be combined
-        // with the physical address from the PDE/PDPE.
-
-        // SAFETY: The PML4E was checked to be present, so the PDPE exists and
-        // can be read safely.
-        let pdpe = unsafe { PTEntry::read_pte(pdpe_addr) };
-        if !pdpe.present() {
-            return None;
-        }
-        if pdpe.huge() {
-            let pa = pdpe.page_frame() + (usize::from(vaddr) & 0x3FFF_FFFF);
-            return Some(PageFrame::Size1G(pa));
-        }
-
-        // SAFETY: The PDPE was checked to be present and not to be a huge
-        // page. So the PDE exists and can be read safely.
-        let pde = unsafe { PTEntry::read_pte(pde_addr) };
-        if !pde.present() {
-            return None;
-        }
-        if pde.huge() {
-            let pa = pde.page_frame() + (usize::from(vaddr) & 0x001F_FFFF);
-            return Some(PageFrame::Size2M(pa));
-        }
-
-        // SAFETY: The PDE was checked to be present and not to be a huge
-        // page. So the PTE exists and can be read safely.
-        let pte = unsafe { PTEntry::read_pte(pte_addr) };
-        if pte.present() {
-            let pa = pte.page_frame() + (usize::from(vaddr) & 0xFFF);
-            Some(PageFrame::Size4K(pa))
-        } else {
-            None
-        }
+        SvsmPageTable::virt_to_frame(vaddr)
     }
 
-    fn alloc_pte_lvl3(entry: &mut PTEntry, vaddr: VirtAddr, size: PageSize) -> Mapping<'_> {
-        let flags = entry.flags();
-
-        if flags.contains(PTEntryFlags::PRESENT) {
-            return Mapping::Level3(entry);
-        }
-
-        let Ok((page, paddr)) = PTPage::alloc() else {
-            return Mapping::Level3(entry);
-        };
-
-        let flags = PTEntryFlags::PRESENT
-            | PTEntryFlags::WRITABLE
-            | PTEntryFlags::USER
-            | PTEntryFlags::ACCESSED;
-        entry.set(make_private_address(paddr), flags);
-
-        let idx = Self::index::<2>(vaddr);
-        Self::alloc_pte_lvl2(&mut page[idx], vaddr, size)
+    /// Allocate a new page table root.
+    ///
+    /// # Errors
+    /// Returns [`SvsmError`] if the page cannot be allocated.
+    fn allocate_new() -> Result<PageBox<Self>, SvsmError> {
+        let mut pgtable: PageBox<Self> = PageBox::try_new_zeroed()?;
+        let paddr = virt_to_phys(pgtable.vaddr());
+        pgtable.init_self_map(paddr);
+        Ok(pgtable)
     }
 
-    fn alloc_pte_lvl2(entry: &mut PTEntry, vaddr: VirtAddr, size: PageSize) -> Mapping<'_> {
-        let flags = entry.flags();
-
-        if flags.contains(PTEntryFlags::PRESENT) {
-            return Mapping::Level2(entry);
-        }
-
-        let Ok((page, paddr)) = PTPage::alloc() else {
-            return Mapping::Level2(entry);
-        };
-
-        let flags = PTEntryFlags::PRESENT
-            | PTEntryFlags::WRITABLE
-            | PTEntryFlags::USER
-            | PTEntryFlags::ACCESSED;
-        entry.set(make_private_address(paddr), flags);
-
-        let idx = Self::index::<1>(vaddr);
-        Self::alloc_pte_lvl1(&mut page[idx], vaddr, size)
-    }
-
-    fn alloc_pte_lvl1(entry: &mut PTEntry, vaddr: VirtAddr, size: PageSize) -> Mapping<'_> {
-        let flags = entry.flags();
-
-        if size == PageSize::Huge || flags.contains(PTEntryFlags::PRESENT) {
-            return Mapping::Level1(entry);
-        }
-
-        let Ok((page, paddr)) = PTPage::alloc() else {
-            return Mapping::Level1(entry);
-        };
-
-        let flags = PTEntryFlags::PRESENT
-            | PTEntryFlags::WRITABLE
-            | PTEntryFlags::USER
-            | PTEntryFlags::ACCESSED;
-        entry.set(make_private_address(paddr), flags);
-
-        let idx = Self::index::<0>(vaddr);
-        Mapping::Level0(&mut page[idx])
-    }
-
-    /// Allocates a 4KB page table entry for a given virtual address.
+    /// Clone the shared part of the page table; excluding the private
+    /// parts.
     ///
-    /// # Parameters
-    /// - `vaddr`: The virtual address for which to allocate the PTE.
-    ///
-    /// # Returns
-    /// A `Mapping` representing the allocated or existing PTE for the address.
-    fn alloc_pte_4k(&mut self, vaddr: VirtAddr) -> Mapping<'_> {
-        let m = self.walk_addr(vaddr);
-
-        match m {
-            Mapping::Level0(entry) => Mapping::Level0(entry),
-            Mapping::Level1(entry) => Self::alloc_pte_lvl1(entry, vaddr, PageSize::Regular),
-            Mapping::Level2(entry) => Self::alloc_pte_lvl2(entry, vaddr, PageSize::Regular),
-            Mapping::Level3(entry) => Self::alloc_pte_lvl3(entry, vaddr, PageSize::Regular),
-        }
-    }
-
-    /// Allocates a 2MB page table entry for a given virtual address.
-    ///
-    /// # Parameters
-    /// - `vaddr`: The virtual address for which to allocate the PTE.
-    ///
-    /// # Returns
-    /// A `Mapping` representing the allocated or existing PTE for the address.
-    fn alloc_pte_2m(&mut self, vaddr: VirtAddr) -> Mapping<'_> {
-        let m = self.walk_addr(vaddr);
-
-        match m {
-            Mapping::Level0(entry) => Mapping::Level0(entry),
-            Mapping::Level1(entry) => Mapping::Level1(entry),
-            Mapping::Level2(entry) => Self::alloc_pte_lvl2(entry, vaddr, PageSize::Huge),
-            Mapping::Level3(entry) => Self::alloc_pte_lvl3(entry, vaddr, PageSize::Huge),
-        }
-    }
-
-    /// Splits a 2MB page into 4KB pages.
-    ///
-    /// # Parameters
-    /// - `entry`: The 2M page table entry to split.
-    ///
-    /// # Returns
-    /// A result indicating success or an error [`SvsmError`] in failure.
-    fn do_split_4k(entry: &mut PTEntry) -> Result<(), SvsmError> {
-        let (page, paddr) = PTPage::alloc()?;
-        let mut flags = entry.flags();
-
-        assert!(flags.contains(PTEntryFlags::HUGE));
-
-        let addr_2m = PhysAddr::from(entry.address().bits() & 0x000f_ffff_fff0_0000);
-
-        flags.remove(PTEntryFlags::HUGE);
-
-        // Prepare PTE leaf page
-        for (i, e) in page.entries.iter_mut().enumerate() {
-            let addr_4k = addr_2m + (i * PAGE_SIZE);
-            e.clear();
-            e.set(make_private_address(addr_4k), flags);
-        }
-
-        entry.set(make_private_address(paddr), flags);
-
-        flush_tlb_global_sync();
-
-        Ok(())
+    /// # Errors
+    /// Returns [`SvsmError`] if the page cannot be allocated.
+    pub fn clone_shared(&self) -> Result<PageBox<PageTable>, SvsmError> {
+        let mut pgtable = Self::allocate_new()?;
+        pgtable.copy_entry(self, PGTABLE_LVL3_IDX_SHARED);
+        Ok(pgtable)
     }
 
     /// Splits a page into 4KB pages if it is part of a larger mapping.
@@ -902,135 +419,18 @@ impl PageTable {
     ///
     /// # Returns
     /// A result indicating success or an error [`SvsmError`].
-    fn split_4k(mapping: Mapping<'_>) -> Result<(), SvsmError> {
-        match mapping {
-            Mapping::Level0(_entry) => Ok(()),
-            Mapping::Level1(entry) => Self::do_split_4k(entry),
-            Mapping::Level2(_entry) => Err(SvsmError::Mem),
-            Mapping::Level3(_entry) => Err(SvsmError::Mem),
-        }
-    }
-
-    fn make_pte_shared(entry: &mut PTEntry) {
-        let flags = entry.flags();
-        let addr = entry.address();
-
-        // entry.address() returned with c-bit clear already
-        entry.set(make_shared_address(addr), flags);
-    }
-
-    fn make_pte_private(entry: &mut PTEntry) {
-        let flags = entry.flags();
-        let addr = entry.address();
-
-        // entry.address() returned with c-bit clear already
-        entry.set(make_private_address(addr), flags);
-    }
-
-    /// Sets the shared state for a 4KB page.
-    ///
-    /// # Parameters
-    /// - `vaddr`: The virtual address of the page.
-    ///
-    /// # Returns
-    /// A result indicating success or an error [`SvsmError`] if the
-    /// operation fails.
-    pub fn set_shared_4k(&mut self, vaddr: VirtAddr) -> Result<(), SvsmError> {
-        let mapping = self.walk_addr(vaddr);
-        Self::split_4k(mapping)?;
-
-        if let Mapping::Level0(entry) = self.walk_addr(vaddr) {
-            Self::make_pte_shared(entry);
-            Ok(())
-        } else {
-            Err(SvsmError::Mem)
-        }
-    }
-
-    /// Sets the encryption state for a 4KB page.
-    ///
-    /// # Parameters
-    /// - `vaddr`: The virtual address of the page.
-    ///
-    /// # Returns
-    /// A result indicating success or an error [`SvsmError`].
-    pub fn set_encrypted_4k(&mut self, vaddr: VirtAddr) -> Result<(), SvsmError> {
-        let mapping = self.walk_addr(vaddr);
-        Self::split_4k(mapping)?;
-
-        if let Mapping::Level0(entry) = self.walk_addr(vaddr) {
-            Self::make_pte_private(entry);
-            Ok(())
-        } else {
-            Err(SvsmError::Mem)
-        }
+    pub fn split_4k(mapping: Mapping<'_>) -> Result<(), SvsmError> {
+        SvsmPageTable::split_4k(mapping)?;
+        Ok(())
     }
 
     /// Gets the physical address for a mapped `vaddr` or `None` if
     /// no such mapping exists.
     pub fn check_mapping(&mut self, vaddr: VirtAddr) -> Option<PhysAddr> {
-        match self.walk_addr(vaddr) {
-            Mapping::Level0(entry) => Some(entry.address()),
-            Mapping::Level1(entry) => Some(entry.address()),
-            _ => None,
-        }
-    }
-
-    /// Maps a 2MB page.
-    ///
-    /// # Parameters
-    /// - `vaddr`: The virtual address to map.
-    /// - `paddr`: The physical address to map to.
-    /// - `flags`: The flags to apply to the mapping.
-    /// - `shared`: Indicates whether the mapping is shared.
-    ///
-    /// # Returns
-    /// A result indicating success or failure ([`SvsmError`]).
-    ///
-    /// # Panics
-    /// Panics if either `vaddr` or `paddr` is not aligned to a 2MB boundary.
-    pub fn map_2m(
-        &mut self,
-        vaddr: VirtAddr,
-        paddr: PhysAddr,
-        flags: PTEntryFlags,
-        shared: bool,
-    ) -> Result<(), SvsmError> {
-        assert!(vaddr.is_aligned(PAGE_SIZE_2M));
-        assert!(paddr.is_aligned(PAGE_SIZE_2M));
-
-        let mapping = self.alloc_pte_2m(vaddr);
-        let addr = if !shared {
-            make_private_address(paddr)
-        } else {
-            make_shared_address(paddr)
-        };
-
-        if let Mapping::Level1(entry) = mapping {
-            entry.set(addr, flags | PTEntryFlags::HUGE);
-            Ok(())
-        } else {
-            Err(SvsmError::Mem)
-        }
-    }
-
-    /// Unmaps a 2MB page.
-    ///
-    /// # Parameters
-    /// - `vaddr`: The virtual address of the mapping to unmap.
-    ///
-    /// # Panics
-    /// Panics if `vaddr` is not aligned to a 2MB boundary.
-    pub fn unmap_2m(&mut self, vaddr: VirtAddr) {
-        assert!(vaddr.is_aligned(PAGE_SIZE_2M));
-
         let mapping = self.walk_addr(vaddr);
-
-        match mapping {
-            Mapping::Level0(_) => unreachable!(),
-            Mapping::Level1(entry) => entry.clear(),
-            Mapping::Level2(entry) => assert!(!entry.present()),
-            Mapping::Level3(entry) => assert!(!entry.present()),
+        match mapping.level {
+            PageLevel::Level0 | PageLevel::Level1 => Some(mapping.entry.address()),
+            _ => None,
         }
     }
 
@@ -1051,68 +451,8 @@ impl PageTable {
         flags: PTEntryFlags,
         shared: bool,
     ) -> Result<(), SvsmError> {
-        let mapping = self.alloc_pte_4k(vaddr);
-        let addr = if !shared {
-            make_private_address(paddr)
-        } else {
-            make_shared_address(paddr)
-        };
-
-        if let Mapping::Level0(entry) = mapping {
-            entry.set(addr, flags);
-            Ok(())
-        } else {
-            Err(SvsmError::Mem)
-        }
-    }
-
-    /// Unmaps a 4KB page.
-    ///
-    /// # Parameters
-    /// - `vaddr`: The virtual address of the mapping to unmap.
-    pub fn unmap_4k(&mut self, vaddr: VirtAddr) {
-        let mapping = self.walk_addr(vaddr);
-
-        match mapping {
-            Mapping::Level0(entry) => entry.clear(),
-            Mapping::Level1(entry) => assert!(!entry.present()),
-            Mapping::Level2(entry) => assert!(!entry.present()),
-            Mapping::Level3(entry) => assert!(!entry.present()),
-        }
-    }
-
-    /// Retrieves the physical address of a mapping.
-    ///
-    /// # Parameters
-    /// - `vaddr`: The virtual address to query.
-    ///
-    /// # Returns
-    /// The physical address of the mapping if present; otherwise, an error
-    /// ([`SvsmError`]).
-    pub fn phys_addr(&mut self, vaddr: VirtAddr) -> Result<PhysAddr, SvsmError> {
-        let mapping = self.walk_addr(vaddr);
-
-        match mapping {
-            Mapping::Level0(entry) => {
-                let offset = vaddr.page_offset();
-                if !entry.flags().contains(PTEntryFlags::PRESENT) {
-                    return Err(SvsmError::Mem);
-                }
-                Ok(entry.address() + offset)
-            }
-            Mapping::Level1(entry) => {
-                let offset = vaddr.bits() & (PAGE_SIZE_2M - 1);
-                if !entry.flags().contains(PTEntryFlags::PRESENT)
-                    || !entry.flags().contains(PTEntryFlags::HUGE)
-                {
-                    return Err(SvsmError::Mem);
-                }
-
-                Ok(entry.address() + offset)
-            }
-            Mapping::Level2(_entry) => Err(SvsmError::Mem),
-            Mapping::Level3(_entry) => Err(SvsmError::Mem),
-        }
+        self.0.map_4k(vaddr, paddr, flags, shared)?;
+        Ok(())
     }
 
     /// Maps a region of memory using 4KB pages.
@@ -1227,13 +567,13 @@ impl PageTable {
         while vaddr < end {
             let mapping = self.walk_addr(vaddr);
 
-            match mapping {
-                Mapping::Level0(entry) => {
-                    entry.clear();
+            match mapping.level {
+                PageLevel::Level0 => {
+                    mapping.entry.clear();
                     vaddr = vaddr + PAGE_SIZE;
                 }
-                Mapping::Level1(entry) => {
-                    entry.clear();
+                PageLevel::Level1 => {
+                    mapping.entry.clear();
                     vaddr = vaddr + PAGE_SIZE_2M;
                 }
                 _ => {
@@ -1257,10 +597,7 @@ impl PageTable {
             | PTEntryFlags::WRITABLE
             | PTEntryFlags::USER
             | PTEntryFlags::ACCESSED;
-        let entry = &mut self.root[idx];
-        let prev = entry.raw();
-        entry.set(make_private_address(paddr), flags);
-        prev != entry.raw()
+        self.set_entry(idx, SvsmPaging::make_private_address(paddr), flags)
     }
 
     /// Makes the memory region pages read-only.
@@ -1279,22 +616,24 @@ impl PageTable {
     ) -> Result<(), SvsmError> {
         for page in region.iter_pages(PageSize::Regular) {
             match self.walk_addr(page) {
-                Mapping::Level0(entry) => {
-                    if !entry.present() || !entry.global() {
+                Mapping {
+                    level: PageLevel::Level0,
+                    entry,
+                } => {
+                    if !entry.present() || !entry.flags().global() {
                         return Err(SvsmError::Mem);
                     }
 
                     let flags = PTEntryFlags::data_ro();
 
-                    let paddr = if is_shared(entry.0) {
-                        make_shared_address(entry.address())
-                    } else {
-                        make_private_address(entry.address())
-                    };
+                    let paddr_field = entry.paddr_field();
 
-                    entry.set(paddr, flags);
+                    entry.set(paddr_field, flags);
                 }
-                Mapping::Level1(entry) | Mapping::Level2(entry) => {
+                Mapping {
+                    level: PageLevel::Level1 | PageLevel::Level2,
+                    entry,
+                } => {
                     // Ensure we never fell on a huge page while iterating over the region pages.
                     if entry.huge() {
                         return Err(SvsmError::Mem);
@@ -1308,243 +647,6 @@ impl PageTable {
     }
 }
 
-/// Represents a sub-tree of a page-table which can be mapped at a top-level index
-#[derive(Debug, FromZeros)]
-struct RawPageTablePart {
-    page: PTPage,
-}
-
-impl RawPageTablePart {
-    /// Frees a level 1 page table.
-    fn free_lvl1(page: &PTPage) {
-        for entry in page.entries.iter() {
-            if let Some(page) = PTPage::from_entry(*entry) {
-                // SAFETY: the page comes from an entry in the page table,
-                // which we allocated using `PTPage::alloc()`, so this is
-                // safe.
-                unsafe { PTPage::free(page) };
-            }
-        }
-    }
-
-    /// Frees a level 2 page table, including all level 1 tables beneath it.
-    fn free_lvl2(page: &PTPage) {
-        for entry in page.entries.iter() {
-            if let Some(l1_page) = PTPage::from_entry(*entry) {
-                Self::free_lvl1(l1_page);
-                // SAFETY: the page comes from an entry in the page table,
-                // which we allocated using `PTPage::alloc()`, so this is
-                // safe.
-                unsafe { PTPage::free(l1_page) };
-            }
-        }
-    }
-
-    /// Frees the resources associated with this page table part.
-    fn free(&self) {
-        RawPageTablePart::free_lvl2(&self.page);
-    }
-
-    /// Returns the physical address of this page table part.
-    fn address(&self) -> PhysAddr {
-        virt_to_phys(VirtAddr::from(self as *const RawPageTablePart))
-    }
-
-    /// Walks the page table at level 3 to find the mapping for a given
-    /// virtual address.
-    ///
-    /// # Parameters
-    /// - `vaddr`: The virtual address to find the mapping for.
-    ///
-    /// # Returns
-    /// The [`Mapping`] for the given virtual address.
-    fn walk_addr(&mut self, vaddr: VirtAddr) -> Mapping<'_> {
-        PageTable::walk_addr_lvl2(&mut self.page, vaddr)
-    }
-
-    /// Allocates a 4KB page table entry for a given virtual address.
-    ///
-    /// # Parameters
-    /// - `vaddr`: The virtual address for which to allocate the PTE.
-    ///
-    /// # Returns
-    /// The [`Mapping`] representing the allocated or existing PTE for the address.
-    ///
-    /// # Panics
-    /// Panics if a level 3 mapping is attempted in a [`RawPageTablePart`].
-    fn alloc_pte_4k(&mut self, vaddr: VirtAddr) -> Mapping<'_> {
-        let m = self.walk_addr(vaddr);
-
-        match m {
-            Mapping::Level0(entry) => Mapping::Level0(entry),
-            Mapping::Level1(entry) => PageTable::alloc_pte_lvl1(entry, vaddr, PageSize::Regular),
-            Mapping::Level2(entry) => PageTable::alloc_pte_lvl2(entry, vaddr, PageSize::Regular),
-            Mapping::Level3(_) => panic!("PT level 3 not possible in PageTablePart"),
-        }
-    }
-
-    /// Allocates a 2MB page table entry for a given virtual address.
-    ///
-    /// # Parameters
-    /// - `vaddr`: The virtual address for which to allocate the PTE.
-    ///
-    /// # Returns
-    /// The [`Mapping`] representing the allocated or existing PTE for the
-    /// address.
-    fn alloc_pte_2m(&mut self, vaddr: VirtAddr) -> Mapping<'_> {
-        let m = self.walk_addr(vaddr);
-
-        match m {
-            Mapping::Level0(entry) => Mapping::Level0(entry),
-            Mapping::Level1(entry) => Mapping::Level1(entry),
-            Mapping::Level2(entry) => PageTable::alloc_pte_lvl2(entry, vaddr, PageSize::Huge),
-            Mapping::Level3(entry) => PageTable::alloc_pte_lvl3(entry, vaddr, PageSize::Huge),
-        }
-    }
-
-    /// Maps a 4KB page.
-    ///
-    /// # Parameters
-    /// - `vaddr`: The virtual address to map.
-    /// - `paddr`: The physical address to map to.
-    /// - `flags`: The flags to apply to the mapping.
-    /// - `shared`: Indicates whether the mapping is shared.
-    ///
-    /// # Returns
-    /// A result indicating success (`Ok`) or failure (`Err`).
-    fn map_4k(
-        &mut self,
-        vaddr: VirtAddr,
-        paddr: PhysAddr,
-        flags: PTEntryFlags,
-        shared: bool,
-    ) -> Result<(), SvsmError> {
-        let mapping = self.alloc_pte_4k(vaddr);
-
-        let addr = if !shared {
-            make_private_address(paddr)
-        } else {
-            make_shared_address(paddr)
-        };
-
-        if let Mapping::Level0(entry) = mapping {
-            entry.set(addr, flags);
-            Ok(())
-        } else {
-            Err(SvsmError::Mem)
-        }
-    }
-
-    /// Unmaps a 4KB page.
-    ///
-    /// # Parameters
-    /// - `vaddr`: The virtual address of the mapping to unmap.
-    ///
-    /// # Returns
-    /// An optional [`PTEntry`] representing the unmapped page table entry.
-    fn unmap_4k(&mut self, vaddr: VirtAddr) -> Option<PTEntry> {
-        let mapping = self.walk_addr(vaddr);
-
-        match mapping {
-            Mapping::Level0(entry) => {
-                let e = *entry;
-                entry.clear();
-                Some(e)
-            }
-            Mapping::Level1(entry) => {
-                assert!(!entry.present());
-                None
-            }
-            Mapping::Level2(entry) => {
-                assert!(!entry.present());
-                None
-            }
-            Mapping::Level3(entry) => {
-                assert!(!entry.present());
-                None
-            }
-        }
-    }
-
-    /// Maps a 2MB page.
-    ///
-    /// # Parameters
-    /// - `vaddr`: The virtual address to map.
-    /// - `paddr`: The physical address to map to.
-    /// - `flags`: The flags to apply to the mapping.
-    /// - `shared`: Indicates whether the mapping is shared
-    ///
-    /// # Returns
-    /// A result indicating success (`Ok`) or failure (`Err`).
-    ///
-    /// # Panics
-    ///
-    /// Panics if `vaddr` or `paddr` are not 2MB-aligned
-    fn map_2m(
-        &mut self,
-        vaddr: VirtAddr,
-        paddr: PhysAddr,
-        flags: PTEntryFlags,
-        shared: bool,
-    ) -> Result<(), SvsmError> {
-        assert!(vaddr.is_aligned(PAGE_SIZE_2M));
-        assert!(paddr.is_aligned(PAGE_SIZE_2M));
-
-        let mapping = self.alloc_pte_2m(vaddr);
-        let addr = if !shared {
-            make_private_address(paddr)
-        } else {
-            make_shared_address(paddr)
-        };
-
-        if let Mapping::Level1(entry) = mapping {
-            entry.set(addr, flags | PTEntryFlags::HUGE);
-            Ok(())
-        } else {
-            Err(SvsmError::Mem)
-        }
-    }
-
-    /// Unmaps a 2MB page.
-    ///
-    /// # Parameters
-    /// - `vaddr`: The virtual address of the mapping to unmap.
-    ///
-    /// # Returns
-    /// An optional [`PTEntry`] representing the unmapped page table entry.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `vaddr` is not memory aligned.
-    fn unmap_2m(&mut self, vaddr: VirtAddr) -> Option<PTEntry> {
-        assert!(vaddr.is_aligned(PAGE_SIZE_2M));
-
-        let mapping = self.walk_addr(vaddr);
-
-        match mapping {
-            Mapping::Level0(_) => None,
-            Mapping::Level1(entry) => {
-                entry.clear();
-                Some(*entry)
-            }
-            Mapping::Level2(entry) => {
-                assert!(!entry.present());
-                None
-            }
-            Mapping::Level3(entry) => {
-                assert!(!entry.present());
-                None
-            }
-        }
-    }
-}
-
-impl Drop for RawPageTablePart {
-    fn drop(&mut self) {
-        self.free();
-    }
-}
-
 /// Sub-tree of a page table that can be populated at the top-level
 /// used for virtual memory management
 #[derive(Debug)]
@@ -1553,6 +655,14 @@ pub struct PageTablePart {
     raw: Option<PageBox<RawPageTablePart>>,
     /// The top-level index this PageTablePart is populated at
     idx: usize,
+}
+
+impl Drop for PageTablePart {
+    fn drop(&mut self) {
+        if let Some(raw) = self.raw.as_deref() {
+            raw.free()
+        }
+    }
 }
 
 impl PageTablePart {
@@ -1606,7 +716,8 @@ impl PageTablePart {
     ///
     /// Physical base address of the page-table sub-tree
     pub fn address(&self) -> Option<PhysAddr> {
-        self.get().map(|p| p.address())
+        self.get()
+            .map(|p| virt_to_phys(VirtAddr::from(p as *const RawPageTablePart)))
     }
 
     /// Map a 4KiB page in the page table sub-tree
@@ -1636,7 +747,9 @@ impl PageTablePart {
     ) -> Result<(), SvsmError> {
         assert!(PageTable::index::<3>(vaddr) == self.idx);
 
-        self.get_or_init_mut().map_4k(vaddr, paddr, flags, shared)
+        self.get_or_init_mut()
+            .map_4k(vaddr, paddr, flags, shared)
+            .map_err(|_| SvsmError::Mem)
     }
 
     /// Unmaps a 4KiB page from the page table sub-tree
@@ -1654,8 +767,7 @@ impl PageTablePart {
     /// This method panics when `vaddr` is not aligned to 4KiB.
     pub fn unmap_4k(&mut self, vaddr: VirtAddr) -> Option<PTEntry> {
         assert!(PageTable::index::<3>(vaddr) == self.idx);
-
-        self.get_mut().and_then(|r| r.unmap_4k(vaddr))
+        self.get_mut()?.unmap_4k(vaddr)
     }
 
     /// Map a 2MiB page in the page table sub-tree
@@ -1685,7 +797,9 @@ impl PageTablePart {
     ) -> Result<(), SvsmError> {
         assert!(PageTable::index::<3>(vaddr) == self.idx);
 
-        self.get_or_init_mut().map_2m(vaddr, paddr, flags, shared)
+        self.get_or_init_mut()
+            .map_2m(vaddr, paddr, flags, shared)
+            .map_err(|_| SvsmError::Mem)
     }
 
     /// Unmaps a 2MiB page from the page table sub-tree
@@ -1703,8 +817,7 @@ impl PageTablePart {
     /// This method panics when `vaddr` is not aligned to 2MiB.
     pub fn unmap_2m(&mut self, vaddr: VirtAddr) -> Option<PTEntry> {
         assert!(PageTable::index::<3>(vaddr) == self.idx);
-
-        self.get_mut().and_then(|r| r.unmap_2m(vaddr))
+        self.get_mut()?.unmap_2m(vaddr)
     }
 }
 
@@ -1811,7 +924,7 @@ impl PTWalkAttr {
         // address with a translation for which the R/W flag is 0 in any
         // paging-structure entry controlling the translation.
         // The same for user mode address
-        if !entry.writable() {
+        if !entry.flags().writable() {
             *pteflags &= !PTEntryFlags::WRITABLE;
         }
 
@@ -1822,9 +935,9 @@ impl PTWalkAttr {
         // controlling the translation; instructions may not be fetched from
         // any supervisor-mode address with a translation for which the XD flag
         // is 1 in any paging-structure entry controlling the translation
-        if self.efer.contains(EFERFlags::NXE) && entry.nx() {
+        if self.efer.contains(EFERFlags::NXE) && entry.flags().nx() {
             *pteflags |= PTEntryFlags::NX;
-        } else if !self.efer.contains(EFERFlags::NXE) && entry.nx() {
+        } else if !self.efer.contains(EFERFlags::NXE) && entry.flags().nx() {
             // XD bit must be 0 if efer.NXE = 0
             return Err(pf_err | PageFaultError::R);
         }

--- a/kernel/src/mm/ptguards.rs
+++ b/kernel/src/mm/ptguards.rs
@@ -7,7 +7,6 @@
 use super::pagetable::PTEntryFlags;
 use crate::address::{Address, PhysAddr, VirtAddr};
 use crate::cpu::percpu::this_cpu;
-use crate::cpu::tlb::flush_tlb_global_percpu_range;
 use crate::error::SvsmError;
 use crate::mm::virtualrange::VRangeAlloc;
 use crate::types::{PAGE_SIZE, PAGE_SIZE_2M, PageSize};
@@ -121,15 +120,12 @@ impl PerCPUPageMappingGuard {
 impl Drop for PerCPUPageMappingGuard {
     fn drop(&mut self) {
         let region = self.mapping.region();
-        let size = if self.mapping.huge() {
-            this_cpu().get_pgtable().unmap_region_2m(region);
-            PageSize::Huge
+        let flush = if self.mapping.huge() {
+            this_cpu().get_pgtable().unmap_region_2m(region)
         } else {
-            this_cpu().get_pgtable().unmap_region_4k(region);
-            PageSize::Regular
+            this_cpu().get_pgtable().unmap_region_4k(region)
         };
-
-        flush_tlb_global_percpu_range(region, size);
+        flush.flush_tlb_global_percpu();
     }
 }
 

--- a/kernel/src/mm/ro_after_init.rs
+++ b/kernel/src/mm/ro_after_init.rs
@@ -4,13 +4,7 @@
 //
 // Author: Thomas Leroy <thomas.leroy.mp@gmail.com>
 
-use crate::{
-    address::VirtAddr,
-    cpu::{flush_tlb_global_sync_range, percpu::this_cpu},
-    error::SvsmError,
-    types::PageSize,
-    utils::MemoryRegion,
-};
+use crate::{address::VirtAddr, cpu::percpu::this_cpu, error::SvsmError, utils::MemoryRegion};
 #[macro_export]
 macro_rules! ro_after_init_section {
     () => {
@@ -31,10 +25,11 @@ unsafe extern "C" {
 pub unsafe fn make_ro(region: MemoryRegion<VirtAddr>) -> Result<(), SvsmError> {
     // SAFETY: delegated to the caller.
     unsafe {
-        this_cpu().get_pgtable().make_region_ro_4k(region)?;
+        this_cpu()
+            .get_pgtable()
+            .make_region_ro_4k(region)?
+            .flush_tlb_global_sync();
     }
-
-    flush_tlb_global_sync_range(region, PageSize::Regular);
 
     Ok(())
 }

--- a/kernel/src/mm/vm/range.rs
+++ b/kernel/src/mm/vm/range.rs
@@ -5,10 +5,9 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 
 use crate::address::{Address, VirtAddr};
-use crate::cpu::{flush_tlb_global_percpu_range, flush_tlb_global_sync_range};
 use crate::error::SvsmError;
 use crate::locking::RWLock;
-use crate::mm::pagetable::{PTEntryFlags, PageTable, PageTablePart};
+use crate::mm::pagetable::{PTEntryFlags, PageTable, PageTablePart, SvsmMayNeedFlush};
 use crate::mm::virt_from_idx;
 use crate::types::{PAGE_SHIFT, PAGE_SIZE, PageSize};
 use crate::utils::{MemoryRegion, align_down, align_up};
@@ -130,12 +129,14 @@ impl VMR {
     /// # Arguments
     ///
     /// * `pgtbl` - A [`PageTable`] pointing to the target page-table
-    pub fn populate(&self, pgtbl: &mut PageTable) {
+    pub fn populate(&self, pgtbl: &mut PageTable) -> SvsmMayNeedFlush {
         let parts = self.pgtbl_parts.lock_read();
-
+        let mut need_flush = SvsmMayNeedFlush::none();
         for part in parts.iter() {
-            pgtbl.populate_pgtbl_part(part);
+            let (_, flush) = pgtbl.populate_pgtbl_part(part);
+            need_flush = flush.and(need_flush);
         }
+        need_flush
     }
 
     fn populate_addr(&self, pgtbl: &mut PageTable, vaddr: VirtAddr) -> Result<(), SvsmError> {
@@ -146,7 +147,9 @@ impl VMR {
 
         let idx = vaddr.to_pgtbl_idx::<3>() - vregion.start().to_pgtbl_idx::<3>();
         let parts = self.pgtbl_parts.lock_read();
-        if !pgtbl.populate_pgtbl_part(&parts[idx]) {
+        let (updated, flush) = pgtbl.populate_pgtbl_part(&parts[idx]);
+        flush.expect_no_flush();
+        if !updated {
             return Err(SvsmError::Mem);
         }
         Ok(())
@@ -241,13 +244,14 @@ impl VMR {
     /// # Arguments
     ///
     /// - `vmm` - Reference to a [`VMM`] instance to unmap from the page-table
-    fn unmap_vmm(&self, vmm: &VMM) {
+    fn unmap_vmm(&self, vmm: &VMM) -> SvsmMayNeedFlush {
         let rstart = self.virt_range().start();
         let (vmm_start, vmm_end) = vmm.range();
         let mut pgtbl_parts = self.pgtbl_parts.lock_write();
         let mapping = vmm.get_mapping();
         let page_size = mapping.page_size();
         let mut offset: usize = 0;
+        let mut flush = SvsmMayNeedFlush::none();
 
         while vmm_start + offset < vmm_end {
             let idx = PageTable::index::<3>(VirtAddr::from(vmm_start - rstart));
@@ -256,12 +260,14 @@ impl VMR {
                 PageSize::Huge => pgtbl_parts[idx].unmap_2m(vmm_start + offset),
             };
 
-            if result.is_some() {
+            if let (Some(_), f) = result {
                 mapping.unmap(offset);
+                flush = flush.and(f);
             }
 
             offset += usize::from(page_size);
         }
+        flush
     }
 
     fn do_insert(
@@ -272,7 +278,12 @@ impl VMR {
     ) -> Result<(), SvsmError> {
         let vmm = Box::new(VMM::new(start_pfn, mapping));
         if let Err(e) = self.map_vmm(&vmm) {
-            self.unmap_vmm(&vmm);
+            let flush = self.unmap_vmm(&vmm);
+            // SAFETY: We skip the TLB flush because the mapping failed due to an allocation error,
+            // caller guarantees that there is no one will touch the region?
+            unsafe {
+                flush.ignore();
+            }
             Err(e)
         } else {
             cursor.insert_before(vmm);
@@ -435,16 +446,11 @@ impl VMR {
 
         let mut cursor = tree.find_mut(&addr);
         let node = cursor.remove().ok_or(SvsmError::Mem)?;
-        self.unmap_vmm(&node);
-
-        let range = node.range();
-        let region = MemoryRegion::from_addresses(range.0, range.1);
-        let pgsize = node.get_mapping().page_size();
-
+        let flush = self.unmap_vmm(&node);
         if self.per_cpu {
-            flush_tlb_global_percpu_range(region, pgsize);
+            flush.flush_tlb_global_percpu();
         } else {
-            flush_tlb_global_sync_range(region, pgsize);
+            flush.flush_tlb_global_sync();
         }
 
         Ok(node)

--- a/kernel/src/sev/ghcb.rs
+++ b/kernel/src/sev/ghcb.rs
@@ -7,7 +7,7 @@
 use crate::address::{Address, PhysAddr, VirtAddr};
 use crate::cpu::msr::{SEV_GHCB, write_msr};
 use crate::cpu::percpu::this_cpu;
-use crate::cpu::{IrqGuard, X86GeneralRegs, flush_tlb_global_sync_page};
+use crate::cpu::{IrqGuard, X86GeneralRegs};
 use crate::error::SvsmError;
 use crate::mm::validate::{
     valid_bitmap_clear_valid_4k, valid_bitmap_set_valid_4k, valid_bitmap_valid_addr,
@@ -158,8 +158,10 @@ impl GhcbPage {
         }
 
         // Map page unencrypted
-        this_cpu().get_pgtable().set_shared_4k(vaddr)?;
-        flush_tlb_global_sync_page(vaddr, PageSize::Regular);
+        this_cpu()
+            .get_pgtable()
+            .set_shared_4k(vaddr)?
+            .flush_tlb_global_sync();
 
         // SAFETY: all zeros is a valid representation for the GHCB.
         Ok(Self(page))
@@ -175,7 +177,8 @@ impl Drop for GhcbPage {
         this_cpu()
             .get_pgtable()
             .set_encrypted_4k(vaddr)
-            .expect("Could not re-encrypt page");
+            .expect("Could not re-encrypt page")
+            .flush_tlb_global_sync();
 
         // Unregister GHCB PA
         // SAFETY: mapping the GHCB at physical address 0 is safe.

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -616,7 +616,12 @@ pub unsafe fn update_task_percpu_page_tables(t: *const Task) {
     // SAFETY: the caller guarantees the correctness of the task pointer.
     let task = unsafe { &*t };
     let mut pt = task.page_table.lock();
-    this_cpu().populate_page_table(&mut pt);
+    let flush = this_cpu().populate_page_table(&mut pt);
+    // SAFETY: The caller guarantees that the task page table is not yet installed,
+    // so it is safe to ignore the flush obligation.
+    unsafe {
+        flush.ignore();
+    }
 }
 
 /// Perform a task switch and hand the CPU over to the next task on the

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -462,7 +462,7 @@ impl Task {
     fn create_common(cpu: &PerCpu, args: CreateTaskArguments) -> Result<TaskPointer, SvsmError> {
         let mut pgtable = cpu.get_pgtable().clone_shared()?;
 
-        cpu.populate_page_table(&mut pgtable);
+        cpu.populate_page_table(&mut pgtable).expect_no_flush();
 
         let (task_mm, objtree) = {
             if let Some(ref parent_thread) = args.thread_of {
@@ -534,7 +534,10 @@ impl Task {
         let kernel_stack_mapping = TaskKernelMapping::new(task_mm.clone(), stack)?;
         let stack_start = kernel_stack_mapping.virt_addr();
 
-        task_mm.kernel_range().populate(&mut pgtable);
+        task_mm
+            .kernel_range()
+            .populate(&mut pgtable)
+            .expect_no_flush();
 
         // Remap at the per-task offset
         let bounds = MemoryRegion::new(stack_start + raw_bounds.start().into(), raw_bounds.len());

--- a/kernel/src/tdx/tdcall.rs
+++ b/kernel/src/tdx/tdcall.rs
@@ -78,7 +78,7 @@ impl From<PageFrame> for EptMappingInfo {
         let (gpa, flags) = match frame {
             PageFrame::Size4K(gpa) => (u64::from(gpa), 0),
             PageFrame::Size2M(gpa) => (u64::from(gpa), 1),
-            PageFrame::Size1G(gpa) => (u64::from(gpa), 2),
+            PageFrame::Size1G(gpa, _) => (u64::from(gpa), 2),
         };
         Self::new()
             .with_flags(flags)

--- a/kernel/src/types.rs
+++ b/kernel/src/types.rs
@@ -7,35 +7,8 @@
 use crate::error::SvsmError;
 use crate::sev::vmsa::VMPL_MAX;
 
-use verus_stub::*;
-#[cfg(verus_keep_ghost)]
-include!("types.verus.rs");
-
-verus! {
-
-pub const PAGE_SHIFT: usize = 12;
-pub const PAGE_SHIFT_2M: usize = 21;
-pub const PAGE_SHIFT_1G: usize = 30;
-pub const PAGE_SIZE: usize = 1 << PAGE_SHIFT;
-pub const PAGE_SIZE_2M: usize = 1 << PAGE_SHIFT_2M;
-pub const PAGE_SIZE_1G: usize = 1 << PAGE_SHIFT_1G;
-
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum PageSize {
-    Regular,
-    Huge,
-}
-
-impl From<PageSize> for usize {
-    fn from(psize: PageSize) -> Self {
-        match psize {
-            PageSize::Regular => PAGE_SIZE,
-            PageSize::Huge => PAGE_SIZE_2M,
-        }
-    }
-}
+// Re-export page types from paging crate
+pub use paging::sizes::*;
 
 #[expect(clippy::identity_op)]
 pub const SVSM_CS: u16 = 1 * 8;

--- a/kernel/src/utils/util.rs
+++ b/kernel/src/utils/util.rs
@@ -5,72 +5,9 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 
 use crate::address::{Address, VirtAddr};
-use crate::types::PAGE_SIZE;
-use core::ops::{Add, BitAnd, Not, Sub};
 
-use verus_stub::*;
-
-#[cfg(verus_keep_ghost)]
-include!("util.verus.rs");
-
-#[verus_spec(ret =>
-    requires
-        align_up_requires((addr, align)),
-    ensures
-        align_up_ens((addr, align), ret),
-)]
-pub fn align_up<T>(addr: T, align: T) -> T
-where
-    T: Add<Output = T> + Sub<Output = T> + BitAnd<Output = T> + Not<Output = T> + From<u8> + Copy,
-{
-    let mask: T = align - T::from(1u8);
-    (addr + mask) & !mask
-}
-
-#[verus_spec(ret =>
-    requires
-        align_down_requires((addr, align)),
-    ensures
-        align_down_ens((addr, align), ret),
-)]
-pub fn align_down<T>(addr: T, align: T) -> T
-where
-    T: Sub<Output = T> + Not<Output = T> + BitAnd<Output = T> + From<u8> + Copy,
-{
-    addr & !(align - T::from(1u8))
-}
-
-#[verus_spec(ret =>
-    requires
-        is_aligned_requires((addr, align)),
-    ensures
-        is_aligned_ens((addr, align), ret)
-)]
-pub fn is_aligned<T>(addr: T, align: T) -> bool
-where
-    T: Sub<Output = T> + BitAnd<Output = T> + PartialEq + From<u8>,
-{
-    (addr & (align - T::from(1u8))) == T::from(0u8)
-}
-
-pub fn page_align_up(x: usize) -> usize {
-    align_up(x, PAGE_SIZE)
-}
-
-pub fn round_to_pages(x: usize) -> usize {
-    page_align_up(x) / PAGE_SIZE
-}
-
-pub fn page_offset(x: usize) -> usize {
-    x & (PAGE_SIZE - 1)
-}
-
-pub fn overlap<T>(x1: T, x2: T, y1: T, y2: T) -> bool
-where
-    T: PartialOrd,
-{
-    x1 <= y2 && y1 <= x2
-}
+// Re-export alignment utilities from paging crate
+pub use paging::util::*;
 
 /// # Safety
 ///
@@ -113,31 +50,8 @@ macro_rules! BIT_MASK {
 #[cfg(test)]
 mod tests {
 
+    use crate::address::VirtAddr;
     use crate::utils::util::*;
-
-    #[test]
-    fn test_mem_utils() {
-        // Align up
-        assert_eq!(align_up(7, 4), 8);
-        assert_eq!(align_up(15, 8), 16);
-        assert_eq!(align_up(10, 2), 10);
-        // Align down
-        assert_eq!(align_down(7, 4), 4);
-        assert_eq!(align_down(15, 8), 8);
-        assert_eq!(align_down(10, 2), 10);
-        // Page align up
-        assert_eq!(page_align_up(4096), 4096);
-        assert_eq!(page_align_up(4097), 8192);
-        assert_eq!(page_align_up(0), 0);
-        // Page offset
-        assert_eq!(page_offset(4096), 0);
-        assert_eq!(page_offset(4097), 1);
-        assert_eq!(page_offset(0), 0);
-        // Overlaps
-        assert!(overlap(1, 5, 3, 6));
-        assert!(overlap(0, 10, 5, 15));
-        assert!(!overlap(1, 5, 6, 8));
-    }
 
     #[test]
     fn test_zero_mem_region() {

--- a/kernel/src/virtio/mmio.rs
+++ b/kernel/src/virtio/mmio.rs
@@ -99,8 +99,11 @@ pub fn probe_mmio_slots(boot_params: &BootParams<'_>) -> MmioSlots {
         // SAFETY: The address is valid, mapped by `map_global_range_4k_shared`, and verified
         // to be VirtIOHeader-aligned by the guard above.
         // The memory region has the same lifetime of the MmioSlot structure which will be consumed by the driver.
-        // Note: QEMU places each MMIO slot on its own page for us, thus mmio_size = PAGE_SIZE.
-        let Ok(transport) = (unsafe { MmioTransport::new(header, PAGE_SIZE) }) else {
+        // TODO: Currently the hypervisor does not advertise the size of the mmio space (header + config space).
+        //       The size will be provided by the device tree. For now, let's just make sure we don't go past
+        //       the boundaries of the allocated space.
+        let Ok(transport) = (unsafe { MmioTransport::new(header, mem.size() - page_offset) })
+        else {
             // Currently QEMU advertises _all_ slots, regardless they are empty or not.
             log::debug!("MmioSlots: {addr:x} empty");
             continue;

--- a/paging/Cargo.toml
+++ b/paging/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "paging"
+version = "0.1.0"
+edition.workspace = true
+description = "Generic page table structures for Rust OS projects"
+
+[dependencies]
+bitflags.workspace = true
+zerocopy.workspace = true
+verus_stub.workspace = true
+verify_proof = { workspace = true, optional = true }
+verify_external = { workspace = true, optional = true }
+vstd = { workspace = true, optional = true }
+
+[features]
+default = []
+verus = ["verify_proof/verus", "verify_external/verus", "vstd", "verus_stub/disable"]
+
+[package.metadata.verus]
+verify = true
+
+[lints]
+workspace = true

--- a/paging/src/address.rs
+++ b/paging/src/address.rs
@@ -4,9 +4,8 @@
 //
 // Author: Carlos López <carlos.lopez@suse.com>
 
-use crate::mm::virt_to_phys;
-use crate::types::{PAGE_SHIFT, PAGE_SIZE};
-use crate::utils::{align_down, align_up, is_aligned};
+use crate::sizes::{PAGE_SHIFT, PAGE_SIZE};
+use crate::util::{align_down, align_up, is_aligned};
 
 use core::fmt;
 use core::ops;
@@ -17,8 +16,8 @@ use verus_stub::*;
 
 use zerocopy::FromBytes;
 
-#[cfg(verus_keep_ghost)]
-include!("address.verus.rs");
+#[cfg(verus_only)]
+include!("specs/address.rs");
 
 // The backing type to represent an address;
 type InnerAddr = usize;
@@ -597,20 +596,5 @@ impl Address for VirtAddr {
         self.bits()
             .checked_sub(off)
             .map(|addr| sign_extend(addr).into())
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-pub struct VirtPhysPair {
-    pub vaddr: VirtAddr,
-    pub paddr: PhysAddr,
-}
-
-impl VirtPhysPair {
-    pub fn new(vaddr: VirtAddr) -> Self {
-        Self {
-            vaddr,
-            paddr: virt_to_phys(vaddr),
-        }
     }
 }

--- a/paging/src/lib.rs
+++ b/paging/src/lib.rs
@@ -11,4 +11,5 @@
 
 pub mod address;
 pub mod sizes;
+pub mod traits;
 pub mod util;

--- a/paging/src/lib.rs
+++ b/paging/src/lib.rs
@@ -12,6 +12,7 @@
 pub mod address;
 pub mod pagetable;
 pub mod sizes;
+pub mod tlb;
 pub mod traits;
 pub mod util;
 pub mod x86_64;

--- a/paging/src/lib.rs
+++ b/paging/src/lib.rs
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! This crate provides page table–related functions and data structures.
+
+#![no_std]
+#![cfg_attr(verus_only, verifier::allow(unknown_automatic_derive))]
+#![cfg_attr(
+    verus_only,
+    allow(macro_expanded_macro_exports_accessed_by_absolute_paths)
+)]
+
+pub mod address;
+pub mod sizes;
+pub mod util;

--- a/paging/src/lib.rs
+++ b/paging/src/lib.rs
@@ -10,6 +10,8 @@
 )]
 
 pub mod address;
+pub mod pagetable;
 pub mod sizes;
 pub mod traits;
 pub mod util;
+pub mod x86_64;

--- a/paging/src/pagetable.rs
+++ b/paging/src/pagetable.rs
@@ -1,0 +1,1933 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2022-2023 SUSE LLC
+//
+// Author: Joerg Roedel <jroedel@suse.de>
+
+use crate::BIT_MASK;
+use crate::address::{Address, PhysAddr, VirtAddr};
+use crate::cpu::control_regs::write_cr3;
+use crate::cpu::flush_tlb_global_sync;
+use crate::cpu::idt::common::PageFaultError;
+use crate::cpu::registers::RFlags;
+use crate::error::SvsmError;
+use crate::mm::{
+    PGTABLE_LVL3_IDX_PTE_SELFMAP, PGTABLE_LVL3_IDX_SHARED, PageBox, SVSM_PTE_BASE, phys_to_virt,
+    virt_to_phys,
+};
+use crate::platform::SvsmPlatform;
+use crate::types::{PAGE_SIZE, PAGE_SIZE_1G, PAGE_SIZE_2M, PageSize};
+use crate::utils::MemoryRegion;
+use crate::utils::immut_after_init::{ImmutAfterInitCell, ImmutAfterInitResult};
+use bitflags::bitflags;
+use core::cmp;
+use core::ops::{Index, IndexMut};
+use core::ptr::NonNull;
+use cpuarch::x86::CR0Flags;
+use cpuarch::x86::CR4Flags;
+use cpuarch::x86::EFERFlags;
+use zerocopy::FromBytes;
+use zerocopy::FromZeros;
+
+/// Number of entries in a page table (4KB/8B).
+pub const ENTRY_COUNT: usize = 512;
+
+/// Mask for private page table entry.
+static PRIVATE_PTE_MASK: ImmutAfterInitCell<usize> = ImmutAfterInitCell::uninit();
+
+/// Mask for shared page table entry.
+static SHARED_PTE_MASK: ImmutAfterInitCell<usize> = ImmutAfterInitCell::uninit();
+
+/// Maximum physical address supported by the system.
+static MAX_PHYS_ADDR: ImmutAfterInitCell<u64> = ImmutAfterInitCell::uninit();
+
+/// Maximum physical address bits supported by the system.
+static PHYS_ADDR_SIZE: ImmutAfterInitCell<u32> = ImmutAfterInitCell::uninit();
+
+/// Physical address for the Launch VMSA (Virtual Machine Saving Area).
+pub const LAUNCH_VMSA_ADDR: PhysAddr = PhysAddr::new(0xFFFFFFFFF000);
+
+/// Feature mask for page table entry flags.
+static FEATURE_MASK: ImmutAfterInitCell<PTEntryFlags> = ImmutAfterInitCell::uninit();
+
+/// Initializes paging settings.
+pub fn paging_init(platform: &dyn SvsmPlatform, suppress_global: bool) -> ImmutAfterInitResult<()> {
+    init_encrypt_mask(platform)?;
+
+    let mut feature_mask = PTEntryFlags::all();
+    if suppress_global {
+        feature_mask.remove(PTEntryFlags::GLOBAL);
+    }
+    FEATURE_MASK.init(feature_mask)
+}
+
+/// Initializes the encrypt mask.
+fn init_encrypt_mask(platform: &dyn SvsmPlatform) -> ImmutAfterInitResult<()> {
+    let masks = platform.get_page_encryption_masks();
+
+    PRIVATE_PTE_MASK.init(masks.private_pte_mask)?;
+    SHARED_PTE_MASK.init(masks.shared_pte_mask)?;
+
+    let guest_phys_addr_size = (masks.phys_addr_sizes >> 16) & 0xff;
+    let host_phys_addr_size = masks.phys_addr_sizes & 0xff;
+    let phys_addr_size = if guest_phys_addr_size == 0 {
+        // When [GuestPhysAddrSize] is zero, refer to the PhysAddrSize field
+        // for the maximum guest physical address size.
+        // - APM3, E.4.7 Function 8000_0008h - Processor Capacity Parameters and Extended Feature Identification
+        host_phys_addr_size
+    } else {
+        guest_phys_addr_size
+    };
+
+    PHYS_ADDR_SIZE.init(phys_addr_size)?;
+
+    // If the C-bit is a physical address bit however, the guest physical
+    // address space is effectively reduced by 1 bit.
+    // - APM2, 15.34.6 Page Table Support
+    let effective_phys_addr_size = cmp::min(masks.addr_mask_width, phys_addr_size);
+
+    let max_addr = 1 << effective_phys_addr_size;
+    MAX_PHYS_ADDR.init(max_addr)
+}
+
+/// Returns the private encrypt mask value.
+pub fn private_pte_mask() -> usize {
+    *PRIVATE_PTE_MASK
+}
+
+/// Returns the shared encrypt mask value.
+fn shared_pte_mask() -> usize {
+    *SHARED_PTE_MASK
+}
+
+/// Returns the exclusive end of the physical address space.
+pub fn max_phys_addr() -> PhysAddr {
+    PhysAddr::from(*MAX_PHYS_ADDR)
+}
+
+/// Returns the supported flags considering the feature mask.
+fn supported_flags(flags: PTEntryFlags) -> PTEntryFlags {
+    flags & *FEATURE_MASK
+}
+
+/// Set address as shared via mask.
+fn make_shared_address(paddr: PhysAddr) -> PhysAddr {
+    (strip_confidentiality_bits(paddr).bits() | shared_pte_mask()).into()
+}
+
+/// Set address as private via mask.
+pub fn make_private_address(paddr: PhysAddr) -> PhysAddr {
+    (strip_shared_address_bits(paddr).bits() | private_pte_mask()).into()
+}
+
+// Returns true if the address is shared.
+fn is_shared(paddr: PhysAddr) -> bool {
+    paddr == make_shared_address(paddr)
+}
+
+fn strip_confidentiality_bits(paddr: PhysAddr) -> PhysAddr {
+    (paddr.bits() & !private_pte_mask()).into()
+}
+
+fn strip_shared_address_bits(paddr: PhysAddr) -> PhysAddr {
+    (paddr.bits() & !shared_pte_mask()).into()
+}
+
+bitflags! {
+    #[derive(Copy, Clone, Debug, Default)]
+    pub struct PTEntryFlags: u64 {
+        const PRESENT       = 1 << 0;
+        const WRITABLE      = 1 << 1;
+        const USER      = 1 << 2;
+        const ACCESSED      = 1 << 5;
+        const DIRTY     = 1 << 6;
+        const HUGE      = 1 << 7;
+        const GLOBAL        = 1 << 8;
+        const NX        = 1 << 63;
+    }
+}
+
+impl PTEntryFlags {
+    pub fn exec() -> Self {
+        Self::PRESENT | Self::GLOBAL | Self::ACCESSED
+    }
+
+    pub fn data() -> Self {
+        Self::PRESENT | Self::GLOBAL | Self::WRITABLE | Self::NX | Self::ACCESSED | Self::DIRTY
+    }
+
+    pub fn data_ro() -> Self {
+        Self::PRESENT | Self::GLOBAL | Self::NX | Self::ACCESSED
+    }
+
+    pub fn task_exec() -> Self {
+        Self::PRESENT | Self::ACCESSED
+    }
+
+    pub fn task_data() -> Self {
+        Self::PRESENT | Self::WRITABLE | Self::NX | Self::ACCESSED | Self::DIRTY
+    }
+
+    pub fn task_data_ro() -> Self {
+        Self::PRESENT | Self::NX | Self::ACCESSED
+    }
+}
+
+/// Represents paging mode.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PagingMode {
+    // Paging mode is disabled
+    NoPaging,
+    // 32bit legacy paging mode
+    NonPAE,
+    // 32bit PAE paging mode
+    PAE,
+    // 4 level paging mode
+    PML4,
+    // 5 level paging mode
+    PML5,
+}
+
+impl PagingMode {
+    pub fn new(efer: EFERFlags, cr0: CR0Flags, cr4: CR4Flags) -> Self {
+        if !cr0.contains(CR0Flags::PG) {
+            // Paging is disabled
+            PagingMode::NoPaging
+        } else if efer.contains(EFERFlags::LMA) {
+            // Long mode is activated
+            if cr4.contains(CR4Flags::LA57) {
+                PagingMode::PML5
+            } else {
+                PagingMode::PML4
+            }
+        } else if cr4.contains(CR4Flags::PAE) {
+            // PAE mode
+            PagingMode::PAE
+        } else {
+            // Non PAE mode
+            PagingMode::NonPAE
+        }
+    }
+}
+
+/// Represents a page table entry.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, FromBytes)]
+pub struct PTEntry(PhysAddr);
+
+impl PTEntry {
+    /// Check if the page table entry is clear (null).
+    pub fn is_clear(&self) -> bool {
+        self.0.is_null()
+    }
+
+    /// Clear the page table entry.
+    pub fn clear(&mut self) {
+        self.0 = PhysAddr::null();
+    }
+
+    /// Check if the page table entry is present.
+    pub fn present(&self) -> bool {
+        self.flags().contains(PTEntryFlags::PRESENT)
+    }
+
+    /// Check if the page table entry is huge.
+    pub fn huge(&self) -> bool {
+        self.flags().contains(PTEntryFlags::HUGE)
+    }
+
+    /// Check if the page table entry is writable.
+    pub fn writable(&self) -> bool {
+        self.flags().contains(PTEntryFlags::WRITABLE)
+    }
+
+    /// Check if the page table entry is NX (no-execute).
+    pub fn nx(&self) -> bool {
+        self.flags().contains(PTEntryFlags::NX)
+    }
+
+    /// Check if the page table entry is user-accessible.
+    pub fn user(&self) -> bool {
+        self.flags().contains(PTEntryFlags::USER)
+    }
+
+    /// Check if the page table entry is global.
+    pub fn global(&self) -> bool {
+        self.flags().contains(PTEntryFlags::GLOBAL)
+    }
+
+    /// Check if the page table entry has reserved bits set.
+    pub fn has_reserved_bits(&self, pm: PagingMode, level: usize) -> bool {
+        let reserved_mask = match pm {
+            PagingMode::NoPaging => unreachable!("NoPaging does not have page table"),
+            PagingMode::NonPAE => {
+                match level {
+                    // No reserved bits in 4k PTE.
+                    0 => 0,
+                    1 => {
+                        if self.huge() {
+                            // Bit21 is reserved in 4M PDE.
+                            BIT_MASK!(21, 21)
+                        } else {
+                            // No reserved bits in PDE.
+                            0
+                        }
+                    }
+                    _ => unreachable!("Invalid NonPAE page table level"),
+                }
+            }
+            PagingMode::PAE => {
+                // Bit62 ~ MAXPHYSADDR are reserved for each
+                // level in PAE page table.
+                BIT_MASK!(62, *PHYS_ADDR_SIZE)
+                    | match level {
+                        // No additional reserved bits in 4k PTE.
+                        0 => 0,
+                        1 => {
+                            if self.huge() {
+                                // Bit20 ~ Bit13 are reserved in 2M PDE.
+                                BIT_MASK!(20, 13)
+                            } else {
+                                // No additional reserved bits in PDE.
+                                0
+                            }
+                        }
+                        // Bit63 and Bit8 ~ Bit5 are reserved in PDPTE.
+                        2 => BIT_MASK!(63, 63) | BIT_MASK!(8, 5),
+                        _ => unreachable!("Invalid PAE page table level"),
+                    }
+            }
+            PagingMode::PML4 | PagingMode::PML5 => {
+                // Bit51 ~ MAXPHYSADDR are reserved for each level
+                // in PML4 and PML5 page table.
+                let common = if *PHYS_ADDR_SIZE > 51 {
+                    0
+                } else {
+                    // Remove the encryption mask bit as this bit is not reserved
+                    BIT_MASK!(51, *PHYS_ADDR_SIZE)
+                        & !((shared_pte_mask() | private_pte_mask()) as u64)
+                };
+
+                common
+                    | match level {
+                        // No additional reserved bits in 4k PTE.
+                        0 => 0,
+                        1 => {
+                            if self.huge() {
+                                // Bit20 ~ Bit13 are reserved in 2M PDE.
+                                BIT_MASK!(20, 13)
+                            } else {
+                                // No additional reserved bits in PDE.
+                                0
+                            }
+                        }
+                        2 => {
+                            if self.huge() {
+                                // Bit29 ~ Bit13 are reserved in 1G PDPTE.
+                                BIT_MASK!(29, 13)
+                            } else {
+                                // No additional reserved bits in PDPTE.
+                                0
+                            }
+                        }
+                        // Bit8 ~ Bit7 are reserved in PML4E.
+                        3 => BIT_MASK!(8, 7),
+                        4 => {
+                            if pm == PagingMode::PML4 {
+                                unreachable!("Invalid PML4 page table level");
+                            } else {
+                                // Bit8 ~ Bit7 are reserved in PML5E.
+                                BIT_MASK!(8, 7)
+                            }
+                        }
+                        _ => unreachable!("Invalid PML4/PML5 page table level"),
+                    }
+            }
+        };
+
+        self.raw() & reserved_mask != 0
+    }
+
+    /// Get the raw bits (`u64`) of the page table entry.
+    pub fn raw(&self) -> u64 {
+        self.0.bits() as u64
+    }
+
+    /// Get the flags of the page table entry.
+    pub fn flags(&self) -> PTEntryFlags {
+        PTEntryFlags::from_bits_truncate(self.0.bits() as u64)
+    }
+
+    /// Set the page table entry with the specified address and flags.
+    pub fn set_unrestricted(&mut self, addr: PhysAddr, flags: PTEntryFlags) {
+        let addr = addr.bits() as u64;
+        assert_eq!(addr & !0x000f_ffff_ffff_f000, 0);
+        self.0 = PhysAddr::from(addr | flags.bits());
+    }
+
+    /// Set the page table entry with the specified address, with flags
+    /// constrained to the supported feature flags.
+    pub fn set(&mut self, addr: PhysAddr, flags: PTEntryFlags) {
+        self.set_unrestricted(addr, supported_flags(flags));
+    }
+
+    /// Inserts the private address mask if the page is present.
+    pub fn make_private_if_present(&mut self) {
+        if self.flags().contains(PTEntryFlags::PRESENT) {
+            self.0 = make_private_address(self.0);
+        }
+    }
+
+    /// Get the address from the page table entry, including the shared bit.
+    pub fn page_frame(&self) -> PhysAddr {
+        let addr = PhysAddr::from(self.0.bits() & 0x000f_ffff_ffff_f000);
+        strip_confidentiality_bits(addr)
+    }
+
+    /// Get the address from the page table entry, excluding the C/shared bit.
+    pub fn address(&self) -> PhysAddr {
+        strip_shared_address_bits(self.page_frame())
+    }
+
+    /// Read a page table entry from the specified virtual address.
+    ///
+    /// # Safety
+    ///
+    /// Reads from an arbitrary virtual address, making this essentially a
+    /// raw pointer read.  The caller must be certain to calculate the correct
+    /// address.
+    pub unsafe fn read_pte(vaddr: VirtAddr) -> Self {
+        // SAFETY: When the methods safety requirements are met, the raw
+        // pointer read is safe.
+        unsafe { *vaddr.as_ptr::<Self>() }
+    }
+}
+
+/// A pagetable page with multiple entries.
+#[repr(C)]
+#[derive(Debug, FromBytes)]
+pub struct PTPage {
+    entries: [PTEntry; ENTRY_COUNT],
+}
+
+impl PTPage {
+    /// Allocates a zeroed pagetable page and returns a `PageBox` containing
+    /// the allocation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SvsmError`] if the page cannot be allocated.
+    pub fn alloc_box() -> Result<PageBox<Self>, SvsmError> {
+        PageBox::try_new_zeroed()
+    }
+
+    /// Allocates a zeroed pagetable page and returns a mutable reference to
+    /// it, plus its physical address.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SvsmError`] if the page cannot be allocated.
+    fn alloc() -> Result<(&'static mut Self, PhysAddr), SvsmError> {
+        let page = Self::alloc_box()?;
+        let paddr = virt_to_phys(page.vaddr());
+        Ok((PageBox::leak(page), paddr))
+    }
+
+    /// Frees a pagetable page.
+    ///
+    /// # Safety
+    ///
+    /// The given reference must correspond to a valid previously allocated
+    /// page table page.
+    unsafe fn free(page: &'static Self) {
+        // SAFETY: The page put into the PageBox is a previously allocated
+        // page table page.
+        unsafe {
+            let _ = PageBox::from_raw(NonNull::from(page));
+        }
+    }
+
+    /// Converts a pagetable entry to a mutable reference to a [`PTPage`],
+    /// if the entry is present and not huge.
+    fn from_entry(entry: PTEntry) -> Option<&'static mut Self> {
+        let flags = entry.flags();
+        if !flags.contains(PTEntryFlags::PRESENT) || flags.contains(PTEntryFlags::HUGE) {
+            return None;
+        }
+
+        let address = phys_to_virt(entry.address());
+        // SAFETY: Every PTEntry points to a previously allocated page-table
+        // page, so this pointer dereference is safe.
+        Some(unsafe { Self::from_vaddr(address) })
+    }
+
+    /// Generates a `PTPage` from a virtual address.
+    /// # Safety
+    /// The caller must ensure that the virtual address is a valid page table.
+    pub unsafe fn from_vaddr(vaddr: VirtAddr) -> &'static mut Self {
+        // SAFETY: the caller guarantees the correctness of the virtual
+        // address.
+        unsafe { &mut *vaddr.as_mut_ptr::<PTPage>() }
+    }
+}
+
+/// Can be used to access page table entries by index.
+impl Index<usize> for PTPage {
+    type Output = PTEntry;
+
+    fn index(&self, index: usize) -> &PTEntry {
+        &self.entries[index]
+    }
+}
+
+/// Can be used to modify page table entries by index.
+impl IndexMut<usize> for PTPage {
+    fn index_mut(&mut self, index: usize) -> &mut PTEntry {
+        &mut self.entries[index]
+    }
+}
+
+/// Mapping levels of page table entries.
+#[derive(Debug)]
+pub enum Mapping<'a> {
+    Level3(&'a mut PTEntry),
+    Level2(&'a mut PTEntry),
+    Level1(&'a mut PTEntry),
+    Level0(&'a mut PTEntry),
+}
+
+/// A physical address within a page frame
+#[derive(Clone, Copy, Debug)]
+pub enum PageFrame {
+    Size4K(PhysAddr),
+    Size2M(PhysAddr),
+    Size1G(PhysAddr),
+}
+
+impl PageFrame {
+    /// Get the address from the page frame, including the shared bit.
+    pub fn page_frame(&self) -> PhysAddr {
+        let paddr = match *self {
+            Self::Size4K(pa) => pa,
+            Self::Size2M(pa) => pa,
+            Self::Size1G(pa) => pa,
+        };
+        strip_confidentiality_bits(paddr)
+    }
+
+    /// Get the address from the page frame, excluding the C/shared bit.
+    pub fn address(&self) -> PhysAddr {
+        strip_shared_address_bits(self.page_frame())
+    }
+
+    pub fn size(&self) -> usize {
+        match self {
+            Self::Size4K(_) => PAGE_SIZE,
+            Self::Size2M(_) => PAGE_SIZE_2M,
+            Self::Size1G(_) => PAGE_SIZE_1G,
+        }
+    }
+
+    pub fn start(&self) -> PhysAddr {
+        let end = self.address().bits() & !(self.size() - 1);
+        end.into()
+    }
+
+    pub fn end(&self) -> PhysAddr {
+        self.start() + self.size()
+    }
+}
+
+/// Page table structure containing a root page with multiple entries.
+#[repr(C)]
+#[derive(Debug, FromZeros)]
+pub struct PageTable {
+    root: PTPage,
+}
+
+impl PageTable {
+    /// Load the current page table into the CR3 register.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure to take other actions to make sure a memory safe
+    /// execution state is warranted (e.g. changing the stack and register state)
+    pub unsafe fn load(&self) {
+        // SAFETY: demanded to the caller
+        unsafe {
+            write_cr3(self.cr3_value());
+        }
+    }
+
+    /// Get the CR3 register value for the current page table.
+    pub fn cr3_value(&self) -> PhysAddr {
+        let pgtable = VirtAddr::from(self as *const Self);
+        virt_to_phys(pgtable)
+    }
+
+    /// Allocate a new page table root.
+    ///
+    /// # Errors
+    /// Returns [`SvsmError`] if the page cannot be allocated.
+    pub fn allocate_new() -> Result<PageBox<Self>, SvsmError> {
+        let mut pgtable: PageBox<Self> = PageBox::try_new_zeroed()?;
+        let paddr = virt_to_phys(pgtable.vaddr());
+
+        // Set the self-map entry.
+        let entry = &mut pgtable.root[PGTABLE_LVL3_IDX_PTE_SELFMAP];
+        let flags = PTEntryFlags::PRESENT
+            | PTEntryFlags::WRITABLE
+            | PTEntryFlags::ACCESSED
+            | PTEntryFlags::DIRTY
+            | PTEntryFlags::NX;
+        entry.set(make_private_address(paddr), flags);
+
+        Ok(pgtable)
+    }
+
+    /// Clone the shared part of the page table; excluding the private
+    /// parts.
+    ///
+    /// # Errors
+    /// Returns [`SvsmError`] if the page cannot be allocated.
+    pub fn clone_shared(&self) -> Result<PageBox<PageTable>, SvsmError> {
+        let mut pgtable = Self::allocate_new()?;
+        pgtable.root.entries[PGTABLE_LVL3_IDX_SHARED] = self.root.entries[PGTABLE_LVL3_IDX_SHARED];
+        Ok(pgtable)
+    }
+
+    /// Copy an entry `entry` from another [`PageTable`].
+    pub fn copy_entry(&mut self, other: &Self, entry: usize) {
+        self.root.entries[entry] = other.root.entries[entry];
+    }
+
+    /// Computes the index within a page table at the given level for a
+    /// virtual address `vaddr`.
+    ///
+    /// # Parameters
+    /// - `vaddr`: The virtual address to compute the index for.
+    ///
+    /// # Returns
+    /// The index within the page table.
+    pub fn index<const L: usize>(vaddr: VirtAddr) -> usize {
+        vaddr.to_pgtbl_idx::<L>()
+        //vaddr.bits() >> (12 + L * 9) & 0x1ff
+    }
+
+    /// Walks a page table at level 0 to find a mapping.
+    ///
+    /// # Parameters
+    /// - `page`: A mutable reference to the root page table.
+    /// - `vaddr`: The virtual address to find a mapping for.
+    ///
+    /// # Returns
+    /// A `Mapping` representing the found mapping.
+    fn walk_addr_lvl0(page: &mut PTPage, vaddr: VirtAddr) -> Mapping<'_> {
+        let idx = Self::index::<0>(vaddr);
+        Mapping::Level0(&mut page[idx])
+    }
+
+    /// Walks a page table at level 1 to find a mapping.
+    ///
+    /// # Parameters
+    /// - `page`: A mutable reference to the root page table.
+    /// - `vaddr`: The virtual address to find a mapping for.
+    ///
+    /// # Returns
+    /// A `Mapping` representing the found mapping.
+    fn walk_addr_lvl1(page: &mut PTPage, vaddr: VirtAddr) -> Mapping<'_> {
+        let idx = Self::index::<1>(vaddr);
+        let entry = page[idx];
+        match PTPage::from_entry(entry) {
+            Some(page) => Self::walk_addr_lvl0(page, vaddr),
+            None => Mapping::Level1(&mut page[idx]),
+        }
+    }
+
+    /// Walks a page table at level 2 to find a mapping.
+    ///
+    /// # Parameters
+    /// - `page`: A mutable reference to the root page table.
+    /// - `vaddr`: The virtual address to find a mapping for.
+    ///
+    /// # Returns
+    /// A `Mapping` representing the found mapping.
+    fn walk_addr_lvl2(page: &mut PTPage, vaddr: VirtAddr) -> Mapping<'_> {
+        let idx = Self::index::<2>(vaddr);
+        let entry = page[idx];
+        match PTPage::from_entry(entry) {
+            Some(page) => Self::walk_addr_lvl1(page, vaddr),
+            None => Mapping::Level2(&mut page[idx]),
+        }
+    }
+
+    /// Walks the page table to find a mapping for a given virtual address.
+    ///
+    /// # Parameters
+    /// - `page`: A mutable reference to the root page table.
+    /// - `vaddr`: The virtual address to find a mapping for.
+    ///
+    /// # Returns
+    /// A `Mapping` representing the found mapping.
+    fn walk_addr_lvl3(page: &mut PTPage, vaddr: VirtAddr) -> Mapping<'_> {
+        let idx = Self::index::<3>(vaddr);
+        let entry = page[idx];
+        match PTPage::from_entry(entry) {
+            Some(page) => Self::walk_addr_lvl2(page, vaddr),
+            None => Mapping::Level3(&mut page[idx]),
+        }
+    }
+
+    /// Walk the virtual address and return the corresponding mapping.
+    ///
+    /// # Parameters
+    /// - `vaddr`: The virtual address to find a mapping for.
+    ///
+    /// # Returns
+    /// A `Mapping` representing the found mapping.
+    fn walk_addr(&mut self, vaddr: VirtAddr) -> Mapping<'_> {
+        Self::walk_addr_lvl3(&mut self.root, vaddr)
+    }
+
+    /// Calculate the virtual address of a PTE in the self-map, which maps a
+    /// specified virtual address.
+    ///
+    /// # Parameters
+    /// - `vaddr': The virtual address whose PTE should be located.
+    ///
+    /// # Returns
+    /// The virtual address of the PTE.
+    fn get_pte_address(vaddr: VirtAddr) -> VirtAddr {
+        SVSM_PTE_BASE + ((usize::from(vaddr) & 0x0000_FFFF_FFFF_F000) >> 9)
+    }
+
+    /// Perform a virtual to physical translation using the self-map.
+    ///
+    /// # Parameters
+    /// - `vaddr': The virtual address to translate.
+    ///
+    /// # Returns
+    /// Some(PageFrame) if the virtual address is valid.
+    /// None if the virtual address is not valid.
+    pub fn virt_to_frame(vaddr: VirtAddr) -> Option<PageFrame> {
+        // Calculate the virtual addresses of each level of the paging
+        // hierarchy in the self-map.
+        let pte_addr = Self::get_pte_address(vaddr);
+        let pde_addr = Self::get_pte_address(pte_addr);
+        let pdpe_addr = Self::get_pte_address(pde_addr);
+        let pml4e_addr = Self::get_pte_address(pdpe_addr);
+
+        // SAFETY: Check each entry in the paging hierarchy to determine
+        // whether this address is mapped.  Because the hierarchy is read from
+        // the top down using self-map addresses that were calculated
+        // correctly, the reads are safe to perform.
+        let pml4e = unsafe { PTEntry::read_pte(pml4e_addr) };
+        if !pml4e.present() {
+            return None;
+        }
+
+        // There is no need to check for a large page in the PML4E because
+        // the architecture does not support the large bit at the top-level
+        // entry.  If a large page is detected at a lower level of the
+        // hierarchy, the low bits from the virtual address must be combined
+        // with the physical address from the PDE/PDPE.
+
+        // SAFETY: The PML4E was checked to be present, so the PDPE exists and
+        // can be read safely.
+        let pdpe = unsafe { PTEntry::read_pte(pdpe_addr) };
+        if !pdpe.present() {
+            return None;
+        }
+        if pdpe.huge() {
+            let pa = pdpe.page_frame() + (usize::from(vaddr) & 0x3FFF_FFFF);
+            return Some(PageFrame::Size1G(pa));
+        }
+
+        // SAFETY: The PDPE was checked to be present and not to be a huge
+        // page. So the PDE exists and can be read safely.
+        let pde = unsafe { PTEntry::read_pte(pde_addr) };
+        if !pde.present() {
+            return None;
+        }
+        if pde.huge() {
+            let pa = pde.page_frame() + (usize::from(vaddr) & 0x001F_FFFF);
+            return Some(PageFrame::Size2M(pa));
+        }
+
+        // SAFETY: The PDE was checked to be present and not to be a huge
+        // page. So the PTE exists and can be read safely.
+        let pte = unsafe { PTEntry::read_pte(pte_addr) };
+        if pte.present() {
+            let pa = pte.page_frame() + (usize::from(vaddr) & 0xFFF);
+            Some(PageFrame::Size4K(pa))
+        } else {
+            None
+        }
+    }
+
+    fn alloc_pte_lvl3(entry: &mut PTEntry, vaddr: VirtAddr, size: PageSize) -> Mapping<'_> {
+        let flags = entry.flags();
+
+        if flags.contains(PTEntryFlags::PRESENT) {
+            return Mapping::Level3(entry);
+        }
+
+        let Ok((page, paddr)) = PTPage::alloc() else {
+            return Mapping::Level3(entry);
+        };
+
+        let flags = PTEntryFlags::PRESENT
+            | PTEntryFlags::WRITABLE
+            | PTEntryFlags::USER
+            | PTEntryFlags::ACCESSED;
+        entry.set(make_private_address(paddr), flags);
+
+        let idx = Self::index::<2>(vaddr);
+        Self::alloc_pte_lvl2(&mut page[idx], vaddr, size)
+    }
+
+    fn alloc_pte_lvl2(entry: &mut PTEntry, vaddr: VirtAddr, size: PageSize) -> Mapping<'_> {
+        let flags = entry.flags();
+
+        if flags.contains(PTEntryFlags::PRESENT) {
+            return Mapping::Level2(entry);
+        }
+
+        let Ok((page, paddr)) = PTPage::alloc() else {
+            return Mapping::Level2(entry);
+        };
+
+        let flags = PTEntryFlags::PRESENT
+            | PTEntryFlags::WRITABLE
+            | PTEntryFlags::USER
+            | PTEntryFlags::ACCESSED;
+        entry.set(make_private_address(paddr), flags);
+
+        let idx = Self::index::<1>(vaddr);
+        Self::alloc_pte_lvl1(&mut page[idx], vaddr, size)
+    }
+
+    fn alloc_pte_lvl1(entry: &mut PTEntry, vaddr: VirtAddr, size: PageSize) -> Mapping<'_> {
+        let flags = entry.flags();
+
+        if size == PageSize::Huge || flags.contains(PTEntryFlags::PRESENT) {
+            return Mapping::Level1(entry);
+        }
+
+        let Ok((page, paddr)) = PTPage::alloc() else {
+            return Mapping::Level1(entry);
+        };
+
+        let flags = PTEntryFlags::PRESENT
+            | PTEntryFlags::WRITABLE
+            | PTEntryFlags::USER
+            | PTEntryFlags::ACCESSED;
+        entry.set(make_private_address(paddr), flags);
+
+        let idx = Self::index::<0>(vaddr);
+        Mapping::Level0(&mut page[idx])
+    }
+
+    /// Allocates a 4KB page table entry for a given virtual address.
+    ///
+    /// # Parameters
+    /// - `vaddr`: The virtual address for which to allocate the PTE.
+    ///
+    /// # Returns
+    /// A `Mapping` representing the allocated or existing PTE for the address.
+    fn alloc_pte_4k(&mut self, vaddr: VirtAddr) -> Mapping<'_> {
+        let m = self.walk_addr(vaddr);
+
+        match m {
+            Mapping::Level0(entry) => Mapping::Level0(entry),
+            Mapping::Level1(entry) => Self::alloc_pte_lvl1(entry, vaddr, PageSize::Regular),
+            Mapping::Level2(entry) => Self::alloc_pte_lvl2(entry, vaddr, PageSize::Regular),
+            Mapping::Level3(entry) => Self::alloc_pte_lvl3(entry, vaddr, PageSize::Regular),
+        }
+    }
+
+    /// Allocates a 2MB page table entry for a given virtual address.
+    ///
+    /// # Parameters
+    /// - `vaddr`: The virtual address for which to allocate the PTE.
+    ///
+    /// # Returns
+    /// A `Mapping` representing the allocated or existing PTE for the address.
+    fn alloc_pte_2m(&mut self, vaddr: VirtAddr) -> Mapping<'_> {
+        let m = self.walk_addr(vaddr);
+
+        match m {
+            Mapping::Level0(entry) => Mapping::Level0(entry),
+            Mapping::Level1(entry) => Mapping::Level1(entry),
+            Mapping::Level2(entry) => Self::alloc_pte_lvl2(entry, vaddr, PageSize::Huge),
+            Mapping::Level3(entry) => Self::alloc_pte_lvl3(entry, vaddr, PageSize::Huge),
+        }
+    }
+
+    /// Splits a 2MB page into 4KB pages.
+    ///
+    /// # Parameters
+    /// - `entry`: The 2M page table entry to split.
+    ///
+    /// # Returns
+    /// A result indicating success or an error [`SvsmError`] in failure.
+    fn do_split_4k(entry: &mut PTEntry) -> Result<(), SvsmError> {
+        let (page, paddr) = PTPage::alloc()?;
+        let mut flags = entry.flags();
+
+        assert!(flags.contains(PTEntryFlags::HUGE));
+
+        let addr_2m = PhysAddr::from(entry.address().bits() & 0x000f_ffff_fff0_0000);
+
+        flags.remove(PTEntryFlags::HUGE);
+
+        // Prepare PTE leaf page
+        for (i, e) in page.entries.iter_mut().enumerate() {
+            let addr_4k = addr_2m + (i * PAGE_SIZE);
+            e.clear();
+            e.set(make_private_address(addr_4k), flags);
+        }
+
+        entry.set(make_private_address(paddr), flags);
+
+        flush_tlb_global_sync();
+
+        Ok(())
+    }
+
+    /// Splits a page into 4KB pages if it is part of a larger mapping.
+    ///
+    /// # Parameters
+    /// - `mapping`: The mapping to split.
+    ///
+    /// # Returns
+    /// A result indicating success or an error [`SvsmError`].
+    fn split_4k(mapping: Mapping<'_>) -> Result<(), SvsmError> {
+        match mapping {
+            Mapping::Level0(_entry) => Ok(()),
+            Mapping::Level1(entry) => Self::do_split_4k(entry),
+            Mapping::Level2(_entry) => Err(SvsmError::Mem),
+            Mapping::Level3(_entry) => Err(SvsmError::Mem),
+        }
+    }
+
+    fn make_pte_shared(entry: &mut PTEntry) {
+        let flags = entry.flags();
+        let addr = entry.address();
+
+        // entry.address() returned with c-bit clear already
+        entry.set(make_shared_address(addr), flags);
+    }
+
+    fn make_pte_private(entry: &mut PTEntry) {
+        let flags = entry.flags();
+        let addr = entry.address();
+
+        // entry.address() returned with c-bit clear already
+        entry.set(make_private_address(addr), flags);
+    }
+
+    /// Sets the shared state for a 4KB page.
+    ///
+    /// # Parameters
+    /// - `vaddr`: The virtual address of the page.
+    ///
+    /// # Returns
+    /// A result indicating success or an error [`SvsmError`] if the
+    /// operation fails.
+    pub fn set_shared_4k(&mut self, vaddr: VirtAddr) -> Result<(), SvsmError> {
+        let mapping = self.walk_addr(vaddr);
+        Self::split_4k(mapping)?;
+
+        if let Mapping::Level0(entry) = self.walk_addr(vaddr) {
+            Self::make_pte_shared(entry);
+            Ok(())
+        } else {
+            Err(SvsmError::Mem)
+        }
+    }
+
+    /// Sets the encryption state for a 4KB page.
+    ///
+    /// # Parameters
+    /// - `vaddr`: The virtual address of the page.
+    ///
+    /// # Returns
+    /// A result indicating success or an error [`SvsmError`].
+    pub fn set_encrypted_4k(&mut self, vaddr: VirtAddr) -> Result<(), SvsmError> {
+        let mapping = self.walk_addr(vaddr);
+        Self::split_4k(mapping)?;
+
+        if let Mapping::Level0(entry) = self.walk_addr(vaddr) {
+            Self::make_pte_private(entry);
+            Ok(())
+        } else {
+            Err(SvsmError::Mem)
+        }
+    }
+
+    /// Gets the physical address for a mapped `vaddr` or `None` if
+    /// no such mapping exists.
+    pub fn check_mapping(&mut self, vaddr: VirtAddr) -> Option<PhysAddr> {
+        match self.walk_addr(vaddr) {
+            Mapping::Level0(entry) => Some(entry.address()),
+            Mapping::Level1(entry) => Some(entry.address()),
+            _ => None,
+        }
+    }
+
+    /// Maps a 2MB page.
+    ///
+    /// # Parameters
+    /// - `vaddr`: The virtual address to map.
+    /// - `paddr`: The physical address to map to.
+    /// - `flags`: The flags to apply to the mapping.
+    /// - `shared`: Indicates whether the mapping is shared.
+    ///
+    /// # Returns
+    /// A result indicating success or failure ([`SvsmError`]).
+    ///
+    /// # Panics
+    /// Panics if either `vaddr` or `paddr` is not aligned to a 2MB boundary.
+    pub fn map_2m(
+        &mut self,
+        vaddr: VirtAddr,
+        paddr: PhysAddr,
+        flags: PTEntryFlags,
+        shared: bool,
+    ) -> Result<(), SvsmError> {
+        assert!(vaddr.is_aligned(PAGE_SIZE_2M));
+        assert!(paddr.is_aligned(PAGE_SIZE_2M));
+
+        let mapping = self.alloc_pte_2m(vaddr);
+        let addr = if !shared {
+            make_private_address(paddr)
+        } else {
+            make_shared_address(paddr)
+        };
+
+        if let Mapping::Level1(entry) = mapping {
+            entry.set(addr, flags | PTEntryFlags::HUGE);
+            Ok(())
+        } else {
+            Err(SvsmError::Mem)
+        }
+    }
+
+    /// Unmaps a 2MB page.
+    ///
+    /// # Parameters
+    /// - `vaddr`: The virtual address of the mapping to unmap.
+    ///
+    /// # Panics
+    /// Panics if `vaddr` is not aligned to a 2MB boundary.
+    pub fn unmap_2m(&mut self, vaddr: VirtAddr) {
+        assert!(vaddr.is_aligned(PAGE_SIZE_2M));
+
+        let mapping = self.walk_addr(vaddr);
+
+        match mapping {
+            Mapping::Level0(_) => unreachable!(),
+            Mapping::Level1(entry) => entry.clear(),
+            Mapping::Level2(entry) => assert!(!entry.present()),
+            Mapping::Level3(entry) => assert!(!entry.present()),
+        }
+    }
+
+    /// Maps a 4KB page.
+    ///
+    /// # Parameters
+    /// - `vaddr`: The virtual address to map.
+    /// - `paddr`: The physical address to map to.
+    /// - `flags`: The flags to apply to the mapping.
+    /// - `shared`: Indicates whether the mapping is shared.
+    ///
+    /// # Returns
+    /// A result indicating success or failure ([`SvsmError`]).
+    pub fn map_4k(
+        &mut self,
+        vaddr: VirtAddr,
+        paddr: PhysAddr,
+        flags: PTEntryFlags,
+        shared: bool,
+    ) -> Result<(), SvsmError> {
+        let mapping = self.alloc_pte_4k(vaddr);
+        let addr = if !shared {
+            make_private_address(paddr)
+        } else {
+            make_shared_address(paddr)
+        };
+
+        if let Mapping::Level0(entry) = mapping {
+            entry.set(addr, flags);
+            Ok(())
+        } else {
+            Err(SvsmError::Mem)
+        }
+    }
+
+    /// Unmaps a 4KB page.
+    ///
+    /// # Parameters
+    /// - `vaddr`: The virtual address of the mapping to unmap.
+    pub fn unmap_4k(&mut self, vaddr: VirtAddr) {
+        let mapping = self.walk_addr(vaddr);
+
+        match mapping {
+            Mapping::Level0(entry) => entry.clear(),
+            Mapping::Level1(entry) => assert!(!entry.present()),
+            Mapping::Level2(entry) => assert!(!entry.present()),
+            Mapping::Level3(entry) => assert!(!entry.present()),
+        }
+    }
+
+    /// Retrieves the physical address of a mapping.
+    ///
+    /// # Parameters
+    /// - `vaddr`: The virtual address to query.
+    ///
+    /// # Returns
+    /// The physical address of the mapping if present; otherwise, an error
+    /// ([`SvsmError`]).
+    pub fn phys_addr(&mut self, vaddr: VirtAddr) -> Result<PhysAddr, SvsmError> {
+        let mapping = self.walk_addr(vaddr);
+
+        match mapping {
+            Mapping::Level0(entry) => {
+                let offset = vaddr.page_offset();
+                if !entry.flags().contains(PTEntryFlags::PRESENT) {
+                    return Err(SvsmError::Mem);
+                }
+                Ok(entry.address() + offset)
+            }
+            Mapping::Level1(entry) => {
+                let offset = vaddr.bits() & (PAGE_SIZE_2M - 1);
+                if !entry.flags().contains(PTEntryFlags::PRESENT)
+                    || !entry.flags().contains(PTEntryFlags::HUGE)
+                {
+                    return Err(SvsmError::Mem);
+                }
+
+                Ok(entry.address() + offset)
+            }
+            Mapping::Level2(_entry) => Err(SvsmError::Mem),
+            Mapping::Level3(_entry) => Err(SvsmError::Mem),
+        }
+    }
+
+    /// Maps a region of memory using 4KB pages.
+    ///
+    /// # Parameters
+    /// - `vregion`: The virtual memory region to map.
+    /// - `phys`: The starting physical address to map to.
+    /// - `flags`: The flags to apply to the mapping.
+    /// - `shared`: Indicates whether the mapping is shared.
+    ///
+    /// # Returns
+    /// A result indicating success or failure ([`SvsmError`]).
+    pub fn map_region_4k(
+        &mut self,
+        vregion: MemoryRegion<VirtAddr>,
+        phys: PhysAddr,
+        flags: PTEntryFlags,
+        shared: bool,
+    ) -> Result<(), SvsmError> {
+        for addr in vregion.iter_pages(PageSize::Regular) {
+            let offset = addr - vregion.start();
+            self.map_4k(addr, phys + offset, flags, shared)?;
+        }
+        Ok(())
+    }
+
+    /// Unmaps a region of memory using 4KB pages.
+    ///
+    /// # Parameters
+    /// - `vregion`: The virtual memory region to unmap.
+    pub fn unmap_region_4k(&mut self, vregion: MemoryRegion<VirtAddr>) {
+        for addr in vregion.iter_pages(PageSize::Regular) {
+            self.unmap_4k(addr);
+        }
+    }
+
+    /// Maps a region of memory using 2MB pages.
+    ///
+    /// # Parameters
+    /// - `vregion`: The virtual memory region to map.
+    /// - `phys`: The starting physical address to map to.
+    /// - `flags`: The flags to apply to the mapping.
+    /// - `shared`: Indicates whether the mapping is shared.
+    ///
+    /// # Returns
+    /// A result indicating success or failure ([`SvsmError`]).
+    pub fn map_region_2m(
+        &mut self,
+        vregion: MemoryRegion<VirtAddr>,
+        phys: PhysAddr,
+        flags: PTEntryFlags,
+        shared: bool,
+    ) -> Result<(), SvsmError> {
+        for addr in vregion.iter_pages(PageSize::Huge) {
+            let offset = addr - vregion.start();
+            self.map_2m(addr, phys + offset, flags, shared)?;
+        }
+        Ok(())
+    }
+
+    /// Unmaps a region `vregion` of 2MB pages. The region must be
+    /// 2MB-aligned and correspond to a set of huge mappings.
+    pub fn unmap_region_2m(&mut self, vregion: MemoryRegion<VirtAddr>) {
+        for addr in vregion.iter_pages(PageSize::Huge) {
+            self.unmap_2m(addr);
+        }
+    }
+
+    /// Maps a memory region to physical memory with specified flags.
+    ///
+    /// # Parameters
+    /// - `region`: The virtual memory region to map.
+    /// - `phys`: The starting physical address to map to.
+    /// - `flags`: The flags to apply to the page table entries.
+    ///
+    /// # Returns
+    /// A result indicating success (`Ok`) or failure (`Err`).
+    pub fn map_region(
+        &mut self,
+        region: MemoryRegion<VirtAddr>,
+        phys: PhysAddr,
+        flags: PTEntryFlags,
+    ) -> Result<(), SvsmError> {
+        let mut vaddr = region.start();
+        let end = region.end();
+        let mut paddr = phys;
+
+        while vaddr < end {
+            if vaddr.is_aligned(PAGE_SIZE_2M)
+                && paddr.is_aligned(PAGE_SIZE_2M)
+                && vaddr + PAGE_SIZE_2M <= end
+                && self.map_2m(vaddr, paddr, flags, false).is_ok()
+            {
+                vaddr = vaddr + PAGE_SIZE_2M;
+                paddr = paddr + PAGE_SIZE_2M;
+                continue;
+            }
+
+            self.map_4k(vaddr, paddr, flags, false)?;
+            vaddr = vaddr + PAGE_SIZE;
+            paddr = paddr + PAGE_SIZE;
+        }
+
+        Ok(())
+    }
+
+    /// Unmaps the virtual memory region `vregion`.
+    pub fn unmap_region(&mut self, vregion: MemoryRegion<VirtAddr>) {
+        let mut vaddr = vregion.start();
+        let end = vregion.end();
+
+        while vaddr < end {
+            let mapping = self.walk_addr(vaddr);
+
+            match mapping {
+                Mapping::Level0(entry) => {
+                    entry.clear();
+                    vaddr = vaddr + PAGE_SIZE;
+                }
+                Mapping::Level1(entry) => {
+                    entry.clear();
+                    vaddr = vaddr + PAGE_SIZE_2M;
+                }
+                _ => {
+                    log::error!("Can't unmap - address not mapped {vaddr:#x}");
+                }
+            }
+        }
+    }
+
+    /// Populates this page table with the contents of the given subtree
+    /// in `part`.
+    ///
+    /// Returns `true` if the PTE contents were updated.
+    pub fn populate_pgtbl_part(&mut self, part: &PageTablePart) -> bool {
+        let Some(paddr) = part.address() else {
+            return false;
+        };
+        let idx = part.index();
+        let flags = PTEntryFlags::PRESENT
+            | PTEntryFlags::WRITABLE
+            | PTEntryFlags::USER
+            | PTEntryFlags::ACCESSED;
+        let entry = &mut self.root[idx];
+        let prev = entry.raw();
+        entry.set(make_private_address(paddr), flags);
+        prev != entry.raw()
+    }
+
+    /// Makes the memory region pages read-only.
+    /// This method is meant for global pages only.
+    ///
+    /// # Safety
+    ///
+    /// The caller should verify that `region` can be made read-only, i.e. that
+    /// no write can happen or that a #PF raised by any tentative write is
+    /// expected.
+    /// The caller must also ensure that the region start and size are 4k
+    /// aligned.
+    pub unsafe fn make_region_ro_4k(
+        &mut self,
+        region: MemoryRegion<VirtAddr>,
+    ) -> Result<(), SvsmError> {
+        for page in region.iter_pages(PageSize::Regular) {
+            match self.walk_addr(page) {
+                Mapping::Level0(entry) => {
+                    if !entry.present() || !entry.global() {
+                        return Err(SvsmError::Mem);
+                    }
+
+                    let flags = PTEntryFlags::data_ro();
+
+                    let paddr = if is_shared(entry.0) {
+                        make_shared_address(entry.address())
+                    } else {
+                        make_private_address(entry.address())
+                    };
+
+                    entry.set(paddr, flags);
+                }
+                Mapping::Level1(entry) | Mapping::Level2(entry) => {
+                    // Ensure we never fell on a huge page while iterating over the region pages.
+                    if entry.huge() {
+                        return Err(SvsmError::Mem);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Represents a sub-tree of a page-table which can be mapped at a top-level index
+#[derive(Debug, FromZeros)]
+struct RawPageTablePart {
+    page: PTPage,
+}
+
+impl RawPageTablePart {
+    /// Frees a level 1 page table.
+    fn free_lvl1(page: &PTPage) {
+        for entry in page.entries.iter() {
+            if let Some(page) = PTPage::from_entry(*entry) {
+                // SAFETY: the page comes from an entry in the page table,
+                // which we allocated using `PTPage::alloc()`, so this is
+                // safe.
+                unsafe { PTPage::free(page) };
+            }
+        }
+    }
+
+    /// Frees a level 2 page table, including all level 1 tables beneath it.
+    fn free_lvl2(page: &PTPage) {
+        for entry in page.entries.iter() {
+            if let Some(l1_page) = PTPage::from_entry(*entry) {
+                Self::free_lvl1(l1_page);
+                // SAFETY: the page comes from an entry in the page table,
+                // which we allocated using `PTPage::alloc()`, so this is
+                // safe.
+                unsafe { PTPage::free(l1_page) };
+            }
+        }
+    }
+
+    /// Frees the resources associated with this page table part.
+    fn free(&self) {
+        RawPageTablePart::free_lvl2(&self.page);
+    }
+
+    /// Returns the physical address of this page table part.
+    fn address(&self) -> PhysAddr {
+        virt_to_phys(VirtAddr::from(self as *const RawPageTablePart))
+    }
+
+    /// Walks the page table at level 3 to find the mapping for a given
+    /// virtual address.
+    ///
+    /// # Parameters
+    /// - `vaddr`: The virtual address to find the mapping for.
+    ///
+    /// # Returns
+    /// The [`Mapping`] for the given virtual address.
+    fn walk_addr(&mut self, vaddr: VirtAddr) -> Mapping<'_> {
+        PageTable::walk_addr_lvl2(&mut self.page, vaddr)
+    }
+
+    /// Allocates a 4KB page table entry for a given virtual address.
+    ///
+    /// # Parameters
+    /// - `vaddr`: The virtual address for which to allocate the PTE.
+    ///
+    /// # Returns
+    /// The [`Mapping`] representing the allocated or existing PTE for the address.
+    ///
+    /// # Panics
+    /// Panics if a level 3 mapping is attempted in a [`RawPageTablePart`].
+    fn alloc_pte_4k(&mut self, vaddr: VirtAddr) -> Mapping<'_> {
+        let m = self.walk_addr(vaddr);
+
+        match m {
+            Mapping::Level0(entry) => Mapping::Level0(entry),
+            Mapping::Level1(entry) => PageTable::alloc_pte_lvl1(entry, vaddr, PageSize::Regular),
+            Mapping::Level2(entry) => PageTable::alloc_pte_lvl2(entry, vaddr, PageSize::Regular),
+            Mapping::Level3(_) => panic!("PT level 3 not possible in PageTablePart"),
+        }
+    }
+
+    /// Allocates a 2MB page table entry for a given virtual address.
+    ///
+    /// # Parameters
+    /// - `vaddr`: The virtual address for which to allocate the PTE.
+    ///
+    /// # Returns
+    /// The [`Mapping`] representing the allocated or existing PTE for the
+    /// address.
+    fn alloc_pte_2m(&mut self, vaddr: VirtAddr) -> Mapping<'_> {
+        let m = self.walk_addr(vaddr);
+
+        match m {
+            Mapping::Level0(entry) => Mapping::Level0(entry),
+            Mapping::Level1(entry) => Mapping::Level1(entry),
+            Mapping::Level2(entry) => PageTable::alloc_pte_lvl2(entry, vaddr, PageSize::Huge),
+            Mapping::Level3(entry) => PageTable::alloc_pte_lvl3(entry, vaddr, PageSize::Huge),
+        }
+    }
+
+    /// Maps a 4KB page.
+    ///
+    /// # Parameters
+    /// - `vaddr`: The virtual address to map.
+    /// - `paddr`: The physical address to map to.
+    /// - `flags`: The flags to apply to the mapping.
+    /// - `shared`: Indicates whether the mapping is shared.
+    ///
+    /// # Returns
+    /// A result indicating success (`Ok`) or failure (`Err`).
+    fn map_4k(
+        &mut self,
+        vaddr: VirtAddr,
+        paddr: PhysAddr,
+        flags: PTEntryFlags,
+        shared: bool,
+    ) -> Result<(), SvsmError> {
+        let mapping = self.alloc_pte_4k(vaddr);
+
+        let addr = if !shared {
+            make_private_address(paddr)
+        } else {
+            make_shared_address(paddr)
+        };
+
+        if let Mapping::Level0(entry) = mapping {
+            entry.set(addr, flags);
+            Ok(())
+        } else {
+            Err(SvsmError::Mem)
+        }
+    }
+
+    /// Unmaps a 4KB page.
+    ///
+    /// # Parameters
+    /// - `vaddr`: The virtual address of the mapping to unmap.
+    ///
+    /// # Returns
+    /// An optional [`PTEntry`] representing the unmapped page table entry.
+    fn unmap_4k(&mut self, vaddr: VirtAddr) -> Option<PTEntry> {
+        let mapping = self.walk_addr(vaddr);
+
+        match mapping {
+            Mapping::Level0(entry) => {
+                let e = *entry;
+                entry.clear();
+                Some(e)
+            }
+            Mapping::Level1(entry) => {
+                assert!(!entry.present());
+                None
+            }
+            Mapping::Level2(entry) => {
+                assert!(!entry.present());
+                None
+            }
+            Mapping::Level3(entry) => {
+                assert!(!entry.present());
+                None
+            }
+        }
+    }
+
+    /// Maps a 2MB page.
+    ///
+    /// # Parameters
+    /// - `vaddr`: The virtual address to map.
+    /// - `paddr`: The physical address to map to.
+    /// - `flags`: The flags to apply to the mapping.
+    /// - `shared`: Indicates whether the mapping is shared
+    ///
+    /// # Returns
+    /// A result indicating success (`Ok`) or failure (`Err`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `vaddr` or `paddr` are not 2MB-aligned
+    fn map_2m(
+        &mut self,
+        vaddr: VirtAddr,
+        paddr: PhysAddr,
+        flags: PTEntryFlags,
+        shared: bool,
+    ) -> Result<(), SvsmError> {
+        assert!(vaddr.is_aligned(PAGE_SIZE_2M));
+        assert!(paddr.is_aligned(PAGE_SIZE_2M));
+
+        let mapping = self.alloc_pte_2m(vaddr);
+        let addr = if !shared {
+            make_private_address(paddr)
+        } else {
+            make_shared_address(paddr)
+        };
+
+        if let Mapping::Level1(entry) = mapping {
+            entry.set(addr, flags | PTEntryFlags::HUGE);
+            Ok(())
+        } else {
+            Err(SvsmError::Mem)
+        }
+    }
+
+    /// Unmaps a 2MB page.
+    ///
+    /// # Parameters
+    /// - `vaddr`: The virtual address of the mapping to unmap.
+    ///
+    /// # Returns
+    /// An optional [`PTEntry`] representing the unmapped page table entry.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `vaddr` is not memory aligned.
+    fn unmap_2m(&mut self, vaddr: VirtAddr) -> Option<PTEntry> {
+        assert!(vaddr.is_aligned(PAGE_SIZE_2M));
+
+        let mapping = self.walk_addr(vaddr);
+
+        match mapping {
+            Mapping::Level0(_) => None,
+            Mapping::Level1(entry) => {
+                entry.clear();
+                Some(*entry)
+            }
+            Mapping::Level2(entry) => {
+                assert!(!entry.present());
+                None
+            }
+            Mapping::Level3(entry) => {
+                assert!(!entry.present());
+                None
+            }
+        }
+    }
+}
+
+impl Drop for RawPageTablePart {
+    fn drop(&mut self) {
+        self.free();
+    }
+}
+
+/// Sub-tree of a page table that can be populated at the top-level
+/// used for virtual memory management
+#[derive(Debug)]
+pub struct PageTablePart {
+    /// The root of the page-table sub-tree
+    raw: Option<PageBox<RawPageTablePart>>,
+    /// The top-level index this PageTablePart is populated at
+    idx: usize,
+}
+
+impl PageTablePart {
+    /// Create a new PageTablePart and allocate a root page for the page-table sub-tree.
+    ///
+    /// # Arguments
+    ///
+    /// - `start`: Virtual start address this PageTablePart maps
+    ///
+    /// # Returns
+    ///
+    /// A new instance of PageTablePart
+    pub fn new(start: VirtAddr) -> Self {
+        PageTablePart {
+            raw: None,
+            idx: PageTable::index::<3>(start),
+        }
+    }
+
+    pub fn alloc(&mut self) {
+        self.get_or_init_mut();
+    }
+
+    fn get_or_init_mut(&mut self) -> &mut RawPageTablePart {
+        self.raw.get_or_insert_with(|| {
+            PageBox::try_new_zeroed().expect("Failed to allocate page table page")
+        })
+    }
+
+    fn get_mut(&mut self) -> Option<&mut RawPageTablePart> {
+        self.raw.as_deref_mut()
+    }
+
+    fn get(&self) -> Option<&RawPageTablePart> {
+        self.raw.as_deref()
+    }
+
+    /// Request PageTable index to populate this instance to
+    ///
+    /// # Returns
+    ///
+    /// Index of the top-level PageTable this sub-tree is populated to
+    pub fn index(&self) -> usize {
+        self.idx
+    }
+
+    /// Request physical base address of the page-table sub-tree. This is
+    /// needed to populate the PageTablePart.
+    ///
+    /// # Returns
+    ///
+    /// Physical base address of the page-table sub-tree
+    pub fn address(&self) -> Option<PhysAddr> {
+        self.get().map(|p| p.address())
+    }
+
+    /// Map a 4KiB page in the page table sub-tree
+    ///
+    /// # Arguments
+    ///
+    /// * `vaddr` - Virtual address to create the mapping. Must be aligned to 4KiB.
+    /// * `paddr` - Physical address to map. Must be aligned to 4KiB.
+    /// * `flags` - PTEntryFlags used for the mapping
+    /// * `shared` - Defines whether the page is mapped shared or private
+    ///
+    /// # Returns
+    ///
+    /// OK(()) on Success, Err(SvsmError::Mem) on error.
+    ///
+    /// This function can fail when there not enough memory to allocate pages for the mapping.
+    ///
+    /// # Panics
+    ///
+    /// This method panics when either `vaddr` or `paddr` are not aligned to 4KiB.
+    pub fn map_4k(
+        &mut self,
+        vaddr: VirtAddr,
+        paddr: PhysAddr,
+        flags: PTEntryFlags,
+        shared: bool,
+    ) -> Result<(), SvsmError> {
+        assert!(PageTable::index::<3>(vaddr) == self.idx);
+
+        self.get_or_init_mut().map_4k(vaddr, paddr, flags, shared)
+    }
+
+    /// Unmaps a 4KiB page from the page table sub-tree
+    ///
+    /// # Arguments
+    ///
+    /// * `vaddr` - The virtual address to unmap. Must be aligned to 4KiB.
+    ///
+    /// # Returns
+    ///
+    /// Returns a copy of the PTEntry that mapped the virtual address, if any.
+    ///
+    /// # Panics
+    ///
+    /// This method panics when `vaddr` is not aligned to 4KiB.
+    pub fn unmap_4k(&mut self, vaddr: VirtAddr) -> Option<PTEntry> {
+        assert!(PageTable::index::<3>(vaddr) == self.idx);
+
+        self.get_mut().and_then(|r| r.unmap_4k(vaddr))
+    }
+
+    /// Map a 2MiB page in the page table sub-tree
+    ///
+    /// # Arguments
+    ///
+    /// * `vaddr` - Virtual address to create the mapping. Must be aligned to 2MiB.
+    /// * `paddr` - Physical address to map. Must be aligned to 2MiB.
+    /// * `flags` - PTEntryFlags used for the mapping
+    /// * `shared` - Defines whether the page is mapped shared or private
+    ///
+    /// # Returns
+    ///
+    /// OK(()) on Success, Err(SvsmError::Mem) on error.
+    ///
+    /// This function can fail when there not enough memory to allocate pages for the mapping.
+    ///
+    /// # Panics
+    ///
+    /// This method panics when either `vaddr` or `paddr` are not aligned to 2MiB.
+    pub fn map_2m(
+        &mut self,
+        vaddr: VirtAddr,
+        paddr: PhysAddr,
+        flags: PTEntryFlags,
+        shared: bool,
+    ) -> Result<(), SvsmError> {
+        assert!(PageTable::index::<3>(vaddr) == self.idx);
+
+        self.get_or_init_mut().map_2m(vaddr, paddr, flags, shared)
+    }
+
+    /// Unmaps a 2MiB page from the page table sub-tree
+    ///
+    /// # Arguments
+    ///
+    /// * `vaddr` - The virtual address to unmap. Must be aligned to 2MiB.
+    ///
+    /// # Returns
+    ///
+    /// Returns a copy of the PTEntry that mapped the virtual address, if any.
+    ///
+    /// # Panics
+    ///
+    /// This method panics when `vaddr` is not aligned to 2MiB.
+    pub fn unmap_2m(&mut self, vaddr: VirtAddr) -> Option<PTEntry> {
+        assert!(PageTable::index::<3>(vaddr) == self.idx);
+
+        self.get_mut().and_then(|r| r.unmap_2m(vaddr))
+    }
+}
+
+bitflags! {
+    /// Flags to represent how memory is accessed, e.g. write data to the
+    /// memory or fetch code from the memory.
+    #[derive(Clone, Copy, Debug)]
+    pub struct MemAccessMode: u32 {
+        const WRITE     = 1 << 0;
+        const FETCH     = 1 << 1;
+    }
+}
+
+/// Attributes to determin Whether a memory access (write/fetch) is permitted
+/// by a translation which includes the paging-mode modifiers in CR0, CR4 and
+/// EFER; EFLAGS.AC; and the supervisor/user mode access.
+#[derive(Clone, Copy, Debug)]
+pub struct PTWalkAttr {
+    cr0: CR0Flags,
+    cr4: CR4Flags,
+    efer: EFERFlags,
+    flags: RFlags,
+    user_mode_access: bool,
+    pm: PagingMode,
+}
+
+impl PTWalkAttr {
+    /// Creates a new `PTWalkAttr` instance with the specified attributes.
+    ///
+    /// # Arguments
+    ///
+    /// * `cr0`, `cr4`, and `efer` - Represent the control register
+    ///   flags for CR0, CR4, and EFER respectively.
+    /// * `flags` - Represents the CPU Flags.
+    /// * `user_mode_access` - Indicates whether the access is in user mode.
+    ///
+    /// Returns a new `PTWalkAttr` instance.
+    pub fn new(
+        cr0: CR0Flags,
+        cr4: CR4Flags,
+        efer: EFERFlags,
+        flags: RFlags,
+        user_mode_access: bool,
+    ) -> Self {
+        Self {
+            cr0,
+            cr4,
+            efer,
+            flags,
+            user_mode_access,
+            pm: PagingMode::new(efer, cr0, cr4),
+        }
+    }
+
+    /// Checks the access rights for a page table entry.
+    ///
+    /// # Arguments
+    ///
+    /// * `entry` - The page table entry to check.
+    /// * `mem_am` - Indicates how to access the memory.
+    /// * `last_level` - Indicates whether the entry is at the last level
+    ///   of the page table.
+    /// * `pteflags` - The PTE flags to indicate if the corresponding page
+    ///   table entry allows the access rights.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok((entry, leaf))` if the access rights are valid, where
+    /// `entry` is the modified page table entry and `leaf` is a boolean
+    /// indicating whether the entry is a leaf node, or `Err(PageFaultError)`
+    /// to indicate the page fault error code if the access rights are invalid.
+    pub fn check_access_rights(
+        &self,
+        entry: PTEntry,
+        mem_am: MemAccessMode,
+        level: usize,
+        pteflags: &mut PTEntryFlags,
+    ) -> Result<(PTEntry, bool), PageFaultError> {
+        let pf_err = self.default_pf_err(mem_am) | PageFaultError::P;
+
+        if !entry.present() {
+            // Entry is not present.
+            return Err(pf_err & !PageFaultError::P);
+        }
+
+        if entry.has_reserved_bits(self.pm, level) {
+            // Reserved bits have been set.
+            return Err(pf_err | PageFaultError::R);
+        }
+
+        // SDM 4.6.1 Determination of Access Rights:
+        // If the U/S flag (bit 2) is 0 in at least one of the
+        // paging-structure entries, the address is a supervisor-mode
+        // address. Otherwise, the address is a user-mode address.
+        // So by-default assume the address is user mode address.
+        if !entry.user() {
+            *pteflags &= !PTEntryFlags::USER;
+        }
+
+        // SDM 4.6.1 Determination of Access Rights:
+        // R/W flag (bit 1) is 1 in every paging-structure entry controlling
+        // the translation and with a protection key for which write access is
+        // permitted; data may not be written to any supervisor-mode
+        // address with a translation for which the R/W flag is 0 in any
+        // paging-structure entry controlling the translation.
+        // The same for user mode address
+        if !entry.writable() {
+            *pteflags &= !PTEntryFlags::WRITABLE;
+        }
+
+        // SDM 4.6.1 Determination of Access Rights:
+        // For non 32-bit paging modes with IA32_EFER.NXE = 1, instructions
+        // may be fetched from any supervisormode address with a translation
+        // for which the XD flag (bit 63) is 0 in every paging-structure entry
+        // controlling the translation; instructions may not be fetched from
+        // any supervisor-mode address with a translation for which the XD flag
+        // is 1 in any paging-structure entry controlling the translation
+        if self.efer.contains(EFERFlags::NXE) && entry.nx() {
+            *pteflags |= PTEntryFlags::NX;
+        } else if !self.efer.contains(EFERFlags::NXE) && entry.nx() {
+            // XD bit must be 0 if efer.NXE = 0
+            return Err(pf_err | PageFaultError::R);
+        }
+
+        let leaf = if level == 0 || entry.huge() {
+            // User mode cannot access any supervisor mode addresses
+            if self.user_mode_access && !pteflags.contains(PTEntryFlags::USER) {
+                return Err(pf_err);
+            }
+
+            // Always check for reading. For the case of supervisor mode read user
+            // mode addresses, do special checking. For other cases, read is allowed.
+            if !self.user_mode_access && pteflags.contains(PTEntryFlags::USER) {
+                // Read not allowed with SMAP = 1 && flags.ac = 0
+                if self.cr4.contains(CR4Flags::SMAP) && !self.flags.contains(RFlags::AC) {
+                    return Err(pf_err);
+                }
+            }
+
+            if mem_am.contains(MemAccessMode::WRITE) {
+                if !self.user_mode_access && pteflags.contains(PTEntryFlags::USER) {
+                    // Check supervisor mode write user mode addresses
+                    if !self.cr0.contains(CR0Flags::WP) {
+                        // Check write with CR0.WP = 0
+                        if self.cr4.contains(CR4Flags::SMAP) && !self.flags.contains(RFlags::AC) {
+                            // Write not allowed with SMAP = 1 && flags.ac = 0
+                            return Err(pf_err);
+                        }
+                    } else {
+                        // Check write with CR0.WP = 1
+                        if !self.cr4.contains(CR4Flags::SMAP) {
+                            // SMAP = 0
+                            if !pteflags.contains(PTEntryFlags::WRITABLE) {
+                                // Write not allowed R/W = 0
+                                return Err(pf_err);
+                            }
+                        } else {
+                            // SMAP = 1
+                            if !self.flags.contains(RFlags::AC)
+                                || !pteflags.contains(PTEntryFlags::WRITABLE)
+                            {
+                                // Write not allowed with flags.AC = 0 || R/W = 0
+                                return Err(pf_err);
+                            }
+                        }
+                    }
+                } else if !self.user_mode_access && !pteflags.contains(PTEntryFlags::USER) {
+                    // Check supervisor mode write supervisor mode addresses
+                    if self.cr0.contains(CR0Flags::WP) && !pteflags.contains(PTEntryFlags::WRITABLE)
+                    {
+                        // Write not allowed with CR0.WP = 1 && R/W = 0
+                        return Err(pf_err);
+                    }
+                } else if self.user_mode_access && pteflags.contains(PTEntryFlags::USER) {
+                    // Check user mode write user mode addresses
+                    if !pteflags.contains(PTEntryFlags::WRITABLE) {
+                        // Write not allowed R/W = 0
+                        return Err(pf_err);
+                    }
+                }
+                // User mode write supervisor mode addresses is checked already
+            }
+
+            if mem_am.contains(MemAccessMode::FETCH) {
+                // For instruction fetch, the rule is the same except for the case of
+                // supervisor mode fetch user mode addresses
+                if !self.user_mode_access && pteflags.contains(PTEntryFlags::USER) {
+                    // Fetch not allowed with SMEP = 1
+                    if self.cr4.contains(CR4Flags::SMEP) {
+                        return Err(pf_err);
+                    }
+                }
+
+                // For non-32bit paging mode, fetch not allowed with efer.NXE = 1 && XD = 1
+                if self.cr4.contains(CR4Flags::PAE)
+                    && self.efer.contains(EFERFlags::NXE)
+                    && pteflags.contains(PTEntryFlags::NX)
+                {
+                    return Err(pf_err);
+                }
+            }
+            true
+        } else {
+            false
+        };
+
+        Ok((entry, leaf))
+    }
+
+    fn default_pf_err(&self, mem_am: MemAccessMode) -> PageFaultError {
+        let mut err = PageFaultError::empty();
+
+        if mem_am.contains(MemAccessMode::WRITE) {
+            err |= PageFaultError::W;
+        }
+
+        if mem_am.contains(MemAccessMode::FETCH) {
+            err |= PageFaultError::I;
+        }
+
+        if self.user_mode_access {
+            err |= PageFaultError::U;
+        }
+
+        err
+    }
+}

--- a/paging/src/pagetable.rs
+++ b/paging/src/pagetable.rs
@@ -12,6 +12,7 @@
 
 use crate::address::{Address, PhysAddr, VirtAddr};
 use crate::sizes::{PAGE_SHIFT, PAGE_SIZE, PAGE_SIZE_1G, PAGE_SIZE_2M, PageSize};
+pub use crate::tlb::MayNeedFlush;
 pub use crate::traits::{
     ArchPagingMeta, GenericPageTableFlags, PageLevel, PagingError, PagingHandler, PagingLevel,
     PagingLevel2, PagingLevel3, SelfMap,
@@ -314,15 +315,28 @@ impl<A: ArchPagingMeta, P: PagingHandler, L: PagingLevel> GenericPageTable<A, P,
     /// Set the entry at the specified index.
     ///
     /// Returns `true` if the entry was updated, `false` otherwise.
-    pub fn set_entry(&mut self, idx: usize, addr: PhysAddr, flags: A::PTFlags) -> bool {
+    pub fn set_entry(
+        &mut self,
+        idx: usize,
+        addr: PhysAddr,
+        flags: A::PTFlags,
+    ) -> (bool, MayNeedFlush<A::TlbFlushTok>) {
         let old_entry = self.root.entries[idx];
         self.root.entries[idx].set(addr, flags);
-        old_entry.raw() != self.root.entries[idx].raw()
+        let updated = old_entry.raw() != self.root.entries[idx].raw();
+        let flush = if updated && old_entry.present() {
+            MayNeedFlush::all()
+        } else {
+            MayNeedFlush::none()
+        };
+        (updated, flush)
     }
 
     /// Copy an entry at `entry` from another `GenericPageTable`.
-    pub fn copy_entry(&mut self, other: &Self, entry: usize) {
-        self.root.entries[entry] = other.root.entries[entry];
+    pub fn copy_entry(&mut self, other: &Self, idx: usize) {
+        let entry = &mut self.root.entries[idx];
+        assert!(!entry.present()); // No TLB flush needed
+        *entry = other.root.entries[idx];
     }
 
     /// Computes the index within a page table at the given level for a
@@ -597,7 +611,13 @@ impl<A: ArchPagingMeta, P: PagingHandler, L: PagingLevel> GenericPageTable<A, P,
     ///
     /// # Returns
     /// A result indicating success or an error [`PagingError`] in failure.
-    fn do_split_4k(entry: &mut PTEntry<A>) -> Result<(), PagingError> {
+    ///
+    /// Does not flush the TLB itself: splitting only republishes the same
+    /// physical range through a new subtable, so the resulting `PTEntry`
+    /// still translates the same addresses. The caller who ultimately edits
+    /// the split-out leaf is responsible for deciding whether that edit
+    /// needs a flush, via the [`MayNeedFlush`] token it returns.
+    fn do_split_4k(entry: &mut PTEntry<A>) -> Result<&mut PTPage<A, P>, PagingError> {
         let (page, paddr) = PTPage::<A, P>::alloc()?;
         let mut flags = entry.flags();
 
@@ -616,22 +636,26 @@ impl<A: ArchPagingMeta, P: PagingHandler, L: PagingLevel> GenericPageTable<A, P,
 
         entry.set(A::make_private_address(paddr), flags);
 
-        A::flush_tlb_global();
-
-        Ok(())
+        Ok(page)
     }
 
-    /// Splits a page into 4KB pages if it is part of a larger mapping.
+    /// Splits a page into 4KB pages for a specific virtual address.
     ///
     /// # Parameters
     /// - `mapping`: The mapping to split.
+    /// - `vaddr`: The virtual address for which to split the page.
     ///
     /// # Returns
-    /// A result indicating success or an error [`PagingError`].
-    pub fn split_4k(mapping: Mapping<'_, A>) -> Result<(), PagingError> {
+    /// A result containing the updated mapping for the virtual address, or an error
+    /// [`PagingError`] in failure.
+    fn split_4k(mapping: Mapping<'_, A>, vaddr: VirtAddr) -> Result<Mapping<'_, A>, PagingError> {
         match mapping.level {
-            PageLevel::Level0 => Ok(()),
-            PageLevel::Level1 => Self::do_split_4k(mapping.entry),
+            PageLevel::Level0 => Ok(mapping),
+            PageLevel::Level1 => {
+                let next = Self::do_split_4k(mapping.entry)?;
+                let idx = vaddr.to_pgtbl_idx::<0>();
+                Ok(Mapping::new(PageLevel::Level0, &mut next.entries[idx]))
+            }
             _ => Err(PagingError::NotMapped),
         }
     }
@@ -658,19 +682,36 @@ impl<A: ArchPagingMeta, P: PagingHandler, L: PagingLevel> GenericPageTable<A, P,
     /// - `vaddr`: The virtual address of the page.
     ///
     /// # Returns
-    /// A result indicating success or an error [`PagingError`] if the
-    /// operation fails.
-    pub fn set_shared_4k(&mut self, vaddr: VirtAddr) -> Result<(), PagingError> {
+    /// The [`MayNeedFlush`] TLB-flush obligation for the now-stale
+    /// translation on success, or a [`PagingError`] on failure.
+    pub fn set_shared_4k(
+        &mut self,
+        vaddr: VirtAddr,
+    ) -> Result<MayNeedFlush<A::TlbFlushTok>, PagingError> {
         let mapping = self.walk_addr(vaddr);
-        Self::split_4k(mapping)?;
+        let old_level = mapping.level;
+
+        // We create the copy to avoid updating reachable entries twice.
+        let mut entry_copy = *mapping.entry;
+        let mapping_copy = Mapping::new(old_level, &mut entry_copy);
+        let mapping_4k = Self::split_4k(mapping_copy, vaddr)?;
 
         if let Mapping {
             level: PageLevel::Level0,
             entry,
-        } = self.walk_addr(vaddr)
+        } = mapping_4k
         {
             Self::make_pte_shared(entry);
-            Ok(())
+
+            // Update the original entry with the new address and flags.
+            mapping.entry.clear();
+            mapping.entry.set(entry_copy.address(), entry_copy.flags());
+            if old_level != PageLevel::Level0 {
+                // conservative: if we split a page, flush all TLB
+                Ok(MayNeedFlush::all())
+            } else {
+                Ok(MayNeedFlush::new(vaddr, old_level))
+            }
         } else {
             Err(PagingError::NotMapped)
         }
@@ -682,18 +723,36 @@ impl<A: ArchPagingMeta, P: PagingHandler, L: PagingLevel> GenericPageTable<A, P,
     /// - `vaddr`: The virtual address of the page.
     ///
     /// # Returns
-    /// A result indicating success or an error [`PagingError`].
-    pub fn set_encrypted_4k(&mut self, vaddr: VirtAddr) -> Result<(), PagingError> {
+    /// The [`MayNeedFlush`] TLB-flush obligation for the now-stale
+    /// translation on success, or a [`PagingError`] on failure.
+    pub fn set_encrypted_4k(
+        &mut self,
+        vaddr: VirtAddr,
+    ) -> Result<MayNeedFlush<A::TlbFlushTok>, PagingError> {
         let mapping = self.walk_addr(vaddr);
-        Self::split_4k(mapping)?;
+        let old_level = mapping.level;
+
+        // We create the copy to avoid updating reachable entries twice.
+        let mut entry_copy = *mapping.entry;
+        let mapping_copy = Mapping::new(old_level, &mut entry_copy);
+        let mapping_4k = Self::split_4k(mapping_copy, vaddr)?;
 
         if let Mapping {
             level: PageLevel::Level0,
             entry,
-        } = self.walk_addr(vaddr)
+        } = mapping_4k
         {
             Self::make_pte_private(entry);
-            Ok(())
+
+            // Update the original entry with the new address and flags.
+            mapping.entry.clear();
+            mapping.entry.set(entry_copy.address(), entry_copy.flags());
+            if old_level != PageLevel::Level0 {
+                // conservative: if we split a page, flush all TLB
+                Ok(MayNeedFlush::all())
+            } else {
+                Ok(MayNeedFlush::new(vaddr, old_level))
+            }
         } else {
             Err(PagingError::NotMapped)
         }
@@ -733,6 +792,7 @@ impl<A: ArchPagingMeta, P: PagingHandler, L: PagingLevel> GenericPageTable<A, P,
             entry,
         } = mapping
         {
+            assert!(!entry.present());
             entry.set(addr, flags | A::PTFlags::HUGE);
             Ok(())
         } else {
@@ -745,23 +805,32 @@ impl<A: ArchPagingMeta, P: PagingHandler, L: PagingLevel> GenericPageTable<A, P,
     /// # Parameters
     /// - `vaddr`: The virtual address of the mapping to unmap.
     ///
+    /// # Returns
+    /// A copy of the [`PTEntry`] that mapped the virtual address together
+    /// with the [`MayNeedFlush`] TLB-flush obligation for the now-stale
+    /// translation, or [`None`] if no huge leaf was mapped.
+    ///
     /// # Panics
     /// Panics if `vaddr` is not aligned to a 2MB boundary.
-    pub fn unmap_2m(&mut self, vaddr: VirtAddr) -> Option<PTEntry<A>> {
+    pub fn unmap_2m(
+        &mut self,
+        vaddr: VirtAddr,
+    ) -> (Option<PTEntry<A>>, MayNeedFlush<A::TlbFlushTok>) {
         assert!(vaddr.is_aligned(PAGE_SIZE_2M));
 
         let mapping = self.walk_addr(vaddr);
 
+        let level = mapping.level;
         match mapping.level {
             PageLevel::Level0 => unreachable!(),
             PageLevel::Level1 => {
                 let entry = *mapping.entry;
                 mapping.entry.clear();
-                Some(entry)
+                (Some(entry), MayNeedFlush::new(vaddr, level))
             }
             _ => {
                 assert!(!mapping.entry.present());
-                None
+                (None, MayNeedFlush::none())
             }
         }
     }
@@ -794,6 +863,7 @@ impl<A: ArchPagingMeta, P: PagingHandler, L: PagingLevel> GenericPageTable<A, P,
             entry,
         } = mapping
         {
+            assert!(!entry.present());
             entry.set(addr, flags);
             Ok(())
         } else {
@@ -805,18 +875,27 @@ impl<A: ArchPagingMeta, P: PagingHandler, L: PagingLevel> GenericPageTable<A, P,
     ///
     /// # Parameters
     /// - `vaddr`: The virtual address of the mapping to unmap.
-    pub fn unmap_4k(&mut self, vaddr: VirtAddr) -> Option<PTEntry<A>> {
+    ///
+    /// # Returns
+    /// A copy of the [`PTEntry`] that mapped the virtual address together
+    /// with the [`MayNeedFlush`] TLB-flush obligation for the now-stale
+    /// translation, or [`None`] if no leaf was mapped.
+    pub fn unmap_4k(
+        &mut self,
+        vaddr: VirtAddr,
+    ) -> (Option<PTEntry<A>>, MayNeedFlush<A::TlbFlushTok>) {
         let mapping = self.walk_addr(vaddr);
+        let level = mapping.level;
 
         match mapping.level {
             PageLevel::Level0 => {
                 let entry = *mapping.entry;
                 mapping.entry.clear();
-                Some(entry)
+                (Some(entry), MayNeedFlush::new(vaddr, level))
             }
             _ => {
                 assert!(!mapping.entry.present());
-                None
+                (None, MayNeedFlush::none())
             }
         }
     }
@@ -844,13 +923,20 @@ impl<A: ArchPagingMeta, P: PagingHandler, L: PagingLevel> GenericPageTable<A, P,
     }
 
     /// Unmaps the half-open virtual range `[start, end)` mapped with 4KB
-    /// pages.
-    pub fn unmap_region_4k(&mut self, start: VirtAddr, end: VirtAddr) {
+    /// pages, returning the combined [`MayNeedFlush`] TLB-flush obligation.
+    pub fn unmap_region_4k(
+        &mut self,
+        start: VirtAddr,
+        end: VirtAddr,
+    ) -> MayNeedFlush<A::TlbFlushTok> {
+        let mut flush = MayNeedFlush::none();
         let mut vaddr = start;
         while vaddr < end {
-            self.unmap_4k(vaddr);
+            let (_, f) = self.unmap_4k(vaddr);
+            flush = flush.and(f);
             vaddr = vaddr + PAGE_SIZE;
         }
+        flush
     }
 
     /// Maps the half-open virtual range `[start, end)` using 2MB pages,
@@ -876,15 +962,22 @@ impl<A: ArchPagingMeta, P: PagingHandler, L: PagingLevel> GenericPageTable<A, P,
     }
 
     /// Unmaps the half-open virtual range `[start, end)` mapped with 2MB
-    /// pages.
+    /// pages, returning the combined [`MayNeedFlush`] TLB-flush obligation.
     ///
     /// The range must be 2MB-aligned and correspond to a set of huge mappings.
-    pub fn unmap_region_2m(&mut self, start: VirtAddr, end: VirtAddr) {
+    pub fn unmap_region_2m(
+        &mut self,
+        start: VirtAddr,
+        end: VirtAddr,
+    ) -> MayNeedFlush<A::TlbFlushTok> {
+        let mut flush = MayNeedFlush::none();
         let mut vaddr = start;
         while vaddr < end {
-            self.unmap_2m(vaddr);
+            let (_, f) = self.unmap_2m(vaddr);
+            flush = flush.and(f);
             vaddr = vaddr + PAGE_SIZE_2M;
         }
+        flush
     }
 
     /// Maps the half-open virtual range `[start, end)` to physical memory
@@ -925,21 +1018,32 @@ impl<A: ArchPagingMeta, P: PagingHandler, L: PagingLevel> GenericPageTable<A, P,
     /// Unmaps the half-open virtual range `[start, end)`, clearing both 4KB
     /// and 2MB leaf entries.
     ///
-    /// Returns whether every page in the range was mapped (`true`) or not
-    /// (`false`). All mapped pages in the range are unmapped regardless.
-    pub fn unmap_region(&mut self, start: VirtAddr, end: VirtAddr) -> bool {
+    /// # Returns
+    /// 1. whether every page in the range was mapped (`true`) or not (`false`).
+    /// 2. a [`MayNeedFlush`] indicating which TLB entries may need to be flushed.
+    ///
+    /// All mapped pages in the range are unmapped regardless.
+    pub fn unmap_region(
+        &mut self,
+        start: VirtAddr,
+        end: VirtAddr,
+    ) -> (bool, MayNeedFlush<A::TlbFlushTok>) {
         let mut vaddr = start;
         let mut was_mapped = true;
+        let mut flush = MayNeedFlush::none();
         while vaddr < end {
             let mapping = self.walk_addr(vaddr);
+            let local_flush = MayNeedFlush::new(vaddr, mapping.level);
             match mapping.level {
                 PageLevel::Level0 => {
                     mapping.entry.clear();
                     vaddr = vaddr + PAGE_SIZE;
+                    flush = flush.and(local_flush);
                 }
                 level if mapping.entry.present() && mapping.entry.huge() => {
                     mapping.entry.clear();
                     vaddr = vaddr + level.size();
+                    flush = flush.and(local_flush);
                 }
                 _ => {
                     was_mapped = false;
@@ -948,7 +1052,7 @@ impl<A: ArchPagingMeta, P: PagingHandler, L: PagingLevel> GenericPageTable<A, P,
             }
         }
 
-        was_mapped
+        (was_mapped, flush)
     }
 
     /// Retrieves the physical address of a mapping.

--- a/paging/src/pagetable.rs
+++ b/paging/src/pagetable.rs
@@ -524,7 +524,12 @@ impl<A: ArchPagingMeta, P: PagingHandler + SelfMap> GenericPageTable<A, P, Pagin
 
 impl<A: ArchPagingMeta, P: PagingHandler, L: PagingLevel> GenericPageTable<A, P, L> {
     /// Allocate from level 3 (PML4E) down to the target level.
-    fn alloc_pte_lvl3(entry: &mut PTEntry<A>, vaddr: VirtAddr, size: PageSize) -> Mapping<'_, A> {
+    fn alloc_pte_lvl3(
+        entry: &mut PTEntry<A>,
+        vaddr: VirtAddr,
+        size: PageSize,
+        parent_flags: A::PTFlags,
+    ) -> Mapping<'_, A> {
         if entry.flags().contains(A::PTFlags::PRESENT) {
             return Mapping::new(PageLevel::Level3, entry);
         }
@@ -533,14 +538,19 @@ impl<A: ArchPagingMeta, P: PagingHandler, L: PagingLevel> GenericPageTable<A, P,
             return Mapping::new(PageLevel::Level3, entry);
         };
 
-        entry.set(A::make_private_address(paddr), A::PTFlags::parent_flags());
+        entry.set(A::make_private_address(paddr), parent_flags);
 
         let idx = vaddr.to_pgtbl_idx::<2>();
-        Self::alloc_pte_lvl2(&mut page[idx], vaddr, size)
+        Self::alloc_pte_lvl2(&mut page[idx], vaddr, size, parent_flags)
     }
 
     /// Allocate from level 2 (PDPTE) down to the target level.
-    fn alloc_pte_lvl2(entry: &mut PTEntry<A>, vaddr: VirtAddr, size: PageSize) -> Mapping<'_, A> {
+    fn alloc_pte_lvl2(
+        entry: &mut PTEntry<A>,
+        vaddr: VirtAddr,
+        size: PageSize,
+        parent_flags: A::PTFlags,
+    ) -> Mapping<'_, A> {
         if entry.flags().contains(A::PTFlags::PRESENT) {
             return Mapping::new(PageLevel::Level2, entry);
         }
@@ -549,15 +559,20 @@ impl<A: ArchPagingMeta, P: PagingHandler, L: PagingLevel> GenericPageTable<A, P,
             return Mapping::new(PageLevel::Level2, entry);
         };
 
-        entry.set(A::make_private_address(paddr), A::PTFlags::parent_flags());
+        entry.set(A::make_private_address(paddr), parent_flags);
 
         let idx = vaddr.to_pgtbl_idx::<1>();
-        Self::alloc_pte_lvl1(&mut page[idx], vaddr, size)
+        Self::alloc_pte_lvl1(&mut page[idx], vaddr, size, parent_flags)
     }
 
     /// Allocate from level 1 (PDE) down to level 0.
     /// Returns at level 1 if `size` is `Huge` (2 MiB page).
-    fn alloc_pte_lvl1(entry: &mut PTEntry<A>, vaddr: VirtAddr, size: PageSize) -> Mapping<'_, A> {
+    fn alloc_pte_lvl1(
+        entry: &mut PTEntry<A>,
+        vaddr: VirtAddr,
+        size: PageSize,
+        parent_flags: A::PTFlags,
+    ) -> Mapping<'_, A> {
         let flags = entry.flags();
         if size == PageSize::Huge || flags.contains(A::PTFlags::PRESENT) {
             return Mapping::new(PageLevel::Level1, entry);
@@ -567,7 +582,7 @@ impl<A: ArchPagingMeta, P: PagingHandler, L: PagingLevel> GenericPageTable<A, P,
             return Mapping::new(PageLevel::Level1, entry);
         };
 
-        entry.set(A::make_private_address(paddr), A::PTFlags::parent_flags());
+        entry.set(A::make_private_address(paddr), parent_flags);
 
         let idx = vaddr.to_pgtbl_idx::<0>();
         Mapping::new(PageLevel::Level0, &mut page[idx])
@@ -577,15 +592,23 @@ impl<A: ArchPagingMeta, P: PagingHandler, L: PagingLevel> GenericPageTable<A, P,
     ///
     /// # Parameters
     /// - `vaddr`: The virtual address for which to allocate the PTE.
+    /// - `parent_flags`: The flags to apply to the allocated page table entries.
+    ///
     /// # Returns
     /// A `Mapping` representing the allocated or existing PTE for the address.
-    fn alloc_pte_4k(&mut self, vaddr: VirtAddr) -> Mapping<'_, A> {
+    fn alloc_pte_4k(&mut self, vaddr: VirtAddr, parent_flags: A::PTFlags) -> Mapping<'_, A> {
         let m = self.walk_addr(vaddr);
         match m.level {
             PageLevel::Level0 => m,
-            PageLevel::Level1 => Self::alloc_pte_lvl1(m.entry, vaddr, PageSize::Regular),
-            PageLevel::Level2 => Self::alloc_pte_lvl2(m.entry, vaddr, PageSize::Regular),
-            PageLevel::Level3 => Self::alloc_pte_lvl3(m.entry, vaddr, PageSize::Regular),
+            PageLevel::Level1 => {
+                Self::alloc_pte_lvl1(m.entry, vaddr, PageSize::Regular, parent_flags)
+            }
+            PageLevel::Level2 => {
+                Self::alloc_pte_lvl2(m.entry, vaddr, PageSize::Regular, parent_flags)
+            }
+            PageLevel::Level3 => {
+                Self::alloc_pte_lvl3(m.entry, vaddr, PageSize::Regular, parent_flags)
+            }
         }
     }
 
@@ -593,14 +616,16 @@ impl<A: ArchPagingMeta, P: PagingHandler, L: PagingLevel> GenericPageTable<A, P,
     ///
     /// # Parameters
     /// - `vaddr`: The virtual address for which to allocate the PTE.
+    /// - `parent_flags`: The flags to apply to the allocated page table entries.
+    ///
     /// # Returns
     /// A `Mapping` representing the allocated or existing PTE for the address.
-    fn alloc_pte_2m(&mut self, vaddr: VirtAddr) -> Mapping<'_, A> {
+    fn alloc_pte_2m(&mut self, vaddr: VirtAddr, parent_flags: A::PTFlags) -> Mapping<'_, A> {
         let m = self.walk_addr(vaddr);
         match m.level {
             PageLevel::Level0 | PageLevel::Level1 => m,
-            PageLevel::Level2 => Self::alloc_pte_lvl2(m.entry, vaddr, PageSize::Huge),
-            PageLevel::Level3 => Self::alloc_pte_lvl3(m.entry, vaddr, PageSize::Huge),
+            PageLevel::Level2 => Self::alloc_pte_lvl2(m.entry, vaddr, PageSize::Huge, parent_flags),
+            PageLevel::Level3 => Self::alloc_pte_lvl3(m.entry, vaddr, PageSize::Huge, parent_flags),
         }
     }
 
@@ -771,16 +796,17 @@ impl<A: ArchPagingMeta, P: PagingHandler, L: PagingLevel> GenericPageTable<A, P,
     ///
     /// # Panics
     /// Panics if either `vaddr` or `paddr` is not aligned to a 2MB boundary.
-    pub fn map_2m(
+    pub fn map_2m_with_parent_flags(
         &mut self,
         vaddr: VirtAddr,
         paddr: PhysAddr,
         flags: A::PTFlags,
         shared: bool,
+        parent_flags: A::PTFlags,
     ) -> Result<(), PagingError> {
         assert!(vaddr.is_aligned(PAGE_SIZE_2M));
         assert!(paddr.is_aligned(PAGE_SIZE_2M));
-        let mapping = self.alloc_pte_2m(vaddr);
+        let mapping = self.alloc_pte_2m(vaddr, parent_flags);
         let addr = if !shared {
             A::make_private_address(paddr)
         } else {
@@ -798,6 +824,29 @@ impl<A: ArchPagingMeta, P: PagingHandler, L: PagingLevel> GenericPageTable<A, P,
         } else {
             Err(PagingError::AllocFrame)
         }
+    }
+
+    /// Maps a 2MB page.
+    ///
+    /// # Parameters
+    /// - `vaddr`: The virtual address to map.
+    /// - `paddr`: The physical address to map to.
+    /// - `flags`: The flags to apply to the mapping.
+    /// - `shared`: Indicates whether the mapping is shared.
+    ///
+    /// # Returns
+    /// A result indicating success or failure ([`PagingError`]).
+    ///
+    /// # Panics
+    /// Panics if either `vaddr` or `paddr` is not aligned to a 2MB boundary.
+    pub fn map_2m(
+        &mut self,
+        vaddr: VirtAddr,
+        paddr: PhysAddr,
+        flags: A::PTFlags,
+        shared: bool,
+    ) -> Result<(), PagingError> {
+        self.map_2m_with_parent_flags(vaddr, paddr, flags, shared, A::PTFlags::parent_flags())
     }
 
     /// Unmaps a 2MB page.
@@ -842,16 +891,19 @@ impl<A: ArchPagingMeta, P: PagingHandler, L: PagingLevel> GenericPageTable<A, P,
     /// - `paddr`: The physical address to map to.
     /// - `flags`: The flags to apply to the mapping.
     /// - `shared`: Indicates whether the mapping is shared.
+    /// - `parent_flags`: The flags to apply to the allocated parent page table entries.
+    ///
     /// # Returns
     /// A result indicating success or failure ([`PagingError`]).
-    pub fn map_4k(
+    pub fn map_4k_with_parent_flags(
         &mut self,
         vaddr: VirtAddr,
         paddr: PhysAddr,
         flags: A::PTFlags,
         shared: bool,
+        parent_flags: A::PTFlags,
     ) -> Result<(), PagingError> {
-        let mapping = self.alloc_pte_4k(vaddr);
+        let mapping = self.alloc_pte_4k(vaddr, parent_flags);
         let addr = if !shared {
             A::make_private_address(paddr)
         } else {
@@ -869,6 +921,26 @@ impl<A: ArchPagingMeta, P: PagingHandler, L: PagingLevel> GenericPageTable<A, P,
         } else {
             Err(PagingError::AllocFrame)
         }
+    }
+
+    /// Maps a 4KB page.
+    ///
+    /// # Parameters
+    /// - `vaddr`: The virtual address to map.
+    /// - `paddr`: The physical address to map to.
+    /// - `flags`: The flags to apply to the mapping.
+    /// - `shared`: Indicates whether the mapping is shared.
+    ///
+    /// # Returns
+    /// A result indicating success or failure ([`PagingError`]).
+    pub fn map_4k(
+        &mut self,
+        vaddr: VirtAddr,
+        paddr: PhysAddr,
+        flags: A::PTFlags,
+        shared: bool,
+    ) -> Result<(), PagingError> {
+        self.map_4k_with_parent_flags(vaddr, paddr, flags, shared, A::PTFlags::parent_flags())
     }
 
     /// Unmaps a 4KB page.

--- a/paging/src/pagetable.rs
+++ b/paging/src/pagetable.rs
@@ -821,6 +821,136 @@ impl<A: ArchPagingMeta, P: PagingHandler, L: PagingLevel> GenericPageTable<A, P,
         }
     }
 
+    /// Maps the half-open virtual range `[start, end)` using 4KB pages,
+    /// starting at physical address `phys`.
+    ///
+    /// # Returns
+    /// A result indicating success or failure ([`PagingError`]).
+    pub fn map_region_4k(
+        &mut self,
+        start: VirtAddr,
+        end: VirtAddr,
+        phys: PhysAddr,
+        flags: A::PTFlags,
+        shared: bool,
+    ) -> Result<(), PagingError> {
+        let mut vaddr = start;
+        while vaddr < end {
+            let offset = vaddr - start;
+            self.map_4k(vaddr, phys + offset, flags, shared)?;
+            vaddr = vaddr + PAGE_SIZE;
+        }
+        Ok(())
+    }
+
+    /// Unmaps the half-open virtual range `[start, end)` mapped with 4KB
+    /// pages.
+    pub fn unmap_region_4k(&mut self, start: VirtAddr, end: VirtAddr) {
+        let mut vaddr = start;
+        while vaddr < end {
+            self.unmap_4k(vaddr);
+            vaddr = vaddr + PAGE_SIZE;
+        }
+    }
+
+    /// Maps the half-open virtual range `[start, end)` using 2MB pages,
+    /// starting at physical address `phys`.
+    ///
+    /// # Returns
+    /// A result indicating success or failure ([`PagingError`]).
+    pub fn map_region_2m(
+        &mut self,
+        start: VirtAddr,
+        end: VirtAddr,
+        phys: PhysAddr,
+        flags: A::PTFlags,
+        shared: bool,
+    ) -> Result<(), PagingError> {
+        let mut vaddr = start;
+        while vaddr < end {
+            let offset = vaddr - start;
+            self.map_2m(vaddr, phys + offset, flags, shared)?;
+            vaddr = vaddr + PAGE_SIZE_2M;
+        }
+        Ok(())
+    }
+
+    /// Unmaps the half-open virtual range `[start, end)` mapped with 2MB
+    /// pages.
+    ///
+    /// The range must be 2MB-aligned and correspond to a set of huge mappings.
+    pub fn unmap_region_2m(&mut self, start: VirtAddr, end: VirtAddr) {
+        let mut vaddr = start;
+        while vaddr < end {
+            self.unmap_2m(vaddr);
+            vaddr = vaddr + PAGE_SIZE_2M;
+        }
+    }
+
+    /// Maps the half-open virtual range `[start, end)` to physical memory
+    /// starting at `phys`, preferring 2MB pages where alignment and size
+    /// allow and falling back to 4KB pages otherwise.
+    ///
+    /// # Returns
+    /// A result indicating success or failure ([`PagingError`]).
+    pub fn map_region(
+        &mut self,
+        start: VirtAddr,
+        end: VirtAddr,
+        phys: PhysAddr,
+        flags: A::PTFlags,
+    ) -> Result<(), PagingError> {
+        let mut vaddr = start;
+        let mut paddr = phys;
+
+        while vaddr < end {
+            if vaddr.is_aligned(PAGE_SIZE_2M)
+                && paddr.is_aligned(PAGE_SIZE_2M)
+                && vaddr + PAGE_SIZE_2M <= end
+                && self.map_2m(vaddr, paddr, flags, false).is_ok()
+            {
+                vaddr = vaddr + PAGE_SIZE_2M;
+                paddr = paddr + PAGE_SIZE_2M;
+                continue;
+            }
+
+            self.map_4k(vaddr, paddr, flags, false)?;
+            vaddr = vaddr + PAGE_SIZE;
+            paddr = paddr + PAGE_SIZE;
+        }
+
+        Ok(())
+    }
+
+    /// Unmaps the half-open virtual range `[start, end)`, clearing both 4KB
+    /// and 2MB leaf entries.
+    ///
+    /// Returns whether every page in the range was mapped (`true`) or not
+    /// (`false`). All mapped pages in the range are unmapped regardless.
+    pub fn unmap_region(&mut self, start: VirtAddr, end: VirtAddr) -> bool {
+        let mut vaddr = start;
+        let mut was_mapped = true;
+        while vaddr < end {
+            let mapping = self.walk_addr(vaddr);
+            match mapping.level {
+                PageLevel::Level0 => {
+                    mapping.entry.clear();
+                    vaddr = vaddr + PAGE_SIZE;
+                }
+                level if mapping.entry.present() && mapping.entry.huge() => {
+                    mapping.entry.clear();
+                    vaddr = vaddr + level.size();
+                }
+                _ => {
+                    was_mapped = false;
+                    vaddr = vaddr + PAGE_SIZE;
+                }
+            }
+        }
+
+        was_mapped
+    }
+
     /// Retrieves the physical address of a mapping.
     ///
     /// # Parameters

--- a/paging/src/pagetable.rs
+++ b/paging/src/pagetable.rs
@@ -1,392 +1,128 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-//
-// Copyright (c) 2022-2023 SUSE LLC
-//
-// Author: Joerg Roedel <jroedel@suse.de>
 
-use crate::BIT_MASK;
+//! Generic page table types and structures for 4 KiB granule paging.
+//!
+//! They are designed for different OS or architectures.
+//!
+//! The implementation assumes a 4 KiB base page granule with a 4-level
+//! page table hierarchy (8-byte PTEntry and 512 entries per page), supporting three page
+//! sizes: 4 KiB, 2 MiB, and 1 GiB. This covers x86_64 (PML4) and
+//! ARM64 with 4 KiB granule. Other granule sizes (16 KiB, 64 KiB on
+//! ARM64) are not supported.
+
 use crate::address::{Address, PhysAddr, VirtAddr};
-use crate::cpu::control_regs::write_cr3;
-use crate::cpu::flush_tlb_global_sync;
-use crate::cpu::idt::common::PageFaultError;
-use crate::cpu::registers::RFlags;
-use crate::error::SvsmError;
-use crate::mm::{
-    PGTABLE_LVL3_IDX_PTE_SELFMAP, PGTABLE_LVL3_IDX_SHARED, PageBox, SVSM_PTE_BASE, phys_to_virt,
-    virt_to_phys,
+use crate::sizes::{PAGE_SHIFT, PAGE_SIZE, PAGE_SIZE_1G, PAGE_SIZE_2M, PageSize};
+pub use crate::traits::{
+    ArchPagingMeta, GenericPageTableFlags, PageLevel, PagingError, PagingHandler, PagingLevel,
+    PagingLevel2, PagingLevel3, SelfMap,
 };
-use crate::platform::SvsmPlatform;
-use crate::types::{PAGE_SIZE, PAGE_SIZE_1G, PAGE_SIZE_2M, PageSize};
-use crate::utils::MemoryRegion;
-use crate::utils::immut_after_init::{ImmutAfterInitCell, ImmutAfterInitResult};
-use bitflags::bitflags;
-use core::cmp;
+use bitflags::Flags;
+use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
-use core::ptr::NonNull;
-use cpuarch::x86::CR0Flags;
-use cpuarch::x86::CR4Flags;
-use cpuarch::x86::EFERFlags;
-use zerocopy::FromBytes;
-use zerocopy::FromZeros;
+use zerocopy::{FromBytes, FromZeros};
+
+/// Number of virtual-address bits indexed by a single page-table level.
+/// Assume 8-byte page table entries and page granularity = 1 << PAGE_SHIFT
+pub(crate) const PTE_SHIFT: usize = PAGE_SHIFT - 3;
 
 /// Number of entries in a page table (4KB/8B).
-pub const ENTRY_COUNT: usize = 512;
+pub(crate) const ENTRY_COUNT: usize = 1 << PTE_SHIFT;
 
-/// Mask for private page table entry.
-static PRIVATE_PTE_MASK: ImmutAfterInitCell<usize> = ImmutAfterInitCell::uninit();
-
-/// Mask for shared page table entry.
-static SHARED_PTE_MASK: ImmutAfterInitCell<usize> = ImmutAfterInitCell::uninit();
-
-/// Maximum physical address supported by the system.
-static MAX_PHYS_ADDR: ImmutAfterInitCell<u64> = ImmutAfterInitCell::uninit();
-
-/// Maximum physical address bits supported by the system.
-static PHYS_ADDR_SIZE: ImmutAfterInitCell<u32> = ImmutAfterInitCell::uninit();
-
-/// Physical address for the Launch VMSA (Virtual Machine Saving Area).
-pub const LAUNCH_VMSA_ADDR: PhysAddr = PhysAddr::new(0xFFFFFFFFF000);
-
-/// Feature mask for page table entry flags.
-static FEATURE_MASK: ImmutAfterInitCell<PTEntryFlags> = ImmutAfterInitCell::uninit();
-
-/// Initializes paging settings.
-pub fn paging_init(platform: &dyn SvsmPlatform, suppress_global: bool) -> ImmutAfterInitResult<()> {
-    init_encrypt_mask(platform)?;
-
-    let mut feature_mask = PTEntryFlags::all();
-    if suppress_global {
-        feature_mask.remove(PTEntryFlags::GLOBAL);
-    }
-    FEATURE_MASK.init(feature_mask)
+const fn virt_from_lvl_idx(idx: usize, level: PageLevel) -> VirtAddr {
+    VirtAddr::new(idx << ((level as usize * PTE_SHIFT) + PAGE_SHIFT))
 }
 
-/// Initializes the encrypt mask.
-fn init_encrypt_mask(platform: &dyn SvsmPlatform) -> ImmutAfterInitResult<()> {
-    let masks = platform.get_page_encryption_masks();
-
-    PRIVATE_PTE_MASK.init(masks.private_pte_mask)?;
-    SHARED_PTE_MASK.init(masks.shared_pte_mask)?;
-
-    let guest_phys_addr_size = (masks.phys_addr_sizes >> 16) & 0xff;
-    let host_phys_addr_size = masks.phys_addr_sizes & 0xff;
-    let phys_addr_size = if guest_phys_addr_size == 0 {
-        // When [GuestPhysAddrSize] is zero, refer to the PhysAddrSize field
-        // for the maximum guest physical address size.
-        // - APM3, E.4.7 Function 8000_0008h - Processor Capacity Parameters and Extended Feature Identification
-        host_phys_addr_size
-    } else {
-        guest_phys_addr_size
-    };
-
-    PHYS_ADDR_SIZE.init(phys_addr_size)?;
-
-    // If the C-bit is a physical address bit however, the guest physical
-    // address space is effectively reduced by 1 bit.
-    // - APM2, 15.34.6 Page Table Support
-    let effective_phys_addr_size = cmp::min(masks.addr_mask_width, phys_addr_size);
-
-    let max_addr = 1 << effective_phys_addr_size;
-    MAX_PHYS_ADDR.init(max_addr)
-}
-
-/// Returns the private encrypt mask value.
-pub fn private_pte_mask() -> usize {
-    *PRIVATE_PTE_MASK
-}
-
-/// Returns the shared encrypt mask value.
-fn shared_pte_mask() -> usize {
-    *SHARED_PTE_MASK
-}
-
-/// Returns the exclusive end of the physical address space.
-pub fn max_phys_addr() -> PhysAddr {
-    PhysAddr::from(*MAX_PHYS_ADDR)
-}
-
-/// Returns the supported flags considering the feature mask.
-fn supported_flags(flags: PTEntryFlags) -> PTEntryFlags {
-    flags & *FEATURE_MASK
-}
-
-/// Set address as shared via mask.
-fn make_shared_address(paddr: PhysAddr) -> PhysAddr {
-    (strip_confidentiality_bits(paddr).bits() | shared_pte_mask()).into()
-}
-
-/// Set address as private via mask.
-pub fn make_private_address(paddr: PhysAddr) -> PhysAddr {
-    (strip_shared_address_bits(paddr).bits() | private_pte_mask()).into()
-}
-
-// Returns true if the address is shared.
-fn is_shared(paddr: PhysAddr) -> bool {
-    paddr == make_shared_address(paddr)
-}
-
-fn strip_confidentiality_bits(paddr: PhysAddr) -> PhysAddr {
-    (paddr.bits() & !private_pte_mask()).into()
-}
-
-fn strip_shared_address_bits(paddr: PhysAddr) -> PhysAddr {
-    (paddr.bits() & !shared_pte_mask()).into()
-}
-
-bitflags! {
-    #[derive(Copy, Clone, Debug, Default)]
-    pub struct PTEntryFlags: u64 {
-        const PRESENT       = 1 << 0;
-        const WRITABLE      = 1 << 1;
-        const USER      = 1 << 2;
-        const ACCESSED      = 1 << 5;
-        const DIRTY     = 1 << 6;
-        const HUGE      = 1 << 7;
-        const GLOBAL        = 1 << 8;
-        const NX        = 1 << 63;
-    }
-}
-
-impl PTEntryFlags {
-    pub fn exec() -> Self {
-        Self::PRESENT | Self::GLOBAL | Self::ACCESSED
-    }
-
-    pub fn data() -> Self {
-        Self::PRESENT | Self::GLOBAL | Self::WRITABLE | Self::NX | Self::ACCESSED | Self::DIRTY
-    }
-
-    pub fn data_ro() -> Self {
-        Self::PRESENT | Self::GLOBAL | Self::NX | Self::ACCESSED
-    }
-
-    pub fn task_exec() -> Self {
-        Self::PRESENT | Self::ACCESSED
-    }
-
-    pub fn task_data() -> Self {
-        Self::PRESENT | Self::WRITABLE | Self::NX | Self::ACCESSED | Self::DIRTY
-    }
-
-    pub fn task_data_ro() -> Self {
-        Self::PRESENT | Self::NX | Self::ACCESSED
-    }
-}
-
-/// Represents paging mode.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum PagingMode {
-    // Paging mode is disabled
-    NoPaging,
-    // 32bit legacy paging mode
-    NonPAE,
-    // 32bit PAE paging mode
-    PAE,
-    // 4 level paging mode
-    PML4,
-    // 5 level paging mode
-    PML5,
-}
-
-impl PagingMode {
-    pub fn new(efer: EFERFlags, cr0: CR0Flags, cr4: CR4Flags) -> Self {
-        if !cr0.contains(CR0Flags::PG) {
-            // Paging is disabled
-            PagingMode::NoPaging
-        } else if efer.contains(EFERFlags::LMA) {
-            // Long mode is activated
-            if cr4.contains(CR4Flags::LA57) {
-                PagingMode::PML5
-            } else {
-                PagingMode::PML4
-            }
-        } else if cr4.contains(CR4Flags::PAE) {
-            // PAE mode
-            PagingMode::PAE
-        } else {
-            // Non PAE mode
-            PagingMode::NonPAE
-        }
-    }
-}
+const _: () = assert!(
+    core::mem::size_of::<PhysAddr>() == 8,
+    "Only supports 8 bytes PTE entry",
+);
 
 /// Represents a page table entry.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, FromBytes)]
-pub struct PTEntry(PhysAddr);
+pub struct PTEntry<A: ArchPagingMeta> {
+    entry: PhysAddr,
+    _phantom: PhantomData<A>,
+}
 
-impl PTEntry {
+impl<A: ArchPagingMeta> PTEntry<A> {
     /// Check if the page table entry is clear (null).
     pub fn is_clear(&self) -> bool {
-        self.0.is_null()
+        self.entry.is_null()
     }
 
     /// Clear the page table entry.
     pub fn clear(&mut self) {
-        self.0 = PhysAddr::null();
+        self.entry = PhysAddr::null();
     }
 
     /// Check if the page table entry is present.
     pub fn present(&self) -> bool {
-        self.flags().contains(PTEntryFlags::PRESENT)
+        self.flags().present()
     }
 
     /// Check if the page table entry is huge.
     pub fn huge(&self) -> bool {
-        self.flags().contains(PTEntryFlags::HUGE)
-    }
-
-    /// Check if the page table entry is writable.
-    pub fn writable(&self) -> bool {
-        self.flags().contains(PTEntryFlags::WRITABLE)
-    }
-
-    /// Check if the page table entry is NX (no-execute).
-    pub fn nx(&self) -> bool {
-        self.flags().contains(PTEntryFlags::NX)
+        self.flags().huge()
     }
 
     /// Check if the page table entry is user-accessible.
     pub fn user(&self) -> bool {
-        self.flags().contains(PTEntryFlags::USER)
+        self.flags().user()
     }
 
-    /// Check if the page table entry is global.
-    pub fn global(&self) -> bool {
-        self.flags().contains(PTEntryFlags::GLOBAL)
-    }
-
-    /// Check if the page table entry has reserved bits set.
-    pub fn has_reserved_bits(&self, pm: PagingMode, level: usize) -> bool {
-        let reserved_mask = match pm {
-            PagingMode::NoPaging => unreachable!("NoPaging does not have page table"),
-            PagingMode::NonPAE => {
-                match level {
-                    // No reserved bits in 4k PTE.
-                    0 => 0,
-                    1 => {
-                        if self.huge() {
-                            // Bit21 is reserved in 4M PDE.
-                            BIT_MASK!(21, 21)
-                        } else {
-                            // No reserved bits in PDE.
-                            0
-                        }
-                    }
-                    _ => unreachable!("Invalid NonPAE page table level"),
-                }
-            }
-            PagingMode::PAE => {
-                // Bit62 ~ MAXPHYSADDR are reserved for each
-                // level in PAE page table.
-                BIT_MASK!(62, *PHYS_ADDR_SIZE)
-                    | match level {
-                        // No additional reserved bits in 4k PTE.
-                        0 => 0,
-                        1 => {
-                            if self.huge() {
-                                // Bit20 ~ Bit13 are reserved in 2M PDE.
-                                BIT_MASK!(20, 13)
-                            } else {
-                                // No additional reserved bits in PDE.
-                                0
-                            }
-                        }
-                        // Bit63 and Bit8 ~ Bit5 are reserved in PDPTE.
-                        2 => BIT_MASK!(63, 63) | BIT_MASK!(8, 5),
-                        _ => unreachable!("Invalid PAE page table level"),
-                    }
-            }
-            PagingMode::PML4 | PagingMode::PML5 => {
-                // Bit51 ~ MAXPHYSADDR are reserved for each level
-                // in PML4 and PML5 page table.
-                let common = if *PHYS_ADDR_SIZE > 51 {
-                    0
-                } else {
-                    // Remove the encryption mask bit as this bit is not reserved
-                    BIT_MASK!(51, *PHYS_ADDR_SIZE)
-                        & !((shared_pte_mask() | private_pte_mask()) as u64)
-                };
-
-                common
-                    | match level {
-                        // No additional reserved bits in 4k PTE.
-                        0 => 0,
-                        1 => {
-                            if self.huge() {
-                                // Bit20 ~ Bit13 are reserved in 2M PDE.
-                                BIT_MASK!(20, 13)
-                            } else {
-                                // No additional reserved bits in PDE.
-                                0
-                            }
-                        }
-                        2 => {
-                            if self.huge() {
-                                // Bit29 ~ Bit13 are reserved in 1G PDPTE.
-                                BIT_MASK!(29, 13)
-                            } else {
-                                // No additional reserved bits in PDPTE.
-                                0
-                            }
-                        }
-                        // Bit8 ~ Bit7 are reserved in PML4E.
-                        3 => BIT_MASK!(8, 7),
-                        4 => {
-                            if pm == PagingMode::PML4 {
-                                unreachable!("Invalid PML4 page table level");
-                            } else {
-                                // Bit8 ~ Bit7 are reserved in PML5E.
-                                BIT_MASK!(8, 7)
-                            }
-                        }
-                        _ => unreachable!("Invalid PML4/PML5 page table level"),
-                    }
-            }
-        };
-
-        self.raw() & reserved_mask != 0
-    }
-
-    /// Get the raw bits (`u64`) of the page table entry.
-    pub fn raw(&self) -> u64 {
-        self.0.bits() as u64
+    /// Get the raw bits (`usize`) of the page table entry.
+    pub fn raw(&self) -> usize {
+        self.entry.bits()
     }
 
     /// Get the flags of the page table entry.
-    pub fn flags(&self) -> PTEntryFlags {
-        PTEntryFlags::from_bits_truncate(self.0.bits() as u64)
+    pub fn flags(&self) -> A::PTFlags {
+        A::PTFlags::from_bits_truncate(self.entry.bits())
     }
 
     /// Set the page table entry with the specified address and flags.
-    pub fn set_unrestricted(&mut self, addr: PhysAddr, flags: PTEntryFlags) {
-        let addr = addr.bits() as u64;
-        assert_eq!(addr & !0x000f_ffff_ffff_f000, 0);
-        self.0 = PhysAddr::from(addr | flags.bits());
+    pub fn set_unrestricted(&mut self, addr: PhysAddr, flags: A::PTFlags) {
+        let addr = addr.bits();
+        assert_eq!(addr & !A::address_mask(), 0);
+        self.entry = PhysAddr::from(addr | flags.bits());
     }
 
     /// Set the page table entry with the specified address, with flags
     /// constrained to the supported feature flags.
-    pub fn set(&mut self, addr: PhysAddr, flags: PTEntryFlags) {
-        self.set_unrestricted(addr, supported_flags(flags));
+    pub fn set(&mut self, addr: PhysAddr, flags: A::PTFlags) {
+        self.set_unrestricted(addr, flags & A::supported_flags());
     }
 
     /// Inserts the private address mask if the page is present.
     pub fn make_private_if_present(&mut self) {
-        if self.flags().contains(PTEntryFlags::PRESENT) {
-            self.0 = make_private_address(self.0);
+        if self.flags().contains(A::PTFlags::PRESENT) {
+            self.entry = A::make_private_address(self.entry);
         }
+    }
+
+    /// Get the paddr field from the entry.
+    ///
+    /// Returns bits `[51:12]` of the entry — the address *including* any
+    /// encryption/confidentiality bits the hardware stores in the upper
+    /// physical address bits.
+    pub fn paddr_field(&self) -> PhysAddr {
+        PhysAddr::from(self.raw() & A::address_mask())
     }
 
     /// Get the address from the page table entry, including the shared bit.
     pub fn page_frame(&self) -> PhysAddr {
-        let addr = PhysAddr::from(self.0.bits() & 0x000f_ffff_ffff_f000);
-        strip_confidentiality_bits(addr)
+        A::strip_confidentiality_bits(self.paddr_field())
     }
 
     /// Get the address from the page table entry, excluding the C/shared bit.
     pub fn address(&self) -> PhysAddr {
-        strip_shared_address_bits(self.page_frame())
+        A::strip_shared_address_bits(self.page_frame())
+    }
+
+    // Returns true if the address is shared.
+    pub fn is_shared(&self) -> bool {
+        A::is_shared_address(self.paddr_field())
     }
 
     /// Read a page table entry from the specified virtual address.
@@ -406,56 +142,35 @@ impl PTEntry {
 /// A pagetable page with multiple entries.
 #[repr(C)]
 #[derive(Debug, FromBytes)]
-pub struct PTPage {
-    entries: [PTEntry; ENTRY_COUNT],
+pub struct PTPage<A: ArchPagingMeta, P: PagingHandler> {
+    pub entries: [PTEntry<A>; ENTRY_COUNT],
+    _phantom: PhantomData<P>,
 }
 
-impl PTPage {
-    /// Allocates a zeroed pagetable page and returns a `PageBox` containing
-    /// the allocation.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`SvsmError`] if the page cannot be allocated.
-    pub fn alloc_box() -> Result<PageBox<Self>, SvsmError> {
-        PageBox::try_new_zeroed()
-    }
-
+impl<A: ArchPagingMeta, P: PagingHandler> PTPage<A, P> {
     /// Allocates a zeroed pagetable page and returns a mutable reference to
     /// it, plus its physical address.
     ///
     /// # Errors
     ///
-    /// Returns [`SvsmError`] if the page cannot be allocated.
-    fn alloc() -> Result<(&'static mut Self, PhysAddr), SvsmError> {
-        let page = Self::alloc_box()?;
-        let paddr = virt_to_phys(page.vaddr());
-        Ok((PageBox::leak(page), paddr))
-    }
-
-    /// Frees a pagetable page.
-    ///
-    /// # Safety
-    ///
-    /// The given reference must correspond to a valid previously allocated
-    /// page table page.
-    unsafe fn free(page: &'static Self) {
-        // SAFETY: The page put into the PageBox is a previously allocated
-        // page table page.
-        unsafe {
-            let _ = PageBox::from_raw(NonNull::from(page));
-        }
+    /// Returns [`PagingError`] if the page cannot be allocated.
+    fn alloc() -> Result<(&'static mut Self, PhysAddr), PagingError> {
+        let paddr = P::allocate_physical_page()?;
+        let vaddr = P::paddr_to_vaddr(paddr);
+        // SAFETY: allocate_physical_page returns a unique, zeroed frame and
+        // paddr_to_vaddr returns a valid virtual mapping for it.
+        let page = unsafe { Self::from_vaddr(vaddr) };
+        Ok((page, paddr))
     }
 
     /// Converts a pagetable entry to a mutable reference to a [`PTPage`],
     /// if the entry is present and not huge.
-    fn from_entry(entry: PTEntry) -> Option<&'static mut Self> {
-        let flags = entry.flags();
-        if !flags.contains(PTEntryFlags::PRESENT) || flags.contains(PTEntryFlags::HUGE) {
+    pub fn from_entry(entry: PTEntry<A>) -> Option<&'static mut Self> {
+        if !entry.present() || entry.huge() {
             return None;
         }
 
-        let address = phys_to_virt(entry.address());
+        let address = P::paddr_to_vaddr(entry.address());
         // SAFETY: Every PTEntry points to a previously allocated page-table
         // page, so this pointer dereference is safe.
         Some(unsafe { Self::from_vaddr(address) })
@@ -467,64 +182,70 @@ impl PTPage {
     pub unsafe fn from_vaddr(vaddr: VirtAddr) -> &'static mut Self {
         // SAFETY: the caller guarantees the correctness of the virtual
         // address.
-        unsafe { &mut *vaddr.as_mut_ptr::<PTPage>() }
+        unsafe { &mut *vaddr.as_mut_ptr::<Self>() }
     }
 }
 
 /// Can be used to access page table entries by index.
-impl Index<usize> for PTPage {
-    type Output = PTEntry;
+impl<A: ArchPagingMeta, P: PagingHandler> Index<usize> for PTPage<A, P> {
+    type Output = PTEntry<A>;
 
-    fn index(&self, index: usize) -> &PTEntry {
+    fn index(&self, index: usize) -> &PTEntry<A> {
         &self.entries[index]
     }
 }
 
 /// Can be used to modify page table entries by index.
-impl IndexMut<usize> for PTPage {
-    fn index_mut(&mut self, index: usize) -> &mut PTEntry {
+impl<A: ArchPagingMeta, P: PagingHandler> IndexMut<usize> for PTPage<A, P> {
+    fn index_mut(&mut self, index: usize) -> &mut PTEntry<A> {
         &mut self.entries[index]
     }
 }
 
 /// Mapping levels of page table entries.
 #[derive(Debug)]
-pub enum Mapping<'a> {
-    Level3(&'a mut PTEntry),
-    Level2(&'a mut PTEntry),
-    Level1(&'a mut PTEntry),
-    Level0(&'a mut PTEntry),
+pub struct Mapping<'a, P: ArchPagingMeta> {
+    pub level: PageLevel,
+    pub entry: &'a mut PTEntry<P>,
+}
+
+impl<'a, P: ArchPagingMeta> Mapping<'a, P> {
+    /// Construct a `Mapping` at the given level.
+    pub fn new(level: PageLevel, entry: &'a mut PTEntry<P>) -> Self {
+        Self { level, entry }
+    }
 }
 
 /// A physical address within a page frame
 #[derive(Clone, Copy, Debug)]
-pub enum PageFrame {
+pub enum PageFrame<A: ArchPagingMeta> {
     Size4K(PhysAddr),
     Size2M(PhysAddr),
-    Size1G(PhysAddr),
+    Size1G(PhysAddr, PhantomData<A>),
 }
 
-impl PageFrame {
+impl<A: ArchPagingMeta> PageFrame<A> {
     /// Get the address from the page frame, including the shared bit.
     pub fn page_frame(&self) -> PhysAddr {
         let paddr = match *self {
             Self::Size4K(pa) => pa,
             Self::Size2M(pa) => pa,
-            Self::Size1G(pa) => pa,
+            Self::Size1G(pa, _) => pa,
         };
-        strip_confidentiality_bits(paddr)
+        // Redundant but explicit.
+        A::strip_confidentiality_bits(paddr)
     }
 
     /// Get the address from the page frame, excluding the C/shared bit.
     pub fn address(&self) -> PhysAddr {
-        strip_shared_address_bits(self.page_frame())
+        A::strip_shared_address_bits(self.page_frame())
     }
 
     pub fn size(&self) -> usize {
         match self {
             Self::Size4K(_) => PAGE_SIZE,
             Self::Size2M(_) => PAGE_SIZE_2M,
-            Self::Size1G(_) => PAGE_SIZE_1G,
+            Self::Size1G(_, _) => PAGE_SIZE_1G,
         }
     }
 
@@ -538,65 +259,68 @@ impl PageFrame {
     }
 }
 
-/// Page table structure containing a root page with multiple entries.
+/// A page table hierarchy rooted at `L::TOP_LEVEL`.
+///
+/// The root is a concrete page-table page (`PTPage`) whose level is described
+/// by `L`. This can represent either a complete top-level page table, such as
+/// a PML4-rooted table, or a lower-level subtree, such as a PDPT-rooted table
+/// that is installed into a top-level page table.
+///
+/// Ownership and synchronization are left to the OS-specific code.
+/// If a lower-level subtree is shared between multiple top-level page tables,
+/// all users of that subtree must coordinate updates to avoid concurrent
+/// modifications to the same page-table entries.
 #[repr(C)]
 #[derive(Debug, FromZeros)]
-pub struct PageTable {
-    root: PTPage,
+pub struct GenericPageTable<A: ArchPagingMeta, P: PagingHandler, L: PagingLevel> {
+    root: PTPage<A, P>,
+    _level: PhantomData<L>,
 }
 
-impl PageTable {
-    /// Load the current page table into the CR3 register.
-    ///
-    /// # Safety
-    ///
-    /// The caller must ensure to take other actions to make sure a memory safe
-    /// execution state is warranted (e.g. changing the stack and register state)
-    pub unsafe fn load(&self) {
-        // SAFETY: demanded to the caller
-        unsafe {
-            write_cr3(self.cr3_value());
+/// Methods for page table hierarchies, independent of the self-map.
+impl<A: ArchPagingMeta, P: PagingHandler, L: PagingLevel> GenericPageTable<A, P, L> {
+    /// Recursively free all page table pages starting from the root page.
+    fn free_lvl(page: &PTPage<A, P>, level: PageLevel) {
+        if level <= PageLevel::Level0 {
+            return;
+        }
+        for entry in page.entries.iter() {
+            if let Some(child) = PTPage::from_entry(*entry) {
+                if let Some(next) = level.next_down() {
+                    Self::free_lvl(child, next);
+                }
+                let paddr = entry.address();
+                // SAFETY: the page was allocated via PagingHandler::allocate_physical_page.
+                unsafe { P::deallocate_physical_page(paddr) };
+            }
         }
     }
 
-    /// Get the CR3 register value for the current page table.
-    pub fn cr3_value(&self) -> PhysAddr {
-        let pgtable = VirtAddr::from(self as *const Self);
-        virt_to_phys(pgtable)
-    }
-
-    /// Allocate a new page table root.
+    /// Free all page table pages starting from the root page.
+    /// We do not set it as a destructor because a page table may contain
+    /// shared sub-trees that may be in use by other root table.
     ///
-    /// # Errors
-    /// Returns [`SvsmError`] if the page cannot be allocated.
-    pub fn allocate_new() -> Result<PageBox<Self>, SvsmError> {
-        let mut pgtable: PageBox<Self> = PageBox::try_new_zeroed()?;
-        let paddr = virt_to_phys(pgtable.vaddr());
-
-        // Set the self-map entry.
-        let entry = &mut pgtable.root[PGTABLE_LVL3_IDX_PTE_SELFMAP];
-        let flags = PTEntryFlags::PRESENT
-            | PTEntryFlags::WRITABLE
-            | PTEntryFlags::ACCESSED
-            | PTEntryFlags::DIRTY
-            | PTEntryFlags::NX;
-        entry.set(make_private_address(paddr), flags);
-
-        Ok(pgtable)
+    /// # Safety
+    /// The caller must ensure that the page table is not in use by any other thread.
+    pub fn free(&self) {
+        Self::free_lvl(&self.root, L::TOP_LEVEL);
     }
 
-    /// Clone the shared part of the page table; excluding the private
-    /// parts.
+    /// Get a copy of the entry at the specified index.
+    pub fn entry(&mut self, idx: usize) -> PTEntry<A> {
+        self.root.entries[idx]
+    }
+
+    /// Set the entry at the specified index.
     ///
-    /// # Errors
-    /// Returns [`SvsmError`] if the page cannot be allocated.
-    pub fn clone_shared(&self) -> Result<PageBox<PageTable>, SvsmError> {
-        let mut pgtable = Self::allocate_new()?;
-        pgtable.root.entries[PGTABLE_LVL3_IDX_SHARED] = self.root.entries[PGTABLE_LVL3_IDX_SHARED];
-        Ok(pgtable)
+    /// Returns `true` if the entry was updated, `false` otherwise.
+    pub fn set_entry(&mut self, idx: usize, addr: PhysAddr, flags: A::PTFlags) -> bool {
+        let old_entry = self.root.entries[idx];
+        self.root.entries[idx].set(addr, flags);
+        old_entry.raw() != self.root.entries[idx].raw()
     }
 
-    /// Copy an entry `entry` from another [`PageTable`].
+    /// Copy an entry at `entry` from another `GenericPageTable`.
     pub fn copy_entry(&mut self, other: &Self, entry: usize) {
         self.root.entries[entry] = other.root.entries[entry];
     }
@@ -609,9 +333,8 @@ impl PageTable {
     ///
     /// # Returns
     /// The index within the page table.
-    pub fn index<const L: usize>(vaddr: VirtAddr) -> usize {
-        vaddr.to_pgtbl_idx::<L>()
-        //vaddr.bits() >> (12 + L * 9) & 0x1ff
+    pub fn index<const LVL: usize>(vaddr: VirtAddr) -> usize {
+        vaddr.to_pgtbl_idx::<LVL>()
     }
 
     /// Walks a page table at level 0 to find a mapping.
@@ -622,9 +345,9 @@ impl PageTable {
     ///
     /// # Returns
     /// A `Mapping` representing the found mapping.
-    fn walk_addr_lvl0(page: &mut PTPage, vaddr: VirtAddr) -> Mapping<'_> {
-        let idx = Self::index::<0>(vaddr);
-        Mapping::Level0(&mut page[idx])
+    fn walk_addr_lvl0(page: &mut PTPage<A, P>, vaddr: VirtAddr) -> Mapping<'_, A> {
+        let idx = vaddr.to_pgtbl_idx::<0>();
+        Mapping::new(PageLevel::Level0, &mut page[idx])
     }
 
     /// Walks a page table at level 1 to find a mapping.
@@ -635,12 +358,12 @@ impl PageTable {
     ///
     /// # Returns
     /// A `Mapping` representing the found mapping.
-    fn walk_addr_lvl1(page: &mut PTPage, vaddr: VirtAddr) -> Mapping<'_> {
-        let idx = Self::index::<1>(vaddr);
+    fn walk_addr_lvl1<'a>(page: &'a mut PTPage<A, P>, vaddr: VirtAddr) -> Mapping<'a, A> {
+        let idx = vaddr.to_pgtbl_idx::<1>();
         let entry = page[idx];
         match PTPage::from_entry(entry) {
-            Some(page) => Self::walk_addr_lvl0(page, vaddr),
-            None => Mapping::Level1(&mut page[idx]),
+            Some(next) => Self::walk_addr_lvl0(next, vaddr),
+            None => Mapping::new(PageLevel::Level1, &mut page[idx]),
         }
     }
 
@@ -652,12 +375,12 @@ impl PageTable {
     ///
     /// # Returns
     /// A `Mapping` representing the found mapping.
-    fn walk_addr_lvl2(page: &mut PTPage, vaddr: VirtAddr) -> Mapping<'_> {
-        let idx = Self::index::<2>(vaddr);
+    fn walk_addr_lvl2<'a>(page: &'a mut PTPage<A, P>, vaddr: VirtAddr) -> Mapping<'a, A> {
+        let idx = vaddr.to_pgtbl_idx::<2>();
         let entry = page[idx];
         match PTPage::from_entry(entry) {
-            Some(page) => Self::walk_addr_lvl1(page, vaddr),
-            None => Mapping::Level2(&mut page[idx]),
+            Some(next) => Self::walk_addr_lvl1(next, vaddr),
+            None => Mapping::new(PageLevel::Level2, &mut page[idx]),
         }
     }
 
@@ -669,12 +392,12 @@ impl PageTable {
     ///
     /// # Returns
     /// A `Mapping` representing the found mapping.
-    fn walk_addr_lvl3(page: &mut PTPage, vaddr: VirtAddr) -> Mapping<'_> {
-        let idx = Self::index::<3>(vaddr);
+    fn walk_addr_lvl3<'a>(page: &'a mut PTPage<A, P>, vaddr: VirtAddr) -> Mapping<'a, A> {
+        let idx = vaddr.to_pgtbl_idx::<3>();
         let entry = page[idx];
         match PTPage::from_entry(entry) {
-            Some(page) => Self::walk_addr_lvl2(page, vaddr),
-            None => Mapping::Level3(&mut page[idx]),
+            Some(next) => Self::walk_addr_lvl2(next, vaddr),
+            None => Mapping::new(PageLevel::Level3, &mut page[idx]),
         }
     }
 
@@ -685,8 +408,31 @@ impl PageTable {
     ///
     /// # Returns
     /// A `Mapping` representing the found mapping.
-    fn walk_addr(&mut self, vaddr: VirtAddr) -> Mapping<'_> {
-        Self::walk_addr_lvl3(&mut self.root, vaddr)
+    pub fn walk_addr(&mut self, vaddr: VirtAddr) -> Mapping<'_, A> {
+        match L::TOP_LEVEL {
+            PageLevel::Level3 => Self::walk_addr_lvl3(&mut self.root, vaddr),
+            PageLevel::Level2 => Self::walk_addr_lvl2(&mut self.root, vaddr),
+            _ => unreachable!(),
+        }
+    }
+}
+
+/// Methods that use the self-map to inspect the *active* top-level page table.
+///
+/// Self-mapped address calculations assume a PML4-rooted table.
+impl<A: ArchPagingMeta, P: PagingHandler + SelfMap> GenericPageTable<A, P, PagingLevel3> {
+    /// Install the self-map entry in a freshly zeroed page table.
+    ///
+    /// `paddr` is the physical address of *this* page table's root page.
+    /// The self-map PML4 entry is written at [`SelfMap::SELFMAP_IDX`].
+    pub fn init_self_map(&mut self, paddr: PhysAddr) {
+        let entry = &mut self.root[P::SELFMAP_IDX];
+        let flags = A::PTFlags::self_map_table_flags();
+        entry.set(A::make_private_address(paddr), flags);
+    }
+
+    const fn pte_base_vaddr() -> VirtAddr {
+        virt_from_lvl_idx(P::SELFMAP_IDX, PagingLevel3::TOP_LEVEL)
     }
 
     /// Calculate the virtual address of a PTE in the self-map, which maps a
@@ -698,7 +444,7 @@ impl PageTable {
     /// # Returns
     /// The virtual address of the PTE.
     fn get_pte_address(vaddr: VirtAddr) -> VirtAddr {
-        SVSM_PTE_BASE + ((usize::from(vaddr) & 0x0000_FFFF_FFFF_F000) >> 9)
+        Self::pte_base_vaddr() + ((usize::from(vaddr) & 0x0000_FFFF_FFFF_F000) >> PTE_SHIFT)
     }
 
     /// Perform a virtual to physical translation using the self-map.
@@ -709,19 +455,15 @@ impl PageTable {
     /// # Returns
     /// Some(PageFrame) if the virtual address is valid.
     /// None if the virtual address is not valid.
-    pub fn virt_to_frame(vaddr: VirtAddr) -> Option<PageFrame> {
-        // Calculate the virtual addresses of each level of the paging
-        // hierarchy in the self-map.
+    pub fn virt_to_frame(vaddr: VirtAddr) -> Option<PageFrame<A>> {
         let pte_addr = Self::get_pte_address(vaddr);
         let pde_addr = Self::get_pte_address(pte_addr);
         let pdpe_addr = Self::get_pte_address(pde_addr);
         let pml4e_addr = Self::get_pte_address(pdpe_addr);
 
-        // SAFETY: Check each entry in the paging hierarchy to determine
-        // whether this address is mapped.  Because the hierarchy is read from
-        // the top down using self-map addresses that were calculated
-        // correctly, the reads are safe to perform.
-        let pml4e = unsafe { PTEntry::read_pte(pml4e_addr) };
+        // SAFETY: Check each entry in the paging hierarchy to ensure it is
+        // safe to read the next entry.
+        let pml4e = unsafe { PTEntry::<A>::read_pte(pml4e_addr) };
         if !pml4e.present() {
             return None;
         }
@@ -732,20 +474,20 @@ impl PageTable {
         // hierarchy, the low bits from the virtual address must be combined
         // with the physical address from the PDE/PDPE.
 
-        // SAFETY: The PML4E was checked to be present, so the PDPE exists and
-        // can be read safely.
-        let pdpe = unsafe { PTEntry::read_pte(pdpe_addr) };
+        // SAFETY: The PML4E was checked to be present, so the PDPE exists
+        // and can be read safely.
+        let pdpe = unsafe { PTEntry::<A>::read_pte(pdpe_addr) };
         if !pdpe.present() {
             return None;
         }
         if pdpe.huge() {
             let pa = pdpe.page_frame() + (usize::from(vaddr) & 0x3FFF_FFFF);
-            return Some(PageFrame::Size1G(pa));
+            return Some(PageFrame::Size1G(pa, PhantomData));
         }
 
         // SAFETY: The PDPE was checked to be present and not to be a huge
         // page. So the PDE exists and can be read safely.
-        let pde = unsafe { PTEntry::read_pte(pde_addr) };
+        let pde = unsafe { PTEntry::<A>::read_pte(pde_addr) };
         if !pde.present() {
             return None;
         }
@@ -756,7 +498,7 @@ impl PageTable {
 
         // SAFETY: The PDE was checked to be present and not to be a huge
         // page. So the PTE exists and can be read safely.
-        let pte = unsafe { PTEntry::read_pte(pte_addr) };
+        let pte = unsafe { PTEntry::<A>::read_pte(pte_addr) };
         if pte.present() {
             let pa = pte.page_frame() + (usize::from(vaddr) & 0xFFF);
             Some(PageFrame::Size4K(pa))
@@ -764,85 +506,72 @@ impl PageTable {
             None
         }
     }
+}
 
-    fn alloc_pte_lvl3(entry: &mut PTEntry, vaddr: VirtAddr, size: PageSize) -> Mapping<'_> {
-        let flags = entry.flags();
-
-        if flags.contains(PTEntryFlags::PRESENT) {
-            return Mapping::Level3(entry);
+impl<A: ArchPagingMeta, P: PagingHandler, L: PagingLevel> GenericPageTable<A, P, L> {
+    /// Allocate from level 3 (PML4E) down to the target level.
+    fn alloc_pte_lvl3(entry: &mut PTEntry<A>, vaddr: VirtAddr, size: PageSize) -> Mapping<'_, A> {
+        if entry.flags().contains(A::PTFlags::PRESENT) {
+            return Mapping::new(PageLevel::Level3, entry);
         }
 
-        let Ok((page, paddr)) = PTPage::alloc() else {
-            return Mapping::Level3(entry);
+        let Ok((page, paddr)) = PTPage::<A, P>::alloc() else {
+            return Mapping::new(PageLevel::Level3, entry);
         };
 
-        let flags = PTEntryFlags::PRESENT
-            | PTEntryFlags::WRITABLE
-            | PTEntryFlags::USER
-            | PTEntryFlags::ACCESSED;
-        entry.set(make_private_address(paddr), flags);
+        entry.set(A::make_private_address(paddr), A::PTFlags::parent_flags());
 
-        let idx = Self::index::<2>(vaddr);
+        let idx = vaddr.to_pgtbl_idx::<2>();
         Self::alloc_pte_lvl2(&mut page[idx], vaddr, size)
     }
 
-    fn alloc_pte_lvl2(entry: &mut PTEntry, vaddr: VirtAddr, size: PageSize) -> Mapping<'_> {
-        let flags = entry.flags();
-
-        if flags.contains(PTEntryFlags::PRESENT) {
-            return Mapping::Level2(entry);
+    /// Allocate from level 2 (PDPTE) down to the target level.
+    fn alloc_pte_lvl2(entry: &mut PTEntry<A>, vaddr: VirtAddr, size: PageSize) -> Mapping<'_, A> {
+        if entry.flags().contains(A::PTFlags::PRESENT) {
+            return Mapping::new(PageLevel::Level2, entry);
         }
 
-        let Ok((page, paddr)) = PTPage::alloc() else {
-            return Mapping::Level2(entry);
+        let Ok((page, paddr)) = PTPage::<A, P>::alloc() else {
+            return Mapping::new(PageLevel::Level2, entry);
         };
 
-        let flags = PTEntryFlags::PRESENT
-            | PTEntryFlags::WRITABLE
-            | PTEntryFlags::USER
-            | PTEntryFlags::ACCESSED;
-        entry.set(make_private_address(paddr), flags);
+        entry.set(A::make_private_address(paddr), A::PTFlags::parent_flags());
 
-        let idx = Self::index::<1>(vaddr);
+        let idx = vaddr.to_pgtbl_idx::<1>();
         Self::alloc_pte_lvl1(&mut page[idx], vaddr, size)
     }
 
-    fn alloc_pte_lvl1(entry: &mut PTEntry, vaddr: VirtAddr, size: PageSize) -> Mapping<'_> {
+    /// Allocate from level 1 (PDE) down to level 0.
+    /// Returns at level 1 if `size` is `Huge` (2 MiB page).
+    fn alloc_pte_lvl1(entry: &mut PTEntry<A>, vaddr: VirtAddr, size: PageSize) -> Mapping<'_, A> {
         let flags = entry.flags();
-
-        if size == PageSize::Huge || flags.contains(PTEntryFlags::PRESENT) {
-            return Mapping::Level1(entry);
+        if size == PageSize::Huge || flags.contains(A::PTFlags::PRESENT) {
+            return Mapping::new(PageLevel::Level1, entry);
         }
 
-        let Ok((page, paddr)) = PTPage::alloc() else {
-            return Mapping::Level1(entry);
+        let Ok((page, paddr)) = PTPage::<A, P>::alloc() else {
+            return Mapping::new(PageLevel::Level1, entry);
         };
 
-        let flags = PTEntryFlags::PRESENT
-            | PTEntryFlags::WRITABLE
-            | PTEntryFlags::USER
-            | PTEntryFlags::ACCESSED;
-        entry.set(make_private_address(paddr), flags);
+        entry.set(A::make_private_address(paddr), A::PTFlags::parent_flags());
 
-        let idx = Self::index::<0>(vaddr);
-        Mapping::Level0(&mut page[idx])
+        let idx = vaddr.to_pgtbl_idx::<0>();
+        Mapping::new(PageLevel::Level0, &mut page[idx])
     }
 
     /// Allocates a 4KB page table entry for a given virtual address.
     ///
     /// # Parameters
     /// - `vaddr`: The virtual address for which to allocate the PTE.
-    ///
     /// # Returns
     /// A `Mapping` representing the allocated or existing PTE for the address.
-    fn alloc_pte_4k(&mut self, vaddr: VirtAddr) -> Mapping<'_> {
+    fn alloc_pte_4k(&mut self, vaddr: VirtAddr) -> Mapping<'_, A> {
         let m = self.walk_addr(vaddr);
-
-        match m {
-            Mapping::Level0(entry) => Mapping::Level0(entry),
-            Mapping::Level1(entry) => Self::alloc_pte_lvl1(entry, vaddr, PageSize::Regular),
-            Mapping::Level2(entry) => Self::alloc_pte_lvl2(entry, vaddr, PageSize::Regular),
-            Mapping::Level3(entry) => Self::alloc_pte_lvl3(entry, vaddr, PageSize::Regular),
+        match m.level {
+            PageLevel::Level0 => m,
+            PageLevel::Level1 => Self::alloc_pte_lvl1(m.entry, vaddr, PageSize::Regular),
+            PageLevel::Level2 => Self::alloc_pte_lvl2(m.entry, vaddr, PageSize::Regular),
+            PageLevel::Level3 => Self::alloc_pte_lvl3(m.entry, vaddr, PageSize::Regular),
         }
     }
 
@@ -850,17 +579,14 @@ impl PageTable {
     ///
     /// # Parameters
     /// - `vaddr`: The virtual address for which to allocate the PTE.
-    ///
     /// # Returns
     /// A `Mapping` representing the allocated or existing PTE for the address.
-    fn alloc_pte_2m(&mut self, vaddr: VirtAddr) -> Mapping<'_> {
+    fn alloc_pte_2m(&mut self, vaddr: VirtAddr) -> Mapping<'_, A> {
         let m = self.walk_addr(vaddr);
-
-        match m {
-            Mapping::Level0(entry) => Mapping::Level0(entry),
-            Mapping::Level1(entry) => Mapping::Level1(entry),
-            Mapping::Level2(entry) => Self::alloc_pte_lvl2(entry, vaddr, PageSize::Huge),
-            Mapping::Level3(entry) => Self::alloc_pte_lvl3(entry, vaddr, PageSize::Huge),
+        match m.level {
+            PageLevel::Level0 | PageLevel::Level1 => m,
+            PageLevel::Level2 => Self::alloc_pte_lvl2(m.entry, vaddr, PageSize::Huge),
+            PageLevel::Level3 => Self::alloc_pte_lvl3(m.entry, vaddr, PageSize::Huge),
         }
     }
 
@@ -870,27 +596,27 @@ impl PageTable {
     /// - `entry`: The 2M page table entry to split.
     ///
     /// # Returns
-    /// A result indicating success or an error [`SvsmError`] in failure.
-    fn do_split_4k(entry: &mut PTEntry) -> Result<(), SvsmError> {
-        let (page, paddr) = PTPage::alloc()?;
+    /// A result indicating success or an error [`PagingError`] in failure.
+    fn do_split_4k(entry: &mut PTEntry<A>) -> Result<(), PagingError> {
+        let (page, paddr) = PTPage::<A, P>::alloc()?;
         let mut flags = entry.flags();
 
-        assert!(flags.contains(PTEntryFlags::HUGE));
+        assert!(flags.huge());
 
         let addr_2m = PhysAddr::from(entry.address().bits() & 0x000f_ffff_fff0_0000);
 
-        flags.remove(PTEntryFlags::HUGE);
+        flags.remove(A::PTFlags::HUGE);
 
         // Prepare PTE leaf page
         for (i, e) in page.entries.iter_mut().enumerate() {
             let addr_4k = addr_2m + (i * PAGE_SIZE);
             e.clear();
-            e.set(make_private_address(addr_4k), flags);
+            e.set(A::make_private_address(addr_4k), flags);
         }
 
-        entry.set(make_private_address(paddr), flags);
+        entry.set(A::make_private_address(paddr), flags);
 
-        flush_tlb_global_sync();
+        A::flush_tlb_global();
 
         Ok(())
     }
@@ -901,30 +627,29 @@ impl PageTable {
     /// - `mapping`: The mapping to split.
     ///
     /// # Returns
-    /// A result indicating success or an error [`SvsmError`].
-    fn split_4k(mapping: Mapping<'_>) -> Result<(), SvsmError> {
-        match mapping {
-            Mapping::Level0(_entry) => Ok(()),
-            Mapping::Level1(entry) => Self::do_split_4k(entry),
-            Mapping::Level2(_entry) => Err(SvsmError::Mem),
-            Mapping::Level3(_entry) => Err(SvsmError::Mem),
+    /// A result indicating success or an error [`PagingError`].
+    pub fn split_4k(mapping: Mapping<'_, A>) -> Result<(), PagingError> {
+        match mapping.level {
+            PageLevel::Level0 => Ok(()),
+            PageLevel::Level1 => Self::do_split_4k(mapping.entry),
+            _ => Err(PagingError::NotMapped),
         }
     }
 
-    fn make_pte_shared(entry: &mut PTEntry) {
+    fn make_pte_shared(entry: &mut PTEntry<A>) {
         let flags = entry.flags();
         let addr = entry.address();
 
         // entry.address() returned with c-bit clear already
-        entry.set(make_shared_address(addr), flags);
+        entry.set(A::make_shared_address(addr), flags);
     }
 
-    fn make_pte_private(entry: &mut PTEntry) {
+    fn make_pte_private(entry: &mut PTEntry<A>) {
         let flags = entry.flags();
         let addr = entry.address();
 
         // entry.address() returned with c-bit clear already
-        entry.set(make_private_address(addr), flags);
+        entry.set(A::make_private_address(addr), flags);
     }
 
     /// Sets the shared state for a 4KB page.
@@ -933,17 +658,21 @@ impl PageTable {
     /// - `vaddr`: The virtual address of the page.
     ///
     /// # Returns
-    /// A result indicating success or an error [`SvsmError`] if the
+    /// A result indicating success or an error [`PagingError`] if the
     /// operation fails.
-    pub fn set_shared_4k(&mut self, vaddr: VirtAddr) -> Result<(), SvsmError> {
+    pub fn set_shared_4k(&mut self, vaddr: VirtAddr) -> Result<(), PagingError> {
         let mapping = self.walk_addr(vaddr);
         Self::split_4k(mapping)?;
 
-        if let Mapping::Level0(entry) = self.walk_addr(vaddr) {
+        if let Mapping {
+            level: PageLevel::Level0,
+            entry,
+        } = self.walk_addr(vaddr)
+        {
             Self::make_pte_shared(entry);
             Ok(())
         } else {
-            Err(SvsmError::Mem)
+            Err(PagingError::NotMapped)
         }
     }
 
@@ -953,26 +682,20 @@ impl PageTable {
     /// - `vaddr`: The virtual address of the page.
     ///
     /// # Returns
-    /// A result indicating success or an error [`SvsmError`].
-    pub fn set_encrypted_4k(&mut self, vaddr: VirtAddr) -> Result<(), SvsmError> {
+    /// A result indicating success or an error [`PagingError`].
+    pub fn set_encrypted_4k(&mut self, vaddr: VirtAddr) -> Result<(), PagingError> {
         let mapping = self.walk_addr(vaddr);
         Self::split_4k(mapping)?;
 
-        if let Mapping::Level0(entry) = self.walk_addr(vaddr) {
+        if let Mapping {
+            level: PageLevel::Level0,
+            entry,
+        } = self.walk_addr(vaddr)
+        {
             Self::make_pte_private(entry);
             Ok(())
         } else {
-            Err(SvsmError::Mem)
-        }
-    }
-
-    /// Gets the physical address for a mapped `vaddr` or `None` if
-    /// no such mapping exists.
-    pub fn check_mapping(&mut self, vaddr: VirtAddr) -> Option<PhysAddr> {
-        match self.walk_addr(vaddr) {
-            Mapping::Level0(entry) => Some(entry.address()),
-            Mapping::Level1(entry) => Some(entry.address()),
-            _ => None,
+            Err(PagingError::NotMapped)
         }
     }
 
@@ -985,7 +708,7 @@ impl PageTable {
     /// - `shared`: Indicates whether the mapping is shared.
     ///
     /// # Returns
-    /// A result indicating success or failure ([`SvsmError`]).
+    /// A result indicating success or failure ([`PagingError`]).
     ///
     /// # Panics
     /// Panics if either `vaddr` or `paddr` is not aligned to a 2MB boundary.
@@ -993,24 +716,27 @@ impl PageTable {
         &mut self,
         vaddr: VirtAddr,
         paddr: PhysAddr,
-        flags: PTEntryFlags,
+        flags: A::PTFlags,
         shared: bool,
-    ) -> Result<(), SvsmError> {
+    ) -> Result<(), PagingError> {
         assert!(vaddr.is_aligned(PAGE_SIZE_2M));
         assert!(paddr.is_aligned(PAGE_SIZE_2M));
-
         let mapping = self.alloc_pte_2m(vaddr);
         let addr = if !shared {
-            make_private_address(paddr)
+            A::make_private_address(paddr)
         } else {
-            make_shared_address(paddr)
+            A::make_shared_address(paddr)
         };
 
-        if let Mapping::Level1(entry) = mapping {
-            entry.set(addr, flags | PTEntryFlags::HUGE);
+        if let Mapping {
+            level: PageLevel::Level1,
+            entry,
+        } = mapping
+        {
+            entry.set(addr, flags | A::PTFlags::HUGE);
             Ok(())
         } else {
-            Err(SvsmError::Mem)
+            Err(PagingError::AllocFrame)
         }
     }
 
@@ -1021,16 +747,22 @@ impl PageTable {
     ///
     /// # Panics
     /// Panics if `vaddr` is not aligned to a 2MB boundary.
-    pub fn unmap_2m(&mut self, vaddr: VirtAddr) {
+    pub fn unmap_2m(&mut self, vaddr: VirtAddr) -> Option<PTEntry<A>> {
         assert!(vaddr.is_aligned(PAGE_SIZE_2M));
 
         let mapping = self.walk_addr(vaddr);
 
-        match mapping {
-            Mapping::Level0(_) => unreachable!(),
-            Mapping::Level1(entry) => entry.clear(),
-            Mapping::Level2(entry) => assert!(!entry.present()),
-            Mapping::Level3(entry) => assert!(!entry.present()),
+        match mapping.level {
+            PageLevel::Level0 => unreachable!(),
+            PageLevel::Level1 => {
+                let entry = *mapping.entry;
+                mapping.entry.clear();
+                Some(entry)
+            }
+            _ => {
+                assert!(!mapping.entry.present());
+                None
+            }
         }
     }
 
@@ -1041,28 +773,31 @@ impl PageTable {
     /// - `paddr`: The physical address to map to.
     /// - `flags`: The flags to apply to the mapping.
     /// - `shared`: Indicates whether the mapping is shared.
-    ///
     /// # Returns
-    /// A result indicating success or failure ([`SvsmError`]).
+    /// A result indicating success or failure ([`PagingError`]).
     pub fn map_4k(
         &mut self,
         vaddr: VirtAddr,
         paddr: PhysAddr,
-        flags: PTEntryFlags,
+        flags: A::PTFlags,
         shared: bool,
-    ) -> Result<(), SvsmError> {
+    ) -> Result<(), PagingError> {
         let mapping = self.alloc_pte_4k(vaddr);
         let addr = if !shared {
-            make_private_address(paddr)
+            A::make_private_address(paddr)
         } else {
-            make_shared_address(paddr)
+            A::make_shared_address(paddr)
         };
 
-        if let Mapping::Level0(entry) = mapping {
+        if let Mapping {
+            level: PageLevel::Level0,
+            entry,
+        } = mapping
+        {
             entry.set(addr, flags);
             Ok(())
         } else {
-            Err(SvsmError::Mem)
+            Err(PagingError::AllocFrame)
         }
     }
 
@@ -1070,14 +805,19 @@ impl PageTable {
     ///
     /// # Parameters
     /// - `vaddr`: The virtual address of the mapping to unmap.
-    pub fn unmap_4k(&mut self, vaddr: VirtAddr) {
+    pub fn unmap_4k(&mut self, vaddr: VirtAddr) -> Option<PTEntry<A>> {
         let mapping = self.walk_addr(vaddr);
 
-        match mapping {
-            Mapping::Level0(entry) => entry.clear(),
-            Mapping::Level1(entry) => assert!(!entry.present()),
-            Mapping::Level2(entry) => assert!(!entry.present()),
-            Mapping::Level3(entry) => assert!(!entry.present()),
+        match mapping.level {
+            PageLevel::Level0 => {
+                let entry = *mapping.entry;
+                mapping.entry.clear();
+                Some(entry)
+            }
+            _ => {
+                assert!(!mapping.entry.present());
+                None
+            }
         }
     }
 
@@ -1088,846 +828,28 @@ impl PageTable {
     ///
     /// # Returns
     /// The physical address of the mapping if present; otherwise, an error
-    /// ([`SvsmError`]).
-    pub fn phys_addr(&mut self, vaddr: VirtAddr) -> Result<PhysAddr, SvsmError> {
+    /// ([`PagingError`]).
+    pub fn phys_addr(&mut self, vaddr: VirtAddr) -> Result<PhysAddr, PagingError> {
         let mapping = self.walk_addr(vaddr);
 
-        match mapping {
-            Mapping::Level0(entry) => {
+        match mapping.level {
+            PageLevel::Level0 => {
                 let offset = vaddr.page_offset();
-                if !entry.flags().contains(PTEntryFlags::PRESENT) {
-                    return Err(SvsmError::Mem);
+                let entry = mapping.entry;
+                if !entry.present() {
+                    return Err(PagingError::NotMapped);
                 }
                 Ok(entry.address() + offset)
             }
-            Mapping::Level1(entry) => {
+            PageLevel::Level1 => {
                 let offset = vaddr.bits() & (PAGE_SIZE_2M - 1);
-                if !entry.flags().contains(PTEntryFlags::PRESENT)
-                    || !entry.flags().contains(PTEntryFlags::HUGE)
-                {
-                    return Err(SvsmError::Mem);
+                let entry = mapping.entry;
+                if !entry.present() || !entry.huge() {
+                    return Err(PagingError::NotMapped);
                 }
-
                 Ok(entry.address() + offset)
             }
-            Mapping::Level2(_entry) => Err(SvsmError::Mem),
-            Mapping::Level3(_entry) => Err(SvsmError::Mem),
+            _ => Err(PagingError::NotMapped),
         }
-    }
-
-    /// Maps a region of memory using 4KB pages.
-    ///
-    /// # Parameters
-    /// - `vregion`: The virtual memory region to map.
-    /// - `phys`: The starting physical address to map to.
-    /// - `flags`: The flags to apply to the mapping.
-    /// - `shared`: Indicates whether the mapping is shared.
-    ///
-    /// # Returns
-    /// A result indicating success or failure ([`SvsmError`]).
-    pub fn map_region_4k(
-        &mut self,
-        vregion: MemoryRegion<VirtAddr>,
-        phys: PhysAddr,
-        flags: PTEntryFlags,
-        shared: bool,
-    ) -> Result<(), SvsmError> {
-        for addr in vregion.iter_pages(PageSize::Regular) {
-            let offset = addr - vregion.start();
-            self.map_4k(addr, phys + offset, flags, shared)?;
-        }
-        Ok(())
-    }
-
-    /// Unmaps a region of memory using 4KB pages.
-    ///
-    /// # Parameters
-    /// - `vregion`: The virtual memory region to unmap.
-    pub fn unmap_region_4k(&mut self, vregion: MemoryRegion<VirtAddr>) {
-        for addr in vregion.iter_pages(PageSize::Regular) {
-            self.unmap_4k(addr);
-        }
-    }
-
-    /// Maps a region of memory using 2MB pages.
-    ///
-    /// # Parameters
-    /// - `vregion`: The virtual memory region to map.
-    /// - `phys`: The starting physical address to map to.
-    /// - `flags`: The flags to apply to the mapping.
-    /// - `shared`: Indicates whether the mapping is shared.
-    ///
-    /// # Returns
-    /// A result indicating success or failure ([`SvsmError`]).
-    pub fn map_region_2m(
-        &mut self,
-        vregion: MemoryRegion<VirtAddr>,
-        phys: PhysAddr,
-        flags: PTEntryFlags,
-        shared: bool,
-    ) -> Result<(), SvsmError> {
-        for addr in vregion.iter_pages(PageSize::Huge) {
-            let offset = addr - vregion.start();
-            self.map_2m(addr, phys + offset, flags, shared)?;
-        }
-        Ok(())
-    }
-
-    /// Unmaps a region `vregion` of 2MB pages. The region must be
-    /// 2MB-aligned and correspond to a set of huge mappings.
-    pub fn unmap_region_2m(&mut self, vregion: MemoryRegion<VirtAddr>) {
-        for addr in vregion.iter_pages(PageSize::Huge) {
-            self.unmap_2m(addr);
-        }
-    }
-
-    /// Maps a memory region to physical memory with specified flags.
-    ///
-    /// # Parameters
-    /// - `region`: The virtual memory region to map.
-    /// - `phys`: The starting physical address to map to.
-    /// - `flags`: The flags to apply to the page table entries.
-    ///
-    /// # Returns
-    /// A result indicating success (`Ok`) or failure (`Err`).
-    pub fn map_region(
-        &mut self,
-        region: MemoryRegion<VirtAddr>,
-        phys: PhysAddr,
-        flags: PTEntryFlags,
-    ) -> Result<(), SvsmError> {
-        let mut vaddr = region.start();
-        let end = region.end();
-        let mut paddr = phys;
-
-        while vaddr < end {
-            if vaddr.is_aligned(PAGE_SIZE_2M)
-                && paddr.is_aligned(PAGE_SIZE_2M)
-                && vaddr + PAGE_SIZE_2M <= end
-                && self.map_2m(vaddr, paddr, flags, false).is_ok()
-            {
-                vaddr = vaddr + PAGE_SIZE_2M;
-                paddr = paddr + PAGE_SIZE_2M;
-                continue;
-            }
-
-            self.map_4k(vaddr, paddr, flags, false)?;
-            vaddr = vaddr + PAGE_SIZE;
-            paddr = paddr + PAGE_SIZE;
-        }
-
-        Ok(())
-    }
-
-    /// Unmaps the virtual memory region `vregion`.
-    pub fn unmap_region(&mut self, vregion: MemoryRegion<VirtAddr>) {
-        let mut vaddr = vregion.start();
-        let end = vregion.end();
-
-        while vaddr < end {
-            let mapping = self.walk_addr(vaddr);
-
-            match mapping {
-                Mapping::Level0(entry) => {
-                    entry.clear();
-                    vaddr = vaddr + PAGE_SIZE;
-                }
-                Mapping::Level1(entry) => {
-                    entry.clear();
-                    vaddr = vaddr + PAGE_SIZE_2M;
-                }
-                _ => {
-                    log::error!("Can't unmap - address not mapped {vaddr:#x}");
-                }
-            }
-        }
-    }
-
-    /// Populates this page table with the contents of the given subtree
-    /// in `part`.
-    ///
-    /// Returns `true` if the PTE contents were updated.
-    pub fn populate_pgtbl_part(&mut self, part: &PageTablePart) -> bool {
-        let Some(paddr) = part.address() else {
-            return false;
-        };
-        let idx = part.index();
-        let flags = PTEntryFlags::PRESENT
-            | PTEntryFlags::WRITABLE
-            | PTEntryFlags::USER
-            | PTEntryFlags::ACCESSED;
-        let entry = &mut self.root[idx];
-        let prev = entry.raw();
-        entry.set(make_private_address(paddr), flags);
-        prev != entry.raw()
-    }
-
-    /// Makes the memory region pages read-only.
-    /// This method is meant for global pages only.
-    ///
-    /// # Safety
-    ///
-    /// The caller should verify that `region` can be made read-only, i.e. that
-    /// no write can happen or that a #PF raised by any tentative write is
-    /// expected.
-    /// The caller must also ensure that the region start and size are 4k
-    /// aligned.
-    pub unsafe fn make_region_ro_4k(
-        &mut self,
-        region: MemoryRegion<VirtAddr>,
-    ) -> Result<(), SvsmError> {
-        for page in region.iter_pages(PageSize::Regular) {
-            match self.walk_addr(page) {
-                Mapping::Level0(entry) => {
-                    if !entry.present() || !entry.global() {
-                        return Err(SvsmError::Mem);
-                    }
-
-                    let flags = PTEntryFlags::data_ro();
-
-                    let paddr = if is_shared(entry.0) {
-                        make_shared_address(entry.address())
-                    } else {
-                        make_private_address(entry.address())
-                    };
-
-                    entry.set(paddr, flags);
-                }
-                Mapping::Level1(entry) | Mapping::Level2(entry) => {
-                    // Ensure we never fell on a huge page while iterating over the region pages.
-                    if entry.huge() {
-                        return Err(SvsmError::Mem);
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        Ok(())
-    }
-}
-
-/// Represents a sub-tree of a page-table which can be mapped at a top-level index
-#[derive(Debug, FromZeros)]
-struct RawPageTablePart {
-    page: PTPage,
-}
-
-impl RawPageTablePart {
-    /// Frees a level 1 page table.
-    fn free_lvl1(page: &PTPage) {
-        for entry in page.entries.iter() {
-            if let Some(page) = PTPage::from_entry(*entry) {
-                // SAFETY: the page comes from an entry in the page table,
-                // which we allocated using `PTPage::alloc()`, so this is
-                // safe.
-                unsafe { PTPage::free(page) };
-            }
-        }
-    }
-
-    /// Frees a level 2 page table, including all level 1 tables beneath it.
-    fn free_lvl2(page: &PTPage) {
-        for entry in page.entries.iter() {
-            if let Some(l1_page) = PTPage::from_entry(*entry) {
-                Self::free_lvl1(l1_page);
-                // SAFETY: the page comes from an entry in the page table,
-                // which we allocated using `PTPage::alloc()`, so this is
-                // safe.
-                unsafe { PTPage::free(l1_page) };
-            }
-        }
-    }
-
-    /// Frees the resources associated with this page table part.
-    fn free(&self) {
-        RawPageTablePart::free_lvl2(&self.page);
-    }
-
-    /// Returns the physical address of this page table part.
-    fn address(&self) -> PhysAddr {
-        virt_to_phys(VirtAddr::from(self as *const RawPageTablePart))
-    }
-
-    /// Walks the page table at level 3 to find the mapping for a given
-    /// virtual address.
-    ///
-    /// # Parameters
-    /// - `vaddr`: The virtual address to find the mapping for.
-    ///
-    /// # Returns
-    /// The [`Mapping`] for the given virtual address.
-    fn walk_addr(&mut self, vaddr: VirtAddr) -> Mapping<'_> {
-        PageTable::walk_addr_lvl2(&mut self.page, vaddr)
-    }
-
-    /// Allocates a 4KB page table entry for a given virtual address.
-    ///
-    /// # Parameters
-    /// - `vaddr`: The virtual address for which to allocate the PTE.
-    ///
-    /// # Returns
-    /// The [`Mapping`] representing the allocated or existing PTE for the address.
-    ///
-    /// # Panics
-    /// Panics if a level 3 mapping is attempted in a [`RawPageTablePart`].
-    fn alloc_pte_4k(&mut self, vaddr: VirtAddr) -> Mapping<'_> {
-        let m = self.walk_addr(vaddr);
-
-        match m {
-            Mapping::Level0(entry) => Mapping::Level0(entry),
-            Mapping::Level1(entry) => PageTable::alloc_pte_lvl1(entry, vaddr, PageSize::Regular),
-            Mapping::Level2(entry) => PageTable::alloc_pte_lvl2(entry, vaddr, PageSize::Regular),
-            Mapping::Level3(_) => panic!("PT level 3 not possible in PageTablePart"),
-        }
-    }
-
-    /// Allocates a 2MB page table entry for a given virtual address.
-    ///
-    /// # Parameters
-    /// - `vaddr`: The virtual address for which to allocate the PTE.
-    ///
-    /// # Returns
-    /// The [`Mapping`] representing the allocated or existing PTE for the
-    /// address.
-    fn alloc_pte_2m(&mut self, vaddr: VirtAddr) -> Mapping<'_> {
-        let m = self.walk_addr(vaddr);
-
-        match m {
-            Mapping::Level0(entry) => Mapping::Level0(entry),
-            Mapping::Level1(entry) => Mapping::Level1(entry),
-            Mapping::Level2(entry) => PageTable::alloc_pte_lvl2(entry, vaddr, PageSize::Huge),
-            Mapping::Level3(entry) => PageTable::alloc_pte_lvl3(entry, vaddr, PageSize::Huge),
-        }
-    }
-
-    /// Maps a 4KB page.
-    ///
-    /// # Parameters
-    /// - `vaddr`: The virtual address to map.
-    /// - `paddr`: The physical address to map to.
-    /// - `flags`: The flags to apply to the mapping.
-    /// - `shared`: Indicates whether the mapping is shared.
-    ///
-    /// # Returns
-    /// A result indicating success (`Ok`) or failure (`Err`).
-    fn map_4k(
-        &mut self,
-        vaddr: VirtAddr,
-        paddr: PhysAddr,
-        flags: PTEntryFlags,
-        shared: bool,
-    ) -> Result<(), SvsmError> {
-        let mapping = self.alloc_pte_4k(vaddr);
-
-        let addr = if !shared {
-            make_private_address(paddr)
-        } else {
-            make_shared_address(paddr)
-        };
-
-        if let Mapping::Level0(entry) = mapping {
-            entry.set(addr, flags);
-            Ok(())
-        } else {
-            Err(SvsmError::Mem)
-        }
-    }
-
-    /// Unmaps a 4KB page.
-    ///
-    /// # Parameters
-    /// - `vaddr`: The virtual address of the mapping to unmap.
-    ///
-    /// # Returns
-    /// An optional [`PTEntry`] representing the unmapped page table entry.
-    fn unmap_4k(&mut self, vaddr: VirtAddr) -> Option<PTEntry> {
-        let mapping = self.walk_addr(vaddr);
-
-        match mapping {
-            Mapping::Level0(entry) => {
-                let e = *entry;
-                entry.clear();
-                Some(e)
-            }
-            Mapping::Level1(entry) => {
-                assert!(!entry.present());
-                None
-            }
-            Mapping::Level2(entry) => {
-                assert!(!entry.present());
-                None
-            }
-            Mapping::Level3(entry) => {
-                assert!(!entry.present());
-                None
-            }
-        }
-    }
-
-    /// Maps a 2MB page.
-    ///
-    /// # Parameters
-    /// - `vaddr`: The virtual address to map.
-    /// - `paddr`: The physical address to map to.
-    /// - `flags`: The flags to apply to the mapping.
-    /// - `shared`: Indicates whether the mapping is shared
-    ///
-    /// # Returns
-    /// A result indicating success (`Ok`) or failure (`Err`).
-    ///
-    /// # Panics
-    ///
-    /// Panics if `vaddr` or `paddr` are not 2MB-aligned
-    fn map_2m(
-        &mut self,
-        vaddr: VirtAddr,
-        paddr: PhysAddr,
-        flags: PTEntryFlags,
-        shared: bool,
-    ) -> Result<(), SvsmError> {
-        assert!(vaddr.is_aligned(PAGE_SIZE_2M));
-        assert!(paddr.is_aligned(PAGE_SIZE_2M));
-
-        let mapping = self.alloc_pte_2m(vaddr);
-        let addr = if !shared {
-            make_private_address(paddr)
-        } else {
-            make_shared_address(paddr)
-        };
-
-        if let Mapping::Level1(entry) = mapping {
-            entry.set(addr, flags | PTEntryFlags::HUGE);
-            Ok(())
-        } else {
-            Err(SvsmError::Mem)
-        }
-    }
-
-    /// Unmaps a 2MB page.
-    ///
-    /// # Parameters
-    /// - `vaddr`: The virtual address of the mapping to unmap.
-    ///
-    /// # Returns
-    /// An optional [`PTEntry`] representing the unmapped page table entry.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `vaddr` is not memory aligned.
-    fn unmap_2m(&mut self, vaddr: VirtAddr) -> Option<PTEntry> {
-        assert!(vaddr.is_aligned(PAGE_SIZE_2M));
-
-        let mapping = self.walk_addr(vaddr);
-
-        match mapping {
-            Mapping::Level0(_) => None,
-            Mapping::Level1(entry) => {
-                entry.clear();
-                Some(*entry)
-            }
-            Mapping::Level2(entry) => {
-                assert!(!entry.present());
-                None
-            }
-            Mapping::Level3(entry) => {
-                assert!(!entry.present());
-                None
-            }
-        }
-    }
-}
-
-impl Drop for RawPageTablePart {
-    fn drop(&mut self) {
-        self.free();
-    }
-}
-
-/// Sub-tree of a page table that can be populated at the top-level
-/// used for virtual memory management
-#[derive(Debug)]
-pub struct PageTablePart {
-    /// The root of the page-table sub-tree
-    raw: Option<PageBox<RawPageTablePart>>,
-    /// The top-level index this PageTablePart is populated at
-    idx: usize,
-}
-
-impl PageTablePart {
-    /// Create a new PageTablePart and allocate a root page for the page-table sub-tree.
-    ///
-    /// # Arguments
-    ///
-    /// - `start`: Virtual start address this PageTablePart maps
-    ///
-    /// # Returns
-    ///
-    /// A new instance of PageTablePart
-    pub fn new(start: VirtAddr) -> Self {
-        PageTablePart {
-            raw: None,
-            idx: PageTable::index::<3>(start),
-        }
-    }
-
-    pub fn alloc(&mut self) {
-        self.get_or_init_mut();
-    }
-
-    fn get_or_init_mut(&mut self) -> &mut RawPageTablePart {
-        self.raw.get_or_insert_with(|| {
-            PageBox::try_new_zeroed().expect("Failed to allocate page table page")
-        })
-    }
-
-    fn get_mut(&mut self) -> Option<&mut RawPageTablePart> {
-        self.raw.as_deref_mut()
-    }
-
-    fn get(&self) -> Option<&RawPageTablePart> {
-        self.raw.as_deref()
-    }
-
-    /// Request PageTable index to populate this instance to
-    ///
-    /// # Returns
-    ///
-    /// Index of the top-level PageTable this sub-tree is populated to
-    pub fn index(&self) -> usize {
-        self.idx
-    }
-
-    /// Request physical base address of the page-table sub-tree. This is
-    /// needed to populate the PageTablePart.
-    ///
-    /// # Returns
-    ///
-    /// Physical base address of the page-table sub-tree
-    pub fn address(&self) -> Option<PhysAddr> {
-        self.get().map(|p| p.address())
-    }
-
-    /// Map a 4KiB page in the page table sub-tree
-    ///
-    /// # Arguments
-    ///
-    /// * `vaddr` - Virtual address to create the mapping. Must be aligned to 4KiB.
-    /// * `paddr` - Physical address to map. Must be aligned to 4KiB.
-    /// * `flags` - PTEntryFlags used for the mapping
-    /// * `shared` - Defines whether the page is mapped shared or private
-    ///
-    /// # Returns
-    ///
-    /// OK(()) on Success, Err(SvsmError::Mem) on error.
-    ///
-    /// This function can fail when there not enough memory to allocate pages for the mapping.
-    ///
-    /// # Panics
-    ///
-    /// This method panics when either `vaddr` or `paddr` are not aligned to 4KiB.
-    pub fn map_4k(
-        &mut self,
-        vaddr: VirtAddr,
-        paddr: PhysAddr,
-        flags: PTEntryFlags,
-        shared: bool,
-    ) -> Result<(), SvsmError> {
-        assert!(PageTable::index::<3>(vaddr) == self.idx);
-
-        self.get_or_init_mut().map_4k(vaddr, paddr, flags, shared)
-    }
-
-    /// Unmaps a 4KiB page from the page table sub-tree
-    ///
-    /// # Arguments
-    ///
-    /// * `vaddr` - The virtual address to unmap. Must be aligned to 4KiB.
-    ///
-    /// # Returns
-    ///
-    /// Returns a copy of the PTEntry that mapped the virtual address, if any.
-    ///
-    /// # Panics
-    ///
-    /// This method panics when `vaddr` is not aligned to 4KiB.
-    pub fn unmap_4k(&mut self, vaddr: VirtAddr) -> Option<PTEntry> {
-        assert!(PageTable::index::<3>(vaddr) == self.idx);
-
-        self.get_mut().and_then(|r| r.unmap_4k(vaddr))
-    }
-
-    /// Map a 2MiB page in the page table sub-tree
-    ///
-    /// # Arguments
-    ///
-    /// * `vaddr` - Virtual address to create the mapping. Must be aligned to 2MiB.
-    /// * `paddr` - Physical address to map. Must be aligned to 2MiB.
-    /// * `flags` - PTEntryFlags used for the mapping
-    /// * `shared` - Defines whether the page is mapped shared or private
-    ///
-    /// # Returns
-    ///
-    /// OK(()) on Success, Err(SvsmError::Mem) on error.
-    ///
-    /// This function can fail when there not enough memory to allocate pages for the mapping.
-    ///
-    /// # Panics
-    ///
-    /// This method panics when either `vaddr` or `paddr` are not aligned to 2MiB.
-    pub fn map_2m(
-        &mut self,
-        vaddr: VirtAddr,
-        paddr: PhysAddr,
-        flags: PTEntryFlags,
-        shared: bool,
-    ) -> Result<(), SvsmError> {
-        assert!(PageTable::index::<3>(vaddr) == self.idx);
-
-        self.get_or_init_mut().map_2m(vaddr, paddr, flags, shared)
-    }
-
-    /// Unmaps a 2MiB page from the page table sub-tree
-    ///
-    /// # Arguments
-    ///
-    /// * `vaddr` - The virtual address to unmap. Must be aligned to 2MiB.
-    ///
-    /// # Returns
-    ///
-    /// Returns a copy of the PTEntry that mapped the virtual address, if any.
-    ///
-    /// # Panics
-    ///
-    /// This method panics when `vaddr` is not aligned to 2MiB.
-    pub fn unmap_2m(&mut self, vaddr: VirtAddr) -> Option<PTEntry> {
-        assert!(PageTable::index::<3>(vaddr) == self.idx);
-
-        self.get_mut().and_then(|r| r.unmap_2m(vaddr))
-    }
-}
-
-bitflags! {
-    /// Flags to represent how memory is accessed, e.g. write data to the
-    /// memory or fetch code from the memory.
-    #[derive(Clone, Copy, Debug)]
-    pub struct MemAccessMode: u32 {
-        const WRITE     = 1 << 0;
-        const FETCH     = 1 << 1;
-    }
-}
-
-/// Attributes to determin Whether a memory access (write/fetch) is permitted
-/// by a translation which includes the paging-mode modifiers in CR0, CR4 and
-/// EFER; EFLAGS.AC; and the supervisor/user mode access.
-#[derive(Clone, Copy, Debug)]
-pub struct PTWalkAttr {
-    cr0: CR0Flags,
-    cr4: CR4Flags,
-    efer: EFERFlags,
-    flags: RFlags,
-    user_mode_access: bool,
-    pm: PagingMode,
-}
-
-impl PTWalkAttr {
-    /// Creates a new `PTWalkAttr` instance with the specified attributes.
-    ///
-    /// # Arguments
-    ///
-    /// * `cr0`, `cr4`, and `efer` - Represent the control register
-    ///   flags for CR0, CR4, and EFER respectively.
-    /// * `flags` - Represents the CPU Flags.
-    /// * `user_mode_access` - Indicates whether the access is in user mode.
-    ///
-    /// Returns a new `PTWalkAttr` instance.
-    pub fn new(
-        cr0: CR0Flags,
-        cr4: CR4Flags,
-        efer: EFERFlags,
-        flags: RFlags,
-        user_mode_access: bool,
-    ) -> Self {
-        Self {
-            cr0,
-            cr4,
-            efer,
-            flags,
-            user_mode_access,
-            pm: PagingMode::new(efer, cr0, cr4),
-        }
-    }
-
-    /// Checks the access rights for a page table entry.
-    ///
-    /// # Arguments
-    ///
-    /// * `entry` - The page table entry to check.
-    /// * `mem_am` - Indicates how to access the memory.
-    /// * `last_level` - Indicates whether the entry is at the last level
-    ///   of the page table.
-    /// * `pteflags` - The PTE flags to indicate if the corresponding page
-    ///   table entry allows the access rights.
-    ///
-    /// # Returns
-    ///
-    /// Returns `Ok((entry, leaf))` if the access rights are valid, where
-    /// `entry` is the modified page table entry and `leaf` is a boolean
-    /// indicating whether the entry is a leaf node, or `Err(PageFaultError)`
-    /// to indicate the page fault error code if the access rights are invalid.
-    pub fn check_access_rights(
-        &self,
-        entry: PTEntry,
-        mem_am: MemAccessMode,
-        level: usize,
-        pteflags: &mut PTEntryFlags,
-    ) -> Result<(PTEntry, bool), PageFaultError> {
-        let pf_err = self.default_pf_err(mem_am) | PageFaultError::P;
-
-        if !entry.present() {
-            // Entry is not present.
-            return Err(pf_err & !PageFaultError::P);
-        }
-
-        if entry.has_reserved_bits(self.pm, level) {
-            // Reserved bits have been set.
-            return Err(pf_err | PageFaultError::R);
-        }
-
-        // SDM 4.6.1 Determination of Access Rights:
-        // If the U/S flag (bit 2) is 0 in at least one of the
-        // paging-structure entries, the address is a supervisor-mode
-        // address. Otherwise, the address is a user-mode address.
-        // So by-default assume the address is user mode address.
-        if !entry.user() {
-            *pteflags &= !PTEntryFlags::USER;
-        }
-
-        // SDM 4.6.1 Determination of Access Rights:
-        // R/W flag (bit 1) is 1 in every paging-structure entry controlling
-        // the translation and with a protection key for which write access is
-        // permitted; data may not be written to any supervisor-mode
-        // address with a translation for which the R/W flag is 0 in any
-        // paging-structure entry controlling the translation.
-        // The same for user mode address
-        if !entry.writable() {
-            *pteflags &= !PTEntryFlags::WRITABLE;
-        }
-
-        // SDM 4.6.1 Determination of Access Rights:
-        // For non 32-bit paging modes with IA32_EFER.NXE = 1, instructions
-        // may be fetched from any supervisormode address with a translation
-        // for which the XD flag (bit 63) is 0 in every paging-structure entry
-        // controlling the translation; instructions may not be fetched from
-        // any supervisor-mode address with a translation for which the XD flag
-        // is 1 in any paging-structure entry controlling the translation
-        if self.efer.contains(EFERFlags::NXE) && entry.nx() {
-            *pteflags |= PTEntryFlags::NX;
-        } else if !self.efer.contains(EFERFlags::NXE) && entry.nx() {
-            // XD bit must be 0 if efer.NXE = 0
-            return Err(pf_err | PageFaultError::R);
-        }
-
-        let leaf = if level == 0 || entry.huge() {
-            // User mode cannot access any supervisor mode addresses
-            if self.user_mode_access && !pteflags.contains(PTEntryFlags::USER) {
-                return Err(pf_err);
-            }
-
-            // Always check for reading. For the case of supervisor mode read user
-            // mode addresses, do special checking. For other cases, read is allowed.
-            if !self.user_mode_access && pteflags.contains(PTEntryFlags::USER) {
-                // Read not allowed with SMAP = 1 && flags.ac = 0
-                if self.cr4.contains(CR4Flags::SMAP) && !self.flags.contains(RFlags::AC) {
-                    return Err(pf_err);
-                }
-            }
-
-            if mem_am.contains(MemAccessMode::WRITE) {
-                if !self.user_mode_access && pteflags.contains(PTEntryFlags::USER) {
-                    // Check supervisor mode write user mode addresses
-                    if !self.cr0.contains(CR0Flags::WP) {
-                        // Check write with CR0.WP = 0
-                        if self.cr4.contains(CR4Flags::SMAP) && !self.flags.contains(RFlags::AC) {
-                            // Write not allowed with SMAP = 1 && flags.ac = 0
-                            return Err(pf_err);
-                        }
-                    } else {
-                        // Check write with CR0.WP = 1
-                        if !self.cr4.contains(CR4Flags::SMAP) {
-                            // SMAP = 0
-                            if !pteflags.contains(PTEntryFlags::WRITABLE) {
-                                // Write not allowed R/W = 0
-                                return Err(pf_err);
-                            }
-                        } else {
-                            // SMAP = 1
-                            if !self.flags.contains(RFlags::AC)
-                                || !pteflags.contains(PTEntryFlags::WRITABLE)
-                            {
-                                // Write not allowed with flags.AC = 0 || R/W = 0
-                                return Err(pf_err);
-                            }
-                        }
-                    }
-                } else if !self.user_mode_access && !pteflags.contains(PTEntryFlags::USER) {
-                    // Check supervisor mode write supervisor mode addresses
-                    if self.cr0.contains(CR0Flags::WP) && !pteflags.contains(PTEntryFlags::WRITABLE)
-                    {
-                        // Write not allowed with CR0.WP = 1 && R/W = 0
-                        return Err(pf_err);
-                    }
-                } else if self.user_mode_access && pteflags.contains(PTEntryFlags::USER) {
-                    // Check user mode write user mode addresses
-                    if !pteflags.contains(PTEntryFlags::WRITABLE) {
-                        // Write not allowed R/W = 0
-                        return Err(pf_err);
-                    }
-                }
-                // User mode write supervisor mode addresses is checked already
-            }
-
-            if mem_am.contains(MemAccessMode::FETCH) {
-                // For instruction fetch, the rule is the same except for the case of
-                // supervisor mode fetch user mode addresses
-                if !self.user_mode_access && pteflags.contains(PTEntryFlags::USER) {
-                    // Fetch not allowed with SMEP = 1
-                    if self.cr4.contains(CR4Flags::SMEP) {
-                        return Err(pf_err);
-                    }
-                }
-
-                // For non-32bit paging mode, fetch not allowed with efer.NXE = 1 && XD = 1
-                if self.cr4.contains(CR4Flags::PAE)
-                    && self.efer.contains(EFERFlags::NXE)
-                    && pteflags.contains(PTEntryFlags::NX)
-                {
-                    return Err(pf_err);
-                }
-            }
-            true
-        } else {
-            false
-        };
-
-        Ok((entry, leaf))
-    }
-
-    fn default_pf_err(&self, mem_am: MemAccessMode) -> PageFaultError {
-        let mut err = PageFaultError::empty();
-
-        if mem_am.contains(MemAccessMode::WRITE) {
-            err |= PageFaultError::W;
-        }
-
-        if mem_am.contains(MemAccessMode::FETCH) {
-            err |= PageFaultError::I;
-        }
-
-        if self.user_mode_access {
-            err |= PageFaultError::U;
-        }
-
-        err
     }
 }

--- a/paging/src/proofs/align.rs
+++ b/paging/src/proofs/align.rs
@@ -4,7 +4,10 @@
 //
 // Author: Ziqiao Zhou <ziqiaozhou@microsoft.com>
 //
-// Proofs related to util.rs
+// Proofs related to alignment helpers.
+use super::*;
+use verus_stub::*;
+
 verus! {
 
 /// A meaningful align_down should be verified to equal to align_up_integer_ens
@@ -35,7 +38,7 @@ pub broadcast proof fn proof_align_up<T: IntegerAligned>(val: T, align: T, ret: 
     T::lemma_align_up(val, align, ret);
 }
 
-broadcast group group_align_proofs {
+pub broadcast group group_align_proofs {
     verify_proof::bits::lemma_bit_u64_not_is_sub,
     verify_proof::bits::lemma_bit_u64_shl_values,
     verify_proof::bits::lemma_bit_u64_and_mask,

--- a/paging/src/proofs/sizes.rs
+++ b/paging/src/proofs/sizes.rs
@@ -3,6 +3,9 @@
 // Copyright (c) Microsoft Corporation
 //
 // Author: Ziqiao Zhou <ziqiaozhou@microsoft.com>
+use super::PAGE_SIZE;
+use verus_stub::*;
+
 verus! {
 
 pub broadcast group group_types_proof {

--- a/paging/src/sizes.rs
+++ b/paging/src/sizes.rs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2022-2023 SUSE LLC
+//
+// Author: Joerg Roedel <jroedel@suse.de>
+
+use verus_stub::*;
+
+#[cfg(verus_only)]
+#[path = "proofs/sizes.rs"]
+mod sizes_spec_defs;
+#[cfg(verus_only)]
+pub use sizes_spec_defs::*;
+#[cfg(verus_only)]
+verus! {
+    broadcast use sizes_spec_defs::group_types_proof;
+}
+
+verus! {
+
+pub const PAGE_SHIFT: usize = 12;
+pub const PAGE_SHIFT_2M: usize = 21;
+pub const PAGE_SHIFT_1G: usize = 30;
+pub const PAGE_SIZE: usize = 1 << PAGE_SHIFT;
+pub const PAGE_SIZE_2M: usize = 1 << PAGE_SHIFT_2M;
+pub const PAGE_SIZE_1G: usize = 1 << PAGE_SHIFT_1G;
+
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PageSize {
+    Regular,
+    Huge,
+}
+
+impl From<PageSize> for usize {
+    fn from(psize: PageSize) -> Self {
+        match psize {
+            PageSize::Regular => PAGE_SIZE,
+            PageSize::Huge => PAGE_SIZE_2M,
+        }
+    }
+}

--- a/paging/src/specs/address.rs
+++ b/paging/src/specs/address.rs
@@ -4,7 +4,7 @@
 //
 // Author: Ziqiao Zhou <ziqiaozhou@microsoft.com>
 //
-use crate::utils::util::{
+use crate::util::{
     align_down_integer_ens, align_up_integer_ens, proof_align_down, proof_align_up,
 };
 use verify_external::convert::{exists_into, forall_into};
@@ -26,7 +26,7 @@ pub broadcast group sign_extend_proof {
 }
 
 pub broadcast group address_align_proof {
-    crate::types::group_types_proof,
+    crate::sizes::group_types_proof,
     verify_proof::bits::lemma_bit_usize_and_mask_is_mod,
     proof_align_up,
     proof_align_down,
@@ -52,7 +52,8 @@ broadcast use vaddr_impl_proof;
 
 /// Define a broadcast function and its related spec function calls in a inner
 /// module to avoid cyclic self-reference
-mod address_spec { include!("address_inner.verus.rs");  }
+#[path = "address_inner.rs"]
+mod address_spec;
 
 pub use address_spec::*;
 

--- a/paging/src/specs/address_inner.rs
+++ b/paging/src/specs/address_inner.rs
@@ -123,7 +123,7 @@ pub broadcast proof fn reveal_pfn(addr: usize)
 
 #[verifier(inline)]
 pub open spec fn align_requires(align: InnerAddr) -> bool {
-    crate::utils::util::align_requires(align as u64)
+    crate::util::align_requires(align as u64)
 }
 
 pub open spec fn addr_align_up_requires<A: AddressSpec>(addr: A, align: InnerAddr) -> bool {
@@ -141,7 +141,7 @@ pub broadcast proof fn lemma_align_up_requires<A: AddressSpec>(
         #[trigger] addr_align_up_requires(addr, align),
         A::into.ensures((addr,), iaddr),
     ensures
-        #[trigger] crate::utils::util::align_up_requires((iaddr, align)),
+        #[trigger] crate::util::align_up_requires((iaddr, align)),
 {
     assert forall|one: usize|
         call_ensures(usize::from, (1u8,), one) implies #[trigger] align.sub_req(one) by {
@@ -157,7 +157,7 @@ pub open spec fn addr_align_up_impl<A: AddressSpec>(addr: A, align: InnerAddr, r
     &&& exists|iaddr: InnerAddr, iret: InnerAddr|
         {
             &&& A::into.ensures((addr,), iaddr)
-            &&& #[trigger] crate::utils::util::align_up_ens((iaddr, align), iret)
+            &&& #[trigger] crate::util::align_up_ens((iaddr, align), iret)
             &&& A::from.ensures((iret,), ret)
         }
 }
@@ -200,10 +200,10 @@ pub broadcast proof fn lemma_align_up_ens<A: AddressSpec>(addr: A, align: InnerA
     let (iaddr, iret) = choose|iaddr: InnerAddr, iret: InnerAddr|
         {
             &&& A::into.ensures((addr,), iaddr)
-            &&& crate::utils::util::align_up_ens((iaddr, align), iret)
+            &&& crate::util::align_up_ens((iaddr, align), iret)
             &&& A::from.ensures((iret,), ret)
         };
-    crate::utils::util::proof_align_up(iaddr, align, iret);
+    crate::util::proof_align_up(iaddr, align, iret);
 }
 
 } // verus!

--- a/paging/src/specs/align.rs
+++ b/paging/src/specs/align.rs
@@ -4,7 +4,9 @@
 //
 // Author: Ziqiao Zhou <ziqiaozhou@microsoft.com>
 //
-// Specifications related to util.rs that are used in proof_align_down and proof_align_up.
+// Specifications related to alignment helpers that are used in proof_align_down and proof_align_up.
+use core::ops::{Add, BitAnd, Not, Sub};
+use verus_stub::*;
 use vstd::std_specs::ops::{AddSpec, BitAndSpec, NotSpec, SubSpec};
 
 #[verus_verify]
@@ -154,4 +156,7 @@ pub open spec fn spec_is_aligned<T>(val: T, align: T) -> bool where T: IsAligned
 }
 
 } // verus!
-include!("util.proof.verus.rs");
+#[path = "../proofs/align.rs"]
+mod align_proofs;
+
+pub use align_proofs::*;

--- a/paging/src/tlb.rs
+++ b/paging/src/tlb.rs
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) Microsoft Corporation
+//
+// Author: Ziqiao Zhou <ziqiaozhou@microsoft.com>
+
+//! TLB invalidation hooks and the [`MayNeedFlush`] obligation token.
+
+use crate::address::VirtAddr;
+use crate::traits::PageLevel;
+
+/// Architecture/OS hooks for TLB invalidation, plus the small algebra used to
+/// combine pending invalidations.
+///
+/// A value implementing `TlbFlush` is an opaque *flush token*: it describes
+/// which TLB entries a page-table mutation may have made stale. The `paging`
+/// crate never flushes directly; it hands these tokens back inside a
+/// [`MayNeedFlush`] and lets the OS decide how and when to discharge them.
+///
+/// This is referenced by [`ArchPagingMeta`](crate::traits::ArchPagingMeta) via
+/// its [`TlbFlushTok`](crate::traits::ArchPagingMeta::TlbFlushTok) associated
+/// type, keeping TLB concerns separate from address-encoding concerns. The
+/// discharge method names mirror the kernel's `cpu::tlb` free functions.
+pub trait TlbFlush: Sized {
+    /// Build a token covering the half-open virtual range `[start, end)` whose
+    /// mapping was changed at `page_size`.
+    fn range(start: VirtAddr, end: VirtAddr, page_size: PageLevel) -> Self;
+
+    /// Build a token that stands for "flush the entire TLB".
+    ///
+    /// Used when a mutation's precise footprint is unknown or when merging two
+    /// disjoint tokens (see [`and`](Self::and)).
+    fn all() -> Self;
+
+    /// Flush the TLB on all CPUs, including global pages.
+    fn flush_tlb_global_sync(self);
+
+    /// Merge two tokens into one that covers both.
+    ///
+    /// The default implementation is conservative: it widens to
+    /// [`all`](Self::all) rather than tracking a union of ranges. Override it
+    /// to preserve range precision when the architecture can flush selectively.
+    fn and(self, _: Self) -> Self {
+        Self::all()
+    }
+
+    /// Flush the TLB on the current CPU only, including global pages.
+    ///
+    /// The default implementation falls back to the cross-CPU
+    /// [`flush_tlb_global_sync`](Self::flush_tlb_global_sync); override it for a
+    /// cheaper CPU-local flush.
+    fn flush_tlb_global_percpu(self) {
+        self.flush_tlb_global_sync()
+    }
+
+    /// Flush the TLB on all CPUs, ignoring global pages.
+    ///
+    /// The default implementation is conservative and falls back to
+    /// [`flush_tlb_global_sync`](Self::flush_tlb_global_sync), which also
+    /// flushes global pages; override it to avoid that extra work.
+    fn flush_tlb_ignore_global_sync(self) {
+        self.flush_tlb_global_sync()
+    }
+
+    /// Flush the TLB on the current CPU only, ignoring global pages.
+    ///
+    /// The default implementation is conservative and falls back to
+    /// [`flush_tlb_global_percpu`](Self::flush_tlb_global_percpu), which also
+    /// flushes global pages; override it to avoid that extra work.
+    fn flush_tlb_ignore_global_percpu(self) {
+        self.flush_tlb_global_percpu()
+    }
+}
+
+/// A `#[must_use]` marker meaning the caller *may* still owe a TLB
+/// invalidation for the mapping it just modified.
+///
+/// `#[must_use]` is **not** a hard check. It does not guarantee a flush ever
+/// happens and it is trivially silenced; it is purely a quick hint that nudges
+/// the developer to handle the obligation at the call site. Treat it as a lint,
+/// not as a verified safety property.
+///
+/// The wrapped `tok` is `None` when no flush is needed and `Some(token)`
+/// otherwise. The token also records *what* to flush: a mutation to a 4 KiB
+/// page may require flushing the enclosing larger page. For example, changing
+/// the encryption flags of a 4 KiB page that was carved out of a 2 MiB huge
+/// page can require flushing the 2 MiB translation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[must_use = "this page-table mutation may have invalidated a live TLB entry; \
+flush the affected page or discharge the obligation with `.ignore(reason)`"]
+pub struct MayNeedFlush<T: TlbFlush> {
+    tok: Option<T>,
+}
+
+impl<A: TlbFlush> MayNeedFlush<A> {
+    pub fn scope(&self) -> &Option<A> {
+        &self.tok
+    }
+    /// Creates an obligation to flush the single page at `vaddr` mapped at
+    /// `level`.
+    ///
+    /// Most callers get their token back from a `paging`-crate mutation helper
+    /// (e.g. `unmap_4k`, `set_shared_4k`) that already captured the level a
+    /// walk stopped at, rather than constructing one directly.
+    pub fn new(vaddr: VirtAddr, level: PageLevel) -> Self {
+        MayNeedFlush {
+            tok: Some(A::range(vaddr, vaddr + level.size(), level)),
+        }
+    }
+
+    /// Creates an obligation to flush the half-open range `[start, end)`,
+    /// where each entry was mapped at `level`.
+    ///
+    /// Use this only when a caller outside of `paging` performs its own
+    /// low-level page-table edit (e.g. looping over a region and writing
+    /// entries directly) and must therefore vouch for the range and level
+    /// itself.
+    pub fn new_range(start: VirtAddr, end: VirtAddr, level: PageLevel) -> Self {
+        MayNeedFlush {
+            tok: Some(A::range(start, end, level)),
+        }
+    }
+
+    /// Creates a discharged token: the mutation needs no flush.
+    ///
+    /// Returned by helpers that observed no change to a live translation (e.g.
+    /// writing a previously-empty entry).
+    pub fn none() -> Self {
+        MayNeedFlush { tok: None }
+    }
+
+    /// Creates an obligation to flush the whole TLB.
+    ///
+    /// Use when a flush is required but its precise footprint is unknown.
+    pub fn all() -> Self {
+        MayNeedFlush {
+            tok: Some(A::all()),
+        }
+    }
+
+    /// Combines two obligations into one covering both.
+    ///
+    /// The result is discharged only if both inputs are; a pending token on
+    /// either side is preserved, and two pending tokens are merged via
+    /// [`TlbFlush::and`].
+    pub fn and(self, other: Self) -> Self {
+        match (self.tok, other.tok) {
+            (Some(tok1), Some(tok2)) => MayNeedFlush {
+                tok: Some(A::and(tok1, tok2)),
+            },
+            (Some(tok), None) | (None, Some(tok)) => MayNeedFlush { tok: Some(tok) },
+            (None, None) => MayNeedFlush { tok: None },
+        }
+    }
+
+    /// Discharge by flushing the TLB on all CPUs, ignoring global pages.
+    ///
+    /// Dispatches to [`TlbFlush::flush_tlb_ignore_global_sync`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the obligation is already discharged (`tok` is `None`); call
+    /// only when a flush is actually pending.
+    pub fn flush_tlb_ignore_global_sync(self) {
+        self.tok.unwrap().flush_tlb_ignore_global_sync();
+    }
+
+    /// Discharge by flushing the whole TLB (including global pages) on all
+    /// CPUs (the coarsest option).
+    ///
+    /// Dispatches to [`TlbFlush::flush_tlb_global_sync`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the obligation is already discharged (`tok` is `None`).
+    pub fn flush_tlb_global_sync(self) {
+        self.tok.unwrap().flush_tlb_global_sync();
+    }
+
+    /// Discharge by flushing the whole TLB (including global pages) on the
+    /// **current CPU only**, without a cross-CPU IPI.
+    ///
+    /// Dispatches to [`TlbFlush::flush_tlb_global_percpu`]. Use only when the
+    /// changed mapping cannot be live on any other CPU.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the obligation is already discharged (`tok` is `None`).
+    pub fn flush_tlb_global_percpu(self) {
+        self.tok.unwrap().flush_tlb_global_percpu();
+    }
+
+    /// Discharge by flushing the non-global TLB entries on the **current CPU
+    /// only**.
+    ///
+    /// Dispatches to [`TlbFlush::flush_tlb_ignore_global_percpu`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the obligation is already discharged (`tok` is `None`).
+    pub fn flush_tlb_percpu(self) {
+        self.tok.unwrap().flush_tlb_ignore_global_percpu();
+    }
+
+    /// Discharge the flush obligation **without** flushing.
+    /// This method is `unsafe` because it allows the caller to bypass the TLB flush
+    /// obligation.
+    ///
+    /// # Safety
+    /// The caller must ensure TLB flush is not needed.
+    pub unsafe fn ignore(self) {}
+
+    /// Assert that no flush is owed, consuming the obligation.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a flush is still pending (`tok` is `Some`). Use at call sites
+    /// that must never produce a stale translation.
+    pub fn expect_no_flush(self) {
+        assert!(self.tok.is_none());
+    }
+}

--- a/paging/src/traits.rs
+++ b/paging/src/traits.rs
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Generic paging traits and marker types.
+
+use crate::address::{Address, PhysAddr, VirtAddr};
+use bitflags::Flags;
+use zerocopy::FromBytes;
+
+/// Page table levels (0-based).
+///
+/// Level0 is the leaf (PTE), Level3 is the root of 4-level paging (PML4E).
+/// At most 4 levels are supported.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(usize)]
+pub enum PageLevel {
+    Level0 = 0,
+    Level1 = 1,
+    Level2 = 2,
+    Level3 = 3,
+}
+
+impl PageLevel {
+    /// Returns the next level down, or `None` at Level0.
+    pub fn next_down(self) -> Option<Self> {
+        match self {
+            Self::Level3 => Some(Self::Level2),
+            Self::Level2 => Some(Self::Level1),
+            Self::Level1 => Some(Self::Level0),
+            Self::Level0 => None,
+        }
+    }
+}
+
+/// Describes how many levels a page table hierarchy has.
+///
+/// `TOP_LEVEL` is the highest (root) level, up to [`PageLevel::Level3`]
+/// (i.e. at most 4 levels: L0-L3).
+///
+/// Architecture-specific ZSTs that implement this trait live in their
+/// respective modules (e.g. `x86_64::Pml4Level`).
+pub trait PagingLevel {
+    /// Highest page table level.
+    const TOP_LEVEL: PageLevel;
+}
+
+#[derive(Debug)]
+pub struct PagingLevel3;
+
+impl PagingLevel for PagingLevel3 {
+    const TOP_LEVEL: PageLevel = PageLevel::Level3;
+}
+
+#[derive(Debug)]
+pub struct PagingLevel2;
+
+impl PagingLevel for PagingLevel2 {
+    const TOP_LEVEL: PageLevel = PageLevel::Level2;
+}
+
+/// Errors that can occur during page table operations.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PagingError {
+    /// Frame allocation failed.
+    AllocFrame,
+    /// The requested virtual address is not mapped.
+    NotMapped,
+}
+
+/// Architecture-specific page table metadata for confidential computing.
+///
+/// Defines how encryption/confidentiality bits are managed in page table
+/// entries. On AMD SEV-SNP the private mask is the C-bit and the shared mask
+/// is zero (or vice-versa depending on convention). On platforms without
+/// memory encryption both masks are zero.
+///
+/// # Required methods
+///
+/// * [`private_pte_mask`](Self::private_pte_mask) — bitmask ORed into PTEs
+///   for private (encrypted) mappings.
+/// * [`shared_pte_mask`](Self::shared_pte_mask) — bitmask ORed into PTEs
+///   for shared (plaintext) mappings.
+/// * [`flush_tlb_global`](Self::flush_tlb_global) — flush the TLB on all
+///   CPUs; called after splitting or changing the encryption state of a page.
+///
+/// # Default methods
+///
+/// The remaining methods (`strip_*`, `make_*`, `is_shared_address`,
+/// `supported_flags`) have default implementations derived from the masks.
+/// Override only if the platform requires non-standard behaviour.
+///
+/// # Implementer requirements
+///
+/// * All methods must be stateless (no `&self`) — the type is used as a
+///   zero-sized marker and never instantiated.
+/// * `private_pte_mask` and `shared_pte_mask` must not share any set bits —
+///   a page is either private *or* shared.
+/// * `make_private_address` and `make_shared_address` must be idempotent.
+pub trait ArchPagingMeta: 'static + Copy {
+    type PTFlags: GenericPageTableFlags;
+
+    /// Returns the bitmask ORed into physical addresses for private
+    /// (encrypted) page table entries.
+    fn private_pte_mask() -> usize;
+
+    /// Returns the bitmask ORed into physical addresses for shared
+    /// (plaintext) page table entries.
+    fn shared_pte_mask() -> usize;
+
+    /// Physical address mask.
+    /// x64 supports 52-bit physical addresses, so the mask is usually 0x000f_ffff_ffff_f000.
+    fn address_mask() -> usize;
+
+    /// Flush the TLB globally and synchronize across all CPUs.
+    ///
+    /// Called after modifying live PTEs (e.g., splitting a 2M page or
+    /// toggling the encryption state of a mapping).
+    fn flush_tlb_global();
+
+    /// Returns a bitmask of PTEntryFlags that the hardware supports.
+    ///
+    /// Override this method to filter unsupported bits (e.g., `GLOBAL` before CR4.PGE is enabled)
+    /// so that they are silently cleared. The default allows all flags.
+    fn supported_flags() -> Self::PTFlags {
+        Self::PTFlags::all()
+    }
+
+    /// Clears the private encryption bit(s) from `paddr`.
+    fn strip_confidentiality_bits(paddr: PhysAddr) -> PhysAddr {
+        (paddr.bits() & !Self::private_pte_mask()).into()
+    }
+
+    /// Clears the shared bit(s) from `paddr`.
+    fn strip_shared_address_bits(paddr: PhysAddr) -> PhysAddr {
+        (paddr.bits() & !Self::shared_pte_mask()).into()
+    }
+
+    /// Returns `paddr` with the private encryption mask applied.
+    ///
+    /// Any shared bits are stripped first so the result is exclusively
+    /// private.
+    fn make_private_address(paddr: PhysAddr) -> PhysAddr {
+        (Self::strip_shared_address_bits(paddr).bits() | Self::private_pte_mask()).into()
+    }
+
+    /// Returns `paddr` with the shared mask applied.
+    ///
+    /// Any confidentiality (private) bits are stripped first so the result
+    /// is exclusively shared.
+    fn make_shared_address(paddr: PhysAddr) -> PhysAddr {
+        (Self::strip_confidentiality_bits(paddr).bits() | Self::shared_pte_mask()).into()
+    }
+
+    /// Returns `true` if `paddr` already has the shared mask applied.
+    fn is_shared_address(paddr: PhysAddr) -> bool {
+        paddr == Self::make_shared_address(paddr)
+    }
+}
+
+/// OS-level page table services: address translation and frame management.
+///
+/// Bridges the generic page table code to the OS memory allocator and
+/// virtual-address layout. Every method is an associated function (no
+/// `&self`) — the implementing type is used as a zero-sized marker and
+/// never instantiated.
+///
+/// # Safety
+///
+/// Implementers must guarantee:
+///
+/// * **`paddr_to_vaddr`** — the returned virtual address is a valid,
+///   dereferenceable mapping of `paddr` for the lifetime of the page table.
+///   `paddr` is always a *clean* physical address (no encryption bits).
+///
+/// * **`allocate_physical_page`** — every successful call returns a *unique*,
+///   page-aligned, *zeroed* physical frame whose address is *clean* (no
+///   encryption/confidentiality bits). The frame remains valid until a
+///   matching `deallocate_physical_page` call.
+///
+/// * **`deallocate_physical_page`** — `paddr` is a value previously returned by
+///   `allocate_physical_page` that has not yet been freed.
+///
+/// # Cross-method invariant
+///
+/// `paddr_to_vaddr` must return a valid, writable mapping for every
+/// address returned by `allocate_physical_page`. The generic page table code
+/// calls `allocate_physical_page` and immediately passes the result to
+/// `paddr_to_vaddr` in order to zero-initialise and populate newly
+/// allocated page table pages. This invariant can be satisfied either
+/// by a linear map of all physical memory (so `paddr_to_vaddr` works
+/// for any physical address) or by having `allocate_physical_page` return only
+/// frames that are already mapped.
+pub unsafe trait PagingHandler: 'static + FromBytes {
+    /// Translate a clean physical address to a virtual address suitable for
+    /// accessing page table pages.
+    fn paddr_to_vaddr(paddr: PhysAddr) -> VirtAddr;
+
+    /// Allocate a zeroed page-table frame.
+    ///
+    /// Returns the *clean* physical address of the frame — no encryption
+    /// or confidentiality bits are set. Callers apply
+    /// [`ArchPagingMeta::make_private_address`] when storing the address
+    /// in a PTE.
+    fn allocate_physical_page() -> Result<PhysAddr, PagingError>;
+
+    /// Deallocate a page-table frame previously returned by
+    /// [`allocate_physical_page`](Self::allocate_physical_page).
+    ///
+    /// # Safety
+    ///
+    /// `paddr` must be a clean physical address previously returned by
+    /// `allocate_physical_page` and not yet freed.
+    unsafe fn deallocate_physical_page(paddr: PhysAddr);
+}
+
+/// Self-map support for page tables.
+///
+/// When a page table contains a self-map entry (a PML4 entry that points
+/// back to the page table root), the CPU's address translation creates a
+/// virtual window through which every PTE of the *active* page table can
+/// be read and written at a known virtual address.
+///
+/// # Implementer requirements
+///
+/// * `PTE_BASE_VADDR` must return the virtual base address of that self-map
+///   window. For a self-map installed at PML4 index *N*, this is
+///   `sign_extend(N << 39 | N << 30 | N << 21 | N << 12)`.
+/// * The self-map entry must be installed before any method in the
+///   `impl<..., P: PagingHandler + SelfMap>` block is called.
+pub trait SelfMap {
+    /// The PML4 index of the self-map entry.
+    const SELFMAP_IDX: usize;
+}
+
+pub trait GenericPageTableFlags:
+    bitflags::Flags<Bits = usize>
+    + core::ops::BitAnd<Output = Self>
+    + core::ops::BitOr<Output = Self>
+    + Copy
+    + Clone
+{
+    const PRESENT: Self;
+    const USER: Self;
+    const HUGE: Self;
+
+    /// Default flags for newly created parent page table entries.
+    ///
+    /// These flags must be permissive enough to form a superset of all
+    /// possible descendant leaf entry permissions, since effective access
+    /// rights are constrained by both parent and leaf entries.
+    fn parent_flags() -> Self;
+
+    /// Flags for the self-map entry itself. This may differ from `parent_flags`
+    fn self_map_table_flags() -> Self;
+
+    fn huge(&self) -> bool {
+        self.contains(Self::HUGE)
+    }
+
+    fn present(&self) -> bool {
+        self.contains(Self::PRESENT)
+    }
+
+    fn user(&self) -> bool {
+        self.contains(Self::USER)
+    }
+}

--- a/paging/src/traits.rs
+++ b/paging/src/traits.rs
@@ -2,7 +2,11 @@
 
 //! Generic paging traits and marker types.
 
-use crate::address::{Address, PhysAddr, VirtAddr};
+use crate::{
+    address::{Address, PhysAddr, VirtAddr},
+    pagetable::ENTRY_COUNT,
+    sizes::{PAGE_SIZE, PAGE_SIZE_1G, PAGE_SIZE_2M},
+};
 use bitflags::Flags;
 use zerocopy::FromBytes;
 
@@ -27,6 +31,15 @@ impl PageLevel {
             Self::Level2 => Some(Self::Level1),
             Self::Level1 => Some(Self::Level0),
             Self::Level0 => None,
+        }
+    }
+
+    pub fn size(&self) -> usize {
+        match self {
+            Self::Level0 => PAGE_SIZE,
+            Self::Level1 => PAGE_SIZE_2M,
+            Self::Level2 => PAGE_SIZE_1G,
+            Self::Level3 => ENTRY_COUNT * PAGE_SIZE_1G,
         }
     }
 }

--- a/paging/src/traits.rs
+++ b/paging/src/traits.rs
@@ -6,6 +6,7 @@ use crate::{
     address::{Address, PhysAddr, VirtAddr},
     pagetable::ENTRY_COUNT,
     sizes::{PAGE_SIZE, PAGE_SIZE_1G, PAGE_SIZE_2M},
+    tlb::TlbFlush,
 };
 use bitflags::Flags;
 use zerocopy::FromBytes;
@@ -17,10 +18,10 @@ use zerocopy::FromBytes;
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(usize)]
 pub enum PageLevel {
-    Level0 = 0,
-    Level1 = 1,
-    Level2 = 2,
-    Level3 = 3,
+    Level0 = 0, // 4K
+    Level1 = 1, // 2M
+    Level2 = 2, // 1G
+    Level3 = 3, // 512G
 }
 
 impl PageLevel {
@@ -92,8 +93,6 @@ pub enum PagingError {
 ///   for private (encrypted) mappings.
 /// * [`shared_pte_mask`](Self::shared_pte_mask) — bitmask ORed into PTEs
 ///   for shared (plaintext) mappings.
-/// * [`flush_tlb_global`](Self::flush_tlb_global) — flush the TLB on all
-///   CPUs; called after splitting or changing the encryption state of a page.
 ///
 /// # Default methods
 ///
@@ -110,6 +109,7 @@ pub enum PagingError {
 /// * `make_private_address` and `make_shared_address` must be idempotent.
 pub trait ArchPagingMeta: 'static + Copy {
     type PTFlags: GenericPageTableFlags;
+    type TlbFlushTok: TlbFlush;
 
     /// Returns the bitmask ORed into physical addresses for private
     /// (encrypted) page table entries.
@@ -122,12 +122,6 @@ pub trait ArchPagingMeta: 'static + Copy {
     /// Physical address mask.
     /// x64 supports 52-bit physical addresses, so the mask is usually 0x000f_ffff_ffff_f000.
     fn address_mask() -> usize;
-
-    /// Flush the TLB globally and synchronize across all CPUs.
-    ///
-    /// Called after modifying live PTEs (e.g., splitting a 2M page or
-    /// toggling the encryption state of a mapping).
-    fn flush_tlb_global();
 
     /// Returns a bitmask of PTEntryFlags that the hardware supports.
     ///

--- a/paging/src/util.rs
+++ b/paging/src/util.rs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2022-2023 SUSE LLC
+//
+// Author: Joerg Roedel <jroedel@suse.de>
+
+use crate::sizes::PAGE_SIZE;
+use core::ops::{Add, BitAnd, Not, Sub};
+
+use verus_stub::*;
+
+#[cfg(verus_only)]
+#[path = "specs/align.rs"]
+mod align_spec_defs;
+#[cfg(verus_only)]
+pub use align_spec_defs::*;
+#[cfg(verus_only)]
+verus! {
+    broadcast use align_spec_defs::group_align_proofs;
+}
+
+#[verus_spec(ret =>
+    requires
+        align_up_requires((addr, align)),
+    ensures
+        align_up_ens((addr, align), ret),
+)]
+pub fn align_up<T>(addr: T, align: T) -> T
+where
+    T: Add<Output = T> + Sub<Output = T> + BitAnd<Output = T> + Not<Output = T> + From<u8> + Copy,
+{
+    let mask: T = align - T::from(1u8);
+    (addr + mask) & !mask
+}
+
+#[verus_spec(ret =>
+    requires
+        align_down_requires((addr, align)),
+    ensures
+        align_down_ens((addr, align), ret),
+)]
+pub fn align_down<T>(addr: T, align: T) -> T
+where
+    T: Sub<Output = T> + Not<Output = T> + BitAnd<Output = T> + From<u8> + Copy,
+{
+    addr & !(align - T::from(1u8))
+}
+
+#[verus_spec(ret =>
+    requires
+        is_aligned_requires((addr, align)),
+    ensures
+        is_aligned_ens((addr, align), ret)
+)]
+pub fn is_aligned<T>(addr: T, align: T) -> bool
+where
+    T: Sub<Output = T> + BitAnd<Output = T> + PartialEq + From<u8>,
+{
+    (addr & (align - T::from(1u8))) == T::from(0u8)
+}
+
+pub fn page_align_up(x: usize) -> usize {
+    align_up(x, PAGE_SIZE)
+}
+
+pub fn round_to_pages(x: usize) -> usize {
+    page_align_up(x) / PAGE_SIZE
+}
+
+pub fn page_offset(x: usize) -> usize {
+    x & (PAGE_SIZE - 1)
+}
+
+pub fn overlap<T>(x1: T, x2: T, y1: T, y2: T) -> bool
+where
+    T: PartialOrd,
+{
+    x1 <= y2 && y1 <= x2
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mem_utils() {
+        // Align up
+        assert_eq!(align_up(7, 4), 8);
+        assert_eq!(align_up(15, 8), 16);
+        assert_eq!(align_up(10, 2), 10);
+        // Align down
+        assert_eq!(align_down(7, 4), 4);
+        assert_eq!(align_down(15, 8), 8);
+        assert_eq!(align_down(10, 2), 10);
+        // Page align up
+        assert_eq!(page_align_up(4096), 4096);
+        assert_eq!(page_align_up(4097), 8192);
+        assert_eq!(page_align_up(0), 0);
+        // Page offset
+        assert_eq!(page_offset(4096), 0);
+        assert_eq!(page_offset(4097), 1);
+        assert_eq!(page_offset(0), 0);
+        // Overlaps
+        assert!(overlap(1, 5, 3, 6));
+        assert!(overlap(0, 10, 5, 15));
+        assert!(!overlap(1, 5, 6, 8));
+    }
+}

--- a/paging/src/x86_64.rs
+++ b/paging/src/x86_64.rs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! x86_64-specific page table entry flags.
+
+use bitflags::bitflags;
+
+use crate::traits::GenericPageTableFlags;
+
+bitflags! {
+    /// x86_64 page table entry flags.
+    ///
+    /// Bit positions follow the Intel/AMD architecture manuals for
+    /// 4-level (PML4) and 5-level (PML5) paging modes.
+    #[derive(Copy, Clone, Debug, Default)]
+    pub struct PTEntryFlags: usize {
+        const PRESENT       = 1 << 0;
+        const WRITABLE      = 1 << 1;
+        const USER          = 1 << 2;
+        const WRITE_THROUGH = 1 << 3;
+        const NO_CACHE      = 1 << 4;
+        const ACCESSED      = 1 << 5;
+        const DIRTY         = 1 << 6;
+        const HUGE          = 1 << 7;
+        const GLOBAL        = 1 << 8;
+        const NX            = 1 << 63;
+    }
+}
+
+impl GenericPageTableFlags for PTEntryFlags {
+    const PRESENT: Self = Self::PRESENT;
+    const USER: Self = Self::USER;
+    const HUGE: Self = Self::HUGE;
+
+    /// present, writable, user-accessible, and accessed.
+    fn parent_flags() -> Self {
+        Self::PRESENT | Self::WRITABLE | Self::USER | Self::ACCESSED
+    }
+
+    /// page table is not accessible by user mode, and is not executable.
+    fn self_map_table_flags() -> Self {
+        Self::PRESENT | Self::WRITABLE | Self::ACCESSED | Self::DIRTY | Self::NX
+    }
+}
+
+impl PTEntryFlags {
+    /// Check if the page table entry is writable.
+    pub fn writable(&self) -> bool {
+        self.contains(Self::WRITABLE)
+    }
+
+    /// Check if the page table entry is user-accessible.
+    pub fn user(&self) -> bool {
+        self.contains(Self::USER)
+    }
+
+    /// Check if the page table entry is NX (no-execute).
+    pub fn nx(&self) -> bool {
+        self.contains(Self::NX)
+    }
+
+    /// Check if the page table entry is global.
+    pub fn global(&self) -> bool {
+        self.contains(Self::GLOBAL)
+    }
+
+    pub fn exec() -> Self {
+        Self::PRESENT | Self::GLOBAL | Self::ACCESSED
+    }
+
+    pub fn data() -> Self {
+        Self::PRESENT | Self::GLOBAL | Self::WRITABLE | Self::NX | Self::ACCESSED | Self::DIRTY
+    }
+
+    pub fn data_ro() -> Self {
+        Self::PRESENT | Self::GLOBAL | Self::NX | Self::ACCESSED
+    }
+
+    pub fn task_exec() -> Self {
+        Self::PRESENT | Self::ACCESSED
+    }
+
+    pub fn task_data() -> Self {
+        Self::PRESENT | Self::WRITABLE | Self::NX | Self::ACCESSED | Self::DIRTY
+    }
+
+    pub fn task_data_ro() -> Self {
+        Self::PRESENT | Self::NX | Self::ACCESSED
+    }
+}
+
+/// x86_64 4-level paging (PML4).
+pub type Pml4Level = crate::traits::PagingLevel3;
+
+/// x86-64 PDPT-rooted 3-level page table sub-tree.
+pub type PdptLevel = crate::traits::PagingLevel2;

--- a/paging/src/x86_64.rs
+++ b/paging/src/x86_64.rs
@@ -32,8 +32,9 @@ impl GenericPageTableFlags for PTEntryFlags {
     const HUGE: Self = Self::HUGE;
 
     /// present, writable, user-accessible, and accessed.
+    /// ACCESSED & DIRTY => prevent future hardware mutations.
     fn parent_flags() -> Self {
-        Self::PRESENT | Self::WRITABLE | Self::USER | Self::ACCESSED
+        Self::PRESENT | Self::WRITABLE | Self::USER | Self::ACCESSED | Self::DIRTY
     }
 
     /// page table is not accessible by user mode, and is not executable.


### PR DESCRIPTION
This is the 3rd PR that should be applied after #1088 and #1062