### PR TITLE
virtio-drivers: Use upstream via custom safe-mmio backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bldr"
@@ -718,9 +718,20 @@ dependencies = [
 
 [[package]]
 name = "embedded-io"
-version = "0.6.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+checksum = "9eb1aa714776b75c7e67e1da744b81a129b3ff919c8712b5e1b32252c1f07cc7"
+
+[[package]]
+name = "enumn"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "ff"
@@ -2092,18 +2103,18 @@ version = "0.1.0"
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2498,12 +2509,15 @@ dependencies = [
 
 [[package]]
 name = "virtio-drivers"
-version = "0.7.5"
-source = "git+https://github.com/coconut-svsm/virtio-drivers.git?rev=dcbdbc8cefc0c985322382acdeb633a63a3a4cc1#dcbdbc8cefc0c985322382acdeb633a63a3a4cc1"
+version = "0.13.0"
+source = "git+https://github.com/rcore-os/virtio-drivers.git?rev=c8786e83e6a64e46ed5cab301048dbaf3aab1444#c8786e83e6a64e46ed5cab301048dbaf3aab1444"
 dependencies = [
  "bitflags",
  "embedded-io",
+ "enumn",
  "log",
+ "safe-mmio",
+ "thiserror",
  "zerocopy",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1772,6 +1772,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "safe-mmio"
+version = "0.3.0"
+source = "git+https://github.com/google/safe-mmio?rev=89f584caaf32fcd4341a5a716c97d67be83edb9c#89f584caaf32fcd4341a5a716c97d67be83edb9c"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2010,6 +2018,7 @@ dependencies = [
  "release",
  "rustc-demangle",
  "rustc_version",
+ "safe-mmio",
  "serde",
  "serde_json",
  "sha2",
@@ -2758,18 +2767,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.30"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea879c944afe8a2b25fef16bb4ba234f47c694565e97383b36f3a878219065c"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.30"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf955aa904d6040f70dc8e9384444cb1030aed272ba3cb09bbc4ab9e7c1f34f5"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ libfuzzer-sys = "0.4"
 log = "0.4.17"
 p384 = { version = "0.13.0" }
 rustc-demangle = { version = "0.1.26" }
+safe-mmio = { version = "0.3", features = ["custom-mmio"] }
 serde = { version = "1.0.215", default-features = false }
 serde_json = { version = "1.0", default-features = false }
 sha2 = { version = "0.10.8", default-features = false }
@@ -110,6 +111,12 @@ vstd = { version = "=0.0.0-2026-04-12-0118", features = ["alloc", "allow_panic"]
 # Verification libs
 verify_proof = { path = "verification/verify_proof", default-features = false  }
 verify_external = { path = "verification/verify_external", default-features = false  }
+
+[patch.crates-io]
+# Force all dependencies to use the same version of safe-mmio, which has
+# the new custom-mmio feature, so that injecting our MMIO backend works.
+# This can be removed once the feature has been released on creates.io.
+safe-mmio = { git = "https://github.com/google/safe-mmio", rev = "89f584caaf32fcd4341a5a716c97d67be83edb9c" }
 
 [profile.release]
 panic = 'abort'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,6 @@ packit = { path = "packit" }
 userlib = { path = "user/lib" }
 userinit = { path = "user/init" }
 release = { path = "release" }
-virtio-drivers = { git = "https://github.com/coconut-svsm/virtio-drivers.git", rev = "dcbdbc8cefc0c985322382acdeb633a63a3a4cc1" }
 
 # crates.io
 aes-gcm = { version = "0.10.3", default-features = false }
@@ -97,10 +96,12 @@ sha2 = { version = "0.10.8", default-features = false }
 uuid = { version = "1.6.1", default-features = false }
 virtfw-libefi = { version = "0.6" }
 virtfw-varstore = { version = "0.6.1" }
+# We can pull virtio-drivers from crates.io once the vsock connection manager
+# changes have been released.
+virtio-drivers = { git = "https://github.com/rcore-os/virtio-drivers.git", rev = "c8786e83e6a64e46ed5cab301048dbaf3aab1444" }
 # Add the derive feature by default because all crates use it.
 zerocopy = { version = "0.8.2", features = ["derive"] }
 zeroize = { version = "1.8.2", default-features = false }
-embedded-io = { version = "0.6.1" }
 
 # Verus repos
 verus_builtin = { version = "=0.0.0-2026-04-12-0118", default-features = false }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -54,6 +54,7 @@ release.workspace = true
 # Need "force-soft", see https://github.com/RustCrypto/hashes/issues/446
 sha2 = { workspace = true, features = ["force-soft"] }
 uuid.workspace = true
+safe-mmio = { workspace = true, optional = true }
 virtio-drivers = { workspace = true, optional = true }
 virtfw-libefi = { workspace = true, optional = true }
 virtfw-varstore = { workspace = true, optional = true }
@@ -80,7 +81,7 @@ nosmap = []
 verus_all = ["verus_builtin", "verus_builtin_macros", "vstd", "verify_proof/verus", "verify_external/verus", "verus_stub/disable"]
 verus = ["verus_all", "verify_proof/noverify", "verify_external/noverify"]
 noverify = []
-virtio-drivers = ["dep:virtio-drivers"]
+virtio-drivers = ["dep:virtio-drivers", "dep:safe-mmio"]
 block = []
 vsock = []
 uefivars = ["dep:virtfw-varstore", "dep:virtfw-libefi"]

--- a/kernel/src/block/virtio_blk.rs
+++ b/kernel/src/block/virtio_blk.rs
@@ -22,7 +22,7 @@ extern crate alloc;
 use alloc::boxed::Box;
 
 pub struct VirtIOBlkDriver {
-    device: SpinLock<VirtIOBlk<SvsmHal, MmioTransport<SvsmHal>>>,
+    device: SpinLock<VirtIOBlk<SvsmHal, MmioTransport<'static>>>,
     _mmio_space: GlobalRangeGuard,
 }
 

--- a/kernel/src/virtio/hal.rs
+++ b/kernel/src/virtio/hal.rs
@@ -7,12 +7,8 @@
 extern crate alloc;
 use crate::{locking::SpinLock, platform::SVSM_PLATFORM};
 use alloc::vec::Vec;
-use core::{
-    cell::OnceCell,
-    mem::{MaybeUninit, size_of},
-    ptr::{NonNull, addr_of},
-};
-use zerocopy::{FromBytes, Immutable, IntoBytes};
+use core::{cell::OnceCell, mem::MaybeUninit, ptr::NonNull};
+use zerocopy::IntoBytes;
 
 use crate::{
     address::{PhysAddr, VirtAddr},
@@ -63,6 +59,7 @@ unsafe impl virtio_drivers::Hal for SvsmHal {
     fn dma_alloc(
         pages: usize,
         _direction: virtio_drivers::BufferDirection,
+        _access_platform: bool,
     ) -> (virtio_drivers::PhysAddr, NonNull<u8>) {
         // TODO: allow more than one page.
         //       This currently works, because in "modern" virtio mode the crate only allocates
@@ -91,6 +88,7 @@ unsafe impl virtio_drivers::Hal for SvsmHal {
         paddr: virtio_drivers::PhysAddr,
         _vaddr: NonNull<u8>,
         pages: usize,
+        _access_platform: bool,
     ) -> i32 {
         //TODO: allow more than one page
         assert!(pages == 1);
@@ -123,6 +121,7 @@ unsafe impl virtio_drivers::Hal for SvsmHal {
     unsafe fn share(
         buffer: NonNull<[u8]>,
         direction: virtio_drivers::BufferDirection,
+        _access_platform: bool,
     ) -> virtio_drivers::PhysAddr {
         // TODO: allow more than one page
         assert!(buffer.len() <= PAGE_SIZE);
@@ -161,6 +160,7 @@ unsafe impl virtio_drivers::Hal for SvsmHal {
         paddr: virtio_drivers::PhysAddr,
         buffer: NonNull<[u8]>,
         direction: virtio_drivers::BufferDirection,
+        _access_platform: bool,
     ) {
         assert!(buffer.len() <= PAGE_SIZE);
 
@@ -188,52 +188,6 @@ unsafe impl virtio_drivers::Hal for SvsmHal {
             }
         }
         // implicit drop of share_page here.
-    }
-
-    /// Performs memory mapped read from location of `src`. `src` itself is not modified,
-    /// the value is returned instead.
-    ///
-    /// The default implementation performs a regular volatile_read. This method is intended
-    /// to be overwritten in case MMIO memory needs to be accessed in a special way (for example AMD SEV-SNP).
-    ///
-    /// # Safety
-    ///
-    /// `src` must be properly aligned and reside at a readable memory address.
-    unsafe fn mmio_read<T: FromBytes + Immutable>(src: &T) -> T {
-        let mut b = MaybeUninit::<T>::uninit();
-        // SAFETY: We are trusting the caller (the virtio driver) to ensure `src` is a valid MMIO
-        // address and that it is aligned properly. If SVSM_PLATFORM.mmio_read() doesn't fail
-        // we can assume that all the bytes are read from the device.
-        unsafe {
-            // MaybeUninit::as_bytes_mut() can avoid this, but it's still
-            // unstable. When it will be stabilized, we can simply use
-            // `b.as_bytes_mut()` instead of creating `b_slice`.
-            let b_slice = core::slice::from_raw_parts_mut(
-                b.as_mut_ptr().cast::<MaybeUninit<u8>>(),
-                size_of::<T>(),
-            );
-            SVSM_PLATFORM
-                .mmio_read(VirtAddr::from(addr_of!(*src)), b_slice)
-                .unwrap();
-            b.assume_init()
-        }
-    }
-
-    /// Performs memory mapped write of `value` to the location of `dst`.
-    ///
-    /// The default implementation performs a regular volatile_write. This method is intended
-    /// to be overwritten in case MMIO memory needs to be accessed in a special way (for example AMD SEV-SNP).
-    ///
-    /// # Safety
-    ///
-    /// `dst` must be properly aligned and reside at a writable memory address.
-    unsafe fn mmio_write<T: IntoBytes + Immutable>(dst: &mut T, v: T) {
-        // SAFETY: We are trusting the caller (the virtio driver) to ensure validity of `paddr` and alignment of data.
-        unsafe {
-            SVSM_PLATFORM
-                .mmio_write(VirtAddr::from(addr_of!(*dst)), v.as_bytes())
-                .unwrap();
-        }
     }
 }
 

--- a/kernel/src/virtio/hal.rs
+++ b/kernel/src/virtio/hal.rs
@@ -236,3 +236,104 @@ unsafe impl virtio_drivers::Hal for SvsmHal {
         }
     }
 }
+
+/// safe-mmio backend implementation
+struct SvsmMmio;
+
+// SAFETY: Each method performs a single MMIO access of the indicated width
+// via the platform's GHCB-based MMIO helpers.
+unsafe impl safe_mmio::custom_mmio::MmioOps for SvsmMmio {
+    unsafe fn read_u8(src: *const u8) -> u8 {
+        let mut data = MaybeUninit::<u8>::uninit();
+        // SAFETY: src is a valid, aligned MMIO pointer per MmioOps contract.
+        unsafe {
+            SVSM_PLATFORM
+                .mmio_read(
+                    VirtAddr::from(src),
+                    core::slice::from_raw_parts_mut(data.as_mut_ptr().cast(), 1),
+                )
+                .unwrap();
+            data.assume_init()
+        }
+    }
+
+    unsafe fn read_u16(src: *const u16) -> u16 {
+        let mut data = MaybeUninit::<u16>::uninit();
+        // SAFETY: src is a valid, aligned MMIO pointer per MmioOps contract.
+        unsafe {
+            SVSM_PLATFORM
+                .mmio_read(
+                    VirtAddr::from(src),
+                    core::slice::from_raw_parts_mut(data.as_mut_ptr().cast(), 2),
+                )
+                .unwrap();
+            data.assume_init()
+        }
+    }
+
+    unsafe fn read_u32(src: *const u32) -> u32 {
+        let mut data = MaybeUninit::<u32>::uninit();
+        // SAFETY: src is a valid, aligned MMIO pointer per MmioOps contract.
+        unsafe {
+            SVSM_PLATFORM
+                .mmio_read(
+                    VirtAddr::from(src),
+                    core::slice::from_raw_parts_mut(data.as_mut_ptr().cast(), 4),
+                )
+                .unwrap();
+            data.assume_init()
+        }
+    }
+
+    unsafe fn read_u64(src: *const u64) -> u64 {
+        let mut data = MaybeUninit::<u64>::uninit();
+        // SAFETY: src is a valid, aligned MMIO pointer per MmioOps contract.
+        unsafe {
+            SVSM_PLATFORM
+                .mmio_read(
+                    VirtAddr::from(src),
+                    core::slice::from_raw_parts_mut(data.as_mut_ptr().cast(), 8),
+                )
+                .unwrap();
+            data.assume_init()
+        }
+    }
+
+    unsafe fn write_u8(dst: *mut u8, value: u8) {
+        // SAFETY: dst is a valid, aligned MMIO pointer per MmioOps contract.
+        unsafe {
+            SVSM_PLATFORM
+                .mmio_write(VirtAddr::from(dst), value.as_bytes())
+                .unwrap();
+        }
+    }
+
+    unsafe fn write_u16(dst: *mut u16, value: u16) {
+        // SAFETY: dst is a valid, aligned MMIO pointer per MmioOps contract.
+        unsafe {
+            SVSM_PLATFORM
+                .mmio_write(VirtAddr::from(dst), value.as_bytes())
+                .unwrap();
+        }
+    }
+
+    unsafe fn write_u32(dst: *mut u32, value: u32) {
+        // SAFETY: dst is a valid, aligned MMIO pointer per MmioOps contract.
+        unsafe {
+            SVSM_PLATFORM
+                .mmio_write(VirtAddr::from(dst), value.as_bytes())
+                .unwrap();
+        }
+    }
+
+    unsafe fn write_u64(dst: *mut u64, value: u64) {
+        // SAFETY: dst is a valid, aligned MMIO pointer per MmioOps contract.
+        unsafe {
+            SVSM_PLATFORM
+                .mmio_write(VirtAddr::from(dst), value.as_bytes())
+                .unwrap();
+        }
+    }
+}
+
+safe_mmio::set_mmio_ops!(SvsmMmio);

--- a/kernel/src/virtio/hal.rs
+++ b/kernel/src/virtio/hal.rs
@@ -133,7 +133,7 @@ unsafe impl virtio_drivers::Hal for SvsmHal {
             let dst = shared_page.addr().as_mut_ptr::<u8>();
 
             // SAFETY: We demand a valid `buffer` from the caller (virtio-drivers crate).
-            //         We assterted that `dst` can hold at least `buffer.len()`.
+            //         We asserted that `dst` can hold at least `buffer.len()`.
             unsafe {
                 core::ptr::copy_nonoverlapping(src, dst, buffer.len());
             }

--- a/kernel/src/virtio/mmio.rs
+++ b/kernel/src/virtio/mmio.rs
@@ -17,11 +17,11 @@ use crate::fw_cfg::FwCfg;
 use crate::mm::{GlobalRangeGuard, map_global_range_4k_shared, pagetable::PTEntryFlags};
 use crate::platform::SVSM_PLATFORM;
 use crate::types::PAGE_SIZE;
-use crate::virtio::hal::{SvsmHal, virtio_init};
+use crate::virtio::hal::virtio_init;
 
 #[derive(Debug)]
 pub struct MmioSlot {
-    pub transport: MmioTransport<SvsmHal>,
+    pub transport: MmioTransport<'static>,
     // Fields are ordered so that `mmio_range` is dropped last.
     // The MmioTransport destructor resets the device via MMIO writes, and
     // dropping `mmio_range` destroys the mapping, so `mmio_range` must be
@@ -102,7 +102,8 @@ pub fn probe_mmio_slots(boot_params: &BootParams<'_>) -> MmioSlots {
         // SAFETY: The address is valid, mapped by `map_global_range_4k_shared`, and verified
         // to be VirtIOHeader-aligned by the guard above.
         // The memory region has the same lifetime of the MmioSlot structure which will be consumed by the driver.
-        let Ok(transport) = (unsafe { MmioTransport::<SvsmHal>::new(header) }) else {
+        // Note: QEMU places each MMIO slot on its own page for us, thus mmio_size = PAGE_SIZE.
+        let Ok(transport) = (unsafe { MmioTransport::new(header, PAGE_SIZE) }) else {
             // Currently QEMU advertises _all_ slots, regardless they are empty or not.
             log::debug!("MmioSlots: {addr:x} empty");
             continue;

--- a/kernel/src/vsock/virtio_vsock.rs
+++ b/kernel/src/vsock/virtio_vsock.rs
@@ -25,7 +25,7 @@ use virtio_drivers::transport::DeviceType::Socket;
 use virtio_drivers::transport::mmio::MmioTransport;
 
 pub struct VirtIOVsockDriver {
-    device: SpinLock<VsockConnectionManager<SvsmHal, MmioTransport<SvsmHal>>>,
+    device: SpinLock<VsockConnectionManager<SvsmHal, MmioTransport<'static>>>,
     _mmio_space: GlobalRangeGuard,
 }
 


### PR DESCRIPTION
Consume the current virtio-drivers master branch directly by implementing a custom MMIO backend for the safe-mmio crate (used by upstream virtio-drivers)
to route accesses through SVSM_PLATFORM.

~~The custom backend feature is not upstream yet (PR soon!), see the changes here:
https://github.com/osteffenrh/safe-mmio/commits/custom-mmio-backend/~~

The custom-mmio backend was added to safe-mmio in this pr: https://github.com/google/safe-mmio/pull/55
It is not published on crates.io yet.
