### PR TITLE
CODEOWNERS: Add Carlos López

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
 # CODEOWNERS file for COCONUT-SVSM
 
 # Technical Steering Committee (TSC)
-# Joerg Roedel, Jon Lange, Peter Fang, Stefano Garzarella
-* joerg.roedel@amd.com jlange@microsoft.com peter.fang@intel.com sgarzare@redhat.com
+# Joerg Roedel, Jon Lange, Peter Fang, Stefano Garzarella, Carlos López
+* joerg.roedel@amd.com jlange@microsoft.com peter.fang@intel.com sgarzare@redhat.com clopez@suse.de
 
 # Subsystem Maintainers


### PR DESCRIPTION
Add Carlos López as a new member of the TSC to CODEOWNERS.