### PR TITLE
virtio/mmio: fix drop order in MmioSlot

### DIFF
--- a/kernel/src/virtio/mmio.rs
+++ b/kernel/src/virtio/mmio.rs
@@ -21,8 +21,18 @@ use crate::virtio::hal::{SvsmHal, virtio_init};
 
 #[derive(Debug)]
 pub struct MmioSlot {
-    pub mmio_range: GlobalRangeGuard,
     pub transport: MmioTransport<SvsmHal>,
+    // Fields are ordered so that `mmio_range` is dropped last.
+    // The MmioTransport destructor resets the device via MMIO writes, and
+    // dropping `mmio_range` destroys the mapping, so `mmio_range` must be
+    // dropped last.
+    // This drop-order behavior is stable.
+    // See https://doc.rust-lang.org/reference/destructors.html
+    //
+    // TODO: The destruction order should be expressed via code rather than
+    // relying on field ordering. This should be addressed when moving to
+    // the upstream virtio-drivers crate.
+    pub mmio_range: GlobalRangeGuard,
 }
 
 #[derive(Debug, Default)]
@@ -101,8 +111,8 @@ pub fn probe_mmio_slots(boot_params: &BootParams<'_>) -> MmioSlots {
         log::info!("MmioSlots: Found {:?} at {addr:x}", transport.device_type());
 
         let slot_type = MmioSlot {
-            mmio_range: mem,
             transport,
+            mmio_range: mem,
         };
 
         slots.push(slot_type);


### PR DESCRIPTION
The MmioTransport destructor resets the device via MMIO writes.
Rust drops struct fields in declaration order, so with the previous
field ordering mmio_range was dropped before transport, destroying
the MMIO mapping before the transport could complete its reset.
This caused SVSM to panic.

Fix this by reordering MmioSlot fields so that transport is declared
before mmio_range, ensuring it is dropped first.

The bug was discovered by enabling the virtio-drivers and block features
without vsock, while QEMU exposes both a block and a vsock device.
In this configuration, `probe_mmio_slots()` discovers both MMIO devices
and creates an MmioSlot for each. However, `initialize_virtio_mmio()` only
calls `initialize_block()`, which consumes the block slot.
The vsock MmioSlot remains unconsumed in the MmioSlots vec. When the
collection goes out of scope, the leftover vsock MmioSlot is dropped,
triggering the drop in the incorrect order.

When vsock is also enabled, `initialize_vsock()` consumes the vsock slot
too, so no MmioSlot is left over and the drop path is never hit.

Fixes: bde88578 ("virtio: introduce MMIOSlots structure")
Reported-by: Stefano Garzarella <sgarzare@redhat.com>