### PR TITLE
Documentation: remove capital letter requirement from commit subject

### DIFF
--- a/Documentation/docs/developer/CONTRIBUTING.md
+++ b/Documentation/docs/developer/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Patch Format
 
 Each patch must start with a subject line that contains the component
 the patch changes and a short description of the change, separated by a
-colon. The text after the colon needs to start with a capital letter.
+colon.
 For example:
 
 ```


### PR DESCRIPTION
The rule requiring the text after the colon to start with a capital letter is not enforced and not all contributors follow it. Remove it to simplify the contributing guidelines.