### PR TITLE
kernel: support dynamically-sized `SharedBox` + multi-page virtio DMA

### DIFF
--- a/kernel/src/mm/page_visibility.rs
+++ b/kernel/src/mm/page_visibility.rs
@@ -4,7 +4,6 @@
 //
 // Author: Jon Lange (jlange@microsoft.com)
 
-use core::mem::MaybeUninit;
 use core::ops::Deref;
 use core::ptr::NonNull;
 
@@ -138,7 +137,7 @@ pub struct SharedBox<T> {
 impl<T: FromZeros> SharedBox<T> {
     /// Allocate some memory and share it with the host.
     pub fn try_new_zeroed() -> Result<Self, SvsmError> {
-        let page_box = PageBox::<MaybeUninit<T>>::try_new_zeroed()?;
+        let page_box = PageBox::<T>::try_new_zeroed()?;
         let vaddr = page_box.vaddr();
 
         // SAFETY: The memory marked shared was just allocated, so there is
@@ -149,9 +148,8 @@ impl<T: FromZeros> SharedBox<T> {
         // the `PageBox` to be dropped.
         unsafe { make_page_range_shared(vaddr, size_of::<T>()) }?;
 
-        // Now leak the memory so that we may take ownership. Casting into
-        // `T` is safe because it implements `FromZeros`.
-        let ptr = NonNull::from(PageBox::leak(page_box)).cast::<T>();
+        // Now leak the memory so that we may take ownership.
+        let ptr = NonNull::from(PageBox::leak(page_box));
         Ok(Self { ptr })
     }
 }

--- a/kernel/src/mm/page_visibility.rs
+++ b/kernel/src/mm/page_visibility.rs
@@ -4,6 +4,7 @@
 //
 // Author: Jon Lange (jlange@microsoft.com)
 
+use core::num::NonZeroUsize;
 use core::ops::Deref;
 use core::ptr::NonNull;
 
@@ -15,7 +16,7 @@ use crate::error::SvsmError;
 use crate::mm::validate::{
     valid_bitmap_clear_valid_4k, valid_bitmap_set_valid_4k, valid_bitmap_valid_addr,
 };
-use crate::mm::{PageBox, virt_to_phys};
+use crate::mm::{PageBox, alloc::AllocError, virt_to_phys};
 use crate::platform::{PageStateChangeOp, PageValidateOp, SVSM_PLATFORM};
 use crate::types::{PAGE_SIZE, PageSize};
 use crate::utils::MemoryRegion;
@@ -172,6 +173,47 @@ impl<T: SharedSize + FromZeros> SharedBox<T> {
         // Now leak the memory so that we may take ownership.
         let ptr = NonNull::from(PageBox::leak(page_box));
         Ok(Self { ptr })
+    }
+}
+
+impl<T: Clone> SharedBox<[T]> {
+    /// Allocates a dynamically-sized slice of `len` items of type `T`, populates
+    /// it with the given value, and shares it with the host. The slice cannot be
+    // resized.
+    pub fn try_new_slice(val: T, len: NonZeroUsize) -> Result<Self, SvsmError> {
+        let page_box = PageBox::try_new_slice(val, len)?;
+        let vaddr = page_box.vaddr();
+
+        let size = len
+            .get()
+            .checked_mul(size_of::<T>())
+            .ok_or(AllocError::OutOfMemory)?;
+
+        // SAFETY: The memory marked shared was just allocated, so there is
+        // no type and no other user associated with it. The memory is also
+        // marked private again when the SharedBox is dropped.
+        // `make_page_range_shared()` only returns with an error after
+        // restoring the pages back into a private state, so it is safe for
+        // the `PageBox` to be dropped.
+        unsafe { make_page_range_shared(vaddr, size) }?;
+
+        // Now leak the memory so that we may take ownership.
+        let ptr = NonNull::from(PageBox::leak(page_box));
+        Ok(Self { ptr })
+    }
+}
+
+impl<T> SharedBox<[T]> {
+    /// Returns the number of items in the slice.
+    pub fn len(&self) -> usize {
+        self.ptr.len()
+    }
+
+    /// Returns `true` if the slice is empty
+    pub fn is_empty(&self) -> bool {
+        // clippy does not like us having a `len()` method without
+        // an `is_empty()` method.
+        self.len() != 0
     }
 }
 

--- a/kernel/src/mm/page_visibility.rs
+++ b/kernel/src/mm/page_visibility.rs
@@ -104,6 +104,32 @@ pub unsafe fn make_page_private(vaddr: VirtAddr) -> Result<(), SvsmError> {
     Ok(())
 }
 
+/// Makes a virtual range shared by revoking its validation, updating the
+/// page state, and modifying the page tables accordingly.
+///
+/// # Safety
+///
+/// `vaddr` must be page-aligned. See safety considerations for
+/// [`make_page_private()`].
+unsafe fn make_page_range_shared(vaddr: VirtAddr, len: usize) -> Result<(), SvsmError> {
+    for offset in (0..len).step_by(PAGE_SIZE) {
+        // SAFETY: delegated to the caller. We make sure to restore state
+        // before returning.
+        let r1 = unsafe { make_page_shared(vaddr + offset) };
+        if let Err(e1) = r1 {
+            for off in (0..offset).step_by(PAGE_SIZE) {
+                // SAFETY: we previously marked this page as shared in this same function
+                let r2 = unsafe { make_page_private(vaddr + off) };
+                if let Err(e2) = r2 {
+                    panic!("Failed to restore page visibility ({e2:?}) after allocation failure");
+                }
+            }
+            return Err(e1);
+        }
+    }
+    Ok(())
+}
+
 /// SharedBox is a safe wrapper around memory pages shared with the host.
 pub struct SharedBox<T> {
     ptr: NonNull<T>,
@@ -115,30 +141,17 @@ impl<T: FromZeros> SharedBox<T> {
         let page_box = PageBox::<MaybeUninit<T>>::try_new_zeroed()?;
         let vaddr = page_box.vaddr();
 
+        // SAFETY: The memory marked shared was just allocated, so there is
+        // no type and no other user associated with it. The memory is also
+        // marked private again when the SharedBox is dropped.
+        // `make_page_range_shared()` only returns with an error after
+        // restoring the pages back into a private state, so it is safe for
+        // the `PageBox` to be dropped.
+        unsafe { make_page_range_shared(vaddr, size_of::<T>()) }?;
+
+        // Now leak the memory so that we may take ownership. Casting into
+        // `T` is safe because it implements `FromZeros`.
         let ptr = NonNull::from(PageBox::leak(page_box)).cast::<T>();
-
-        for offset in (0..core::mem::size_of::<T>()).step_by(PAGE_SIZE) {
-            // SAFETY: The memory marked shared was just allocated, so there is
-            // no type and no other user associated with it. The memory is also
-            // marked private again in the error path or when the SharedBox is
-            // dropped.
-            let r1 = unsafe { make_page_shared(vaddr + offset) };
-            if let Err(e1) = r1 {
-                for off in (0..offset).step_by(PAGE_SIZE) {
-                    // SAFETY: we previously marked this page as shared in this same function.
-                    let r2 = unsafe { make_page_private(vaddr + off) };
-                    if let Err(e2) = r2 {
-                        panic!(
-                            "Failed to restore page visibility ({e2:?}) after allocation failure"
-                        );
-                    }
-                }
-                // SAFETY: we previously allocated these pages in this same function
-                let _ = unsafe { PageBox::from_raw(ptr) };
-                return Err(e1);
-            }
-        }
-
         Ok(Self { ptr })
     }
 }

--- a/kernel/src/mm/page_visibility.rs
+++ b/kernel/src/mm/page_visibility.rs
@@ -129,12 +129,33 @@ unsafe fn make_page_range_shared(vaddr: VirtAddr, len: usize) -> Result<(), Svsm
     Ok(())
 }
 
+/// A trait to abstract away retrieving the size of some type
+/// from a pointer to it.
+///
+/// This is needed because `size_of::<T>()` does not work for
+/// unsized types, and `core::mem::size_of_val_raw` is not stable.
+pub trait SharedSize {
+    fn size(ptr: NonNull<Self>) -> usize;
+}
+
+impl<T> SharedSize for T {
+    fn size(_: NonNull<Self>) -> usize {
+        size_of::<T>()
+    }
+}
+
+impl<T> SharedSize for [T] {
+    fn size(ptr: NonNull<Self>) -> usize {
+        size_of::<T>() * ptr.len()
+    }
+}
+
 /// SharedBox is a safe wrapper around memory pages shared with the host.
-pub struct SharedBox<T> {
+pub struct SharedBox<T: ?Sized + SharedSize> {
     ptr: NonNull<T>,
 }
 
-impl<T: FromZeros> SharedBox<T> {
+impl<T: SharedSize + FromZeros> SharedBox<T> {
     /// Allocate some memory and share it with the host.
     pub fn try_new_zeroed() -> Result<Self, SvsmError> {
         let page_box = PageBox::<T>::try_new_zeroed()?;
@@ -154,12 +175,14 @@ impl<T: FromZeros> SharedBox<T> {
     }
 }
 
-impl<T> SharedBox<T> {
+impl<T: ?Sized + SharedSize> SharedBox<T> {
     /// Returns the virtual address of the memory.
     pub fn addr(&self) -> VirtAddr {
-        VirtAddr::from(self.ptr.as_ptr())
+        VirtAddr::from(self.ptr.as_ptr().expose_provenance())
     }
+}
 
+impl<T: SharedSize> SharedBox<T> {
     /// Read the currently stored value into `out`.
     pub fn read_into(&self, out: &mut T)
     where
@@ -253,15 +276,15 @@ impl<T: FromBytes + Sync> AsRef<T> for SharedBox<T> {
 
 // SAFETY: SharedBox can be Send when T is Send because the Sharedbox
 // implementation does not implement any !Send behavior around type T.
-unsafe impl<T> Send for SharedBox<T> where T: Send {}
+unsafe impl<T: ?Sized + SharedSize> Send for SharedBox<T> where T: Send {}
 // SAFETY: SharedBox can be Sync when T is Sync because the implementation
 // does not have any !Sync behavior around T.
-unsafe impl<T> Sync for SharedBox<T> where T: Sync {}
+unsafe impl<T: ?Sized + SharedSize> Sync for SharedBox<T> where T: Sync {}
 
-impl<T> Drop for SharedBox<T> {
+impl<T: ?Sized + SharedSize> Drop for SharedBox<T> {
     fn drop(&mut self) {
         // Re-encrypt the pages.
-        let res = (0..size_of::<T>())
+        let res = (0..T::size(self.ptr))
             .step_by(PAGE_SIZE)
             // SAFETY: This makes the owned pages private again. Since this is
             // the drop() method, there are no users left.
@@ -271,7 +294,7 @@ impl<T> Drop for SharedBox<T> {
         if res.is_ok() {
             // SAFETY: The ptr was previously allocated via a PageBox and is
             // therefore valid.
-            drop(unsafe { PageBox::from_raw(self.ptr.cast::<MaybeUninit<T>>()) });
+            drop(unsafe { PageBox::from_raw(self.ptr) });
         } else {
             log::error!("failed to set pages to encrypted. Memory leak!");
         }

--- a/kernel/src/virtio/hal.rs
+++ b/kernel/src/virtio/hal.rs
@@ -5,10 +5,11 @@
 // Author: Oliver Steffen <osteffen@redhat.com>
 
 extern crate alloc;
-use crate::{locking::SpinLock, platform::SVSM_PLATFORM};
+use crate::{locking::SpinLock, platform::SVSM_PLATFORM, types::PAGE_SHIFT};
 use alloc::vec::Vec;
 use core::{
     mem::{MaybeUninit, size_of},
+    num::NonZeroUsize,
     ptr::{NonNull, addr_of},
 };
 use zerocopy::{FromBytes, Immutable, IntoBytes};
@@ -19,7 +20,7 @@ use crate::{
 };
 
 struct PageStore {
-    pages: Vec<(PhysAddr, SharedBox<[u8; PAGE_SIZE]>)>,
+    pages: Vec<(PhysAddr, SharedBox<[u8]>)>,
 }
 
 impl PageStore {
@@ -27,11 +28,11 @@ impl PageStore {
         PageStore { pages: Vec::new() }
     }
 
-    pub fn push(&mut self, pa: PhysAddr, shared_page: SharedBox<[u8; PAGE_SIZE]>) {
-        self.pages.push((pa, shared_page));
+    pub fn push(&mut self, pa: PhysAddr, shared_pages: SharedBox<[u8]>) {
+        self.pages.push((pa, shared_pages));
     }
 
-    pub fn pop(&mut self, pa: PhysAddr) -> Option<SharedBox<[u8; PAGE_SIZE]>> {
+    pub fn pop(&mut self, pa: PhysAddr) -> Option<SharedBox<[u8]>> {
         if let Some(p) = self.pages.iter().position(|e| e.0 == pa) {
             Some(self.pages.remove(p).1)
         } else {
@@ -53,22 +54,17 @@ pub struct SvsmHal;
 unsafe impl virtio_drivers::Hal for SvsmHal {
     /// Allocates and zeroes the given number of contiguous physical pages of DMA memory for VirtIO
     /// use.
-    ///
-    /// Limitation: `pages == 1` required.
     fn dma_alloc(
         pages: usize,
         _direction: virtio_drivers::BufferDirection,
     ) -> (virtio_drivers::PhysAddr, NonNull<u8>) {
-        // TODO: allow more than one page.
-        //       This currently works, because in "modern" virtio mode the crate only allocates
-        //       one page at a time.
-        assert!(pages == 1);
+        let size = NonZeroUsize::new(pages << PAGE_SHIFT).unwrap();
+        let shared_pages = SharedBox::try_new_slice(0u8, size).unwrap();
 
-        let shared_page = SharedBox::<[u8; PAGE_SIZE]>::try_new_zeroed().unwrap();
-        let pa = virt_to_phys(shared_page.addr());
-        let p = NonNull::<u8>::new(shared_page.addr().as_mut_ptr()).unwrap();
+        let pa = virt_to_phys(shared_pages.addr());
+        let p = NonNull::<u8>::new(shared_pages.addr().as_mut_ptr()).unwrap();
 
-        SHARED_MEM.lock().push(pa, shared_page);
+        SHARED_MEM.lock().push(pa, shared_pages);
 
         (pa.into(), p)
     }
@@ -80,18 +76,13 @@ unsafe impl virtio_drivers::Hal for SvsmHal {
     /// The memory must have been allocated by `dma_alloc` on the same `Hal` implementation, and not
     /// yet deallocated. `pages` must be the same number passed to `dma_alloc` originally, and both
     /// `paddr` and `vaddr` must be the values returned by `dma_alloc`.
-    ///
-    /// Limitation: `pages == 1` required.
     unsafe fn dma_dealloc(
         paddr: virtio_drivers::PhysAddr,
         _vaddr: NonNull<u8>,
         pages: usize,
     ) -> i32 {
-        //TODO: allow more than one page
-        assert!(pages == 1);
-
-        SHARED_MEM.lock().pop(paddr.into()).unwrap();
-
+        let shared_pages = SHARED_MEM.lock().pop(paddr.into()).unwrap();
+        debug_assert_eq!(shared_pages.len() >> PAGE_SHIFT, pages);
         0
     }
 
@@ -108,20 +99,16 @@ unsafe impl virtio_drivers::Hal for SvsmHal {
     ///
     /// The buffer must be a valid pointer to a non-empty memory range which will not be accessed by
     /// any other thread for the duration of this method call.
-    ///
-    /// Limitation: `buffer.len() <= PAGE_SIZE`
     unsafe fn share(
         buffer: NonNull<[u8]>,
         direction: virtio_drivers::BufferDirection,
     ) -> virtio_drivers::PhysAddr {
-        // TODO: allow more than one page
-        assert!(buffer.len() <= PAGE_SIZE);
-
-        let shared_page = SharedBox::<[u8; PAGE_SIZE]>::try_new_zeroed().unwrap();
+        let size = NonZeroUsize::new(buffer.len()).unwrap();
+        let shared_pages = SharedBox::try_new_slice(0u8, size).unwrap();
 
         if direction == virtio_drivers::BufferDirection::DriverToDevice {
             let src = buffer.as_ptr().cast::<u8>();
-            let dst = shared_page.addr().as_mut_ptr::<u8>();
+            let dst = shared_pages.addr().as_mut_ptr::<u8>();
 
             // SAFETY: We demand a valid `buffer` from the caller (virtio-drivers crate).
             //         We assterted that `dst` can hold at least `buffer.len()`.
@@ -130,8 +117,8 @@ unsafe impl virtio_drivers::Hal for SvsmHal {
             }
         }
 
-        let pa = virt_to_phys(shared_page.addr());
-        SHARED_MEM.lock().push(pa, shared_page);
+        let pa = virt_to_phys(shared_pages.addr());
+        SHARED_MEM.lock().push(pa, shared_pages);
 
         // return pa of shared page
         pa.into()
@@ -145,15 +132,11 @@ unsafe impl virtio_drivers::Hal for SvsmHal {
     /// The buffer must be a valid pointer to a non-empty memory range which will not be accessed by
     /// any other thread for the duration of this method call. The `paddr` must be the value
     /// previously returned by the corresponding `share` call.
-    ///
-    /// Limitation: `buffer.len() <= PAGE_SIZE`
     unsafe fn unshare(
         paddr: virtio_drivers::PhysAddr,
         buffer: NonNull<[u8]>,
         direction: virtio_drivers::BufferDirection,
     ) {
-        assert!(buffer.len() <= PAGE_SIZE);
-
         match SHARED_MEM.lock().pop(paddr.into()) {
             Some(shared_page) => {
                 let vaddr = phys_to_virt(paddr.into());

--- a/kernel/src/virtio/hal.rs
+++ b/kernel/src/virtio/hal.rs
@@ -8,7 +8,6 @@ extern crate alloc;
 use crate::{locking::SpinLock, platform::SVSM_PLATFORM};
 use alloc::vec::Vec;
 use core::{
-    cell::OnceCell,
     mem::{MaybeUninit, size_of},
     ptr::{NonNull, addr_of},
 };
@@ -24,7 +23,7 @@ struct PageStore {
 }
 
 impl PageStore {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         PageStore { pages: Vec::new() }
     }
 
@@ -41,11 +40,7 @@ impl PageStore {
     }
 }
 
-static SHARED_MEM: SpinLock<OnceCell<PageStore>> = SpinLock::new(OnceCell::new());
-
-pub fn virtio_init() {
-    SHARED_MEM.lock().get_or_init(PageStore::new);
-}
+static SHARED_MEM: SpinLock<PageStore> = SpinLock::new(PageStore::new());
 
 #[derive(Debug)]
 pub struct SvsmHal;
@@ -73,7 +68,7 @@ unsafe impl virtio_drivers::Hal for SvsmHal {
         let pa = virt_to_phys(shared_page.addr());
         let p = NonNull::<u8>::new(shared_page.addr().as_mut_ptr()).unwrap();
 
-        SHARED_MEM.lock().get_mut().unwrap().push(pa, shared_page);
+        SHARED_MEM.lock().push(pa, shared_page);
 
         (pa.into(), p)
     }
@@ -95,12 +90,7 @@ unsafe impl virtio_drivers::Hal for SvsmHal {
         //TODO: allow more than one page
         assert!(pages == 1);
 
-        SHARED_MEM
-            .lock()
-            .get_mut()
-            .unwrap()
-            .pop(paddr.into())
-            .unwrap();
+        SHARED_MEM.lock().pop(paddr.into()).unwrap();
 
         0
     }
@@ -141,7 +131,7 @@ unsafe impl virtio_drivers::Hal for SvsmHal {
         }
 
         let pa = virt_to_phys(shared_page.addr());
-        SHARED_MEM.lock().get_mut().unwrap().push(pa, shared_page);
+        SHARED_MEM.lock().push(pa, shared_page);
 
         // return pa of shared page
         pa.into()
@@ -164,7 +154,7 @@ unsafe impl virtio_drivers::Hal for SvsmHal {
     ) {
         assert!(buffer.len() <= PAGE_SIZE);
 
-        match SHARED_MEM.lock().get_mut().unwrap().pop(paddr.into()) {
+        match SHARED_MEM.lock().pop(paddr.into()) {
             Some(shared_page) => {
                 let vaddr = phys_to_virt(paddr.into());
                 let va_from_shared = shared_page.addr();

--- a/kernel/src/virtio/mmio.rs
+++ b/kernel/src/virtio/mmio.rs
@@ -16,7 +16,7 @@ use crate::fw_cfg::FwCfg;
 use crate::mm::{GlobalRangeGuard, map_global_range_4k_shared, pagetable::PTEntryFlags};
 use crate::platform::SVSM_PLATFORM;
 use crate::types::PAGE_SIZE;
-use crate::virtio::hal::{SvsmHal, virtio_init};
+use crate::virtio::hal::SvsmHal;
 
 #[derive(Debug)]
 pub struct MmioSlot {
@@ -52,8 +52,6 @@ pub fn probe_mmio_slots(boot_params: &BootParams<'_>) -> MmioSlots {
     if !boot_params.has_fw_cfg_port() {
         return MmioSlots::default();
     }
-
-    virtio_init();
 
     let cfg = FwCfg::new(SVSM_PLATFORM.get_io_port());
     let Ok(dev) = cfg.get_virtio_mmio_addresses() else {


### PR DESCRIPTION
Add support in `SharedBox` to allocate dynamically-sized slices, just like `PageBox` does. This allows removing a long-standing TODO in the virtio HAL code where we can only allocate a single page for DMA.

This PR also includes some minor cleanups, like removing the unneeded `virtio_init()`.