### PR TITLE
task: support multiple waiters in WaitQueue

### DIFF
--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -37,6 +37,7 @@ extern crate alloc;
 use super::tasks::TASK_ACTIVE_OFFSET;
 use super::tasks::TASK_CUR_CPU_OFFSET;
 use super::tasks::TaskExitStatus;
+use super::tasks::TaskWaitListAdapter;
 use super::{
     INITIAL_TASK_ID, KernelThreadStartInfo, Task, TaskListAdapter, TaskPointer, TaskRunListAdapter,
     UserExecInfo,
@@ -282,7 +283,7 @@ impl TaskList {
     /// # Safety
     /// The caller must ensure that `task` is already a member of this task
     /// list.
-    unsafe fn terminate(&mut self, task: TaskPointer) -> Option<TaskPointer> {
+    unsafe fn terminate(&mut self, task: TaskPointer) -> LinkedList<TaskWaitListAdapter> {
         // Set the task state as terminated. If the task being terminated is the
         // current task then the task context will still need to be in scope until
         // the next schedule() has completed. Schedule will keep a reference to this
@@ -292,7 +293,7 @@ impl TaskList {
         let mut cursor = unsafe { self.list().cursor_mut_from_ptr(task.as_ref()) };
         cursor.remove();
 
-        // Inform the caller about any task that may need to be woken.
+        // Inform the caller about any tasks that may need to be woken.
         wakeup
     }
 }
@@ -435,11 +436,11 @@ fn current_task_terminated() {
     // SAFETY: the scheduler guarantees that `current_task` always points to a
     // valid task, and every task has its pointer pushed into the global task
     // list during its creation.
-    let wakeup = unsafe { TASKLIST.lock().terminate(task_node.clone()) };
+    let mut wakeup = unsafe { TASKLIST.lock().terminate(task_node.clone()) };
 
-    // If another thread must be woken as a result of the termination, then
-    // schedule it now.
-    if let Some(wake_task) = wakeup {
+    // Remove each task from the wakeup list before making it runnable so it
+    // can immediately join another wait queue.
+    while let Some(wake_task) = wakeup.pop_front() {
         rq.prepare_run_task(wake_task);
     }
 }
@@ -904,10 +905,12 @@ const CONTEXT_SWITCH_RESTORE_TOKEN: VirtAddr = SVSM_CONTEXT_SWITCH_SHADOW_STACK.
 #[cfg(all(test, test_in_svsm))]
 mod test {
     use super::KernelThreadStartInfo;
+    use super::schedule;
     use super::set_affinity;
     use super::start_kernel_task;
     use super::wait_for_termination;
     use crate::cpu::percpu::{PERCPU_AREAS, this_cpu};
+    use core::sync::atomic::AtomicBool;
     use core::sync::atomic::AtomicU32;
     use core::sync::atomic::Ordering;
 
@@ -959,6 +962,96 @@ mod test {
         // Wait again for the task to terminate.  This should return
         // immediately.
         wait_for_termination(task);
+    }
+
+    #[cfg(test)]
+    static MULTI_WAITER_COUNTER: AtomicU32 = AtomicU32::new(0);
+    static MULTI_WAITER_WAITING_COUNTER: AtomicU32 = AtomicU32::new(0);
+    static MULTI_WAITER_TARGET_RELEASED: AtomicBool = AtomicBool::new(false);
+    // Distinguishes each waiter from the target task's single increment.
+    const MULTI_WAITER_TASK_INCREMENT: u32 = 10;
+
+    fn multi_waiter_target(_: usize) {
+        let current_cpu = this_cpu().get_cpu_index();
+        let target_cpu = PERCPU_AREAS.len() - 1;
+        set_affinity(if current_cpu == target_cpu {
+            0
+        } else {
+            target_cpu
+        });
+
+        while !MULTI_WAITER_TARGET_RELEASED.load(Ordering::Acquire) {
+            if PERCPU_AREAS.len() > 1 {
+                core::hint::spin_loop();
+            } else {
+                schedule();
+            }
+        }
+
+        MULTI_WAITER_COUNTER.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn waiting_task(target_id: usize) {
+        // Look up the target task by id and wait for it to terminate.
+        let task = super::TASKLIST
+            .lock()
+            .get_task(target_id as u32)
+            .expect("Failed to find multi-waiter target task");
+        super::preemption_checks();
+        let guard = task
+            .wait_for_exit()
+            .expect("Multi-waiter target terminated before waiter blocked");
+        MULTI_WAITER_WAITING_COUNTER.fetch_add(1, Ordering::Release);
+        super::select_new_task(false, Some(guard));
+        MULTI_WAITER_COUNTER.fetch_add(MULTI_WAITER_TASK_INCREMENT, Ordering::Relaxed);
+    }
+
+    #[test]
+    #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
+    fn test_wait_for_termination_multiple_waiters() {
+        MULTI_WAITER_COUNTER.store(0, Ordering::Relaxed);
+        MULTI_WAITER_WAITING_COUNTER.store(0, Ordering::Relaxed);
+        MULTI_WAITER_TARGET_RELEASED.store(false, Ordering::Relaxed);
+
+        // Start the task that will be waited on.
+        let target = start_kernel_task(
+            KernelThreadStartInfo::new(multi_waiter_target, 0),
+            "multi-waiter target",
+        )
+        .expect("Failed to start target task");
+        let target_id = target.get_task_id() as usize;
+
+        // Start two waiter tasks that each wait on the same target task.
+        let waiter1 = start_kernel_task(
+            KernelThreadStartInfo::new(waiting_task, target_id),
+            "waiter 1",
+        )
+        .expect("Failed to start waiter 1");
+
+        let waiter2 = start_kernel_task(
+            KernelThreadStartInfo::new(waiting_task, target_id),
+            "waiter 2",
+        )
+        .expect("Failed to start waiter 2");
+
+        while MULTI_WAITER_WAITING_COUNTER.load(Ordering::Acquire) < 2 {
+            schedule();
+        }
+        assert_eq!(MULTI_WAITER_WAITING_COUNTER.load(Ordering::Acquire), 2);
+
+        // Both waiters have joined the target's wait queue, so allow the
+        // target to terminate before this task waits for it too.
+        MULTI_WAITER_TARGET_RELEASED.store(true, Ordering::Release);
+        wait_for_termination(target);
+        wait_for_termination(waiter1);
+        wait_for_termination(waiter2);
+
+        // Both waiter tasks must have run: multi_waiter_target adds 1,
+        // each waiting_task adds MULTI_WAITER_TASK_INCREMENT.
+        assert_eq!(
+            MULTI_WAITER_COUNTER.load(Ordering::Relaxed),
+            1 + (MULTI_WAITER_TASK_INCREMENT * 2)
+        );
     }
 
     #[test]

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -46,7 +46,7 @@ use crate::mm::{
 use crate::syscall::{Obj, ObjError, ObjHandle};
 use crate::types::{SVSM_USER_CPL, SVSM_USER_CS, SVSM_USER_DS};
 use crate::utils::{MemoryRegion, is_aligned};
-use intrusive_collections::{LinkedListAtomicLink, intrusive_adapter};
+use intrusive_collections::{LinkedList, LinkedListAtomicLink, intrusive_adapter};
 
 use super::exec::exec;
 use super::schedule::complete_task_switch;
@@ -380,6 +380,9 @@ pub struct Task {
     /// Link to scheduler run queue
     runlist_link: LinkedListAtomicLink,
 
+    /// Link to wait queue
+    waitlist_link: LinkedListAtomicLink,
+
     /// Objects shared among threads within the same process
     objs: Arc<RWLock<BTreeMap<ObjHandle, Arc<dyn Obj>>>>,
 
@@ -409,6 +412,7 @@ pub type TaskPointer = Arc<Task>;
 
 intrusive_adapter!(pub TaskRunListAdapter = TaskPointer: Task { runlist_link: LinkedListAtomicLink });
 intrusive_adapter!(pub TaskListAdapter = TaskPointer: Task { list_link: LinkedListAtomicLink });
+intrusive_adapter!(pub TaskWaitListAdapter = TaskPointer: Task { waitlist_link: LinkedListAtomicLink });
 
 impl PartialEq for Task {
     fn eq(&self, other: &Self) -> bool {
@@ -560,6 +564,7 @@ impl Task {
             rootdir: args.rootdir,
             list_link: LinkedListAtomicLink::default(),
             runlist_link: LinkedListAtomicLink::default(),
+            waitlist_link: LinkedListAtomicLink::default(),
             objs: objtree,
             wait_queue: SpinLockIrqSafe::new(WaitQueue::new()),
             exit_status: AtomicU32::new(TaskExitStatus::default().into()),
@@ -671,11 +676,11 @@ impl Task {
         self.sched_state.set_state(TaskState::RUNNING);
     }
 
-    pub fn set_task_terminated(&self) -> Option<TaskPointer> {
+    pub fn set_task_terminated(&self) -> LinkedList<TaskWaitListAdapter> {
         self.sched_state
             .panic_on_idle("Trying to terminate idle task")
             .set_state(TaskState::TERMINATED);
-        self.wait_queue.lock().wakeup()
+        self.wait_queue.lock().wakeup(true)
     }
 
     pub fn set_task_blocked(&self) {

--- a/kernel/src/task/waiting.rs
+++ b/kernel/src/task/waiting.rs
@@ -4,26 +4,37 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
-use super::tasks::TaskPointer;
+use intrusive_collections::LinkedList;
 
-#[derive(Debug, Default)]
+use super::tasks::{TaskPointer, TaskWaitListAdapter};
+
+/// A queue of tasks waiting for a single event. Multiple tasks may wait
+/// simultaneously.
+#[derive(Debug)]
 pub struct WaitQueue {
-    waiter: Option<TaskPointer>,
+    waiters: LinkedList<TaskWaitListAdapter>,
 }
 
 impl WaitQueue {
-    pub const fn new() -> Self {
-        Self { waiter: None }
+    pub fn new() -> Self {
+        Self {
+            waiters: LinkedList::new(TaskWaitListAdapter::new()),
+        }
     }
 
+    /// Register `current_task` as a waiter on this queue. The task is
+    /// immediately marked as blocked. Multiple callers may wait concurrently.
     pub fn wait_for_event(&mut self, current_task: TaskPointer) {
-        assert!(self.waiter.is_none());
-
         current_task.set_task_blocked();
-        self.waiter = Some(current_task);
+        self.waiters.push_back(current_task);
     }
 
-    pub fn wakeup(&mut self) -> Option<TaskPointer> {
-        self.waiter.take()
+    /// Wake all waiting tasks. Returns the waiters so the caller can unlink
+    /// and schedule each one.
+    pub fn wakeup(&mut self, wake_all: bool) -> LinkedList<TaskWaitListAdapter> {
+        // TODO: handle the case of waking a single waiter.
+        assert!(wake_all);
+
+        self.waiters.take()
     }
 }


### PR DESCRIPTION
## Summary

`WaitQueue` used `Option<TaskPointer>` to hold at most one waiter and panicked if a second task called `wait_for_event` while one was already queued. This made it impossible for multiple tasks to call `wait_for_termination` on the same target task simultaneously.

## Why this matters

As described in #1104, the `wait_for_termination` API is the natural way to join a task, but any scenario where two tasks join the same target — e.g., a parent and a monitor both waiting on a worker — triggers an unconditional panic. The fix unlocks that usage pattern without any heap allocation in the wake path.

## Changes

- **`kernel/src/task/waiting.rs`**: Replace `waiter: Option<TaskPointer>` with `waiters: Vec<TaskPointer>`. Remove the `assert!(self.waiter.is_none())` guard. `wait_for_event` now pushes onto the vec; `wakeup` drains it (alloc-free at wake time) and returns the full list.
- **`kernel/src/task/tasks.rs`**: `set_task_terminated` now returns `Vec<TaskPointer>` instead of `Option<TaskPointer>`.
- **`kernel/src/task/schedule.rs`**: `TaskList::terminate` returns `Vec<TaskPointer>`; `current_task_terminated` iterates over all returned waiters and calls `enqueue_task` for each. Adds `test_wait_for_termination_multiple_waiters`: two tasks each call `wait_for_termination` on a third task; both must resume after it terminates.

Fixes #1104

Signed-off-by: Matt Van Horn <mvanhorn@gmail.com>
