### PR TITLE
kernel/tests: fix test_fpu_context_switch

### DIFF
--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -1094,14 +1094,14 @@ mod tests {
     test_fpu:
         movq $0x3ff, %rax
         shl $52, %rax
-        // rax contains 1 in Double Precison FP representation
-        movd %rax, %xmm1
+        // rax contains 1.0 in Double Precision FP representation
+        movq %rax, %xmm1
         movapd %xmm1, %xmm3
 
         movq $0x400, %rax
         shl $52, %rax
-        // rax contains 2 in Double Precison FP representation
-        movd %rax, %xmm2
+        // rax contains 2.0 in Double Precision FP representation
+        movq %rax, %xmm2
 
         divsd %xmm2, %xmm3
         movq $0, %rax
@@ -1117,16 +1117,16 @@ mod tests {
         movq $1, %rax
         movq $0x3ff, %rbx
         shl $52, %rbx
-        // rbx contains 1 in Double Precison FP representation
-        movd %rbx, %xmm4
+        // rbx contains 1.0 in Double Precision FP representation
+        movq %rbx, %xmm4
         movapd %xmm4, %xmm6
         comisd %xmm4, %xmm1
         jnz 1f
 
         movq $0x400, %rbx
         shl $52, %rbx
-        // rbx contains 2 in Double Precison FP representation
-        movd %rbx, %xmm5
+        // rbx contains 2.0 in Double Precision FP representation
+        movq %rbx, %xmm5
         comisd %xmm5, %xmm2
         jnz 1f
 
@@ -1146,14 +1146,14 @@ mod tests {
     alter_fpu:
         movq $0x400, %rax
         shl $52, %rax
-        // rax contains 2 in Double Precison FP representation
-        movd %rax, %xmm1
+        // rax contains 2.0 in Double Precision FP representation
+        movq %rax, %xmm1
         movapd %xmm1, %xmm3
 
         movq $0x3ff, %rax
         shl $52, %rax
-        // rax contains 1 in Double Precison FP representation
-        movd %rax, %xmm2
+        // rax contains 1.0 in Double Precision FP representation
+        movq %rax, %xmm2
         divsd %xmm3, %xmm2
         movq $0, %rax
         ret

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -1072,7 +1072,7 @@ fn task_exit() {
 #[cfg(all(test, test_in_svsm))]
 mod tests {
     extern crate alloc;
-    use crate::task::{KernelThreadStartInfo, start_kernel_task};
+    use crate::task::{KernelThreadStartInfo, start_kernel_task, wait_for_termination};
     use alloc::string::String;
     use core::arch::asm;
     use core::arch::global_asm;
@@ -1164,8 +1164,10 @@ mod tests {
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn test_fpu_context_switch() {
-        start_kernel_task(KernelThreadStartInfo::new(task1, 1), String::from("task1"))
+        let task1 = start_kernel_task(KernelThreadStartInfo::new(task1, 1), String::from("task1"))
             .expect("Failed to launch request processing task");
+
+        wait_for_termination(task1);
     }
 
     fn task1(start_parameter: usize) {
@@ -1176,8 +1178,10 @@ mod tests {
             asm!("call test_fpu", options(att_syntax));
         }
 
-        start_kernel_task(KernelThreadStartInfo::new(task2, 2), String::from("task2"))
+        let task2 = start_kernel_task(KernelThreadStartInfo::new(task2, 2), String::from("task2"))
             .expect("Failed to launch request processing task");
+
+        wait_for_termination(task2);
 
         unsafe {
             asm!("call check_fpu", out("rax") ret, options(att_syntax));


### PR DESCRIPTION
From #926:
`
 CI is failing [1], I don't know why (yet), but at least now it fails in the right place. (before it failed after the print that all kernel tests succeeded, which was not true [2] as this is a failure in a kernel test)
 `

After some testing [3], a possible scheduling order is as follows: when the `SVSM test task` starts `task1` in `test_fpu_context_switch`, `task1` is scheduled. However, when `task1` starts `task2`, the `SVSM test task` is scheduled and continues until it finishes (printing `All tests passed!`, which is not true). Then `task2` is scheduled until it finishes, after which `task1` resumes.

This is not the correct behaviour as we want that all the tests to finish before printing `All tests passed!`.

Add `wait_for_termination` after starting `task1` and `task2`, so `SVSM test task` can continue at the right time.

Note: I'm not sure if the relative ordering between `task1` and `task2` is relevant for the test (and the assertion failure), but we must be sure that they are both terminated before `SVSM test task` continues.

[1] https://github.com/coconut-svsm/svsm/actions/runs/27468738903/job/81195646363?pr=926
[2] https://github.com/coconut-svsm/svsm/actions/runs/27468172423/job/81194123020
[3] https://github.com/n-ramacciotti/svsm/actions/runs/27494307809/job/81265414543?pr=22