### PR TITLE
kernel: mm/pagetables: ensure progress in `PageTable::unmap_region()`

### DIFF
--- a/kernel/src/mm/pagetable.rs
+++ b/kernel/src/mm/pagetable.rs
@@ -1238,6 +1238,7 @@ impl PageTable {
                 }
                 _ => {
                     log::error!("Can't unmap - address not mapped {vaddr:#x}");
+                    vaddr = vaddr + PAGE_SIZE;
                 }
             }
         }


### PR DESCRIPTION
If `PageTable::unmap_region()` attempts to unmap a non-existing page, it logs the error but does not advance the loop index, resulting in an infinite loop. Ensure that `vaddr` is advanced by the minimum supported page size.

Note that this function is currently unused.