### PR TITLE
kernel/task: preserve r12-r15 across context switch

### DIFF
--- a/kernel/src/debug/gdbstub.rs
+++ b/kernel/src/debug/gdbstub.rs
@@ -480,10 +480,10 @@ pub mod svsm_gdbstub {
                 0, // r9
                 0, // r10
                 0, // r11
-                0, // r12
-                0, // r13
-                0, // r14
-                0, // r15
+                value.regs.r12 as u64,
+                value.regs.r13 as u64,
+                value.regs.r14 as u64,
+                value.regs.r15 as u64,
             ];
             regs
         }

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -703,6 +703,10 @@ global_asm!(
         // stack.
         pushq   %rbp
         pushq   %rbx
+        pushq   %r15
+        pushq   %r14
+        pushq   %r13
+        pushq   %r12
         subq    $24, %rsp
 
         // If `prev` is not null...
@@ -811,6 +815,10 @@ global_asm!(
         popq    %rsi
         popq    %rdx
         popq    %rcx
+        popq    %r12
+        popq    %r13
+        popq    %r14
+        popq    %r15
         popq    %rbx
         popq    %rbp
 

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -210,6 +210,10 @@ pub struct X86TaskSwitchRegs {
     pub rcx: usize,
 
     // Callee-save registers come next.
+    pub r12: usize,
+    pub r13: usize,
+    pub r14: usize,
+    pub r15: usize,
     pub rbx: usize,
     pub rbp: usize,
 }


### PR DESCRIPTION
`switch_context` is declared as extern "C", so the Rust compiler expects
it to follow the System V x86-64 ABI, which requires preserving all
callee-saved registers: rbx, rbp, r12, r13, r14, and r15.
    
However, commit ef4cd9ee ("task: streamline register preservation during
context switch") removed the push/pop of r12-r15 from the
`switch_context` assembly, keeping only rbx and rbp. This means that after
a context switch, r12-r15 contain stale values from whatever task last
ran on that CPU — not the values the compiler expects.
    
This issue, reported by Nicola, caused an assert in `test_fpu_context_switch`,
when he added a call to `wait_for_termination` to task1 and task2 to
address a scheduling problem.
    
Fix this by saving and restoring r12-r15 in the switch_context assembly
and adding the corresponding fields to X86TaskSwitchRegs. Also update
the gdbstub TaskContext-to-register conversion to report the now
available r12-r15 values instead of zeros.

This issue was found by @n-ramacciotti in #1115

/cc @msft-jlange @n-ramacciotti 
