### PR TITLE
build: link virtio-drivers dependency to block/vsock features

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -80,10 +80,10 @@ verus_all = ["verus_builtin", "verus_builtin_macros", "vstd", "verify_proof/veru
 verus = ["verus_all", "verify_proof/noverify", "verify_external/noverify"]
 noverify = []
 virtio-drivers = ["dep:virtio-drivers"]
-block = []
-vsock = []
 uefivars = ["dep:virtfw-varstore", "dep:virtfw-libefi"]
 secureboot = ["uefivars"]
+block = ["virtio-drivers"]
+vsock = ["virtio-drivers"]
 
 [dev-dependencies]
 sha2 = { workspace = true, features = ["force-soft"] }


### PR DESCRIPTION
Enabling the block or vsock subsystems alone does not automatically pull the virtio-drivers dependency. It silently skips the dependency during compilation.

Make the block and vsock Cargo features depend on the virtio-drivers feature in the kernel Cargo.toml, thereby allowing it to automatically pull virtio-drivers.