### PR TITLE
aproxy: Support Trustee KBS (CoCo) as the backend storage and verifier for attestation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -87,15 +87,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -106,7 +106,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -117,7 +117,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -139,6 +139,8 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sev",
+ "sha2",
  "vsock",
 ]
 
@@ -159,9 +161,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base16ct"
@@ -177,9 +179,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bindgen"
@@ -195,7 +197,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
+ "shlex 1.3.0",
  "syn",
 ]
 
@@ -204,6 +206,26 @@ name = "bit_field"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
+name = "bitfield"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21ba6517c6b0f2bf08be60e187ab64b038438f22dd755614d8fe4d4098c46419"
+dependencies = [
+ "bitfield-macros",
+]
+
+[[package]]
+name = "bitfield-macros"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f48d6ace212fdf1b45fd6b566bb40808415344642b76c3224c07c8df9da81e97"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "bitfield-struct"
@@ -229,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "bitfield-struct"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8769c4854c5ada2852ddf6fd09d15cf43d4c2aaeccb4de6432f5402f08a6003b"
+checksum = "3ca6739863c590881f038d033a146c51ddae239186a4327014839fd864f44ed5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -281,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -293,9 +315,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "camellia"
@@ -325,14 +347,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.47"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd405d82c84ff7f35739f175f67d8b9fb7687a0e84ccdc78bd3568839827cf07"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -399,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.53"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -409,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.53"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -421,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -433,24 +455,24 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmpa"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be785eeeffa3c5f99e7f71775051590c14b68b7f07fdf85641648d89dc9bf16"
+checksum = "360388c699cb87bbff6ad171727548056ccf43cc8fa442a745ad0676ab23b888"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "cocoon-tpm-crypto"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b7633b7e5996b4b5d15929736d10910c087713a9bdf9b7a05c1f16d192ae413"
+checksum = "71653c30341696a1a0e29b527b27fbaa9880c666ddb5999bdc6f47aca5e02562"
 dependencies = [
  "aes 0.8.4",
  "camellia",
@@ -462,7 +484,7 @@ dependencies = [
  "cocoon-tpm-utils-common",
  "crypto-common 0.1.7",
  "digest",
- "generic-array 1.3.5",
+ "generic-array 1.4.3",
  "hmac",
  "ofb",
  "sha2",
@@ -473,15 +495,15 @@ dependencies = [
 
 [[package]]
 name = "cocoon-tpm-tpm2-interface"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd87d8fabcfd5949ef574c04814c6c783858310bdcc58d807003fc8da56eac23"
+checksum = "f524208dcc8aa8c63f8d0a1a64f458beeb6eff7d7d64deec515be639a57811ea"
 
 [[package]]
 name = "cocoon-tpm-utils-common"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19fa8730c221b252c85b70e895101b9022cd5777d8c8d3c35e9f92d1a27d1b45"
+checksum = "8ac4f8367a407cdc3781da84c898cb0de567866816ee8f62bf2195e2605e068b"
 dependencies = [
  "cmpa",
  "zeroize",
@@ -489,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "concat-kdf"
@@ -542,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "cookie_store"
-version = "0.21.1"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eac901828f88a5241ee0600950ab981148a18f2f756900ffba1b125ca6a3ef9"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
 dependencies = [
  "cookie",
  "document-features",
@@ -666,12 +688,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
-dependencies = [
- "powerfmt",
-]
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "derive_arbitrary"
@@ -697,10 +716,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
+name = "dirs"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -732,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elf"
@@ -793,15 +833,30 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.5"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flagset"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -814,9 +869,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -824,33 +879,33 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -858,7 +913,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -899,9 +953,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "1.3.5"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf57c49a95fd1fe24b90b3033bee6dc7e8f1288d51494cb44e627c295e38542"
+checksum = "c2e55f16dcf0e9c00efbe2e655ffe45fc98e7066b52bc92f8a79e64060a79351"
 dependencies = [
  "rustversion",
  "typenum",
@@ -909,9 +963,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
@@ -995,9 +1049,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -1043,9 +1097,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1056,7 +1110,6 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1064,14 +1117,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.18"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -1088,12 +1140,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1101,9 +1154,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1114,9 +1167,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1128,15 +1181,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1148,15 +1201,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1180,9 +1233,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1281,20 +1334,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipnet"
-version = "2.11.0"
+name = "iocuddle"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d8972d5be69940353d5347a1344cb375d9b457d6809b428b05bb1ca2fb9ce007"
 
 [[package]]
-name = "iri-string"
-version = "0.7.9"
+name = "ipnet"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
-dependencies = [
- "memchr",
- "serde",
-]
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1313,9 +1362,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
@@ -1329,11 +1378,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -1368,6 +1418,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libaproxy"
 version = "0.1.0"
 dependencies = [
@@ -1380,15 +1436,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.10"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5037190e1f70cbeef565bd267599242926f724d3b8a9f510fd7e0b540cfa4404"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
 dependencies = [
  "arbitrary",
  "cc",
@@ -1405,6 +1461,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "libtcgtpm"
 version = "0.1.0"
 dependencies = [
@@ -1413,9 +1478,9 @@ dependencies = [
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -1425,9 +1490,9 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "managed"
@@ -1437,9 +1502,9 @@ checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
@@ -1467,20 +1532,20 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "nix"
-version = "0.29.0"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1501,9 +1566,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -1525,9 +1590,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1562,6 +1627,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "p384"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1584,9 +1702,9 @@ dependencies = [
 
 [[package]]
 name = "pastey"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pem-rfc7468"
@@ -1605,15 +1723,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs8"
@@ -1624,6 +1736,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polyval"
@@ -1639,9 +1757,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -1663,9 +1781,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -1708,9 +1826,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -1727,7 +1845,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1737,10 +1855,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cc2191ec1fd850e3ede4cf09ccfd40a33df561111f73e96e1b7c3f9eee31328"
 
 [[package]]
-name = "regex"
-version = "1.12.2"
+name = "rdrand"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "d92195228612ac8eed47adbc2ed0f04e513a4ccb98175b6f2bd04d963b533655"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1750,9 +1888,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1761,9 +1899,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "release"
@@ -1771,9 +1909,9 @@ version = "0.1.0"
 
 [[package]]
 name = "reqwest"
-version = "0.12.24"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
@@ -1817,15 +1955,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -1844,9 +1982,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safe-mmio"
@@ -1872,9 +2010,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "seq-macro"
@@ -1890,6 +2028,25 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1914,15 +2071,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1935,6 +2092,30 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sev"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5031e00ad6d00d24f6b9990a181fdc8dc6e6222ba9ef657f2d8cf29e4c36b948"
+dependencies = [
+ "base64",
+ "bitfield",
+ "bitflags",
+ "byteorder",
+ "dirs",
+ "hex",
+ "iocuddle",
+ "lazy_static",
+ "libc",
+ "openssl",
+ "rdrand",
+ "serde",
+ "serde-big-array",
+ "serde_bytes",
+ "static_assertions",
+ "uuid",
 ]
 
 [[package]]
@@ -1955,6 +2136,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1966,9 +2153,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "sm3"
@@ -1990,18 +2177,18 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2126,9 +2313,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2189,12 +2376,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -2204,15 +2390,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2220,9 +2406,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2230,22 +2416,22 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
  "socket2",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -2258,20 +2444,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.7"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf146f99d442e8e68e585f5d798ccd3cad9a7835b917e09728880a862706456"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -2288,9 +2474,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -2299,9 +2485,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2310,9 +2496,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
@@ -2348,9 +2534,9 @@ dependencies = [
 
 [[package]]
 name = "uefi"
-version = "0.36.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fe9058b73ee2b6559524af9e33199c13b2485ddbf3ad1181b68051cdc50c17"
+checksum = "66ab9569afdd1e33a31d8002343aa1df594f055347b1a66136bf9dd6cbc3ec37"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2375,9 +2561,9 @@ dependencies = [
 
 [[package]]
 name = "uefi-raw"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f64fe59e11af447d12fd60a403c74106eb104309f34b4c6dbce6e927d97da9d"
+checksum = "f3775e5934877acaef4b00f254f252df1e2266903c31e51455c117f4f2824eda"
 dependencies = [
  "bitflags",
  "uguid",
@@ -2391,9 +2577,9 @@ checksum = "0c8352f8c05e47892e7eaf13b34abd76a7f4aeaf817b716e88789381927f199c"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-xid"
@@ -2413,9 +2599,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2452,9 +2638,20 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+dependencies = [
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "verify_external"
@@ -2553,11 +2750,11 @@ dependencies = [
 
 [[package]]
 name = "virtfw-libefi"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfe5a2adf2b20c1cdb1f24614c3f07a94398995ab6c2c2562f97d1b2f0d9fb7"
+checksum = "fb4aef72886dee346d48d924558d655ae104f673ace87d21a9a78ea572428204"
 dependencies = [
- "bitfield-struct 0.12.1",
+ "bitfield-struct 0.13.0",
  "byteorder",
  "der",
  "log",
@@ -2568,9 +2765,9 @@ dependencies = [
 
 [[package]]
 name = "virtfw-varstore"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e006f827ff617f08e9cb01ab51e87e261153970359cd3365f5a39702812aaf6c"
+checksum = "03e5480af9b224e5cb71d41cc82a851bb1a8522dcbf511d8eb4f603aefd912e0"
 dependencies = [
  "der",
  "hex",
@@ -2598,9 +2795,9 @@ dependencies = [
 
 [[package]]
 name = "vsock"
-version = "0.5.1"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e8b4d00e672f147fc86a09738fadb1445bd1c0a40542378dfb82909deeee688"
+checksum = "6ba782755fc073877e567c2253c0be48e4aa9a254c232d36d3985dfae0bd5205"
 dependencies = [
  "libc",
  "nix",
@@ -2634,18 +2831,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2656,22 +2853,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.55"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2679,9 +2873,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2692,18 +2886,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.82"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2717,15 +2911,6 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -2734,81 +2919,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x509-cert"
@@ -2833,9 +2953,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -2844,9 +2964,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2876,18 +2996,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2897,18 +3017,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2917,9 +3037,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -2928,9 +3048,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2939,11 +3059,17 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,8 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sev",
+ "sha2",
  "vsock",
 ]
 
@@ -196,7 +198,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -206,6 +208,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
+name = "bitfield"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b45721c9db4c7a20899d05efb7ad9235f50b256e980db30ffb229abf732934c3"
+dependencies = [
+ "bitfield-macros",
+]
+
+[[package]]
+name = "bitfield-macros"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0cb6f3d4773a2107b94cbeccaa5b5f0b35a88389b5d522d13d659f64317b22d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "bitfield-struct"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,7 +235,7 @@ checksum = "2be5a46ba01b60005ae2c51a36a29cfe134bcacae2dd5cedcd4615fbaad1494b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -224,7 +246,7 @@ checksum = "8769c4854c5ada2852ddf6fd09d15cf43d4c2aaeccb4de6432f5402f08a6003b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -235,7 +257,7 @@ checksum = "3ca6739863c590881f038d033a146c51ddae239186a4327014839fd864f44ed5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -428,7 +450,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -689,7 +711,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -709,7 +731,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -725,6 +747,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,7 +775,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -815,7 +858,7 @@ checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -845,6 +888,21 @@ name = "flagset"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1321,6 +1379,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4275b20e6057cd7733fd8df8a5a31701e4fe44497dad0f3fa0e1c4fb971506be"
 
 [[package]]
+name = "iocuddle"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8972d5be69940353d5347a1344cb375d9b457d6809b428b05bb1ca2fb9ce007"
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,6 +1472,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libaproxy"
 version = "0.1.0"
 dependencies = [
@@ -1442,6 +1512,15 @@ checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
  "windows-link",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1598,8 +1677,61 @@ checksum = "8d1296fab5231654a5aec8bf9e87ba4e3938c502fc4c3c0425a00084c78944be"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
+
+[[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "p384"
@@ -1664,6 +1796,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polyval"
@@ -1733,7 +1871,7 @@ checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1775,6 +1913,26 @@ name = "range_map_vec"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cc2191ec1fd850e3ede4cf09ccfd40a33df561111f73e96e1b7c3f9eee31328"
+
+[[package]]
+name = "rdrand"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92195228612ac8eed47adbc2ed0f04e513a4ccb98175b6f2bd04d963b533655"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror",
+]
 
 [[package]]
 name = "regex"
@@ -1934,6 +2092,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1950,7 +2127,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1976,6 +2153,30 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sev"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5031e00ad6d00d24f6b9990a181fdc8dc6e6222ba9ef657f2d8cf29e4c36b948"
+dependencies = [
+ "base64",
+ "bitfield",
+ "bitflags",
+ "byteorder",
+ "dirs",
+ "hex",
+ "iocuddle",
+ "lazy_static",
+ "libc",
+ "openssl",
+ "rdrand",
+ "serde",
+ "serde-big-array",
+ "serde_bytes",
+ "static_assertions",
+ "uuid",
 ]
 
 [[package]]
@@ -2099,7 +2300,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2181,6 +2382,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2197,7 +2409,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2229,7 +2441,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2350,7 +2562,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2415,7 +2627,7 @@ checksum = "4687412b5ac74d245d5bfb1733ede50c31be19bf8a4b6a967a29b451bab49e67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2501,6 +2713,17 @@ name = "uuid"
 version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "verify_external"
@@ -2542,7 +2765,7 @@ checksum = "3fb60e3a141ababe618fbdb759f14aa8544f6346a98a44c1e3a7dbe20b1f2892"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
  "verus_prettyplease",
  "verus_syn",
@@ -2732,7 +2955,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -2896,7 +3119,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -2917,7 +3140,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2937,7 +3160,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -2958,7 +3181,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2991,5 +3214,5 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]

--- a/Documentation/docs/developer/ATTESTATION.md
+++ b/Documentation/docs/developer/ATTESTATION.md
@@ -12,6 +12,7 @@
     - [Host Proxy Diagram](#host-proxy-diagram)
   - [Transport Methods](#transport-methods)
   - [Try for yourself](#try-for-yourself)
+  - [Try with Trustee KBS](#try-with-trustee-kbs)
 <!--toc:end-->
 
 ## Background
@@ -53,35 +54,21 @@ tuple [MAJOR, MINOR, PATCH]. The current version is 0.1.0.
 - `tee`: The TEE hardware architecture that SVSM is running on.
 
 The proxy will then complete the negotiation phase with the remote attestation
-server and reply with a list of negotiation parameters that must be included in
-the attestation evidence.
+server and reply with a challenge nonce that must be included in the attestation evidence.
 
 A `NegotiationResponse` is sent from the proxy to SVSM.
 An example `NegotiationResponse` is shown below.
 ```json
 {
     "challenge": "oFlY92ZdS3ymzxokYuDzxw==\",
-    "params": [
-                "EcPublicKeyBytes",
-                "Challenge"
-              ]
 }
 ```
 - `challenge`: The challenge nonce returned by the remote attestation server
 that will likely need to be hashed into the attestation evidence to ensure
 freshness. Represented as variably-sized array of bytes.
-- `params`: The negotiation parameters. Each `NegotiationParam` represents some
-form of data that must be hashed into the attestation evidence. This hash will
-be reconstructed by the remote attestation server when the evidence is presented
-from SVSM.
 
-The valid negotiation parameters are as follows:
-- `Challenge`: The bytes represented in the `challenge`.
-- `EcPublicKeyBytes`: The byte buffers of the public key's x and y coordinates
-(in that order).
-
-SVSM can then collect the attestation evidence (with the negotiation parameters
-embedded within the report data) and continue to the attestation phase.
+aproxy builds the entire KBS runtime JSON object, hashes it on the host using Sha384,
+and returns the hash as a single challenge for SVSM to put in its report.
 
 ### Attestation Phase
 
@@ -146,7 +133,7 @@ example).
 
 Valid evidence formats are the following:
 - `Snp`: SEV-SNP
-    - `report`: Attestation report bytes.
+    - `attestation_report`: Attestation report bytes.
     - `certs_buf`: Optional byte buffer representing SEV-SNP certificate chain
                    (ARK, ASK, VEK) set by the host hypervisor.
 
@@ -390,3 +377,8 @@ SEV-SNP machine with an SVSM-enabled kernel.
     cd kbs-test
     cargo run -- --measurement 9ef6c500d19addcd5937c6c8bd4e51b1893f048eea03d5407cfb0692c06615e3f6c044c667c32e520913d93234e836fe
     ```
+
+## Try with Trustee KBS
+
+You can also try with the official Trustee KBS and SVSM setup. See [KBS-SVSM](KBS-SVSM.md)
+

--- a/Documentation/docs/developer/ATTESTATION.md
+++ b/Documentation/docs/developer/ATTESTATION.md
@@ -12,6 +12,7 @@
     - [Host Proxy Diagram](#host-proxy-diagram)
   - [Transport Methods](#transport-methods)
   - [Try for yourself](#try-for-yourself)
+  - [Try with Trustee KBS](#try-with-trustee-kbs)
 <!--toc:end-->
 
 ## Background
@@ -60,25 +61,20 @@ A `NegotiationResponse` is sent from the proxy to SVSM.
 An example `NegotiationResponse` is shown below.
 ```json
 {
-    "challenge": "oFlY92ZdS3ymzxokYuDzxw==\",
-    "params": [
-                "EcPublicKeyBytes",
-                "Challenge"
-              ]
+    "challenge": "oFlY92ZdS3ymzxokYuDzxw==",
+    "hash_algo": "Sha384",
+    "payload_format": "JwsJson"
 }
 ```
 - `challenge`: The challenge nonce returned by the remote attestation server
 that will likely need to be hashed into the attestation evidence to ensure
 freshness. Represented as variably-sized array of bytes.
-- `params`: The negotiation parameters. Each `NegotiationParam` represents some
-form of data that must be hashed into the attestation evidence. This hash will
-be reconstructed by the remote attestation server when the evidence is presented
-from SVSM.
+- `hash_algo`: The cryptographic hash algorithm that SVSM must use (`Sha256`, `Sha384`, or `Sha512`).
+- `payload_format`: The structural layout format SVSM must construct before hashing (`RawBinary` or `JwsJson`).
 
-The valid negotiation parameters are as follows:
-- `Challenge`: The bytes represented in the `challenge`.
-- `EcPublicKeyBytes`: The byte buffers of the public key's x and y coordinates
-(in that order).
+The valid payload formats are as follows:
+  *   `RawBinary`: Instructs SVSM to format the public key coordinates and challenge nonce as a sequential binary layout.
+  *   `JwsJson`: Instructs SVSM to format, serialize, and hash a standard, JWS JSON map containing the public key and challenge nonce (specifically required by Trustee KBS).
 
 SVSM can then collect the attestation evidence (with the negotiation parameters
 embedded within the report data) and continue to the attestation phase.
@@ -126,7 +122,7 @@ An example `AttestationRequest` is shown below.
                        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
                        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
                        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\",
-            "certs_buf": null
+            "cert_chain": null
         }
     },
     "challenge": "oFlY92ZdS3ymzxokYuDzxw==\",
@@ -146,8 +142,8 @@ example).
 
 Valid evidence formats are the following:
 - `Snp`: SEV-SNP
-    - `report`: Attestation report bytes.
-    - `certs_buf`: Optional byte buffer representing SEV-SNP certificate chain
+    - `attestation_report`: Attestation report bytes.
+    - `cert_chain`: Optional byte buffer representing SEV-SNP certificate chain
                    (ARK, ASK, VEK) set by the host hypervisor.
 
 - `challenge`: The original challenge nonce given in the `NegotiationResponse`.
@@ -390,3 +386,7 @@ SEV-SNP machine with an SVSM-enabled kernel.
     cd kbs-test
     cargo run -- --measurement 9ef6c500d19addcd5937c6c8bd4e51b1893f048eea03d5407cfb0692c06615e3f6c044c667c32e520913d93234e836fe
     ```
+
+## Try with Trustee KBS
+
+You can also try with the official Trustee KBS and SVSM setup. See [KBS-SVSM](KBS-SVSM.md)

--- a/Documentation/docs/developer/KBS-SVSM.md
+++ b/Documentation/docs/developer/KBS-SVSM.md
@@ -1,0 +1,188 @@
+# Attestation in SVSM using Trustee KBS
+
+We need,
+1. SVSM (with attest feature),
+    > git clone https://github.com/coconut-svsm/svsm.git
+2. The aproxy on the host.
+3. Trustee KBS server (For now, the KBS softhsm container, is not upstream)
+    > git clone https://github.com/armenon-rh/trustee.git
+
+This document explains the steps to perform a complete attestation.
+
+# Prerequisites & Architectural Overview
+The Key Broker Service (KBS) handles confidential computing attestation and secret provisioning. Depending on your security requirements, it can be deployed in one of the two modes:
+
+## Mode A: Resource Key-Value Storage Backend (Default)
+Act as a direct storage repository for secrets.
+- Flow: SVSM <--> aproxy <--> KBS (Resource kvstorage backend)
+- Concept: The user provisions a secret into the KBS storage via kbs-client. SVSM later presents its attestation token to retrieve that raw secret.
+
+## Mode B: PKCS#11 Plugin Backend (softHSM)
+Offloads cryptographic operations and key management to a Software HSM.
+- Flow: SVSM <--> aproxy <--> KBS(PKCS#11 plugin) <--> softHSM
+- Concept: The user generates a 32-byte symmetric key, which softHSM wraps (encrypts) using its internal public key. The user uses the raw key to encrypt vTPM state, but implants the wrapped key into the metadata header. During boot, SVSM hands the wrapped key to KBS, which requests softHSM to unwrap it, passing back the raw key only after attestation.
+
+# Step by Step implementation
+
+## 1. Build the image
+
+An Ubuntu based KBS container image that also has softHSM and opensc (pkcs11-tool to interact with softHSM) packages installed.
+
+```bash
+cd trustee/
+podman build -t kbs-service -f kbs/docker/kbs-softhsm-pkcs11/Dockerfile .
+```
+
+## 2. Initialize Host storage directories
+
+Create the required host workspaces to persist softHSM tokens and KBS resource assets
+
+```bash
+mkdir -p $HOME/kbs-workspace/softhsm_tokens
+mkdir -p $HOME/kbs-workspace/kbs-storage
+```
+
+## 3. Configure Attestation Policy
+Create the repository directory and establish the Open Policy Agent (OPA) Rego policy file that dictates KBS access rules.
+
+```bash
+mkdir -p kbs-workspace/repository/kbs && cd kbs-workspace/repository/kbs
+
+cat <<EOF > resource-policy.rego
+package policy
+
+default allow = false
+
+allow if {
+    true
+}
+EOF
+
+cd -
+```
+
+## 4. Run the KBS container
+Choose the configuration profile that fits your desired operational mode:
+
+### Option A: Run as Resource Backend (KV Storage)
+
+```bash
+podman run -d \
+    --name kbs-pkcs11-service \
+    -p 8080:8080 \
+    -v $HOME/kbs-workspace/repository/kbs/resource-policy.rego:/etc/kbs/repository/kbs/resource-policy.rego:Z \
+    -v $HOME/kbs-workspace/kbs-storage/:/opt/confidential-containers/storage:Z \
+    kbs-service:latest /usr/local/bin/kbs --config-file /etc/kbs/kbs-config-resource.toml
+```
+
+### Option B: Run as PKCS#11 Plugin Backend
+```bash
+podman run -d \
+    --name kbs-resource-service \
+    -p 8080:8080 \
+    -v $HOME/kbs-workspace/softhsm_tokens/:/var/lib/softhsm/tokens:Z \
+    -v $HOME/kbs-workspace/repository/kbs/resource-policy.rego:/etc/kbs/repository/kbs/resource-policy.rego:Z \
+    -v $HOME/test/trustee/kbs/docker/kbs-softhsm-pkcs11/config_pkcs11.toml:/etc/kbs/kbs-config.toml \
+    kbs-service:latest
+```
+
+## 5. Generate Cryptographic assets
+```bash
+openssl rand 32 > rand.bin
+echo "My secret" > secret.txt
+```
+The secret will be stored in kbs resource backend, whereas if we want to use the pkcs11 plugin then the key will be wrapped.
+
+## 6. Provision or Wrap the cryptographic assets
+
+### Option A: Store Secret in Resource Backend
+
+```bash
+make -C kbs cli FEATURES
+./target/release/kbs-client --url http://0.0.0.0:8080 config  set-resource --path default/sample/test --resource-file secret.txt
+```
+The secret will be store in KBS.
+
+### Option B: Wrap Key via PKCS#11 Plugin
+```bash
+curl -X POST http://0.0.0.0:8080/kbs/v0/pkcs11/wrap-key \
+     -H "Content-Type: application/octet-stream" \
+     --data-binary @rand.bin \
+     --output wrapped_rand.bin
+```
+wrapped_rand.bin will contain the wrapped key
+
+## 7. Use [tpm provisioner](https://github.com/armenon-rh/tpm_provisioner) to create an NVChip file
+
+```bash
+cd ../
+git clone https://github.com/armenon-rh/tpm_provisioner.git && cd tpm_provisioner
+
+podman build -t tpm-provisioner -f Dockerfile .
+
+podman run -it --name tpm-lab tpm-provisioner
+
+cargo run && verify
+
+# Generate the ek public key from tpm, store it in ek.pub --> 1
+tpm2_createek -T mssim:host=localhost,port=2321 -c ek.ctx -u ek.pub -G rsa
+
+# print the public part of it the endorsement key  --> 2
+tpm2_print -t TPM2B_PUBLIC ek.pub
+
+# Retrieve the certificate from nvram, in DER format --> 3
+tpm2_nvread -T mssim:host=localhost,port=2321 -C o 0x1c00002 -o ek_cert.der
+
+# Extract public key from certificate, in PEM format --> 4
+openssl x509 -in ek_cert.der -inform DER -pubkey -noout > cert_key.pem
+
+# print the public key, modulus will be printed --> 5
+openssl rsa -pubin -in cert_key.pem -text -noout
+
+# modulus in 2 and 5 should match!
+
+# copy the important files to host
+# ek_cert.der, ek_cert.pem, local_ca.pem, cert_key.pem, NVChip
+podman cp tpm-lab:/app/tpm_provisioner/<file_name> /path/on/host/<file_name>
+
+```
+
+## 8. Use [vtpm-to-svsm-blk](https://github.com/armenon-rh/vtpm-to-svsm-blk) to create a virtio block image
+- use rand.bin from step 5 as key for encryption param
+- use wrapped_rand.bin from step 6 as wrapped key param
+vtpm_state.img is ready, which has payload encrypted and a header with the wrapped key.
+
+```bash
+git clone https://github.com/armenon-rh/vtpm-to-svsm-blk.git && cd vtpm-to-svsm-blk
+
+cargo build
+
+cargo run -- -k rand.bin -w wrapped_rand.bin -s /path/on/host/<NVChip> -o /path/on/host/to/store/vtpm_state.img
+
+# This will create a vTPM image, that can be attached to SVSM as a virtio block
+
+```
+
+## 9. Run Aproxy on the host
+
+```bash
+cd svsm/
+make aproxy
+./bin/aproxy --protocol kbs \
+    --url http://0.0.0.0:8080 \
+    --unix /tmp/svsm-proxy.sock \
+    --force > aproxy.log 2>&1 &
+```
+
+## 10. Launch the confidential guest
+
+Assuming that qemu is compiled using the [svsm](https://github.com/coconut-svsm/qemu.git) branch and SVSM is compiled using the latest [OVMF.FD file](https://github.com/coconut-svsm/edk2.git), and the fedora image is built using [image builder](https://github.com/stefano-garzarella/snp-svsm-vtpm/blob/main/build-vm-image.sh)
+
+```bash
+./scripts/launch_guest.sh --aproxy /tmp/svsm-proxy.sock \
+    --qemu $HOME/test/qemu/bin/qemu-system-x86_64 \
+    --image $HOME/test/snp-svsm-vtpm/images/fedora-luks.qcow2 \
+    --state ../vtpm_state.img
+```
+
+Note: Make sure to add the option --pcd PcdUninstallMemAttrProtocol=TRUE while building edk2 for Fedora 42 images. See [instructions](../installation/INSTALL.md#building-the-guest-firmware)

--- a/Documentation/docs/developer/KBS-SVSM.md
+++ b/Documentation/docs/developer/KBS-SVSM.md
@@ -1,0 +1,198 @@
+# Attestation in SVSM using Trustee KBS
+
+We need,
+1. SVSM (with attest feature),
+    > git clone https://github.com/coconut-svsm/svsm.git
+2. The aproxy on the host.
+3. Trustee KBS server (For now, the KBS softhsm container, is not upstream)
+    > git clone https://github.com/armenon-rh/trustee.git
+
+This document explains the steps to perform a complete attestation.
+
+# Prerequisites & Architectural Overview
+The Key Broker Service (KBS) handles confidential computing attestation and secret provisioning. Depending on your security requirements, it can be deployed in one of the two modes:
+
+## Mode A: Resource Key-Value Storage Backend (Default)
+Act as a direct storage repository for secrets.
+- Flow: SVSM <--> aproxy <--> KBS (Resource kvstorage backend)
+- Concept: The user provisions a secret into the KBS storage via kbs-client. SVSM later presents its attestation token to retrieve that raw secret.
+
+## Mode B: PKCS#11 Plugin Backend (softHSM)
+Offloads cryptographic operations and key management to a Software HSM.
+- Flow: SVSM <--> aproxy <--> KBS(PKCS#11 plugin) <--> softHSM
+- Concept: The user generates a 32-byte symmetric key, which softHSM wraps (encrypts) using its internal public key. The user uses the raw key to encrypt vTPM state, but implants the wrapped key into the metadata header. During boot, SVSM hands the wrapped key to KBS, which requests softHSM to unwrap it, passing back the raw key only after attestation.
+
+# Step by Step implementation
+
+## 1. Build the image
+
+An Ubuntu based KBS container image that also has softHSM and opensc (pkcs11-tool to interact with softHSM) packages installed.
+
+```bash
+cd trustee/
+podman build -t kbs-service -f kbs/docker/kbs-softhsm-pkcs11/Dockerfile .
+```
+
+## 2. Initialize Host storage directories
+
+Create the required host workspaces to persist softHSM tokens and KBS resource assets
+
+```bash
+mkdir -p $HOME/kbs-workspace/softhsm_tokens
+mkdir -p $HOME/kbs-workspace/kbs-storage
+```
+
+## 3. Configure Attestation Policy
+Create the repository directory and establish the Open Policy Agent (OPA) Rego policy file that dictates KBS access rules.
+
+```bash
+mkdir -p kbs-workspace/repository/kbs && cd kbs-workspace/repository/kbs
+
+cat <<EOF > resource-policy.rego
+package policy
+
+default allow = false
+
+allow if {
+    true
+}
+EOF
+
+cd -
+```
+
+## 4. Run the KBS container
+Choose the configuration profile that fits your desired operational mode:
+
+### Option A: Run as Resource Backend (KV Storage)
+
+```bash
+
+podman run -d \
+    --name kbs-resource-service \
+    -p 8080:8080 \
+    -v $HOME/kbs-workspace/repository/kbs/resource-policy.rego:/etc/kbs/repository/kbs/resource-policy.rego:Z \
+    -v $HOME/kbs-workspace/kbs-storage/:/opt/confidential-containers/storge:Z \
+    -v $HOME/test/trustee/kbs/docker/kbs-softhsm-pkcs11/config_resource.toml:/etc/kbs/kbs-config-resource.toml \ kbs-service:latest  /usr/local/bin/kbs --config-file /etc/kbs/kbs-config-resource.toml
+
+```
+
+### Option B: Run as PKCS#11 Plugin Backend
+```bash
+podman run -d \
+    --name kbs-resource-pkcs11 \
+    -p 8080:8080 \
+    -v $HOME/kbs-workspace/softhsm_tokens/:/var/lib/softhsm/tokens:Z \
+    -v $HOME/kbs-workspace/repository/kbs/resource-policy.rego:/etc/kbs/repository/kbs/resource-policy.rego:Z \
+    -v $HOME/kbs-workspace/kbs-storage/:/opt/confidential-containers/storge:Z \
+    -v $HOME/test/trustee/kbs/docker/kbs-softhsm-pkcs11/config_pkcs11.toml:/etc/kbs/kbs-config.toml \
+    kbs-service:latest
+```
+
+## 5. Generate Cryptographic assets
+```bash
+openssl rand 32 > rand.bin
+echo "My secret" > secret.txt
+```
+The secret will be stored in kbs resource backend, whereas if we want to use the pkcs11 plugin then the key will be wrapped.
+
+## 6. Provision or Wrap the cryptographic assets
+
+### Option A: Store Secret in Resource Backend
+
+```bash
+make -C kbs cli FEATURES
+./target/release/kbs-client --url http://0.0.0.0:8080 config  set-resource --path default/sample/test --resource-file secret.txt
+```
+The secret will be store in KBS.
+
+### Option B: Wrap Key via PKCS#11 Plugin
+```bash
+curl -X POST http://0.0.0.0:8080/kbs/v0/pkcs11/wrap-key \
+     -H "Content-Type: application/octet-stream" \
+     --data-binary @rand.bin \
+     --output wrapped_rand.bin
+```
+wrapped_rand.bin will contain the wrapped key
+
+## 7. Use [tpm provisioner](https://github.com/armenon-rh/tpm_provisioner) to create an NVChip file
+
+```bash
+cd ../
+git clone https://github.com/armenon-rh/tpm_provisioner.git && cd tpm_provisioner
+
+podman build -t tpm-provisioner -f Dockerfile .
+
+podman run -it --name tpm-lab tpm-provisioner
+
+# Refer the readme in tpm_provisioner project
+tpm_provisioner provision && verify;
+
+# Generate the ek public key from tpm, store it in ek.pub --> 1
+tpm2_createek -T mssim:host=localhost,port=2321 -c ek.ctx -u ek.pub -G rsa
+
+# print the public part of it the endorsement key  --> 2
+tpm2_print -t TPM2B_PUBLIC ek.pub
+
+# Retrieve the certificate from nvram, in DER format --> 3
+tpm2_nvread -T mssim:host=localhost,port=2321 -C o 0x1c00002 -o ek_cert.der
+
+# Extract public key from certificate, in PEM format --> 4
+openssl x509 -in ek_cert.der -inform DER -pubkey -noout > cert_key.pem
+
+# print the public key, modulus will be printed --> 5
+openssl rsa -pubin -in cert_key.pem -text -noout
+
+# modulus in 2 and 5 should match!
+
+# copy the important files to host
+# ek_cert.der, ek_cert.pem, local_ca.pem, cert_key.pem, NVChip
+podman cp tpm-lab:/app/tpm_provisioner/<file_name> /path/on/host/<file_name>
+
+```
+
+## 8. Use [vtpm-to-svsm-blk](https://github.com/armenon-rh/vtpm-to-svsm-blk) to create a virtio block image
+- use rand.bin from step 5 as key for encryption param
+- use wrapped_rand.bin from step 6 as wrapped key param
+vtpm_state.img is ready, which has payload encrypted and a header with the wrapped key.
+
+```bash
+git clone https://github.com/armenon-rh/vtpm-to-svsm-blk.git && cd vtpm-to-svsm-blk
+
+cargo build
+
+cargo run -- -k rand.bin -w wrapped_rand.bin -s /path/on/host/<NVChip> -o /path/on/host/to/store/vtpm_state.img
+
+# This will create a vTPM image, that can be attached to SVSM as a virtio block
+
+```
+
+## 9. Run Aproxy on the host
+
+```bash
+cd svsm/
+make aproxy
+
+# Based on what protocol you want to use (kbs or kbs-trustee)
+
+./bin/aproxy --protocol kbs \
+    --url http://127.0.0.1:8080 \
+    --vsock > aproxy.log 2>&1 &
+
+```
+
+## 10. Launch the confidential guest
+
+Assuming that qemu is compiled using the [svsm](https://github.com/coconut-svsm/qemu.git) branch and SVSM is compiled using the latest [OVMF.FD file](https://github.com/coconut-svsm/edk2.git), and the fedora image is built using [image builder](https://github.com/stefano-garzarella/snp-svsm-vtpm/blob/main/build-vm-image.sh)
+
+```bash
+
+./scripts/launch_guest.sh --vsock 3 \
+    --qemu $HOME/test/qemu/build/qemu-system-x86_64 \
+    --image $HOME/test/snp-svsm-vtpm/images/fedora-luks.qcow2
+    # provide VTPM state file if necessary
+    # --state ../vtpm_state.img
+
+```
+
+Note: Make sure to add the option --pcd PcdUninstallMemAttrProtocol=TRUE while building edk2 for Fedora 42 images. See [instructions](../installation/INSTALL.md#building-the-guest-firmware)

--- a/kernel/src/attest.rs
+++ b/kernel/src/attest.rs
@@ -33,12 +33,13 @@ use cocoon_tpm_utils_common::{
 use kbs_types::Tee;
 use libaproxy::*;
 use serde::Serialize;
-use sha2::{Digest, Sha512};
 use zerocopy::{FromBytes, IntoBytes};
 
 #[cfg(feature = "attest-serial")]
 // TODO: Make the IO port configurable/discoverable or drop the support entirely.
 const ATTEST_DEFAULT_SERIAL_IO_ADDR: u16 = 0x3e8; // COM3
+const CHALLENGE_LEN: usize = 48;
+const TEE_REPORT_DATA_LEN: usize = 64;
 
 enum Transport {
     Vsock(VsockStream),
@@ -174,7 +175,7 @@ impl AttestationDriver {
     fn attestation(&mut self, n: NegotiationResponse) -> Result<SecretSlice, AttestationError> {
         let pub_key = self.get_tpm_pub_key()?;
 
-        let evidence = evidence(&self.tee, hash(&n, &pub_key)?)?;
+        let evidence = evidence(&self.tee, prepare_report_data(&n)?)?;
 
         let req = AttestationRequest {
             tee: self.tee,
@@ -306,6 +307,8 @@ pub enum AttestationError {
     Crypto(CryptoError),
     /// Guest has failed attestation.
     Failed,
+    /// Negotiation Response challenge length from KBS is invalid
+    InvalidChallengeLength,
     // Unable to derive wrap key.
     KeyDerivation(concat_kdf::Error),
     /// Error deserializing the negotiation response from JSON bytes.
@@ -408,26 +411,14 @@ fn evidence(tee: &Tee, hash: Vec<u8>) -> Result<AttestationEvidence, Attestation
     Ok(evidence)
 }
 
-/// Hash the negotiation parameters from the attestation server for inclusion in the
-/// attestation evidence.
-fn hash(
-    n: &NegotiationResponse,
-    pub_key: &TpmsEccPoint<'static>,
-) -> Result<Vec<u8>, AttestationError> {
-    let mut sha = Sha512::new();
-
-    for p in &n.params {
-        match p {
-            NegotiationParam::Challenge => {
-                sha.update(&n.challenge);
-            }
-            #[allow(irrefutable_let_patterns)]
-            NegotiationParam::EcPublicKeyBytes => {
-                sha.update(&*pub_key.x.buffer);
-                sha.update(&*pub_key.y.buffer);
-            }
-        }
+/// Take 48 byte negotiation challenge nonce from aproxy into 64 byte array required for the TEE attestation evidence report
+fn prepare_report_data(n: &NegotiationResponse) -> Result<Vec<u8>, AttestationError> {
+    if n.challenge.len() != CHALLENGE_LEN {
+        return Err(AttestationError::InvalidChallengeLength);
     }
 
-    try_to_vec(&sha.finalize()).or(Err(AttestationError::VecAlloc))
+    let mut report_data = [0u8; TEE_REPORT_DATA_LEN];
+    report_data[..CHALLENGE_LEN].copy_from_slice(&n.challenge);
+
+    Ok(report_data.to_vec())
 }

--- a/kernel/src/attest.rs
+++ b/kernel/src/attest.rs
@@ -130,6 +130,19 @@ impl TryFrom<Tee> for AttestationDriver {
 }
 
 impl AttestationDriver {
+    /// Extracts the public key coordinates as a TPM ECC point from the internal `EccKey`.
+    fn get_tpm_pub_key(&self) -> Result<TpmsEccPoint<'static>, AttestationError> {
+        let curve =
+            Curve::new(self.ecc.pub_key().get_curve_id()).map_err(AttestationError::Crypto)?;
+
+        let curve_ops = curve.curve_ops().map_err(AttestationError::Crypto)?;
+
+        self.ecc
+            .pub_key()
+            .to_tpms_ecc_point(&curve_ops)
+            .map_err(AttestationError::Crypto)
+    }
+
     /// Attest SVSM's launch state by communicating with the attestation proxy.
     pub fn attest(&mut self) -> Result<SecretSlice, SvsmError> {
         let negotiation = self.negotiation()?;
@@ -141,9 +154,12 @@ impl AttestationDriver {
     /// that should be included in attestation evidence (e.g. through SEV-SNP's REPORT_DATA
     /// mechanism).
     fn negotiation(&mut self) -> Result<NegotiationResponse, AttestationError> {
+        let pub_key = self.get_tpm_pub_key()?;
+
         let request = NegotiationRequest {
             version: (0, 1, 0), // Only version supported at present.
             tee: self.tee,
+            key: (self.ecc.pub_key().get_curve_id(), &pub_key).into(),
         };
 
         self.write(request)?;
@@ -156,14 +172,7 @@ impl AttestationDriver {
     /// containing the status (success/fail) and an optional secret returned from the server upon
     /// successful attestation.
     fn attestation(&mut self, n: NegotiationResponse) -> Result<SecretSlice, AttestationError> {
-        let curve =
-            Curve::new(self.ecc.pub_key().get_curve_id()).map_err(AttestationError::Crypto)?;
-
-        let pub_key = self
-            .ecc
-            .pub_key()
-            .to_tpms_ecc_point(&curve.curve_ops().map_err(AttestationError::Crypto)?)
-            .map_err(AttestationError::Crypto)?;
+        let pub_key = self.get_tpm_pub_key()?;
 
         let evidence = evidence(&self.tee, hash(&n, &pub_key)?)?;
 

--- a/kernel/src/attest.rs
+++ b/kernel/src/attest.rs
@@ -395,20 +395,41 @@ impl HashAlgoExt for HashAlgo {
     }
 }
 
+trait PayloadFormatter {
+    fn format(
+        &self,
+        challenge: &[u8],
+        pub_key: &TpmsEccPoint<'_>,
+    ) -> Result<Vec<u8>, AttestationError>;
+}
+
+struct RawBinaryFormatter;
+
+impl PayloadFormatter for RawBinaryFormatter {
+    fn format(
+        &self,
+        challenge: &[u8],
+        pub_key: &TpmsEccPoint<'_>,
+    ) -> Result<Vec<u8>, AttestationError> {
+        let mut buffer = Vec::new();
+        buffer.extend_from_slice(&pub_key.x.buffer);
+        buffer.extend_from_slice(&pub_key.y.buffer);
+        buffer.extend_from_slice(challenge);
+        Ok(buffer)
+    }
+}
+
 /// Hash the negotiation parameters from the attestation server for inclusion in the
 /// attestation evidence.
 fn hash(
     n: &NegotiationResponse,
     pub_key: &TpmsEccPoint<'static>,
 ) -> Result<Vec<u8>, AttestationError> {
-    match n.payload_format {
-        PayloadFormat::RawBinary => {
-            let mut buffer = Vec::new();
-            buffer.extend_from_slice(&pub_key.x.buffer);
-            buffer.extend_from_slice(&pub_key.y.buffer);
-            buffer.extend_from_slice(&n.challenge);
-            n.hash_algo.digest(&buffer)
-        }
-        PayloadFormat::JwsJson => Err(AttestationError::UnsupportedTee),
-    }
+    let formatter: &dyn PayloadFormatter = match n.payload_format {
+        PayloadFormat::RawBinary => &RawBinaryFormatter,
+        PayloadFormat::JwsJson => return Err(AttestationError::UnsupportedTee),
+    };
+
+    let formatted_bytes = formatter.format(&n.challenge, pub_key)?;
+    n.hash_algo.digest(&formatted_bytes)
 }

--- a/kernel/src/attest.rs
+++ b/kernel/src/attest.rs
@@ -360,12 +360,12 @@ fn evidence(tee: &Tee, hash: Vec<u8>) -> Result<AttestationEvidence, Attestation
 
             // Get the attestation report as bytes for serialization in the
             // AttestationRequest.
-            let report =
+            let attestation_report =
                 try_to_vec(resp.report().as_bytes()).or(Err(AttestationError::VecAlloc))?;
 
             AttestationEvidence::Snp {
-                report,
-                certs_buf: None,
+                attestation_report,
+                cert_chain: None,
             }
         }
         // We check for supported TEE architectures in the AttestationDriver's constructor.

--- a/kernel/src/attest.rs
+++ b/kernel/src/attest.rs
@@ -19,7 +19,7 @@ use crate::{io::DEFAULT_IO_DRIVER, serial::SerialPort};
 use crate::{vsock::VMADDR_CID_HOST, vsock::stream::VsockStream};
 use aes_gcm::{AeadInPlace, Aes256Gcm, KeyInit, Nonce, aead::generic_array::GenericArray};
 use aes_kw::{KeyInit as _, KwAes256};
-use alloc::{string::ToString, vec::Vec};
+use alloc::{collections::BTreeMap, string::ToString, vec::Vec};
 use cocoon_tpm_crypto::{
     CryptoError,
     ecc::{EccKey, curve::Curve, ecdh::ecdh_c_1_1_cdh_compute_z},
@@ -28,12 +28,14 @@ use cocoon_tpm_tpm2_interface::{TpmEccCurve, TpmsEccPoint};
 use kbs_types::Tee;
 use libaproxy::*;
 use serde::Serialize;
+use serde_json::json;
 use sha2::{Digest, Sha256, Sha384, Sha512};
 use zerocopy::{FromBytes, IntoBytes};
 
 #[cfg(feature = "attest-serial")]
 // TODO: Make the IO port configurable/discoverable or drop the support entirely.
 const ATTEST_DEFAULT_SERIAL_IO_ADDR: u16 = 0x3e8; // COM3
+const TEE_REPORT_DATA_LEN: usize = 64;
 
 enum Transport {
     Vsock(VsockStream),
@@ -160,7 +162,8 @@ impl AttestationDriver {
             .to_tpms_ecc_point(&curve.curve_ops().map_err(AttestationError::Crypto)?)
             .map_err(AttestationError::Crypto)?;
 
-        let evidence = evidence(&self.tee, hash(&n, &pub_key)?)?;
+        let digest = hash(&n, &pub_key)?;
+        let evidence = evidence(&self.tee, prepare_report_data(&digest)?)?;
 
         let req = AttestationRequest {
             tee: self.tee,
@@ -292,6 +295,8 @@ pub enum AttestationError {
     Crypto(CryptoError),
     /// Guest has failed attestation.
     Failed,
+    /// Negotiation Response challenge length from KBS is invalid
+    InvalidChallengeLength,
     // Unable to derive wrap key.
     KeyDerivation(concat_kdf::Error),
     /// Error deserializing the negotiation response from JSON bytes.
@@ -381,6 +386,14 @@ fn run_digest<D: Digest>(data: &[u8]) -> Result<Vec<u8>, AttestationError> {
     try_to_vec(&h.finalize()).or(Err(AttestationError::VecAlloc))
 }
 
+fn base64_encode(input: &[u8]) -> alloc::string::String {
+    BASE64_STANDARD.encode(input)
+}
+
+fn base64url_encode(input: &[u8]) -> alloc::string::String {
+    BASE64_URL_SAFE_NO_PAD.encode(input)
+}
+
 trait HashAlgoExt {
     fn digest(&self, data: &[u8]) -> Result<Vec<u8>, AttestationError>;
 }
@@ -419,6 +432,34 @@ impl PayloadFormatter for RawBinaryFormatter {
     }
 }
 
+struct JwsJsonFormatter;
+
+impl PayloadFormatter for JwsJsonFormatter {
+    fn format(
+        &self,
+        challenge: &[u8],
+        pub_key: &TpmsEccPoint<'_>,
+    ) -> Result<Vec<u8>, AttestationError> {
+        let x_encoded = base64url_encode(&pub_key.x.buffer);
+        let y_encoded = base64url_encode(&pub_key.y.buffer);
+        let nonce_encoded = base64_encode(challenge);
+
+        let mut key_map = BTreeMap::new();
+        key_map.insert("alg".to_string(), json!("ECDH-ES+A256KW"));
+        key_map.insert("crv".to_string(), json!("P-521"));
+        key_map.insert("kty".to_string(), json!("EC"));
+        key_map.insert("x".to_string(), json!(x_encoded));
+        key_map.insert("y".to_string(), json!(y_encoded));
+
+        let mut runtime_data = BTreeMap::new();
+        runtime_data.insert("additional-evidence".to_string(), json!(""));
+        runtime_data.insert("nonce".to_string(), json!(nonce_encoded));
+        runtime_data.insert("tee-pubkey".to_string(), json!(key_map));
+
+        serde_json::to_vec(&runtime_data).map_err(|_| AttestationError::NegotiationSerialize)
+    }
+}
+
 /// Hash the negotiation parameters from the attestation server for inclusion in the
 /// attestation evidence.
 fn hash(
@@ -427,9 +468,22 @@ fn hash(
 ) -> Result<Vec<u8>, AttestationError> {
     let formatter: &dyn PayloadFormatter = match n.payload_format {
         PayloadFormat::RawBinary => &RawBinaryFormatter,
-        PayloadFormat::JwsJson => return Err(AttestationError::UnsupportedTee),
+        PayloadFormat::JwsJson => &JwsJsonFormatter,
     };
 
     let formatted_bytes = formatter.format(&n.challenge, pub_key)?;
     n.hash_algo.digest(&formatted_bytes)
+}
+
+/// Take variable-sized negotiation challenge nonce from aproxy into 64 byte array required
+/// for the TEE attestation evidence report
+fn prepare_report_data(challenge_digest: &[u8]) -> Result<Vec<u8>, AttestationError> {
+    if challenge_digest.len() > TEE_REPORT_DATA_LEN {
+        return Err(AttestationError::InvalidChallengeLength);
+    }
+
+    let mut report_data = [0u8; TEE_REPORT_DATA_LEN];
+    report_data[..challenge_digest.len()].copy_from_slice(challenge_digest);
+
+    Ok(report_data.to_vec())
 }

--- a/kernel/src/attest.rs
+++ b/kernel/src/attest.rs
@@ -28,7 +28,7 @@ use cocoon_tpm_tpm2_interface::{TpmEccCurve, TpmsEccPoint};
 use kbs_types::Tee;
 use libaproxy::*;
 use serde::Serialize;
-use sha2::{Digest, Sha512};
+use sha2::{Digest, Sha256, Sha384, Sha512};
 use zerocopy::{FromBytes, IntoBytes};
 
 #[cfg(feature = "attest-serial")]
@@ -375,26 +375,40 @@ fn evidence(tee: &Tee, hash: Vec<u8>) -> Result<AttestationEvidence, Attestation
     Ok(evidence)
 }
 
+fn run_digest<D: Digest>(data: &[u8]) -> Result<Vec<u8>, AttestationError> {
+    let mut h = D::new();
+    h.update(data);
+    try_to_vec(&h.finalize()).or(Err(AttestationError::VecAlloc))
+}
+
+trait HashAlgoExt {
+    fn digest(&self, data: &[u8]) -> Result<Vec<u8>, AttestationError>;
+}
+
+impl HashAlgoExt for HashAlgo {
+    fn digest(&self, data: &[u8]) -> Result<Vec<u8>, AttestationError> {
+        match self {
+            HashAlgo::Sha256 => run_digest::<Sha256>(data),
+            HashAlgo::Sha384 => run_digest::<Sha384>(data),
+            HashAlgo::Sha512 => run_digest::<Sha512>(data),
+        }
+    }
+}
+
 /// Hash the negotiation parameters from the attestation server for inclusion in the
 /// attestation evidence.
 fn hash(
     n: &NegotiationResponse,
     pub_key: &TpmsEccPoint<'static>,
 ) -> Result<Vec<u8>, AttestationError> {
-    let mut sha = Sha512::new();
-
-    for p in &n.params {
-        match p {
-            NegotiationParam::Challenge => {
-                sha.update(&n.challenge);
-            }
-            #[allow(irrefutable_let_patterns)]
-            NegotiationParam::EcPublicKeyBytes => {
-                sha.update(&*pub_key.x.buffer);
-                sha.update(&*pub_key.y.buffer);
-            }
+    match n.payload_format {
+        PayloadFormat::RawBinary => {
+            let mut buffer = Vec::new();
+            buffer.extend_from_slice(&pub_key.x.buffer);
+            buffer.extend_from_slice(&pub_key.y.buffer);
+            buffer.extend_from_slice(&n.challenge);
+            n.hash_algo.digest(&buffer)
         }
+        PayloadFormat::JwsJson => Err(AttestationError::UnsupportedTee),
     }
-
-    try_to_vec(&sha.finalize()).or(Err(AttestationError::VecAlloc))
 }

--- a/libaproxy/src/attestation.rs
+++ b/libaproxy/src/attestation.rs
@@ -126,7 +126,7 @@ pub enum AttestationEvidence {
             serialize_with = "serialize_base64",
             deserialize_with = "deserialize_base64"
         )]
-        report: Vec<u8>,
+        attestation_report: Vec<u8>,
         /// Certificates that may be available from the host hypervisor.
         #[serde(
             skip_serializing_if = "Option::is_none",
@@ -134,7 +134,7 @@ pub enum AttestationEvidence {
             serialize_with = "serialize_base64_option",
             deserialize_with = "deserialize_base64_option"
         )]
-        certs_buf: Option<Vec<u8>>,
+        cert_chain: Option<Vec<u8>>,
     },
 }
 

--- a/libaproxy/src/lib.rs
+++ b/libaproxy/src/lib.rs
@@ -16,7 +16,8 @@ pub use attestation::*;
 pub use negotiation::*;
 
 use alloc::{string::String, vec::Vec};
-use base64::{Engine, prelude::BASE64_STANDARD};
+pub use base64::Engine;
+pub use base64::prelude::{BASE64_STANDARD, BASE64_URL_SAFE_NO_PAD};
 use serde::Deserialize;
 
 #[derive(Debug)]

--- a/libaproxy/src/negotiation.rs
+++ b/libaproxy/src/negotiation.rs
@@ -18,6 +18,7 @@ pub struct NegotiationRequest {
     /// Version of the attestation protocol, represented as semver (MAJOR.MINOR.PATCH).
     pub version: (u32, u32, u32),
     pub tee: kbs_types::Tee,
+    pub key: EcP256PublicKey,
 }
 
 /// A parameter that must be hashed into the negotiation hash.

--- a/libaproxy/src/negotiation.rs
+++ b/libaproxy/src/negotiation.rs
@@ -21,15 +21,6 @@ pub struct NegotiationRequest {
     pub key: EcP256PublicKey,
 }
 
-/// A parameter that must be hashed into the negotiation hash.
-#[derive(Serialize, Deserialize, Debug)]
-pub enum NegotiationParam {
-    /// Hash the challenge returned from attestation server.
-    Challenge,
-    /// Hash the EC public key's `Elliptic-Curve-Point-to-Octet-String` encoding.
-    EcPublicKeyBytes,
-}
-
 #[derive(Serialize, Deserialize, Debug)]
 pub struct NegotiationResponse {
     /// Challenge returned from the attestation server to verify freshness of attestation evidence.
@@ -38,6 +29,4 @@ pub struct NegotiationResponse {
         deserialize_with = "deserialize_base64"
     )]
     pub challenge: Vec<u8>,
-    /// Parameters to be hashed in the specific order defined by the array
-    pub params: Vec<NegotiationParam>,
 }

--- a/libaproxy/src/negotiation.rs
+++ b/libaproxy/src/negotiation.rs
@@ -20,13 +20,21 @@ pub struct NegotiationRequest {
     pub tee: kbs_types::Tee,
 }
 
-/// A parameter that must be hashed into the negotiation hash.
-#[derive(Serialize, Deserialize, Debug)]
-pub enum NegotiationParam {
-    /// Hash the challenge returned from attestation server.
-    Challenge,
-    /// Hash the EC public key's `Elliptic-Curve-Point-to-Octet-String` encoding.
-    EcPublicKeyBytes,
+/// The cryptographic hashing algorithm SVSM should use to digest the formatted payload.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HashAlgo {
+    Sha256,
+    Sha384,
+    Sha512,
+}
+
+/// The payload serialization format SVSM should use to organize public key components and nonces.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PayloadFormat {
+    /// Raw sequential binary representation of public key coordinates and challenge.
+    RawBinary,
+    /// JWS-compliant JSON formatted representation of runtime_data.
+    JwsJson,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -37,6 +45,8 @@ pub struct NegotiationResponse {
         deserialize_with = "deserialize_base64"
     )]
     pub challenge: Vec<u8>,
-    /// Parameters to be hashed in the specific order defined by the array
-    pub params: Vec<NegotiationParam>,
+    /// The hashing algorithm to use.
+    pub hash_algo: HashAlgo,
+    /// The payload formatting to use.
+    pub payload_format: PayloadFormat,
 }

--- a/tools/aproxy/Cargo.toml
+++ b/tools/aproxy/Cargo.toml
@@ -16,6 +16,8 @@ libaproxy.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 vsock = "0.5.1"
+sha2 = { workspace = true }
+sev = { version = "8.0.0", features = ["snp", "serde"] }
 
 [lints]
 workspace = true

--- a/tools/aproxy/Cargo.toml
+++ b/tools/aproxy/Cargo.toml
@@ -20,6 +20,8 @@ libaproxy.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 vsock = "0.5.1"
+sha2 = { workspace = true }
+sev = { version = "8.0.0", features = ["snp", "serde"] }
 
 [lints]
 workspace = true

--- a/tools/aproxy/src/backend/kbs.rs
+++ b/tools/aproxy/src/backend/kbs.rs
@@ -6,18 +6,19 @@
 // Author: Tyler Fanelli <tfanelli@redhat.com>
 
 use super::*;
-use anyhow::{Context, bail};
-use base64::{
-    Engine,
-    prelude::{BASE64_STANDARD, BASE64_URL_SAFE_NO_PAD},
-};
+use anyhow::{Context, anyhow};
+use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
 use kbs_types::*;
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use serde_json::json;
+use sha2::{Digest, Sha384};
 
-#[derive(Clone, Copy, Debug, Default)]
-pub struct KbsProtocol;
+#[derive(Clone, Debug, Default)]
+pub struct KbsProtocol {
+    original_nonce: Option<String>,
+}
 
 #[derive(Deserialize, Debug)]
 struct TokenResponse {
@@ -60,21 +61,36 @@ impl AttestationProtocol for KbsProtocol {
         let challenge: Challenge =
             serde_json::from_str(&text).context("unable to convert KBS /auth response to JSON")?;
 
-        // Challenge nonce is a base64-encoded byte vector. Inform SVSM of this so it could
-        // decode the bytes and hash them into the TEE evidence.
-        let params = vec![
-            NegotiationParam::EcPublicKeyBytes,
-            NegotiationParam::Challenge,
-        ];
+        self.original_nonce = Some(challenge.nonce.clone());
 
-        let resp = NegotiationResponse {
-            challenge: BASE64_STANDARD
-                .decode(challenge.nonce)
-                .context("unable to decode challenge nonce from base64")?,
-            params,
-        };
+        let mut runtime_data = serde_json::Map::new();
+        runtime_data.insert("additional-evidence".to_string(), json!(""));
+        runtime_data.insert("nonce".to_string(), json!(challenge.nonce));
 
-        Ok(resp)
+        let mut key_map = serde_json::Map::new();
+        key_map.insert("alg".to_string(), json!("ECDH-ES+A256KW"));
+        key_map.insert("crv".to_string(), json!("P-521"));
+        key_map.insert("kty".to_string(), json!("EC"));
+        key_map.insert(
+            "x".to_string(),
+            json!(BASE64_URL_SAFE_NO_PAD.encode(&request.key.x)),
+        );
+        key_map.insert(
+            "y".to_string(),
+            json!(BASE64_URL_SAFE_NO_PAD.encode(&request.key.y)),
+        );
+
+        runtime_data.insert("tee-pubkey".to_string(), json!(key_map));
+
+        let json_bytes = serde_json::to_vec(&runtime_data)?;
+
+        let mut hasher = Sha384::new();
+        hasher.update(&json_bytes);
+        let hash_result = hasher.finalize();
+
+        Ok(NegotiationResponse {
+            challenge: hash_result.to_vec(),
+        })
     }
 
     /// With the serialized TEE evidence and key, complete the attestation. Serialize the evidence
@@ -92,7 +108,10 @@ impl AttestationProtocol for KbsProtocol {
         let attestation = Attestation {
             init_data: None,
             runtime_data: RuntimeData {
-                nonce: BASE64_STANDARD.encode(request.challenge),
+                nonce: self
+                    .original_nonce
+                    .take()
+                    .context("Original nonce is missing")?,
                 tee_pubkey: request.key.into(),
             },
             tee_evidence: CompositeEvidence {
@@ -218,33 +237,32 @@ fn unwrap_epk(resp: &Response) -> anyhow::Result<EcP256PublicKey> {
 #[serde(untagged)]
 enum KbsEvidence {
     Snp {
-        #[serde(rename = "snp-report")]
-        snp_report: String,
-        #[serde(rename = "certs-buf")]
-        certs_buf: Option<String>,
+        #[serde(rename = "attestation_report")]
+        snp_report: sev::firmware::guest::AttestationReport,
+        #[serde(rename = "cert_chain")]
+        certs_buf: Option<Vec<u8>>,
     },
 }
 
 impl TryFrom<&AttestationRequest> for KbsEvidence {
     type Error = anyhow::Error;
-
-    // At the moment, only SEV-SNP evidence is allowed. However, preserve the following match
-    // statement to describe how other TEE architectures would serialize AttestationEvidence.
-    #[allow(irrefutable_let_patterns)]
     fn try_from(data: &AttestationRequest) -> anyhow::Result<Self> {
         match data.tee {
             Tee::Snp => {
                 let AttestationEvidence::Snp {
                     ref report,
-                    ref certs_buf,
-                } = data.evidence
-                else {
-                    bail!("invalid SEV-SNP evidence")
-                };
+                    certs_buf: _,
+                } = data.evidence;
+
+                use sev::parser::Decoder;
+                let mut reader = std::io::Cursor::new(&report[..]);
+                let report_struct =
+                    sev::firmware::guest::AttestationReport::decode(&mut reader, ())
+                        .context("unable to decode AttestationReport using sev::parser::Decoder")?;
 
                 Ok(Self::Snp {
-                    snp_report: BASE64_STANDARD.encode(report),
-                    certs_buf: certs_buf.clone().map(|certs| BASE64_STANDARD.encode(certs)),
+                    snp_report: report_struct,
+                    certs_buf: None,
                 })
             }
             _ => Err(anyhow!("invalid TEE")),

--- a/tools/aproxy/src/backend/kbs.rs
+++ b/tools/aproxy/src/backend/kbs.rs
@@ -60,18 +60,12 @@ impl AttestationProtocol for KbsProtocol {
         let challenge: Challenge =
             serde_json::from_str(&text).context("unable to convert KBS /auth response to JSON")?;
 
-        // Challenge nonce is a base64-encoded byte vector. Inform SVSM of this so it could
-        // decode the bytes and hash them into the TEE evidence.
-        let params = vec![
-            NegotiationParam::EcPublicKeyBytes,
-            NegotiationParam::Challenge,
-        ];
-
         let resp = NegotiationResponse {
             challenge: BASE64_STANDARD
                 .decode(challenge.nonce)
                 .context("unable to decode challenge nonce from base64")?,
-            params,
+            hash_algo: HashAlgo::Sha512,
+            payload_format: PayloadFormat::RawBinary,
         };
 
         Ok(resp)

--- a/tools/aproxy/src/backend/kbs.rs
+++ b/tools/aproxy/src/backend/kbs.rs
@@ -6,7 +6,7 @@
 // Author: Tyler Fanelli <tfanelli@redhat.com>
 
 use super::*;
-use anyhow::Context;
+use anyhow::{Context, anyhow};
 use base64::{
     Engine,
     prelude::{BASE64_STANDARD, BASE64_URL_SAFE_NO_PAD},
@@ -16,8 +16,32 @@ use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-#[derive(Clone, Copy, Debug, Default)]
-pub struct KbsProtocol;
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum KbsBackendType {
+    /// Trustee KBS backend using JWS-compliant JSON (SHA-384)
+    Trustee,
+    /// Legacy or Mock KBS client backend using raw key and challenge bytes (SHA-512)
+    Legacy,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct KbsProtocol {
+    backend_type: KbsBackendType,
+}
+
+impl KbsProtocol {
+    pub fn new(backend_type: KbsBackendType) -> Self {
+        Self { backend_type }
+    }
+}
+
+impl Default for KbsProtocol {
+    fn default() -> Self {
+        Self {
+            backend_type: KbsBackendType::Legacy,
+        }
+    }
+}
 
 #[derive(Deserialize, Debug)]
 struct TokenResponse {
@@ -60,15 +84,21 @@ impl AttestationProtocol for KbsProtocol {
         let challenge: Challenge =
             serde_json::from_str(&text).context("unable to convert KBS /auth response to JSON")?;
 
-        let resp = NegotiationResponse {
-            challenge: BASE64_STANDARD
-                .decode(challenge.nonce)
-                .context("unable to decode challenge nonce from base64")?,
-            hash_algo: HashAlgo::Sha512,
-            payload_format: PayloadFormat::RawBinary,
+        let decoded_nonce = BASE64_URL_SAFE_NO_PAD
+            .decode(&challenge.nonce)
+            .or_else(|_| BASE64_STANDARD.decode(&challenge.nonce))
+            .context("unable to decode challenge nonce from base64")?;
+
+        let (hash_algo, payload_format) = match self.backend_type {
+            KbsBackendType::Trustee => (HashAlgo::Sha384, PayloadFormat::JwsJson),
+            KbsBackendType::Legacy => (HashAlgo::Sha512, PayloadFormat::RawBinary),
         };
 
-        Ok(resp)
+        Ok(NegotiationResponse {
+            challenge: decoded_nonce,
+            hash_algo,
+            payload_format,
+        })
     }
 
     /// With the serialized TEE evidence and key, complete the attestation. Serialize the evidence
@@ -80,18 +110,52 @@ impl AttestationProtocol for KbsProtocol {
         http: &mut HttpClient,
         request: AttestationRequest,
     ) -> anyhow::Result<AttestationResponse> {
-        let evidence: KbsEvidence = (&request).try_into()?;
+        let primary_evidence = match self.backend_type {
+            KbsBackendType::Trustee => {
+                let AttestationEvidence::Snp {
+                    ref attestation_report,
+                    cert_chain: _,
+                } = request.evidence;
+
+                use sev::parser::Decoder;
+                let mut reader = std::io::Cursor::new(&attestation_report[..]);
+                let report_struct =
+                    sev::firmware::guest::AttestationReport::decode(&mut reader, ())
+                        .context("unable to decode AttestationReport using sev::parser::Decoder")?;
+
+                let trustee_evidence = TrusteeEvidence::Snp {
+                    attestation_report: report_struct,
+                    cert_chain: None,
+                };
+                serde_json::to_value(&trustee_evidence)
+                    .context("unable to serialize Trustee attestation evidence to JSON")?
+            }
+            KbsBackendType::Legacy => {
+                let AttestationEvidence::Snp {
+                    ref attestation_report,
+                    ref cert_chain,
+                } = request.evidence;
+
+                let legacy_evidence = LegacyEvidence::Snp {
+                    snp_report: BASE64_STANDARD.encode(attestation_report),
+                    certs_buf: cert_chain
+                        .clone()
+                        .map(|certs| BASE64_STANDARD.encode(certs)),
+                };
+                serde_json::to_value(&legacy_evidence)
+                    .context("unable to serialize Legacy attestation evidence to JSON")?
+            }
+        };
 
         // Create a KBS attestation object from the TEE evidence and key.
         let attestation = Attestation {
             init_data: None,
             runtime_data: RuntimeData {
-                nonce: BASE64_STANDARD.encode(request.challenge),
+                nonce: BASE64_STANDARD.encode(&request.challenge),
                 tee_pubkey: request.key.into(),
             },
             tee_evidence: CompositeEvidence {
-                primary_evidence: serde_json::to_value(&evidence)
-                    .context("unable to serialize attestation evidence to JSON")?,
+                primary_evidence,
                 additional_evidence: String::new(),
             },
         };
@@ -210,39 +274,20 @@ fn unwrap_epk(resp: &Response) -> anyhow::Result<EcP256PublicKey> {
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(untagged)]
-enum KbsEvidence {
+enum LegacyEvidence {
+    Snp {
+        #[serde(rename = "snp-report")]
+        snp_report: String,
+        #[serde(rename = "certs-buf")]
+        certs_buf: Option<String>,
+    },
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+enum TrusteeEvidence {
     Snp {
         attestation_report: sev::firmware::guest::AttestationReport,
         cert_chain: Option<Vec<u8>>,
     },
-}
-
-impl TryFrom<&AttestationRequest> for KbsEvidence {
-    type Error = anyhow::Error;
-
-    // At the moment, only SEV-SNP evidence is allowed. However, preserve the following match
-    // statement to describe how other TEE architectures would serialize AttestationEvidence.
-    #[allow(irrefutable_let_patterns)]
-    fn try_from(data: &AttestationRequest) -> anyhow::Result<Self> {
-        match data.tee {
-            Tee::Snp => {
-                let AttestationEvidence::Snp {
-                    ref attestation_report,
-                    cert_chain: _,
-                } = data.evidence;
-
-                use sev::parser::Decoder;
-                let mut reader = std::io::Cursor::new(&attestation_report[..]);
-                let report_struct =
-                    sev::firmware::guest::AttestationReport::decode(&mut reader, ())
-                        .context("unable to decode AttestationReport using sev::parser::Decoder")?;
-
-                Ok(Self::Snp {
-                    attestation_report: report_struct,
-                    cert_chain: None,
-                })
-            }
-            _ => Err(anyhow!("invalid TEE")),
-        }
-    }
 }

--- a/tools/aproxy/src/backend/kbs.rs
+++ b/tools/aproxy/src/backend/kbs.rs
@@ -218,10 +218,8 @@ fn unwrap_epk(resp: &Response) -> anyhow::Result<EcP256PublicKey> {
 #[serde(untagged)]
 enum KbsEvidence {
     Snp {
-        #[serde(rename = "snp-report")]
-        snp_report: String,
-        #[serde(rename = "certs-buf")]
-        certs_buf: Option<String>,
+        attestation_report: String,
+        cert_chain: Option<String>,
     },
 }
 
@@ -235,16 +233,18 @@ impl TryFrom<&AttestationRequest> for KbsEvidence {
         match data.tee {
             Tee::Snp => {
                 let AttestationEvidence::Snp {
-                    ref report,
-                    ref certs_buf,
+                    ref attestation_report,
+                    ref cert_chain,
                 } = data.evidence
                 else {
                     bail!("invalid SEV-SNP evidence")
                 };
 
                 Ok(Self::Snp {
-                    snp_report: BASE64_STANDARD.encode(report),
-                    certs_buf: certs_buf.clone().map(|certs| BASE64_STANDARD.encode(certs)),
+                    attestation_report: BASE64_STANDARD.encode(attestation_report),
+                    cert_chain: cert_chain
+                        .clone()
+                        .map(|certs| BASE64_STANDARD.encode(certs)),
                 })
             }
             _ => Err(anyhow!("invalid TEE")),

--- a/tools/aproxy/src/backend/kbs.rs
+++ b/tools/aproxy/src/backend/kbs.rs
@@ -6,7 +6,7 @@
 // Author: Tyler Fanelli <tfanelli@redhat.com>
 
 use super::*;
-use anyhow::{Context, bail};
+use anyhow::Context;
 use base64::{
     Engine,
     prelude::{BASE64_STANDARD, BASE64_URL_SAFE_NO_PAD},
@@ -212,8 +212,8 @@ fn unwrap_epk(resp: &Response) -> anyhow::Result<EcP256PublicKey> {
 #[serde(untagged)]
 enum KbsEvidence {
     Snp {
-        attestation_report: String,
-        cert_chain: Option<String>,
+        attestation_report: sev::firmware::guest::AttestationReport,
+        cert_chain: Option<Vec<u8>>,
     },
 }
 
@@ -228,17 +228,18 @@ impl TryFrom<&AttestationRequest> for KbsEvidence {
             Tee::Snp => {
                 let AttestationEvidence::Snp {
                     ref attestation_report,
-                    ref cert_chain,
-                } = data.evidence
-                else {
-                    bail!("invalid SEV-SNP evidence")
-                };
+                    cert_chain: _,
+                } = data.evidence;
+
+                use sev::parser::Decoder;
+                let mut reader = std::io::Cursor::new(&attestation_report[..]);
+                let report_struct =
+                    sev::firmware::guest::AttestationReport::decode(&mut reader, ())
+                        .context("unable to decode AttestationReport using sev::parser::Decoder")?;
 
                 Ok(Self::Snp {
-                    attestation_report: BASE64_STANDARD.encode(attestation_report),
-                    cert_chain: cert_chain
-                        .clone()
-                        .map(|certs| BASE64_STANDARD.encode(certs)),
+                    attestation_report: report_struct,
+                    cert_chain: None,
                 })
             }
             _ => Err(anyhow!("invalid TEE")),

--- a/tools/aproxy/src/backend/mod.rs
+++ b/tools/aproxy/src/backend/mod.rs
@@ -8,10 +8,11 @@
 mod kbs;
 
 use crate::ArgsBackend;
-use anyhow::{Context, anyhow};
+use anyhow::Context;
 use kbs::KbsProtocol;
 use libaproxy::*;
 use reqwest::{blocking::Client, cookie::Jar};
+use std::mem;
 use std::sync::Arc;
 
 /// HTTP client and protocol identifier.
@@ -35,20 +36,26 @@ impl HttpClient {
     pub fn negotiation(&mut self, req: NegotiationRequest) -> anyhow::Result<NegotiationResponse> {
         // Depending on the underlying protocol of the attestation server, gather negotiation
         // parameters accordingly.
-        match self.protocol {
-            Protocol::Kbs(mut kbs) => kbs.negotiation(self, req),
-        }
+        let mut protocol = mem::replace(&mut self.protocol, Protocol::Kbs(KbsProtocol::default()));
+        let result = match &mut protocol {
+            Protocol::Kbs(kbs) => kbs.negotiation(self, req),
+        };
+        self.protocol = protocol;
+        result
     }
 
     pub fn attestation(&mut self, req: AttestationRequest) -> anyhow::Result<AttestationResponse> {
-        match self.protocol {
-            Protocol::Kbs(mut kbs) => kbs.attestation(self, req),
-        }
+        let mut protocol = mem::replace(&mut self.protocol, Protocol::Kbs(KbsProtocol::default()));
+        let result = match &mut protocol {
+            Protocol::Kbs(kbs) => kbs.attestation(self, req),
+        };
+        self.protocol = protocol;
+        result
     }
 }
 
 /// Attestation Protocol identifier.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub enum Protocol {
     Kbs(KbsProtocol),
 }
@@ -56,7 +63,7 @@ pub enum Protocol {
 impl From<ArgsBackend> for Protocol {
     fn from(value: ArgsBackend) -> Self {
         match value {
-            ArgsBackend::Kbs => Self::Kbs(KbsProtocol),
+            ArgsBackend::Kbs => Self::Kbs(KbsProtocol::default()),
         }
     }
 }

--- a/tools/aproxy/src/backend/mod.rs
+++ b/tools/aproxy/src/backend/mod.rs
@@ -8,8 +8,8 @@
 mod kbs;
 
 use crate::ArgsBackend;
-use anyhow::{Context, anyhow};
-use kbs::KbsProtocol;
+use anyhow::Context;
+use kbs::{KbsBackendType, KbsProtocol};
 use libaproxy::*;
 use reqwest::{blocking::Client, cookie::Jar};
 use std::sync::Arc;
@@ -56,7 +56,8 @@ pub enum Protocol {
 impl From<ArgsBackend> for Protocol {
     fn from(value: ArgsBackend) -> Self {
         match value {
-            ArgsBackend::Kbs => Self::Kbs(KbsProtocol),
+            ArgsBackend::Kbs => Self::Kbs(KbsProtocol::new(KbsBackendType::Legacy)),
+            ArgsBackend::KbsTrustee => Self::Kbs(KbsProtocol::new(KbsBackendType::Trustee)),
         }
     }
 }

--- a/tools/aproxy/src/main.rs
+++ b/tools/aproxy/src/main.rs
@@ -49,7 +49,10 @@ struct Args {
 /// to work.
 #[derive(Clone, Copy, Debug, ValueEnum)]
 enum ArgsBackend {
+    /// Legacy or Mock KBS (raw public key & challenge, SHA-512)
     Kbs,
+    /// Trustee KBS (JWS JSON, SHA-384)
+    KbsTrustee,
 }
 
 fn accept_loop<S: Read + Write>(


### PR DESCRIPTION
Currently, attestation only works with the mock kbs server. Against the production grade Trustee KBS, attestation fails due to 
1. differences in payload format (JWS JSON vs binary),
2. hashing algorithms (SHA-384 vs SHA512) and
3. key binding structures.

This PR fixes the attestation flow against a trustee KBS (CoCo) server.
1. Use sev crate as a dependency for AttestationReport struct.
2. Create generic formats to incorporate different hash algorithms (sha512, sha384) and payload formats (binary vs JwsJson) combinations to create runtime_data.


Verified that the attestation token is successfully issued by the trustee KBS instance, see kbs container logs below

```
2026-06-16T07:48:09.055691Z  INFO actix_web::middleware::logger: 10.8.1.184 "POST /kbs/v0/attest HTTP/1.1" 200 2368 "-" "-" 0.164425
2026-06-16T07:48:09.056259Z  INFO kbs::attestation::backend: Cookie 60e3c85e8d4c471eaadd0ce24c5f6e5d request to get resource
2026-06-16T07:48:09.058087Z  INFO actix_web::middleware::logger: 10.8.1.184 "GET /kbs/v0/resource/coco/mykey/k2 HTTP/1.1" 200 554 "-" "-" 0.001929

```

