### PR TITLE
kernel: cpu/apic: various fixes

### DIFF
--- a/cpuarch/src/x86apic.rs
+++ b/cpuarch/src/x86apic.rs
@@ -74,7 +74,7 @@ pub struct ApicIcr {
     pub message_type: IcrMessageType,
     pub destination_mode: bool,
     pub delivery_status: bool,
-    rsvd_13: bool,
+    pub rsvd_13: bool,
     pub assert: bool,
     pub trigger_mode: bool,
     #[bits(2)]
@@ -82,6 +82,6 @@ pub struct ApicIcr {
     #[bits(2)]
     pub destination_shorthand: IcrDestFmt,
     #[bits(12)]
-    rsvd_31_20: u64,
+    pub rsvd_31_20: u64,
     pub destination: u32,
 }

--- a/cpuarch/src/x86apic.rs
+++ b/cpuarch/src/x86apic.rs
@@ -10,6 +10,7 @@ pub const APIC_REGISTER_APIC_ID: u64 = 0x802;
 pub const APIC_REGISTER_TPR: u64 = 0x808;
 pub const APIC_REGISTER_PPR: u64 = 0x80A;
 pub const APIC_REGISTER_EOI: u64 = 0x80B;
+pub const APIC_REGISTER_LDR: u64 = 0x80D;
 pub const APIC_REGISTER_ISR_0: u64 = 0x810;
 pub const APIC_REGISTER_ISR_7: u64 = 0x817;
 pub const APIC_REGISTER_TMR_0: u64 = 0x818;

--- a/kernel/src/cpu/apic.rs
+++ b/kernel/src/cpu/apic.rs
@@ -561,7 +561,7 @@ impl LocalApic {
             IcrMessageType::Fixed | IcrMessageType::Nmi
         );
 
-        if !valid_type {
+        if !valid_type || icr.rsvd_13() || icr.rsvd_31_20() != 0 {
             return Err(SvsmError::Apic(Emulation));
         }
 

--- a/kernel/src/cpu/apic.rs
+++ b/kernel/src/cpu/apic.rs
@@ -7,7 +7,7 @@
 use crate::cpu::idt::common::INT_INJ_VECTOR;
 use crate::cpu::percpu::{PERCPU_AREAS, PerCpuShared, current_ghcb, this_cpu};
 use crate::cpu::x86::apic_post_irq;
-use crate::error::ApicError::Emulation;
+use crate::error::ApicError::{Emulation, InvalidRegister};
 use crate::error::SvsmError;
 use crate::mm::GuestPtr;
 use crate::platform::guest_cpu::GuestCpuState;
@@ -547,7 +547,9 @@ impl LocalApic {
             }
             APIC_REGISTER_TPR => Ok(cpu_state.get_tpr() as u64),
             APIC_REGISTER_PPR => Ok(self.get_ppr(cpu_state) as u64),
-            _ => Err(SvsmError::Apic(Emulation)),
+            // Write-only registers
+            APIC_REGISTER_EOI | APIC_REGISTER_SELF_IPI => Err(SvsmError::Apic(Emulation)),
+            _ => Err(SvsmError::Apic(InvalidRegister)),
         }
     }
 
@@ -613,7 +615,14 @@ impl LocalApic {
                 self.post_interrupt(vector, false);
                 Ok(())
             }
-            _ => Err(SvsmError::Apic(Emulation)),
+            // Read-only registers
+            APIC_REGISTER_APIC_ID
+            | APIC_REGISTER_PPR
+            | APIC_REGISTER_LDR
+            | APIC_REGISTER_ISR_0..=APIC_REGISTER_ISR_7
+            | APIC_REGISTER_TMR_0..=APIC_REGISTER_TMR_7
+            | APIC_REGISTER_IRR_0..=APIC_REGISTER_IRR_7 => Err(SvsmError::Apic(Emulation)),
+            _ => Err(SvsmError::Apic(InvalidRegister)),
         }
     }
 

--- a/kernel/src/cpu/apic.rs
+++ b/kernel/src/cpu/apic.rs
@@ -24,6 +24,7 @@ use cpuarch::x86apic::APIC_REGISTER_IRR_0;
 use cpuarch::x86apic::APIC_REGISTER_IRR_7;
 use cpuarch::x86apic::APIC_REGISTER_ISR_0;
 use cpuarch::x86apic::APIC_REGISTER_ISR_7;
+use cpuarch::x86apic::APIC_REGISTER_LDR;
 use cpuarch::x86apic::APIC_REGISTER_PPR;
 use cpuarch::x86apic::APIC_REGISTER_SELF_IPI;
 use cpuarch::x86apic::APIC_REGISTER_TMR_0;
@@ -529,6 +530,7 @@ impl LocalApic {
         match register {
             APIC_REGISTER_ICR => Ok(self.handle_icr_read()),
             APIC_REGISTER_APIC_ID => Ok(u64::from(cpu_shared.apic_id())),
+            APIC_REGISTER_LDR => Ok(self.handle_ldr_read()),
             APIC_REGISTER_IRR_0..=APIC_REGISTER_IRR_7 => {
                 let offset = register - APIC_REGISTER_IRR_0;
                 let index: usize = offset.try_into().unwrap();
@@ -551,6 +553,12 @@ impl LocalApic {
 
     fn handle_icr_read(&self) -> u64 {
         self.icr.into()
+    }
+
+    fn handle_ldr_read(&self) -> u64 {
+        let apic_id = this_cpu().get_apic_id();
+        let ldr = ((apic_id & !0xF) << 12) | (1 << (apic_id & 0xF));
+        ldr as u64
     }
 
     fn handle_icr_write(&mut self, value: u64) -> Result<(), SvsmError> {

--- a/kernel/src/cpu/apic.rs
+++ b/kernel/src/cpu/apic.rs
@@ -322,9 +322,10 @@ impl LocalApic {
 
     fn perform_host_eoi(vector: u8) {
         // Errors from the host are not expected and cannot be meaningfully
-        // handled, so simply ignore them.
-        let _r = current_ghcb().specific_eoi(vector, GUEST_VMPL.try_into().unwrap());
-        assert!(_r.is_ok());
+        // handled, so simply log them but do not propagate the error
+        if let Err(e) = current_ghcb().specific_eoi(vector, GUEST_VMPL.try_into().unwrap()) {
+            log::warn!("Host EOI failed: {e:?}");
+        }
     }
 
     fn perform_eoi(&mut self) {

--- a/kernel/src/cpu/apic.rs
+++ b/kernel/src/cpu/apic.rs
@@ -593,6 +593,9 @@ impl LocalApic {
                 Ok(())
             }
             APIC_REGISTER_EOI => {
+                if value != 0 {
+                    return Err(SvsmError::Apic(Emulation));
+                }
                 self.perform_eoi();
                 Ok(())
             }

--- a/kernel/src/cpu/apic.rs
+++ b/kernel/src/cpu/apic.rs
@@ -437,7 +437,7 @@ impl LocalApic {
         // as a self-IPI. Otherwise, locate the target processor by APIC ID.
         let destination = icr.destination();
         if destination == this_cpu().get_apic_id() {
-            self.post_interrupt(icr.vector(), false);
+            self.post_icr_interrupt(icr);
             false
         } else {
             // If the target CPU cannot be located, then simply drop the

--- a/kernel/src/cpu/apic.rs
+++ b/kernel/src/cpu/apic.rs
@@ -153,8 +153,8 @@ impl LocalApic {
 
     fn get_ppr_with_tpr(&self, tpr: u8) -> u8 {
         // Determine the priority of the current in-service interrupt, if any.
-        let ppr = if self.isr_stack_index != 0 {
-            self.isr_stack[self.isr_stack_index]
+        let ppr = if let Some(idx) = self.isr_stack_index.checked_sub(1) {
+            self.isr_stack[idx]
         } else {
             0
         };

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -57,6 +57,9 @@ pub enum ApicError {
     /// An error related to APIC emulation.
     Emulation,
 
+    /// An access was attempted on an invalid or unsupported register.
+    InvalidRegister,
+
     /// An error related to APIC registration.
     Registration,
 }

--- a/kernel/src/protocols/errors.rs
+++ b/kernel/src/protocols/errors.rs
@@ -81,6 +81,7 @@ impl From<SvsmError> for SvsmReqError {
             SvsmError::Apic(e) => match e {
                 ApicError::Disabled => Self::unsupported_protocol(),
                 ApicError::Emulation => Self::invalid_parameter(),
+                ApicError::InvalidRegister => Self::invalid_address(),
                 ApicError::Registration => Self::protocol(SVSM_ERR_APIC_CANNOT_REGISTER),
             },
             SvsmError::Attestation(e) => Self::protocol(e as u64),


### PR DESCRIPTION
Fix a variety of issues with the APIC emulation code:
* Ignore errors when requesting host EOI
* Verify `value != 0` for EOI writes (as mandated by spec).
* Verify verify must-be-zero bits for ICR writes (as mandated by spec).
* Fix index used in `get_ppr_with_tpr()`
* Fix NMI delivery in physical mode for current CPU.
* Handle LDR register reads (as mandated by spec).
* Fix returned error on invalid register access  (as mandated by spec).