### PR TITLE
xbuild: build test kernels directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ ifdef RELEASE
 TARGET_PATH=release
 CARGO_ARGS += --release
 XBUILD_ARGS += --release
+XBUILD_ARGS_TEST += --release
 OBJCOPY_ELF_ARGS := --strip-unneeded
 else
 TARGET_PATH=debug

--- a/Makefile
+++ b/Makefile
@@ -149,13 +149,6 @@ bin/svsm-kernel.elf: bin
 	cargo build --package svsm --bin svsm ${CARGO_ARGS} ${SVSM_ARGS} --target=x86_64-unknown-none
 	objcopy -O elf64-x86-64 ${OBJCOPY_ELF_ARGS} ${SVSM_KERNEL_ELF} $@
 
-bin/test-kernel.elf: bin
-# RUSTDOC=true removes doctests, which is necessary as they do not work with
-# custom test runners. See https://github.com/coconut-svsm/svsm/issues/705.
-	RUSTDOC=true LINK_TEST=1 cargo +nightly test --package svsm ${CARGO_ARGS} ${SVSM_ARGS_TEST} \
-		--target=x86_64-unknown-none \
-		--config 'target.x86_64-unknown-none.runner=["sh", "-c", "cp $$0 ../$@"]'
-
 ${FS_BIN}: bin
 ifneq ($(FS_FILE), none)
 	cp -f $(FS_FILE) ${FS_BIN}
@@ -178,4 +171,4 @@ clean:
 
 distclean: clean
 
-.PHONY: test miri clean clippy bin/bldr.bin bin/svsm-kernel.elf bin/test-kernel.elf distclean $(APROXYBIN) $(IGVM_FILES) $(IGVM_TEST_FILES)
+.PHONY: test miri clean clippy bin/bldr.bin bin/svsm-kernel.elf distclean $(APROXYBIN) $(IGVM_FILES) $(IGVM_TEST_FILES)

--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,6 @@ else ifeq ($(V), 2)
 CARGO_ARGS += -vv
 endif
 
-STAGE1_RUSTC_ARGS += -C panic=abort
-
-STAGE1_ELF = "target/x86_64-unknown-none/${TARGET_PATH}/stage1"
 BLDR_ELF = "target/x86_64-unknown-none/$(TARGET_PATH)/bldr"
 SVSM_KERNEL_ELF = "target/x86_64-unknown-none/${TARGET_PATH}/svsm"
 FS_BIN=bin/svsm-fs.bin
@@ -165,21 +162,12 @@ ifneq ($(FS_FILE), none)
 endif
 	touch ${FS_BIN}
 
-stage1_elf_trampoline:
-	cargo rustc --manifest-path stage1/Cargo.toml ${CARGO_ARGS} --target=x86_64-unknown-none --bin stage1 -- ${STAGE1_RUSTC_ARGS}
-
-bin/stage1-trampoline: stage1_elf_trampoline
-	cp -f $(STAGE1_ELF) $@
-
-bin/stage1-trampoline.bin: bin/stage1-trampoline
-	objcopy -O binary $< $@
-
 clippy:
 	${CARGO} clippy ${CLIPPY_OPTIONS} --workspace --exclude svsm --exclude stage1 --exclude svsm-fuzz -- ${CLIPPY_ARGS}
 	RUSTFLAGS="--cfg fuzzing" ${CARGO} clippy ${CLIPPY_OPTIONS} --package svsm-fuzz -- ${CLIPPY_ARGS}
 	${CARGO} clippy ${CLIPPY_OPTIONS} --package svsm --target x86_64-unknown-none -- ${CLIPPY_ARGS}
 	${CARGO} clippy ${CLIPPY_OPTIONS} --package bldr --target x86_64-unknown-none -- ${CLIPPY_ARGS}
-	${CARGO} clippy ${CLIPPY_OPTIONS} --package stage1 --target x86_64-unknown-none -- ${CLIPPY_ARGS} ${STAGE1_RUSTC_ARGS}
+	${CARGO} clippy ${CLIPPY_OPTIONS} --package stage1 --target x86_64-unknown-none -- ${CLIPPY_ARGS}
 	${CARGO} clippy ${CLIPPY_OPTIONS} --workspace --tests --exclude svsm -- ${CLIPPY_ARGS}
 	${CARGO} clippy ${CLIPPY_OPTIONS} --package svsm --tests -- ${CLIPPY_ARGS}
 
@@ -190,4 +178,4 @@ clean:
 
 distclean: clean
 
-.PHONY: test miri clean clippy bin/bldr.bin bin/svsm-kernel.elf bin/test-kernel.elf stage1_elf_trampoline distclean $(APROXYBIN) $(IGVM_FILES) $(IGVM_TEST_FILES)
+.PHONY: test miri clean clippy bin/bldr.bin bin/svsm-kernel.elf bin/test-kernel.elf distclean $(APROXYBIN) $(IGVM_FILES) $(IGVM_TEST_FILES)

--- a/configs/all-targets.json
+++ b/configs/all-targets.json
@@ -44,8 +44,8 @@
             "objcopy": "binary"
         },
         "tdx-stage1": {
-            "type": "make",
-            "output_file": "bin/stage1-trampoline",
+            "manifest": "stage1/Cargo.toml",
+            "binary": true,
             "objcopy": "binary"
         }
     },

--- a/configs/hyperv-target.json
+++ b/configs/hyperv-target.json
@@ -23,8 +23,8 @@
             "objcopy": "binary"
         },
         "tdx-stage1": {
-            "type": "make",
-            "output_file": "bin/stage1-trampoline",
+            "manifest": "stage1/Cargo.toml",
+            "binary": true,
             "objcopy": "binary"
         }
     },

--- a/configs/qemu-target.json
+++ b/configs/qemu-target.json
@@ -23,8 +23,8 @@
             "objcopy": "binary"
         },
         "tdx-stage1": {
-            "type": "make",
-            "output_file": "bin/stage1-trampoline",
+            "manifest": "stage1/Cargo.toml",
+            "binary": true,
             "objcopy": "binary"
         }
     },

--- a/configs/test/hyperv-test-target.json
+++ b/configs/test/hyperv-test-target.json
@@ -14,8 +14,13 @@
     },
     "kernel": {
         "svsm": {
-            "type": "make",
-            "output_file": "bin/test-kernel.elf"
+            "type": "test",
+            "toolchain": "nightly",
+            "no_default_features": true,
+            "env": {
+                "RUSTDOC": "true",
+                "LINK_TEST": "1"
+            }
         },
         "bldr": {
             "manifest": "boot/bldr/Cargo.toml",

--- a/configs/test/hyperv-test-target.json
+++ b/configs/test/hyperv-test-target.json
@@ -23,8 +23,8 @@
             "objcopy": "binary"
         },
         "tdx-stage1": {
-            "type": "make",
-            "output_file": "bin/stage1-trampoline",
+            "manifest": "stage1/Cargo.toml",
+            "binary": true,
             "objcopy": "binary"
         }
     },

--- a/configs/test/qemu-test-target.json
+++ b/configs/test/qemu-test-target.json
@@ -21,8 +21,8 @@
             "objcopy": "binary"
         },
         "tdx-stage1": {
-            "type": "make",
-            "output_file": "bin/stage1-trampoline",
+            "manifest": "stage1/Cargo.toml",
+            "binary": true,
             "objcopy": "binary"
         }
     },

--- a/configs/test/qemu-test-target.json
+++ b/configs/test/qemu-test-target.json
@@ -12,8 +12,13 @@
     },
     "kernel": {
         "svsm": {
-            "type": "make",
-            "output_file": "bin/test-kernel.elf"
+            "type": "test",
+            "toolchain": "nightly",
+            "no_default_features": true,
+            "env": {
+                "RUSTDOC": "true",
+                "LINK_TEST": "1"
+            }
         },
         "bldr": {
             "manifest": "boot/bldr/Cargo.toml",

--- a/configs/test/vanadium-test-target.json
+++ b/configs/test/vanadium-test-target.json
@@ -14,8 +14,13 @@
     },
     "kernel": {
         "svsm": {
-            "type": "make",
-            "output_file": "bin/test-kernel.elf"
+            "type": "test",
+            "toolchain": "nightly",
+            "no_default_features": true,
+            "env": {
+                "RUSTDOC": "true",
+                "LINK_TEST": "1"
+            }
         },
         "bldr": {
             "manifest": "boot/bldr/Cargo.toml",

--- a/configs/test/vanadium-test-target.json
+++ b/configs/test/vanadium-test-target.json
@@ -23,8 +23,8 @@
             "objcopy": "binary"
         },
         "tdx-stage1": {
-            "type": "make",
-            "output_file": "bin/stage1-trampoline",
+            "manifest": "stage1/Cargo.toml",
+            "binary": true,
             "objcopy": "binary"
         }
     },

--- a/configs/vanadium-target.json
+++ b/configs/vanadium-target.json
@@ -23,8 +23,8 @@
             "objcopy": "binary"
         },
         "tdx-stage1": {
-            "type": "make",
-            "output_file": "bin/stage1-trampoline",
+            "manifest": "stage1/Cargo.toml",
+            "binary": true,
             "objcopy": "binary"
         }
     },

--- a/stage1/Cargo.toml
+++ b/stage1/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 
 [[bin]]
-name = "stage1"
+name = "tdx-stage1"
 path = "src/stage1.rs"
 test = false
 

--- a/stage1/build.rs
+++ b/stage1/build.rs
@@ -5,11 +5,11 @@
 // Author: Peter Fang <peter.fang@intel.com>
 
 fn main() {
-    println!("cargo:rustc-link-arg-bin=stage1=-nostdlib");
-    println!("cargo:rustc-link-arg-bin=stage1=--build-id=none");
-    println!("cargo:rustc-link-arg-bin=stage1=-Tstage1/stage1.lds");
-    println!("cargo:rustc-link-arg-bin=stage1=-no-pie");
-    println!("cargo:rustc-link-arg-bin=stage1=-no-gc-sections");
+    println!("cargo:rustc-link-arg-bin=tdx-stage1=-nostdlib");
+    println!("cargo:rustc-link-arg-bin=tdx-stage1=--build-id=none");
+    println!("cargo:rustc-link-arg-bin=tdx-stage1=-Tstage1/stage1.lds");
+    println!("cargo:rustc-link-arg-bin=tdx-stage1=-no-pie");
+    println!("cargo:rustc-link-arg-bin=tdx-stage1=-no-gc-sections");
 
-    println!("cargo:rerun-if-changed=stage1.lds");
+    println!("cargo:rerun-if-changed=tdx-stage1.lds");
 }

--- a/xbuild/src/cargo.rs
+++ b/xbuild/src/cargo.rs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Author: Carlos López <clopez@suse.de>
+
+use serde::Deserialize;
+use std::path::PathBuf;
+
+/// A subset of the `cargo --message-format=json` schema. Only
+/// fields we inspect are modeled, everything else falling back
+/// to the `Other` variant.
+#[derive(Deserialize)]
+#[serde(tag = "reason", rename_all = "kebab-case")]
+enum CargoMessage {
+    CompilerArtifact {
+        target: ArtifactTarget,
+        profile: ArtifactProfile,
+        executable: Option<PathBuf>,
+    },
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Deserialize)]
+struct ArtifactTarget {
+    name: String,
+}
+
+#[derive(Deserialize)]
+struct ArtifactProfile {
+    test: bool,
+}
+
+/// Parse the stdout of `cargo test --no-run --message-format=json` and return
+/// the path to the test executable produced for package `pkg`.
+///
+/// Cargo emits one JSON object per line. Look for the `compiler-artifact`
+/// record whose target name matches `pkg`, was built in test mode, and has
+/// an `executable` path. If cargo produces several such records (e.g. lib +
+/// integration tests) the last one wins.
+pub fn find_test_executable(stdout: &[u8], pkg: &str) -> Option<PathBuf> {
+    std::str::from_utf8(stdout)
+        .ok()?
+        .lines()
+        .filter_map(|line| serde_json::from_str::<CargoMessage>(line).ok())
+        .filter_map(|msg| match msg {
+            CargoMessage::CompilerArtifact {
+                target,
+                profile,
+                executable,
+            } if target.name == pkg && profile.test => executable,
+            _ => None,
+        })
+        .next_back()
+}

--- a/xbuild/src/main.rs
+++ b/xbuild/src/main.rs
@@ -143,6 +143,8 @@ struct ComponentConfig {
     #[serde(default)]
     features: Option<String>,
     #[serde(default)]
+    no_default_features: bool,
+    #[serde(default)]
     binary: bool,
     #[serde(default)]
     objcopy: Objcopy,
@@ -171,6 +173,23 @@ impl ComponentConfig {
             .unwrap_or_default()
     }
 
+    /// Append `--all-features`, `--no-default-features` and/or `--features`
+    /// to `cmd` based on the recipe/command-line options.
+    fn apply_features(&self, cmd: &mut Command, args: &Args, pkg: &str, cmd_feats: &mut Features) {
+        if args.all_features {
+            cmd.arg("--all-features");
+            return;
+        }
+        if self.no_default_features {
+            cmd.arg("--no-default-features");
+        }
+        let mut features = self.features();
+        features.append(&mut cmd_feats.feature_list(pkg));
+        if !features.is_empty() {
+            cmd.args(["--features", features.join(",").as_str()]);
+        }
+    }
+
     /// Build this component as a cargo binary
     fn cargo_build(
         &self,
@@ -191,15 +210,7 @@ impl ComponentConfig {
             cmd.args(["--target", triple]);
             bin.push(triple);
         };
-        if args.all_features {
-            cmd.args(["--all-features"]);
-        } else {
-            let mut features = self.features();
-            features.append(&mut cmd_feats.feature_list(pkg));
-            if !features.is_empty() {
-                cmd.args(["--features", features.join(",").as_str()]);
-            }
-        }
+        self.apply_features(&mut cmd, args, pkg, cmd_feats);
         if let Some(manifest) = self.manifest.as_ref() {
             cmd.args(["--manifest-path".as_ref(), manifest.as_os_str()]);
         }

--- a/xbuild/src/main.rs
+++ b/xbuild/src/main.rs
@@ -18,6 +18,7 @@ use clap::Parser;
 use serde::Deserialize;
 use std::borrow::{Borrow, BorrowMut};
 use std::boxed::Box;
+use std::collections::HashMap;
 use std::error::Error;
 use std::fs::File;
 use std::path::{Path, PathBuf};
@@ -153,6 +154,9 @@ struct ComponentConfig {
     /// Disallowed for non-test builds.
     #[serde(default)]
     toolchain: Option<String>,
+    /// Extra environment variables passed to the build command.
+    #[serde(default)]
+    env: HashMap<String, String>,
 }
 
 impl ComponentConfig {
@@ -234,6 +238,9 @@ impl ComponentConfig {
         }
         if args.verbose {
             cmd.arg("-vv");
+        }
+        for (k, v) in self.env.iter() {
+            cmd.env(k, v);
         }
         run_cmd_checked(cmd, args)?;
 

--- a/xbuild/src/main.rs
+++ b/xbuild/src/main.rs
@@ -2,6 +2,7 @@
 //
 // Author: Carlos López <carlos.lopezr4096@gmail.com>
 
+mod cargo;
 mod features;
 mod fs;
 mod fw;
@@ -22,7 +23,7 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::fs::File;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 type BuildResult<T> = Result<T, Box<dyn Error>>;
 
@@ -107,6 +108,7 @@ enum BuildType {
     #[default]
     Cargo,
     Make,
+    Test,
 }
 
 /// Binutils target used in objcopy
@@ -171,6 +173,7 @@ impl ComponentConfig {
         match self.build_type {
             BuildType::Cargo => self.cargo_build(args, pkg, target, cmd_feats),
             BuildType::Make => self.makefile_build(args, pkg, cmd_feats),
+            BuildType::Test => self.cargo_test_build(args, pkg, target, cmd_feats),
         }
     }
 
@@ -246,6 +249,62 @@ impl ComponentConfig {
 
         bin.push(pkg);
         Ok(bin)
+    }
+
+    /// Build this component as a cargo test binary. Runs `cargo test --no-run`
+    /// with machine-readable output and returns the path to the test
+    /// executable cargo produced.
+    fn cargo_test_build(
+        &self,
+        args: &Args,
+        pkg: &str,
+        target: BuildTarget,
+        cmd_feats: &mut Features,
+    ) -> BuildResult<PathBuf> {
+        let mut cmd = Command::new("cargo");
+        if let Some(tc) = self.toolchain.as_deref() {
+            cmd.arg(format!("+{tc}"));
+        }
+        cmd.args([
+            "test",
+            "--no-run",
+            "--message-format=json-render-diagnostics",
+            "--package",
+            pkg,
+        ]);
+        if let Some(triple) = target.as_str() {
+            cmd.args(["--target", triple]);
+        }
+        self.apply_features(&mut cmd, args, pkg, cmd_feats);
+        if let Some(manifest) = self.manifest.as_ref() {
+            cmd.args(["--manifest-path".as_ref(), manifest.as_os_str()]);
+        }
+        if args.release {
+            cmd.arg("--release");
+        }
+        if args.offline {
+            cmd.args(["--offline", "--locked"]);
+        }
+        if args.verbose {
+            cmd.arg("-vv");
+        }
+        for (k, v) in &self.env {
+            cmd.env(k, v);
+        }
+
+        if args.verbose {
+            println!("{cmd:?}");
+        }
+
+        // Capture stdout for JSON parsing and let stderr go through so
+        // it is visble to the user
+        let output = cmd.stderr(Stdio::inherit()).output()?;
+        if !output.status.success() {
+            return Err(format!("cargo test failed for {pkg}").into());
+        }
+
+        cargo::find_test_executable(&output.stdout, pkg)
+            .ok_or_else(|| format!("no test executable found for {pkg}").into())
     }
 
     /// Build this component as a Makefile binary.

--- a/xbuild/src/main.rs
+++ b/xbuild/src/main.rs
@@ -149,6 +149,10 @@ struct ComponentConfig {
     #[serde(default)]
     objcopy: Objcopy,
     path: Option<PathBuf>,
+    /// Toolchain override passed to cargo as `+<toolchain>` (e.g. "nightly").
+    /// Disallowed for non-test builds.
+    #[serde(default)]
+    toolchain: Option<String>,
 }
 
 impl ComponentConfig {
@@ -201,6 +205,11 @@ impl ComponentConfig {
         let mut bin = PathBuf::from("target");
 
         let mut cmd = Command::new("cargo");
+        if let Some(tc) = self.toolchain.as_deref() {
+            return Err(
+                format!("non-default toolchain is only allowed for test builds ('{tc}'").into(),
+            );
+        }
         cmd.args([
             "build",
             if self.binary { "--bin" } else { "--package" },


### PR DESCRIPTION
Currently, building test kernels is a complex process: the user invokes the Makefile, the Makefile invokes xbuild with a test configuration, and the test configuration directs xbuild to call back into the Makefile to build the kernel component.

Instead, add the dedicated infrastructure in xbuild to not depend on the Makefile, removing the last users of the "make" build type in the build recipes. This is done by adding a new build type, "test", which invokes `cargo test --no-run` and picks up the built binary.

This PR also includes a cleanup of the TDX build, and a fix to correctly forward `RELEASE=1` for test kernels.

### Before

JSON recipe:

```json
        "svsm": {
            "type": "make",
            "output_file": "bin/test-kernel.elf"
        },
```

Makefile:

```makefile
bin/test-kernel.elf: bin
	RUSTDOC=true LINK_TEST=1 cargo +nightly test --package svsm ${CARGO_ARGS} ${SVSM_ARGS_TEST} \
		--target=x86_64-unknown-none \
		--config 'target.x86_64-unknown-none.runner=["sh", "-c", "cp $$0 ../$@"]'
```

### After

JSON recipe:

```json
        "svsm": {
            "type": "test",
            "toolchain": "nightly",
            "no_default_features": true,
            "env": {
                "RUSTDOC": "true",
                "LINK_TEST": "1"
            }
        },
```

No Makefile involvement

