### PR TITLE
kernel/task: save exit code

### DIFF
--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -28,7 +28,7 @@ use crate::mm::GuestPtr;
 use crate::mm::PAGE_SIZE;
 use crate::platform::PageValidateOp;
 use crate::platform::SvsmPlatform;
-use crate::task::{is_task_fault, terminate};
+use crate::task::{TaskExitStatus, is_task_fault, terminate};
 use crate::tdx::ve::handle_virtualization_exception;
 use crate::utils::MemoryRegion;
 use crate::utils::immut_after_init::ImmutAfterInitCell;
@@ -194,7 +194,7 @@ extern "C" fn ex_handler_terminate(ctx: &mut X86ExceptionContext, vector: usize)
             vector,
             { ctx.frame.rip }
         );
-        terminate();
+        terminate(Some(TaskExitStatus::Exception));
     } else {
         // Kernel-mode tasks should never cause a termination class exception,
         // so any such exception is grounds for panic.
@@ -225,7 +225,7 @@ extern "C" fn ex_handler_double_fault(ctxt: &mut X86ExceptionContext) {
         log::error!(
             "Double-Fault at RIP {rip:#018x} RSP: {rsp:#018x} CR2: {cr2:#018x} - Terminating task"
         );
-        terminate();
+        terminate(Some(TaskExitStatus::Exception));
     } else {
         panic!(
             "Double-Fault at RIP {:#018x} RSP: {:#018x} CR2: {:#018x}",
@@ -245,7 +245,7 @@ extern "C" fn ex_handler_general_protection(ctxt: &mut X86ExceptionContext) {
         log::error!(
             "Unhandled General-Protection-Fault at RIP {rip:#018x} error code: {err:#018x} rsp: {rsp:#018x} - Terminating task"
         );
-        terminate();
+        terminate(Some(TaskExitStatus::Exception));
     } else if !handle_exception_table(ctxt) {
         panic!(
             "Unhandled General-Protection-Fault at RIP {:#018x} error code: {:#018x} rsp: {:#018x}",
@@ -290,7 +290,7 @@ extern "C" fn ex_handler_page_fault(ctxt: &mut X86ExceptionContext, vector: usiz
             log::error!(
                 "Unexpected user-mode page-fault at RIP {rip:#018x} CR2: {cr2:#018x} error code: {err:#018x} - Terminating task"
             );
-            terminate();
+            terminate(Some(TaskExitStatus::Exception));
         }
     } else if this_cpu()
         .handle_pf(
@@ -377,7 +377,7 @@ extern "C" fn ex_handler_ve(ctxt: &mut X86ExceptionContext) {
             log::error!(
                 "Failed to handle #VE from user-mode at RIP {rip:#018x} code: {code:#018x} - Terminating task"
             );
-            terminate();
+            terminate(Some(TaskExitStatus::Exception));
         } else {
             panic!(
                 "Failed to handle #VE from kernel-mode at RIP {:#018x} code: {:#018x}",
@@ -399,7 +399,7 @@ extern "C" fn ex_handler_vmm_communication(ctxt: &mut X86ExceptionContext, vecto
             log::error!(
                 "Failed to handle #VC from user-mode at RIP {rip:#018x} code: {code:#018x} - Terminating task"
             );
-            terminate();
+            terminate(Some(TaskExitStatus::Exception));
         } else {
             panic!(
                 "Failed to handle #VC from kernel-mode at RIP {:#018x} code: {:#018x}",

--- a/kernel/src/syscall/class0.rs
+++ b/kernel/src/syscall/class0.rs
@@ -9,17 +9,19 @@ use crate::address::VirtAddr;
 use crate::cpu::percpu::current_task;
 use crate::fs::find_dir;
 use crate::mm::guestmem::UserPtr;
+use crate::task::TaskExitStatus;
 use crate::task::exec_user;
 use crate::task::terminate;
 use core::ffi::c_char;
 use syscall::SysCallError;
 
 pub fn sys_exit(exit_code: u32) -> ! {
+    let code = (exit_code & 0xffff) as u16;
     log::info!(
-        "Terminating task {}, exit_code {exit_code}",
+        "Terminating task {}, exit_code {code}",
         current_task().get_task_name()
     );
-    terminate();
+    terminate(Some(TaskExitStatus::Exited(code)));
 }
 
 pub fn sys_exec(file: usize, root: usize, _flags: usize) -> Result<u64, SysCallError> {

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -18,7 +18,7 @@ pub use schedule::{
 
 pub use tasks::{
     INITIAL_TASK_ID, KernelThreadStartInfo, TASK_FLAG_SHARE_PT, Task, TaskContext, TaskError,
-    TaskListAdapter, TaskPointer, TaskRunListAdapter, TaskState, is_task_fault,
+    TaskExitStatus, TaskListAdapter, TaskPointer, TaskRunListAdapter, TaskState, is_task_fault,
 };
 
 pub use exec::exec_user;

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -36,6 +36,7 @@ extern crate alloc;
 
 use super::tasks::TASK_ACTIVE_OFFSET;
 use super::tasks::TASK_CUR_CPU_OFFSET;
+use super::tasks::TaskExitStatus;
 use super::{
     INITIAL_TASK_ID, KernelThreadStartInfo, Task, TaskListAdapter, TaskPointer, TaskRunListAdapter,
 };
@@ -440,10 +441,18 @@ fn current_task_terminated() {
     }
 }
 
-pub fn terminate() -> ! {
+/// Terminate the current task and optionally set its exit status.
+/// If no exit status is provided, then the task will terminate
+/// with the default value `Exited(0)`.
+pub fn terminate(exit_status: Option<TaskExitStatus>) -> ! {
     // Terminating a task will result in a task change, so preemption must
     // be allowable.
     preemption_checks();
+
+    if let Some(status) = exit_status {
+        current_task().set_exit_status(status);
+    }
+
     current_task_terminated();
 
     // The current task will not run again, so switch to a different task.

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -159,6 +159,40 @@ impl From<TaskState> for u32 {
     }
 }
 
+#[derive(PartialEq, Debug, Copy, Clone)]
+pub enum TaskExitStatus {
+    /// Task called sys_exit(code).
+    Exited(u16),
+    /// Task was killed by an x86 exception.
+    Exception,
+}
+
+impl From<u32> for TaskExitStatus {
+    fn from(v: u32) -> Self {
+        let (code, exception) = ((v >> 16) as u16, (v & 0xFFFF) as u16);
+        if exception != 0 {
+            Self::Exception
+        } else {
+            Self::Exited(code)
+        }
+    }
+}
+
+impl From<TaskExitStatus> for u32 {
+    fn from(s: TaskExitStatus) -> u32 {
+        match s {
+            TaskExitStatus::Exited(code) => (code as u32) << 16,
+            TaskExitStatus::Exception => 1,
+        }
+    }
+}
+
+impl Default for TaskExitStatus {
+    fn default() -> Self {
+        Self::Exited(0)
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub enum TaskError {
     // Attempt to close a non-terminated task

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -195,7 +195,7 @@ impl Default for TaskExitStatus {
 
 #[derive(Clone, Copy, Debug)]
 pub enum TaskError {
-    // Attempt to close a non-terminated task
+    // Attempt to close or to retrieve the exit status of a non-terminated task
     NotTerminated,
     // A closed task could not be removed from the task list
     CloseFailed,
@@ -355,6 +355,9 @@ pub struct Task {
 
     /// Queue of tasks waiting for completion of this task.
     wait_queue: SpinLockIrqSafe<WaitQueue>,
+
+    /// Exit status of the task
+    exit_status: AtomicU32,
 }
 
 // Expose the offsets of critical task fields to assembly.
@@ -529,6 +532,7 @@ impl Task {
             runlist_link: LinkedListAtomicLink::default(),
             objs: objtree,
             wait_queue: SpinLockIrqSafe::new(WaitQueue::new()),
+            exit_status: AtomicU32::new(TaskExitStatus::default().into()),
         }))
     }
 
@@ -646,6 +650,27 @@ impl Task {
 
     pub fn is_terminated(&self) -> bool {
         self.sched_state.get_state() == TaskState::TERMINATED
+    }
+
+    pub fn set_exit_status(&self, exit_status: TaskExitStatus) {
+        assert!(
+            !self.is_terminated(),
+            "The exit status can only be set for a task that is not yet terminated"
+        );
+        // Use Relaxed order since the exit status is set before the task
+        // is marked terminated with Release order
+        self.exit_status
+            .store(exit_status.into(), Ordering::Relaxed);
+    }
+
+    pub fn get_exit_status(&self) -> Result<TaskExitStatus, SvsmError> {
+        if self.is_terminated() {
+            // Use Relaxed order since the exit status is read after the task
+            // state is checked with Acquire order
+            Ok(self.exit_status.load(Ordering::Relaxed).into())
+        } else {
+            Err(TaskError::NotTerminated.into())
+        }
     }
 
     pub fn set_idle_task(&self) {

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -1131,7 +1131,7 @@ unsafe fn run_kernel_task<T: KernelThreadStartParameter>(
 }
 
 fn task_exit() {
-    terminate();
+    terminate(None);
 }
 
 #[cfg(all(test, test_in_svsm))]

--- a/syscall/src/class0.rs
+++ b/syscall/src/class0.rs
@@ -8,6 +8,9 @@ use super::call::{SysCallError, syscall1, syscall3};
 use super::{SYS_EXEC, SYS_EXIT};
 use core::ffi::CStr;
 
+/// Terminate the current task with the given exit code. The kernel only
+/// supports exit codes on 16 bits, so the upper 16 bits of the provided
+/// code will be ignored.
 pub fn exit(code: u32) -> ! {
     // SAFETY: SYS_EXIT is supported syscall number by the svsm kernel.
     unsafe {


### PR DESCRIPTION
Add exit code handling to `Task`  introducing it in `TaskSchedState.state`, making it an `AtomicU64` from `AtomicU32` to store both `TaskState` and the exit code.

Add exit code handling to the termination functions chain.

I added a `[test]` commit to set and assert the exit value of `init`.

I'm not sure this is the right approach, so I marked this as draft:
- I think that `Taskstate::TERMINATED` and `exit_code` should be updated together. Another possibility was to introduce an additional field `exit_code` in `Task`, but with this I think an additional lock should be added to synchronize `TaskSchedState.state` and `Task.exit_code`. If this is not the case I can move the field to `Task`

I'd like some feedback!

Fixes: #1105 

[@stefano-garzarella ]