### PR TITLE
task: introduce `PENDING` state

### DIFF
--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -46,9 +46,13 @@ use crate::sev::ghcb::{GHCB, GhcbPage};
 use crate::sev::hv_doorbell::{HVDoorbell, allocate_hv_doorbell_page};
 use crate::sev::utils::RMPFlags;
 use crate::sev::vmsa::{VMSAControl, VmsaPage};
-use crate::task::{
-    KernelThreadStartInfo, RunQueue, Task, TaskPointer, schedule, schedule_task, scheduler_idle,
-};
+use crate::task::KernelThreadStartInfo;
+use crate::task::RunQueue;
+use crate::task::Task;
+use crate::task::TaskPointer;
+use crate::task::schedule;
+use crate::task::scheduler_idle;
+use crate::task::wake_and_schedule_task;
 use crate::types::{
     PAGE_SHIFT, PAGE_SHIFT_2M, PAGE_SIZE, PAGE_SIZE_2M, SVSM_TR_ATTRIBUTES, SVSM_TSS,
 };
@@ -1498,7 +1502,7 @@ pub fn cpu_idle_loop(cpu_index: usize) {
         // result of the wake from idle.
         let maybe_task = this_cpu().runqueue_mut().wake_from_idle();
         if let Some(task) = maybe_task {
-            schedule_task(task);
+            wake_and_schedule_task(task);
         }
 
         // Execute any tasks that are currently runnable.

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -12,8 +12,8 @@ mod waiting;
 
 pub use schedule::{
     RunQueue, TASKLIST, create_user_task, current_task, finish_user_task, go_idle, is_current_task,
-    schedule, schedule_init, schedule_task, scheduler_idle, set_affinity, start_kernel_task,
-    start_kernel_thread, terminate, wait_for_termination,
+    schedule, schedule_init, scheduler_idle, set_affinity, start_kernel_task, start_kernel_thread,
+    terminate, wait_for_termination, wake_and_schedule_task,
 };
 
 pub use tasks::{

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -10,6 +10,9 @@
 //! It works by assigning a single owner for each struct [`Task`]. The owner
 //! depends on the state of the task:
 //!
+//! * [`PENDING`] A task has been created but has not yet been scheduled for
+//!   the first time, nor has it been placed into any wait queue or any other
+//!   type of queue.
 //! * [`RUNNING`] A task in running state is owned by the [`RunQueue`] and either
 //!   stored in the `run_list` (when the task is not actively running) or in
 //!   `current_task` when it is scheduled on the CPU.
@@ -24,6 +27,7 @@
 //! specific CPU. Tasks in the [`BLOCKED`] state have no CPU assigned and will run
 //! on the CPU where their event is triggered that makes them [`RUNNING`] again.
 //!
+//! [`PENDING`]: super::tasks::TaskState::PENDING
 //! [`RUNNING`]: super::tasks::TaskState::RUNNING
 //! [`BLOCKED`]: super::tasks::TaskState::BLOCKED
 //! [`TERMINATED`]: super::tasks::TaskState::TERMINATED
@@ -113,11 +117,19 @@ impl RunQueue {
 
     /// Place a task back onto the run queue so it can be scheduled again.
     fn enqueue_task(&mut self, task: TaskPointer) {
-        // Task termination should not follow this path.
-        debug_assert!(!task.is_terminated());
+        // Callers are expected to place the task into the RUNNING state
+        // before a task is queued.
+        debug_assert!(task.is_running());
         if !task.is_idle_task() {
             self.run_list.push_back(task);
         }
+    }
+
+    /// Prepare to run a task by marking it runnable and placing it into the
+    /// run queue.
+    fn prepare_run_task(&mut self, task: TaskPointer) {
+        task.set_task_running();
+        self.enqueue_task(task);
     }
 
     /// Initializes the scheduler for this (RunQueue)[RunQueue]. This method is
@@ -160,7 +172,6 @@ impl RunQueue {
             // important to make sure the last runnable task keeps running,
             // even if it calls schedule()
             let current = self.current_task.take().unwrap();
-            debug_assert!(current.is_running());
             self.enqueue_task(current.clone());
             current
         } else {
@@ -200,6 +211,7 @@ impl RunQueue {
     /// Panics if the idle task was already set.
     pub fn set_idle_task(&mut self, task: TaskPointer) {
         task.set_idle_task();
+        task.set_task_running();
 
         // Add idle task to global task list
         TASKLIST.lock().list().push_front(task.clone());
@@ -304,7 +316,7 @@ pub fn start_kernel_task(
     TASKLIST.lock().list().push_back(task.clone());
 
     // Put task on the runqueue of this CPU
-    cpu.runqueue_mut().enqueue_task(task.clone());
+    cpu.runqueue_mut().prepare_run_task(task.clone());
 
     schedule();
 
@@ -335,7 +347,7 @@ pub fn start_kernel_thread(start_info: KernelThreadStartInfo) -> Result<TaskPoin
     TASKLIST.lock().list().push_back(task.clone());
 
     // Put task on the runqueue of this CPU
-    cpu.runqueue_mut().enqueue_task(task.clone());
+    cpu.runqueue_mut().prepare_run_task(task.clone());
 
     schedule();
 
@@ -372,7 +384,7 @@ pub fn finish_user_task(task: TaskPointer) {
     TASKLIST.lock().list().push_back(task.clone());
 
     // Put task on the runqueue of this CPU
-    this_cpu().runqueue_mut().enqueue_task(task);
+    this_cpu().runqueue_mut().prepare_run_task(task);
 }
 
 pub fn current_task() -> TaskPointer {
@@ -420,12 +432,11 @@ fn current_task_terminated() {
     // valid task, and every task has its pointer pushed into the global task
     // list during its creation.
     let wakeup = unsafe { TASKLIST.lock().terminate(task_node.clone()) };
-    drop(rq);
 
     // If another thread must be woken as a result of the termination, then
     // schedule it now.
     if let Some(wake_task) = wakeup {
-        enqueue_task(wake_task);
+        rq.prepare_run_task(wake_task);
     }
 }
 
@@ -672,13 +683,9 @@ fn select_new_task(reschedule: bool, irq_guard: Option<IrqGuard>) {
     drop(prev_task);
 }
 
-fn enqueue_task(task: TaskPointer) {
-    task.set_task_running();
-    this_cpu().runqueue_mut().enqueue_task(task);
-}
-
-pub fn schedule_task(task: TaskPointer) {
-    enqueue_task(task);
+pub fn wake_and_schedule_task(task: TaskPointer) {
+    debug_assert!(!task.is_running());
+    this_cpu().runqueue_mut().prepare_run_task(task);
     schedule();
 }
 

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -135,9 +135,10 @@ enum ThreadStartInfo {
 #[derive(PartialEq, Debug, Copy, Clone, Default)]
 #[repr(u32)]
 pub enum TaskState {
+    #[default]
+    PENDING,
     RUNNING,
     BLOCKED,
-    #[default]
     TERMINATED,
 }
 
@@ -146,7 +147,8 @@ impl From<u32> for TaskState {
         match v {
             x if x == Self::RUNNING as u32 => Self::RUNNING,
             x if x == Self::BLOCKED as u32 => Self::BLOCKED,
-            _ => Self::TERMINATED,
+            x if x == Self::TERMINATED as u32 => Self::TERMINATED,
+            _ => Self::PENDING,
         }
     }
 }
@@ -241,7 +243,7 @@ impl TaskSchedState {
         Self {
             idle_task: AtomicBool::new(false),
             active: AtomicBool::new(false),
-            state: AtomicU32::new(TaskState::RUNNING.into()),
+            state: AtomicU32::new(TaskState::PENDING.into()),
             cpu_index: AtomicUsize::new(cpu_index),
         }
     }
@@ -361,7 +363,7 @@ impl Drop for Task {
         // Check that the task state is correct and that interrupts are
         // enabled.  These don't affect memory safety so they are debug-only,
         // but they are good sanity checks on the scheduler.
-        debug_assert!(self.is_terminated());
+        debug_assert!(self.is_terminated() || self.is_pending());
         debug_assert!(irqs_enabled());
     }
 }
@@ -598,6 +600,10 @@ impl Task {
 
     pub fn is_running(&self) -> bool {
         self.sched_state.get_state() == TaskState::RUNNING
+    }
+
+    pub fn is_pending(&self) -> bool {
+        self.sched_state.get_state() == TaskState::PENDING
     }
 
     pub fn is_terminated(&self) -> bool {


### PR DESCRIPTION
Define a new pending state to describe a task that has been created but never inserted into any run queue.  This ensures that if the task object is dropped before it is ever run, and thus never goes through a termination flow, there will not be an assertion failure due to the fact that the task was not explicitly terminated.