### PR TITLE
kernel: protocols/attest: spec-align `SVSM_ATTEST_SERVICES` request

### DIFF
--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -61,25 +61,6 @@ pub enum ApicError {
     Registration,
 }
 
-/// Errors related to Attestation handling. These may originate from multiple
-/// layers in the system. Added to protocol base for protocol error.
-#[repr(u64)]
-#[derive(Clone, Copy, Debug)]
-pub enum AttestError {
-    /// An error related to attestation report.
-    Report = 0,
-
-    /// An error related to attestation manifest.
-    Manifest = 1,
-
-    /// An error related to attestation certificates.
-    Certificate = 2,
-
-    /// Error reported when size of the certificates exceeds the size of the supplied
-    /// certificate buffer. Required size in bytes is returned in RDX register.
-    CertificateSize = 3,
-}
-
 /// A generic error during SVSM operation.
 #[derive(Clone, Copy, Debug)]
 pub enum SvsmError {
@@ -145,8 +126,6 @@ pub enum SvsmError {
     SnpGuestRequest(u32),
     /// Generic errors related to APIC emulation.
     Apic(ApicError),
-    /// Generic errors related to attestation handling.
-    Attestation(AttestError),
     /// Errors related to Hyper-V.
     HyperV(u16),
     /// Errors related to Virtio drivers.
@@ -182,12 +161,6 @@ impl From<ElfError> for SvsmError {
 impl From<ApicError> for SvsmError {
     fn from(err: ApicError) -> Self {
         Self::Apic(err)
-    }
-}
-
-impl From<AttestError> for SvsmError {
-    fn from(err: AttestError) -> Self {
-        Self::Attestation(err)
     }
 }
 

--- a/kernel/src/protocols/attest.rs
+++ b/kernel/src/protocols/attest.rs
@@ -366,107 +366,53 @@ fn get_attestation_report_extended(
     Ok((resp, certs))
 }
 
-fn write_report_and_manifest(
+fn write_attestation_report(
     manifest: &[u8],
-    params: &mut RequestParams,
-    ops: &AttestServicesOp,
     report: &[u8],
-) -> Result<(), SvsmReqError> {
-    // Get attestation report buffer's gPA from call's Attest Services Operation structure.
-    // The buffer is required to be page aligned but can be bigger than 4K so can cross pages.
-    // If it is bigger than 4K, it must be physically contiguous.
-    let report_region = ops.get_report_region()?;
-
-    // Get manifest buffer's GPA from call's Attest Services Operation structure
-    // The buffer is required to be page aligned but can be bigger than 4K so can cross pages.
-    // If it is bigger than 4K, it must be physically contiguous.
-    let manifest_region = ops.get_manifest_region()?;
-
-    // Check that the manifest will fit in the buffer by checking that the length of the manifest
-    // is less than the size of the buffer. The size of the buffer was used to create the guard,
-    // so can not be tricked into writing outside the buffer.
-    // If the manifest is larger than the buffer, it is either a malformed manifest or buffer too
-    // small. In either case, return an error.
-    if manifest.len() > manifest_region.len() {
-        return Err(SvsmError::Attestation(AttestError::Manifest).into());
-    }
-
-    // Check that the attestation report will fit in the buffer by checking that the length of the
-    // report is less than the size of the buffer. The size of the buffer was used to create the
-    // guard, so can not be tricked into writing outside the buffer.
-    // If the report is larger than the buffer, it is either a malformed report or buffer too small.
-    // In either case, return an error.
-    if report.len() > report_region.len() {
-        return Err(SvsmError::Attestation(AttestError::Report).into());
-    }
-
-    copy_slice_to_guest(report, report_region.start())?;
-
-    // Set report size in bytes in r8 register
-    params.r8 = report
-        .len()
-        .try_into()
-        .map_err(|_| SvsmError::Attestation(AttestError::Report))?;
-
-    copy_slice_to_guest(manifest, manifest_region.start())?;
-
-    // Set the manifest size in bytes in rcx register
-    params.rcx = manifest
-        .len()
-        .try_into()
-        .map_err(|_| SvsmError::Attestation(AttestError::Manifest))?;
-
-    Ok(())
-}
-
-fn write_certs(
-    certs: &[u8],
-    params: &mut RequestParams,
+    certs: Option<&[u8]>,
     ops: &AttestServicesOp,
+    params: &mut RequestParams,
 ) -> Result<(), SvsmReqError> {
-    // Get certificate buffer's gPA from call's Attest Services Operation structure.
-    // The buffer is required to be page aligned but can be bigger than 4K so can cross pages.
-    // If it is bigger than 4K, it must be physically contiguous.
+    // Get guest physical addresses to copy data to.
+    let manifest_region = ops.get_manifest_region()?;
+    let report_region = ops.get_report_region()?;
     let cert_region = ops.get_certificate_region()?;
-
-    // If certificate region is None, it means that the certificate buffer is not present.
-    // This is valid and shall not return an error.
-    let cert_region = match cert_region {
-        Some(region) => region,
-        None => {
-            // If the certificate region is None, it means that the certificate buffer is not present.
-            // This is valid and shall not return an error.
-            // It is used to indicate that the user does not want an extended attestation
-            // that returns certificates.
-            // Set certificate size to 0, so that the caller knows that there is no certificate.
-            params.rdx = 0;
-            return Ok(());
-        }
-    };
 
     // According to "SEV-ES Guest-Hypervisor Communication Block Standardization, Revision 2.04"
     // the initial 24 bytes of the certificate buffer is the certificate header and will be all zeros
-    // if there is no certificate returned.
-    // This is valid and shall not return an error.
-    // Set certificate size to 0, so that the caller knows that there is no certificate.
-    if certs[..24] == [0; 24] {
-        params.rdx = 0;
-        return Ok(());
+    // if there is no certificate returned. Treat "the guest did not supply a buffer" and "the host
+    // did not supply a certificate" equally.
+    let certs = match (cert_region.as_ref(), certs) {
+        (Some(_), Some(data)) if data.get(..24).is_some_and(|h| h != [0u8; 24]) => Some(data),
+        _ => None,
+    };
+
+    // Write output registers. The guest relies on these to resize its
+    // provided buffers if they are too small.
+    params.rcx = manifest.len() as u64;
+    params.rdx = certs.as_ref().map_or(0, |certs| certs.len() as u64);
+    params.r8 = report.len() as u64;
+
+    // Now check that data fits in the guest buffers. Return the error required by the
+    // spec and let the guest resize the buffer and call again.
+    if manifest.len() > manifest_region.len() {
+        return Err(SvsmReqError::invalid_parameter());
+    }
+    if report.len() > report_region.len() {
+        return Err(SvsmReqError::invalid_parameter());
+    }
+    if let (Some(region), Some(data)) = (cert_region.as_ref(), certs) {
+        if data.len() > region.len() {
+            return Err(SvsmReqError::invalid_parameter());
+        }
     }
 
-    // Check that certificates fit in the buffer. If too large,
-    // return an error indicating the buffer is too small .
-    if certs.len() > cert_region.len() {
-        return Err(SvsmError::Attestation(AttestError::CertificateSize).into());
+    // All sizes match, copy data to guest
+    copy_slice_to_guest(report, report_region.start())?;
+    copy_slice_to_guest(manifest, manifest_region.start())?;
+    if let (Some(region), Some(data)) = (cert_region, certs) {
+        copy_slice_to_guest(data, region.start())?;
     }
-
-    copy_slice_to_guest(certs, cert_region.start())?;
-
-    // Set certificate size in bytes in rdx register
-    params.rdx = certs
-        .len()
-        .try_into()
-        .map_err(|_| SvsmError::Attestation(AttestError::Certificate))?;
 
     Ok(())
 }
@@ -494,18 +440,24 @@ fn get_attestation_report(
                 // The required size is in certs_buffer_size but specified as number of 4 KB pages.
                 // Per SVSM spec, return required size (in bytes) in rdx and raise an error
                 params.rdx = certs_buffer_size << PAGE_SHIFT;
-                return Err(SvsmError::Attestation(AttestError::CertificateSize).into());
+                params.rcx = manifest.len() as u64;
+                return Err(SvsmReqError::invalid_parameter());
             }
             Err(e) => return Err(e),
         };
 
-        write_report_and_manifest(manifest, params, ops, resp.report.as_bytes())?;
-        write_certs(certs.as_slice(), params, ops)
+        write_attestation_report(
+            manifest,
+            resp.report.as_bytes(),
+            Some(certs.as_slice()),
+            ops,
+            params,
+        )
     } else {
         // Get attestation standard report from PSP with Sha512(nonce||manifest) as REPORT_DATA.
         let resp = get_attestation_report_standard(hash)?;
 
-        write_report_and_manifest(manifest, params, ops, resp.report.as_bytes())
+        write_attestation_report(manifest, resp.report.as_bytes(), None, ops, params)
     }
 }
 

--- a/kernel/src/protocols/attest.rs
+++ b/kernel/src/protocols/attest.rs
@@ -423,15 +423,15 @@ fn get_attestation_report(
     params: &mut RequestParams,
     ops: &AttestServicesOp,
 ) -> Result<(), SvsmReqError> {
-    if ops.is_extended_report()? {
+    let (resp, certs) = if ops.is_extended_report()? {
         // If the report is an extended report, it means that the caller requested a certificate.
         // Get extended attestation report from PSP with Sha512(nonce||manifest) as REPORT_DATA.
         // Handle SvsmReqError::FatalError(SvsmError::Ghcb(GhcbError::VmgexitError(certs_buffer_size,psp_rc,)))
         // from the PSP indicating that the certificate buffer is too small.
         // The required size (in 4 KB pages) is in certs_buffer_size.
         // Per SVSM spec, return required size (in bytes) in rdx register and raise an error.
-        let (resp, certs) = match get_attestation_report_extended(hash) {
-            Ok((resp, certs)) => (resp, certs),
+        match get_attestation_report_extended(hash) {
+            Ok((resp, certs)) => (resp, Some(certs)),
             Err(SvsmReqError::FatalError(SvsmError::Ghcb(GhcbError::VmgexitError(
                 certs_buffer_size,
                 _psp_rc,
@@ -444,21 +444,20 @@ fn get_attestation_report(
                 return Err(SvsmReqError::invalid_parameter());
             }
             Err(e) => return Err(e),
-        };
-
-        write_attestation_report(
-            manifest,
-            resp.report.as_bytes(),
-            Some(certs.as_slice()),
-            ops,
-            params,
-        )
+        }
     } else {
         // Get attestation standard report from PSP with Sha512(nonce||manifest) as REPORT_DATA.
         let resp = get_attestation_report_standard(hash)?;
+        (resp, None)
+    };
 
-        write_attestation_report(manifest, resp.report.as_bytes(), None, ops, params)
-    }
+    write_attestation_report(
+        manifest,
+        resp.report.as_bytes(),
+        certs.as_deref().map(|b| b.as_bytes()),
+        ops,
+        params,
+    )
 }
 
 #[allow(dead_code)]

--- a/kernel/src/protocols/attest.rs
+++ b/kernel/src/protocols/attest.rs
@@ -10,7 +10,7 @@ extern crate alloc;
 
 use crate::address::{Address, PhysAddr};
 use crate::crypto::digest::{Algorithm, Sha512};
-use crate::error::{AttestError, SvsmError};
+use crate::error::SvsmError;
 use crate::greq::services::get_extended_report;
 use crate::greq::{
     pld_report::{SnpReportRequest, SnpReportResponse},

--- a/kernel/src/protocols/errors.rs
+++ b/kernel/src/protocols/errors.rs
@@ -83,7 +83,6 @@ impl From<SvsmError> for SvsmReqError {
                 ApicError::Emulation => Self::invalid_parameter(),
                 ApicError::Registration => Self::protocol(SVSM_ERR_APIC_CANNOT_REGISTER),
             },
-            SvsmError::Attestation(e) => Self::protocol(e as u64),
             SvsmError::InvalidParameter => Self::invalid_parameter(),
             SvsmError::InvalidFormat => Self::invalid_format(),
             SvsmError::NotSupported


### PR DESCRIPTION
The handling of `SVSM_ATTEST_SERVICES` is not fully compliant to the SVSM spec on several counts:
    
1. The returned error for an insufficiently large guest-provided buffer is incorrect, as the spec states that it should be `SVSM_ERR_INVALID_PARAMETER`; this is also what the Linux driver checks for. The current code returns a protocol-specific error.
2. The output registers are only written on success, but they should be written on the error path as well so that the lower-privilege guest can re-allocate its buffers to the required size. The Linux guest driver also relies on this behavior if the aforementioned error is returned.
    
Fix this by unifying the extended and non-extended attestation paths, always setting the output registers, and returning `SVSM_ERR_INVALID_PARAMETER` as appropriate.

The first commit fixes the core issue. Commits 2 and 3 bring in additional cleanups.