### PR TITLE
kernel: mm/alloc: convert linear bitscan to trailing bit count

### DIFF
--- a/kernel/src/mm/alloc.rs
+++ b/kernel/src/mm/alloc.rs
@@ -1873,18 +1873,26 @@ impl<const N: usize> SlabPage<N> {
             return Err(AllocError::OutOfMemory);
         }
 
-        for i in 0..self.get_capacity() {
-            let idx = i / 64;
-            let mask = 1u64 << (i % 64);
+        let capacity = self.get_capacity();
 
-            if self.used_bitmap[idx] & mask == 0 {
-                self.used_bitmap[idx] |= mask;
-                self.free -= 1;
-                let vaddr = self.vaddr + (N * i);
-                // SAFETY: `self.vaddr` is set when `self.free` is initialized to a non-zero
-                // value, which we have checked above.
-                return unsafe { Ok(NonNull::new_unchecked(vaddr.as_mut_ptr())) };
+        for (idx, slot) in self.used_bitmap.iter_mut().enumerate() {
+            if *slot == u64::MAX {
+                continue;
             }
+
+            let bit = slot.trailing_ones() as usize;
+            let abs_bit = bit + idx * (u64::BITS as usize);
+            if abs_bit >= capacity {
+                break;
+            }
+
+            *slot |= 1 << bit;
+            self.free -= 1;
+            let vaddr = self.vaddr + (N * abs_bit);
+
+            // SAFETY: `self.vaddr` is set when `self.free` is initialized to a non-zero
+            // value, which we have checked above.
+            return unsafe { Ok(NonNull::new_unchecked(vaddr.as_mut_ptr())) };
         }
 
         Err(AllocError::OutOfMemory)


### PR DESCRIPTION
When SlabPage allocates a slot within its storage, it tries to find a zero bit within a 128-bit bitmap (implemented with two u64s). The scan is limited to the page size divided by the size of each slot (`N`).

Instead of iterating over every possible bit position and testing with a bitmask, use `u64::trailing_ones()` to find the lowest zero bit within each u64 in the bitmap. This allows the CPU to use a dedicated bitwise instruction.