### PR TITLE
docs/attestation: fix attestation test steps

### DIFF
--- a/Documentation/docs/developer/ATTESTATION.md
+++ b/Documentation/docs/developer/ATTESTATION.md
@@ -261,7 +261,8 @@ To try for yourself, we provide a test KBS server that requires no configuration
 and simply indicates if attestation was successful or not. This requires a
 SEV-SNP machine with an SVSM-enabled kernel.
 
-1. Clone and build SVSM
+1. Clone and build SVSM (see [INSTALL.md](../installation/INSTALL.md) for more
+   details)
 
     ```shell
     git clone https://github.com/coconut-svsm/svsm.git

--- a/Documentation/docs/developer/ATTESTATION.md
+++ b/Documentation/docs/developer/ATTESTATION.md
@@ -261,7 +261,16 @@ To try for yourself, we provide a test KBS server that requires no configuration
 and simply indicates if attestation was successful or not. This requires a
 SEV-SNP machine with an SVSM-enabled kernel.
 
-1. Clone and run the `kbs-test` server used for testing. Supply the following
+1. Clone and build SVSM
+
+    ```shell
+    git clone https://github.com/coconut-svsm/svsm.git
+    # ... build OVMF, qemu, SVSM IGVM, etc...
+    FW_FILE=... make FEATURES=attest                       # serial transport
+    FW_FILE=... make FEATURES=attest,vsock,virtio-drivers  # vsock transport (with serial fallback)
+    ```
+
+2. Clone and run the `kbs-test` server used for testing. Supply the following
    argument on the command line:
 
     * `--measurement`: hex-encoded expected launch measurement (64 bytes in size).
@@ -274,15 +283,6 @@ SEV-SNP machine with an SVSM-enabled kernel.
     cargo run -- --measurement $MEASUREMENT --secret $HEX_SECRET
     ```
     This will run the `kbs-test` server at <http://0.0.0.0:8080>.
-
-2. Clone and build SVSM
-
-    ```shell
-    git clone https://github.com/coconut-svsm/svsm.git
-    # ... build OVMF, qemu, SVSM IGVM, etc...
-    FW_FILE=... make FEATURES=attest                       # serial transport
-    FW_FILE=... make FEATURES=attest,vsock,virtio-drivers  # vsock transport (with serial fallback)
-    ```
 
 3. Run the proxy on the host
 

--- a/Documentation/docs/developer/ATTESTATION.md
+++ b/Documentation/docs/developer/ATTESTATION.md
@@ -271,15 +271,18 @@ SEV-SNP machine with an SVSM-enabled kernel.
     ```
 
 2. Clone and run the `kbs-test` server used for testing. Supply the following
-   argument on the command line:
+   arguments on the command line:
 
     * `--measurement`: hex-encoded expected launch measurement (64 bytes in size).
+    * `--secret` (optional): hex-encoded secret payload that will be delivered
+      to SVSM upon successful attestation.
 
     ```shell
     # SVSM=<path to your Coconut SVSM directory>
     git clone https://github.com/coconut-svsm/kbs-test.git
     cd kbs-test
     MEASUREMENT="$(${SVSM}/bin/igvmmeasure --check-kvm ${SVSM}/bin/coconut-qemu.igvm measure -b)"
+    HEX_SECRET="$(openssl rand -hex 32)"
     cargo run -- --measurement $MEASUREMENT --secret $HEX_SECRET
     ```
     This will run the `kbs-test` server at <http://0.0.0.0:8080>.


### PR DESCRIPTION
I had these changes locally while I was testing the various releases, and I always forgot to fix them.

Move SVSM build step as first step since it's needed for the measurement, and document kbs-test `--secret` parameter adding also an example.

CC @tylerfanelli @armenon-rh