### PR TITLE
kernel: sev/hv_doorbell: treat NoEoiRequired as a single field

### DIFF
--- a/kernel/src/sev/hv_doorbell.rs
+++ b/kernel/src/sev/hv_doorbell.rs
@@ -156,28 +156,9 @@ impl HVDoorbell {
 
     pub fn no_eoi_required(&self) -> bool {
         // Check to see if the "no EOI required" flag is set to determine
-        // whether an explicit EOI can be avoided.
-        let mut no_eoi_required = self.no_eoi_required.load(Ordering::Relaxed);
-        loop {
-            // If the flag is not set, then an explicit EOI is required.
-            if (no_eoi_required & 1) == 0 {
-                return false;
-            }
-            // Attempt to atomically clear the flag.
-            match self.no_eoi_required.compare_exchange_weak(
-                no_eoi_required,
-                no_eoi_required & !1,
-                Ordering::Relaxed,
-                Ordering::Relaxed,
-            ) {
-                Ok(_) => break,
-                Err(new) => no_eoi_required = new,
-            }
-        }
-
-        // If the flag was successfully cleared, then no explicit EOI is
-        // required.
-        true
+        // whether an explicit EOI can be avoided. If the flag was successfully
+        // cleared, then no explicit EOI is required, and required otherwise.
+        self.no_eoi_required.swap(0, Ordering::Relaxed) != 0
     }
 }
 


### PR DESCRIPTION
The #HV doorbell page has a byte-sized field to determine whether an an EOI is required to service an interrupt. The GHCB spec says:

    When it is possible to perform an EOI without exiting the guest,
    NoEoiRequired will be set to a non-zero value by the host,
    indicating that no explicit EOI is required. When the guest
    wishes to perform an EOI, it should attempt to atomically change
    NoEoiRequired from non-zero to zero.

However, the current code in the SVSM only looks at bit 0 in the field, and performs a CAS loop to only update this bit, which does not match what the spec says.

This is the pseudocode provided in the GHCB spec:

    NoEoiRequired := XCHG(Doorbell.NoEoiRequired, 0)
    IF NoEoiRequired = 0
        WRMSR(X2APIC_EOI)
    FI

Any reasonable hypervisor will write bit 0, but do not rely on this behavior and simplify the code. Swap the whole field to 0 and treat any non-zero value as "no EOI required".