### PR TITLE
kernel: cpu/apic: reject more fields on ICR writes

### DIFF
--- a/kernel/src/cpu/apic.rs
+++ b/kernel/src/cpu/apic.rs
@@ -571,7 +571,14 @@ impl LocalApic {
             IcrMessageType::Fixed | IcrMessageType::Nmi
         );
 
-        if !valid_type || icr.rsvd_13() || icr.rsvd_31_20() != 0 {
+        // Reject invalid message types, and make sure must-be-zero and
+        // x2APIC reserved fields are not set by the guest.
+        if !valid_type
+            || icr.rsvd_13()
+            || icr.rsvd_31_20() != 0
+            || icr.remote_read_status() != 0
+            || icr.delivery_status()
+        {
             return Err(SvsmError::Apic(Emulation));
         }
 


### PR DESCRIPTION
The SVSM spec states that must-be-zero fields in APIC registers must be checked on emulated register writes, returning an error on an invalid value. The SVSM already checks some of these fields, but a couple are missing.

Bits 16 and 17 (remote read status) are reserved in x2APIC mode, which is what the SVSM emulates. Bit 12 is only checked by hardware on AMD (Intel ignores it), but since APIC emulation ony makes sense on AMD SEV-SNP with restricted injection, emulate what the hardware does as well.