### PR TITLE
kernel: zeroize more secrets

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,6 +4,7 @@
 rustflags = [
 	"-C", "force-frame-pointers",
 	"--cfg", "aes_force_soft",
+	"--cfg", 'aes_backend="soft"',
 	"--cfg", "polyval_force_soft",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,7 @@ dependencies = [
  "ctr",
  "ghash",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array 0.14.7",
 ]
 
@@ -19,8 +19,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
- "cpufeatures",
+ "cipher 0.4.4",
+ "cpufeatures 0.2.17",
+ "zeroize",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
  "zeroize",
 ]
 
@@ -31,8 +43,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
- "aes",
- "cipher",
+ "aes 0.8.4",
+ "cipher 0.4.4",
  "ctr",
  "ghash",
  "subtle",
@@ -41,11 +53,12 @@ dependencies = [
 
 [[package]]
 name = "aes-kw"
-version = "0.2.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69fa2b352dcefb5f7f3a5fb840e02665d311d878955380515e4fd50095dd3d8c"
+checksum = "41ac571010bd60765c56085a4f1d412012a9be2663b1a2f2b19b49318653fd0d"
 dependencies = [
- "aes",
+ "aes 0.9.1",
+ "zeroize",
 ]
 
 [[package]]
@@ -291,7 +304,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3264e2574e9ef2b53ce6f536dea83a69ac0bc600b762d1523ff83fe07230ce30"
 dependencies = [
  "byteorder",
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -300,7 +313,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -337,7 +350,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "738b8d467867f80a71351933f70461f5b56f24d5c93e0cf216e59229c968d330"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -358,9 +371,19 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
- "inout",
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
  "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -429,15 +452,15 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b7633b7e5996b4b5d15929736d10910c087713a9bdf9b7a05c1f16d192ae413"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "camellia",
  "cbc",
  "cfb-mode",
- "cipher",
+ "cipher 0.4.4",
  "cmpa",
  "cocoon-tpm-tpm2-interface",
  "cocoon-tpm-utils-common",
- "crypto-common",
+ "crypto-common 0.1.7",
  "digest",
  "generic-array 1.3.5",
  "hmac",
@@ -545,10 +568,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -585,12 +623,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -645,7 +692,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -975,6 +1022,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,6 +1249,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array 0.14.7",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1444,7 +1509,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cc40678e045ff4eb1666ea6c0f994b133c31f673c09aed292261b6d5b6963a0"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1556,7 +1621,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -1860,7 +1925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -1901,7 +1966,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d7abf5135ffd68fb4b438e1fb246923b80d25eda386d8b798bb4ad3ed00f75f"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -2240,9 +2305,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucs2"
@@ -2314,7 +2379,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ virtio-drivers = { git = "https://github.com/coconut-svsm/virtio-drivers.git", r
 
 # crates.io
 aes-gcm = { version = "0.10.3", default-features = false }
-aes-kw = { version = "0.2.1", default-features = false }
+aes-kw = { version = "0.3.1", default-features = false }
 arbitrary = "1.3.0"
 base64 = { version = "0.22.1", default-features = false }
 bindgen = {version = "0.71.0", default-features = false }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -21,7 +21,7 @@ elf.workspace = true
 syscall.workspace = true
 
 aes-gcm = { workspace = true, features = ["aes", "alloc", "zeroize"] }
-aes-kw = { workspace = true, optional = true }
+aes-kw = { workspace = true, features = ["zeroize"], optional = true }
 bitfield-struct.workspace = true
 bitflags.workspace = true
 cocoon-tpm-crypto = { workspace = true, features = [

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -20,7 +20,7 @@ libaproxy = { workspace = true, optional = true }
 elf.workspace = true
 syscall.workspace = true
 
-aes-gcm = { workspace = true, features = ["aes", "alloc"] }
+aes-gcm = { workspace = true, features = ["aes", "alloc", "zeroize"] }
 aes-kw = { workspace = true, optional = true }
 bitfield-struct.workspace = true
 bitflags.workspace = true

--- a/kernel/src/attest.rs
+++ b/kernel/src/attest.rs
@@ -228,8 +228,8 @@ impl AttestationDriver<'_> {
             Kek::new(&GenericArray::from(sized))
         };
 
-        let mut cek =
-            vec_sized(&decryption.wrapped_cek.len() - 8).or(Err(AttestationError::VecAlloc))?;
+        let mut cek = SecretSlice::new_sized(&decryption.wrapped_cek.len() - 8)
+            .or(Err(AttestationError::VecAlloc))?;
 
         wrapping_key
             .unwrap(&decryption.wrapped_cek, &mut cek)

--- a/kernel/src/attest.rs
+++ b/kernel/src/attest.rs
@@ -216,16 +216,12 @@ impl AttestationDriver<'_> {
         kdm.extend_from_slice(&(256_u32).to_be_bytes());
 
         let wrapping_key: KekAes256 = {
-            let mut buf: Vec<u8> = vec_sized(32).or(Err(AttestationError::VecAlloc))?;
+            let mut buf = SecretSlice::new_sized(32).or(Err(AttestationError::VecAlloc))?;
 
             concat_kdf::derive_key_into::<sha2::Sha256>(&z, &kdm, &mut buf)
                 .map_err(AttestationError::KeyDerivation)?;
 
-            let sized: [u8; 32] = buf
-                .try_into()
-                .or(Err(AttestationError::WrapKeyArrayConvert))?;
-
-            Kek::new(&GenericArray::from(sized))
+            Kek::new(GenericArray::from_slice(&buf))
         };
 
         let mut cek = SecretSlice::new_sized(&decryption.wrapped_cek.len() - 8)

--- a/kernel/src/attest.rs
+++ b/kernel/src/attest.rs
@@ -18,7 +18,7 @@ use crate::{
 #[cfg(feature = "vsock")]
 use crate::{vsock::VMADDR_CID_HOST, vsock::stream::VsockStream};
 use aes_gcm::{AeadInPlace, Aes256Gcm, KeyInit, Nonce, aead::generic_array::GenericArray};
-use aes_kw::{Kek, KekAes256};
+use aes_kw::{KeyInit as _, KwAes256};
 use alloc::{string::ToString, vec::Vec};
 use cocoon_tpm_crypto::{
     CryptoError, EmptyCryptoIoSlices,
@@ -215,20 +215,20 @@ impl AttestationDriver<'_> {
         kdm.extend_from_slice(&(0_u32).to_be_bytes());
         kdm.extend_from_slice(&(256_u32).to_be_bytes());
 
-        let wrapping_key: KekAes256 = {
+        let wrapping_key: KwAes256 = {
             let mut buf = SecretSlice::new_sized(32).or(Err(AttestationError::VecAlloc))?;
 
             concat_kdf::derive_key_into::<sha2::Sha256>(&z, &kdm, &mut buf)
                 .map_err(AttestationError::KeyDerivation)?;
 
-            Kek::new(GenericArray::from_slice(&buf))
-        };
+            KwAes256::new_from_slice(&buf).or(Err(AttestationError::WrapKeyArrayConvert))
+        }?;
 
         let mut cek = SecretSlice::new_sized(&decryption.wrapped_cek.len() - 8)
             .or(Err(AttestationError::VecAlloc))?;
 
         wrapping_key
-            .unwrap(&decryption.wrapped_cek, &mut cek)
+            .unwrap_key(&decryption.wrapped_cek, &mut cek)
             .or(Err(AttestationError::CekUnwrap))?;
 
         let cipher = Aes256Gcm::new(GenericArray::from_slice(&cek));

--- a/kernel/src/crypto/mod.rs
+++ b/kernel/src/crypto/mod.rs
@@ -9,7 +9,10 @@
 extern crate alloc;
 
 use alloc::boxed::Box;
+use alloc::collections::TryReserveError;
 use zeroize::{Zeroize, ZeroizeOnDrop};
+
+use crate::utils::vec::vec_sized;
 
 /// Container for sensitive byte data.
 ///
@@ -17,6 +20,13 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 /// [`zeroize`](Zeroize::zeroize)d.
 #[derive(Zeroize, ZeroizeOnDrop)]
 pub struct SecretSlice(Box<[u8]>);
+
+impl SecretSlice {
+    pub fn new_sized(size: usize) -> Result<Self, TryReserveError> {
+        let v = vec_sized(size)?;
+        Ok(Self(v.into_boxed_slice()))
+    }
+}
 
 impl From<Box<[u8]>> for SecretSlice {
     fn from(data: Box<[u8]>) -> Self {

--- a/kernel/src/greq/driver.rs
+++ b/kernel/src/greq/driver.rs
@@ -22,7 +22,7 @@ use crate::{
     error::SvsmError,
     greq::msg::{SnpGuestRequestExtData, SnpGuestRequestMsg, SnpGuestRequestMsgType},
     locking::SpinLock,
-    sev::{VMPCK_SIZE, ghcb::GhcbError, secrets_page, secrets_page_mut},
+    sev::{ghcb::GhcbError, secrets_page, secrets_page_mut},
     types::PAGE_SHIFT,
     utils::page_align_up,
 };
@@ -150,7 +150,7 @@ impl SnpGuestRequestDriver {
         command_len: usize,
     ) -> Result<(), SvsmError> {
         // VMPL0 `SNP_GUEST_REQUEST` commands are encrypted with the VMPCK0 key
-        let vmpck0: [u8; VMPCK_SIZE] = secrets_page().unwrap().get_vmpck(0);
+        let vmpck0 = secrets_page().unwrap().get_vmpck(0);
 
         let inbuf = buffer
             .get(..command_len)
@@ -171,7 +171,7 @@ impl SnpGuestRequestDriver {
         msg_type: SnpGuestRequestMsgType,
         buffer: &mut [u8],
     ) -> Result<usize, SvsmError> {
-        let vmpck0: [u8; VMPCK_SIZE] = secrets_page().unwrap().get_vmpck(0);
+        let vmpck0 = secrets_page().unwrap().get_vmpck(0);
 
         // For security reasons, decrypt the message in protected memory (staging)
         self.response.read_into(&mut self.staging);

--- a/kernel/src/sev/secrets_page.rs
+++ b/kernel/src/sev/secrets_page.rs
@@ -14,6 +14,7 @@ use crate::utils::immut_after_init::ImmutAfterInitCell;
 extern crate alloc;
 use alloc::boxed::Box;
 use core::ptr;
+use zeroize::Zeroizing;
 
 pub const VMPCK_SIZE: usize = 32;
 
@@ -122,8 +123,8 @@ impl SecretsPage {
         self.svsm_guest_vmpl = GUEST_VMPL as u8;
     }
 
-    pub fn get_vmpck(&self, idx: usize) -> [u8; VMPCK_SIZE] {
-        self.vmpck[idx]
+    pub fn get_vmpck(&self, idx: usize) -> Zeroizing<[u8; VMPCK_SIZE]> {
+        Zeroizing::new(self.vmpck[idx])
     }
 
     pub fn is_vmpck_clear(&self, idx: usize) -> bool {


### PR DESCRIPTION
* Zeroize VMPCK after use.
* Enable `zeroize` feature for `aes-gcm` crate
* Zeroize KEK and CEK after use during attestation secret retrieval
* Update `aes-kw` and enable `zeroize` feature

Closes: #807