### PR TITLE
kernel: migrate CPUID feature detection to cpufeature crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,6 +574,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
+name = "cpufeature"
+version = "0.1.0"
+source = "git+https://github.com/coconut-svsm/cpufeature.git?rev=0182d61954372552fe2a40477340e949471a49ee#0182d61954372552fe2a40477340e949471a49ee"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2082,6 +2087,7 @@ dependencies = [
  "cocoon-tpm-utils-common",
  "concat-kdf",
  "cpuarch",
+ "cpufeature",
  "elf",
  "gdbstub",
  "gdbstub_arch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,8 @@ virtio-drivers = { git = "https://github.com/rcore-os/virtio-drivers.git", rev =
 zerocopy = { version = "0.8.2", features = ["derive"] }
 zeroize = { version = "1.8.2", default-features = false }
 
+cpufeature = { git = "https://github.com/coconut-svsm/cpufeature.git", rev = "0182d61954372552fe2a40477340e949471a49ee" }
+
 # Verus repos
 verus_builtin = { version = "=0.0.0-2026-04-12-0118", default-features = false }
 verus_builtin_macros = { version = "=0.0.0-2026-04-12-0118", features = ["vpanic"], default-features = false }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -16,6 +16,7 @@ doctest = true
 bootdefs.workspace = true
 bootimg.workspace = true
 cpuarch.workspace = true
+cpufeature.workspace = true
 libaproxy = { workspace = true, optional = true }
 elf.workspace = true
 syscall.workspace = true

--- a/kernel/src/cpu/features.rs
+++ b/kernel/src/cpu/features.rs
@@ -5,18 +5,49 @@
 // Authors: Joerg Roedel <jroedel@suse.de>
 //          Carlos López <clopez@suse.de>
 
-use core::arch::x86_64::CpuidResult;
+use crate::platform::cpuid;
+use crate::utils::immut_after_init::ImmutAfterInitCell;
+use cpufeature::CpuidFeature;
+use cpufeature::CpuidRegister;
+use cpufeature::leaves::{
+    CET_SS, INVLPGB_MAX_PAGES, PTE_CBIT_POS, X86_FEATURE_PGE, X86_FEATURE_SMAP, X86_FEATURE_SMEP,
+    X86_FEATURE_UMIP, X86_FEATURE_X2APIC, X86_FEATURE_XMM, X86_FEATURE_XSAVE, X86_FEATURE_XSAVEOPT,
+    XCR0_AVX, XCR0_SSE, XCR0_X87,
+};
 
-use crate::{platform::cpuid, utils::immut_after_init::ImmutAfterInitCell};
+/// CPUID leaf 0 — CPU vendor ID string (EBX/ECX/EDX).
+///
+/// Not exposed under that name in the cpufeature database (leaf 0 is
+/// `MAX_STD_LEAF` on EAX), so keep a local descriptor for vendor detection.
+pub const CPU_VENDOR_ID: CpuidFeature = CpuidFeature {
+    leaf: 0,
+    subleaf: 0,
+    register: CpuidRegister::Edx,
+    shift: 0,
+    width: 32,
+};
 
-/// The CPUID output register for a particular feature
-#[derive(Clone, Copy, Debug)]
-enum CpuidReg {
-    Eax,
-    Ebx,
-    Ecx,
-    Edx,
-}
+/// Raw EAX from CPUID leaf 0x8000_0008 — processor capacity parameters.
+/// Not in the cpufeature database as a full-register field (only the individual
+/// bit ranges are), so keep a local descriptor for the full EAX value.
+const PHYS_ADDR_SIZES: CpuidFeature = CpuidFeature {
+    leaf: 0x8000_0008,
+    subleaf: 0,
+    register: CpuidRegister::Eax,
+    shift: 0,
+    width: 32,
+};
+
+/// CPUID.4000_0001:EAX — Hyper-V interface signature ("Hv#1").
+const HYPERV_INTERFACE: CpuidFeature = CpuidFeature {
+    leaf: 0x4000_0001,
+    subleaf: 0,
+    register: CpuidRegister::Eax,
+    shift: 0,
+    width: 32,
+};
+
+const HYPERV_INTERFACE_SIGNATURE: u32 = 0x3123_7648;
 
 /// A discoverable CPU feature.
 ///
@@ -26,78 +57,35 @@ enum CpuidReg {
 struct CpuFeat {
     /// Raw value
     val: ImmutAfterInitCell<u32>,
-    /// CPUID leaf
-    leaf: u32,
-    /// CPUID subleaf
-    subleaf: u32,
-    /// CPUID output register
-    reg: CpuidReg,
-    /// Bitshift to apply to raw value
-    shift: u8,
-    /// Bitmask to apply to raw value
-    bitsize: u8,
+    /// Location of the feature within a CPUID leaf
+    feature: CpuidFeature,
     /// Expected value after shift + mask
     expected: u32,
 }
 
 impl CpuFeat {
-    /// Create a new feature, indicated by a single bit in the specified
-    /// register in the given CPUID leaf.
-    const fn new_bit(leaf: u32, reg: CpuidReg, bit: u8) -> Self {
-        Self::new(leaf, reg, bit, 1, 1)
+    /// Create a new feature, indicated by a single bit (expected value 1).
+    const fn new_bit(feature: CpuidFeature) -> Self {
+        Self::new(feature, 1)
     }
 
-    /// Create a new feature, indicated by the full value of a register
-    /// in the given CPUID leaf.
-    const fn new_u32(leaf: u32, reg: CpuidReg, expected: u32) -> Self {
-        Self::new(leaf, reg, 0, u32::BITS as u8, expected)
-    }
-
-    /// Create a new CPU feature, detected by querying the given CPUID leaf, and applying
-    /// a bitshift and bitmask on the specified output register to compare it to the given
-    /// expected value.
-    const fn new(leaf: u32, reg: CpuidReg, shift: u8, bitsize: u8, expected: u32) -> Self {
-        // This method is only called from const context, so these assertions have no
-        // runtime effect.
-        assert!((shift as u32) < u32::BITS);
-        assert!((bitsize as u32) <= u32::BITS);
+    /// Create a new CPU feature from a cpufeature descriptor, comparing the
+    /// extracted field against the given expected value.
+    const fn new(feature: CpuidFeature, expected: u32) -> Self {
         Self {
             val: ImmutAfterInitCell::uninit(),
-            leaf,
-            subleaf: 0,
-            reg,
-            shift,
-            bitsize,
+            feature,
             expected,
         }
-    }
-
-    /// Create a copy of the given CPU feature, but with the specified
-    /// subleaf.
-    const fn with_subfn(mut self, subleaf: u32) -> Self {
-        self.subleaf = subleaf;
-        self
-    }
-
-    /// Get the CPUID register that corresponds to this feature
-    const fn get_reg(&self, cpuid: &CpuidResult) -> u32 {
-        match self.reg {
-            CpuidReg::Eax => cpuid.eax,
-            CpuidReg::Ebx => cpuid.ebx,
-            CpuidReg::Ecx => cpuid.ecx,
-            CpuidReg::Edx => cpuid.edx,
-        }
-    }
-
-    const fn mask(&self) -> u32 {
-        ((1u64 << self.bitsize) - 1) as u32
     }
 
     fn get_or_init(&self) -> u32 {
         if let Ok(val) = self.val.try_get_inner() {
             return *val;
         }
-        let val = cpuid(self.leaf, self.subleaf).map_or(0, |c| self.get_reg(&c));
+        let val = cpuid(&self.feature).map_or(0, |c| {
+            self.feature.register.select(c.eax, c.ebx, c.ecx, c.edx)
+        });
         // If init() fails it means the cell got initialized by someone else
         // concurrently, which is always benign.
         let _ = self.val.init(val);
@@ -107,7 +95,8 @@ impl CpuFeat {
     /// Gets the raw value of this feature, lazily querying CPUID if
     /// the value is not cached from a previous query
     fn get(&self) -> u32 {
-        (self.get_or_init() >> self.shift) & self.mask()
+        let mask = ((1u64 << self.feature.width) as u32).wrapping_sub(1);
+        (self.get_or_init() >> self.feature.shift) & mask
     }
 
     /// Checks whether this feature is available by comparing it to
@@ -155,20 +144,20 @@ pub fn cpu_get_feat(feat: Feature) -> u32 {
 }
 
 define_cpu_feats! {
-    X2Apic => CpuFeat::new_bit(0x0000_0001, CpuidReg::Ecx, 21),
-    Xsave => CpuFeat::new_bit(0x0000_0001, CpuidReg::Ecx, 26),
-    Pge => CpuFeat::new_bit(0x0000_0001, CpuidReg::Edx, 13),
-    Sse1 => CpuFeat::new_bit(0x0000_0001, CpuidReg::Edx, 25),
-    Smep => CpuFeat::new_bit(0x0000_0007, CpuidReg::Ebx, 7),
-    Smap => CpuFeat::new_bit(0x0000_0007, CpuidReg::Ebx, 20),
-    Umip => CpuFeat::new_bit(0x0000_0007, CpuidReg::Ecx, 2),
-    CetSS => CpuFeat::new_bit(0x0000_0007, CpuidReg::Ecx, 7),
-    Xcr0X87 => CpuFeat::new_bit(0x0000_000d, CpuidReg::Eax, 0),
-    Xcr0Sse => CpuFeat::new_bit(0x0000_000d, CpuidReg::Eax, 1),
-    Xcr0Avx => CpuFeat::new_bit(0x0000_000d, CpuidReg::Eax, 2),
-    XsaveOpt => CpuFeat::new_bit(0x0000_000d, CpuidReg::Eax, 0).with_subfn(1),
-    HyperV => CpuFeat::new_u32(0x40000001, CpuidReg::Eax, 0x31237648),
-    PhysAddrSizes => CpuFeat::new_u32(0x80000008, CpuidReg::Eax, 0),
-    InvlpgbMax => CpuFeat::new(0x80000008, CpuidReg::Edx, 0, u16::BITS as u8, 0),
-    Cbit => CpuFeat::new(0x8000001f, CpuidReg::Ebx, 0, 6, 0),
+    X2Apic => CpuFeat::new_bit(X86_FEATURE_X2APIC),
+    Xsave => CpuFeat::new_bit(X86_FEATURE_XSAVE),
+    Pge => CpuFeat::new_bit(X86_FEATURE_PGE),
+    Sse1 => CpuFeat::new_bit(X86_FEATURE_XMM),
+    Smep => CpuFeat::new_bit(X86_FEATURE_SMEP),
+    Smap => CpuFeat::new_bit(X86_FEATURE_SMAP),
+    Umip => CpuFeat::new_bit(X86_FEATURE_UMIP),
+    CetSS => CpuFeat::new_bit(CET_SS),
+    Xcr0X87 => CpuFeat::new_bit(XCR0_X87),
+    Xcr0Sse => CpuFeat::new_bit(XCR0_SSE),
+    Xcr0Avx => CpuFeat::new_bit(XCR0_AVX),
+    XsaveOpt => CpuFeat::new_bit(X86_FEATURE_XSAVEOPT),
+    HyperV => CpuFeat::new(HYPERV_INTERFACE, HYPERV_INTERFACE_SIGNATURE),
+    PhysAddrSizes => CpuFeat::new(PHYS_ADDR_SIZES, 0),
+    InvlpgbMax => CpuFeat::new(INVLPGB_MAX_PAGES, 0),
+    Cbit => CpuFeat::new(PTE_CBIT_POS, 0),
 }

--- a/kernel/src/cpu/sse.rs
+++ b/kernel/src/cpu/sse.rs
@@ -5,13 +5,13 @@
 // Author: Vasant Karasulli <vkarasulli@suse.de>
 
 use crate::cpu::control_regs::{cr0_sse_enable, cr4_osfxsr_enable, cr4_xsave_enable};
+use crate::cpu::features::{Feature, cpu_has_feat};
 use crate::platform::cpuid;
 use core::arch::asm;
 use core::arch::x86_64::{_xgetbv, _xsetbv};
 use core::sync::atomic::{AtomicU64, Ordering};
-
-use super::features::{Feature, cpu_has_feat};
-
+use cpufeature::CpuidFeature;
+use cpufeature::leaves::XSAVE_SZ;
 const XCR0_X87_ENABLE: u64 = 0x1;
 const XCR0_SSE_ENABLE: u64 = 0x2;
 const XCR0_YMM_ENABLE: u64 = 0x4;
@@ -75,7 +75,11 @@ pub fn xsave_area_size() -> u32 {
         if xcr0 & (1u64 << bit) == 0 {
             continue;
         }
-        let Some(result) = cpuid(0xd, bit) else {
+        let feature = CpuidFeature {
+            subleaf: bit,
+            ..XSAVE_SZ
+        };
+        let Some(result) = cpuid(&feature) else {
             log::warn!("FP feature {bit:#x} enabled but not present in CPUID");
             continue;
         };

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -19,9 +19,11 @@ use snp::SnpPlatform;
 use tdp::TdpPlatform;
 
 use core::arch::asm;
-use core::arch::x86_64::{__cpuid_count, CpuidResult};
+use core::arch::x86_64::CpuidResult;
 use core::fmt::Debug;
 use core::mem::MaybeUninit;
+use cpufeature::CpuidFeature;
+use cpufeature::backend::CpuidBackend;
 
 use crate::address::{PhysAddr, VirtAddr};
 use crate::boot_params::BootParams;
@@ -180,20 +182,6 @@ pub trait SvsmPlatform: Sync {
         input_control: hyperv::HvHypercallInput,
         hypercall_pages: &hyperv::HypercallPagesGuard<'_>,
     ) -> hyperv::HvHypercallOutput;
-
-    /// Obtain CPUID using platform-specific tables.
-    fn cpuid(eax: u32, ecx: u32) -> Option<CpuidResult>
-    where
-        Self: Sized,
-    {
-        // Stable clippy and the nightly rust compiler disagree on the safety
-        // of __cpuid_count(). Silence both until this is resolved.
-        #[allow(unused_unsafe)]
-        // SAFETY: CPUID is always safe
-        unsafe {
-            Some(__cpuid_count(eax, ecx))
-        }
-    }
 
     /// Write a host-owned MSR.
     /// # Safety
@@ -364,8 +352,8 @@ macro_rules! platform_method {
 }
 
 #[inline]
-pub fn cpuid(leaf: u32, subleaf: u32) -> Option<CpuidResult> {
-    platform_method!(cpuid, leaf, subleaf)
+pub fn cpuid(feature: &CpuidFeature) -> Option<CpuidResult> {
+    platform_method!(cpuid, feature)
 }
 
 pub fn halt() {

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -12,11 +12,10 @@ use super::PageStateChangeOp;
 use super::PageValidateOp;
 use super::SvsmPlatform;
 use super::capabilities::Caps;
-use super::cpuid;
 use crate::address::{PhysAddr, VirtAddr};
 use crate::console::init_svsm_console;
 use crate::cpu::IrqGuard;
-use crate::cpu::features::{Feature, cpu_get_feat, cpu_has_feat};
+use crate::cpu::features::{CPU_VENDOR_ID, Feature, cpu_get_feat, cpu_has_feat};
 use crate::cpu::irq_state::raw_irqs_disable;
 use crate::cpu::msr::write_msr;
 use crate::cpu::percpu::PerCpu;
@@ -38,6 +37,7 @@ use cpuarch::x86apic::IcrMessageType;
 use bootdefs::kernel_launch::BLDR_BASE;
 use core::arch::asm;
 use core::mem::MaybeUninit;
+use cpufeature::backend::CpuidBackend;
 use syscall::GlobalFeatureFlags;
 
 #[cfg(debug_assertions)]
@@ -58,6 +58,8 @@ impl NativePlatform {
         Self {}
     }
 }
+
+impl CpuidBackend for NativePlatform {}
 
 impl SvsmPlatform for NativePlatform {
     #[cfg(test)]
@@ -87,7 +89,7 @@ impl SvsmPlatform for NativePlatform {
     }
 
     fn get_cpu_vendor(&self) -> CpuVendor {
-        if let Some(r) = cpuid(0, 0) {
+        if let Some(r) = Self::cpuid(&CPU_VENDOR_ID) {
             match r.edx {
                 0x69746e65 => CpuVendor::AMD,
                 0x49656e69 => CpuVendor::Intel,

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -58,6 +58,8 @@ use core::arch::x86_64::CpuidResult;
 use core::mem::MaybeUninit;
 use core::ptr;
 use core::sync::atomic::{AtomicU32, Ordering};
+use cpufeature::CpuidFeature;
+use cpufeature::backend::CpuidBackend;
 use syscall::GlobalFeatureFlags;
 
 static GHCB_IO_DRIVER: GHCBIOPort = GHCBIOPort::new();
@@ -292,20 +294,6 @@ impl SvsmPlatform for SnpPlatform {
         })
     }
 
-    fn cpuid(eax: u32, ecx: u32) -> Option<CpuidResult>
-    where
-        Self: Sized,
-    {
-        // If this is an architectural CPUID leaf, then extract the result
-        // from the CPUID table.  Otherwise, request the value from the
-        // hypervisor.
-        if (eax >> 28) == 4 {
-            current_ghcb().cpuid(eax, ecx).ok()
-        } else {
-            cpuid_table(eax, ecx)
-        }
-    }
-
     unsafe fn write_host_msr(&self, msr: u32, value: u64) {
         current_ghcb()
             .wrmsr(msr, value)
@@ -469,6 +457,22 @@ impl SvsmPlatform for SnpPlatform {
         // outright prior to shutdown.
         raw_irqs_disable();
         request_termination_msr();
+    }
+}
+
+impl CpuidBackend for SnpPlatform {
+    fn cpuid(feature: &CpuidFeature) -> Option<CpuidResult>
+    where
+        Self: Sized,
+    {
+        // If this is an architectural CPUID leaf, then extract the result
+        // from the CPUID table.  Otherwise, request the value from the
+        // hypervisor.
+        if (feature.leaf >> 28) == 4 {
+            current_ghcb().cpuid(feature.leaf, feature.subleaf).ok()
+        } else {
+            cpuid_table(feature.leaf, feature.subleaf)
+        }
     }
 }
 

--- a/kernel/src/platform/tdp.rs
+++ b/kernel/src/platform/tdp.rs
@@ -37,6 +37,7 @@ use crate::utils::{MemoryRegion, is_aligned};
 use bootdefs::tdp_start::TdpStartContext;
 use core::mem::MaybeUninit;
 use core::sync::atomic::Ordering;
+use cpufeature::backend::CpuidBackend;
 use syscall::GlobalFeatureFlags;
 
 #[cfg(test)]
@@ -53,6 +54,8 @@ impl TdpPlatform {
         Self {}
     }
 }
+
+impl CpuidBackend for TdpPlatform {}
 
 impl SvsmPlatform for TdpPlatform {
     #[cfg(test)]


### PR DESCRIPTION
SVSM maintained hand-written CPUID checks, with each CPU feature requiring custom leaf/register/bit logic. This was repetitive and error-prone as new features were added. Replace it with the shared, auto-generated cpufeature crate to provide a single, consistent source of CPU feature detection.

cpufeature crate, generated from the X86-CPUID
database, as the single source of truth for standard feature
descriptors. Call sites pass cpufeature::leaves constants directly
to cpu_has_feat() and cpu_get_feat() instead of a local Feature
enum, so leaf numbers, registers, and bit positions are no longer
hand-maintained in the kernel.

Platform CPUID goes through CpuidBackend: native and TDP use the
default backend; SNP routes architectural leaves through the CPUID
table and hypervisor leaves through GHCB. platform::cpuid() takes a
CpuidFeature descriptor, so feature checks and platform dispatch
share one path. features.rs keeps only leaves outside the database
(HYPERV_INTERFACE, PHYS_ADDR_SIZES).

This removes about 110 lines of custom detection code, eliminates
the macro-generatedd lookup table, and simplifies future feature
additions by relying on external cpufeature crate instead
of extending another local table.

cpufeature crate:- https://github.com/coconut-svsm/cpufeature