### PR TITLE
xbuild/fs: Handle multi-level path

### DIFF
--- a/xbuild/src/fs.rs
+++ b/xbuild/src/fs.rs
@@ -27,7 +27,7 @@ impl FsConfig {
     pub fn build(
         &self,
         args: &Args,
-        mut dst: PathBuf,
+        dst: PathBuf,
         cmd_feats: &mut Features,
     ) -> BuildResult<Option<PathBuf>> {
         if dst.try_exists()? {
@@ -51,19 +51,24 @@ impl FsConfig {
                 .path
                 .as_deref()
                 .unwrap_or_else(|| Path::new(comp.name));
-            // Pushing an absolute path to a PathBuf will overwrite
+            // Joining an absolute path to a PathBuf will overwrite
             // previous elements, so remove leading slash.
             if dst_file.starts_with("/") {
                 dst_file = dst_file.strip_prefix("/").unwrap();
             }
-            dst.push(dst_file);
-            comp.config.objcopy.copy(&bin, &dst, args)?;
+
+            let current_dst = dst.join(dst_file);
+
+            if let Some(parent) = current_dst.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+
+            comp.config.objcopy.copy(&bin, &current_dst, args)?;
 
             let filename = dst_file
                 .to_str()
                 .ok_or_else(|| format!("invalid file name: {}", dst_file.display()))?;
-            enc.load_file(filename, &std::fs::File::open(&dst)?)?;
-            dst.pop();
+            enc.load_file(filename, &std::fs::File::open(&current_dst)?)?;
         }
 
         Ok(Some(fs_path))


### PR DESCRIPTION
Currently, when attempting to build the filesystem, the build fails if the specified file path is multi-level (like `test/usermodule`) as it is not guaranteed that all the directories exist.

Check for the presence of the directories and create them if they are not already present before copying the file.

Avoid modifying `dst` directly as a single `push` with multiple levels requires multiple `pop` operations.