### PR TITLE
COCONUT-SVSM Release 2026.06-devel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1377,9 +1377,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memmap2"
-version = "0.7.1"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]

--- a/release/src/lib.rs
+++ b/release/src/lib.rs
@@ -51,7 +51,7 @@ impl fmt::Display for SvsmVersion {
 }
 
 const VERSION_YEAR: u32 = 2026;
-const VERSION_MONTH: u32 = 5;
+const VERSION_MONTH: u32 = 6;
 #[allow(dead_code)]
 const VERSION_COUNTER: u32 = 0;
 


### PR DESCRIPTION
Development release for June 2026.

Release-testing outcome:

- ~Verus verification is currently broken~ **Actually works, just throws warnings**
- ~Packit pulls an outdated dependency~ **Fixed**

All other tests passed.