### PR TITLE
scripts: align pre-commit SPDX check with check-spdx.sh

### DIFF
--- a/scripts/check-spdx.sh
+++ b/scripts/check-spdx.sh
@@ -7,6 +7,7 @@
 #
 # Modes:
 #   --all				check every tracked file.
+#   --files <path> [<path> ...]	check one or more files.
 #   <start_commit> [<end_commit>]	check only files added in this commit range.
 #					<end_commit> defaults to HEAD.
 
@@ -17,12 +18,20 @@ cd "$(git rev-parse --show-toplevel)"
 
 if [ $# -lt 1 ]; then
 	echo "Usage: $0 --all"
+	echo "       $0 --files <path> [<path> ...]"
 	echo "       $0 <start_commit> [<end_commit>]"
 	exit 1
 fi
 
 if [ "$1" = "--all" ]; then
 	files=$(git ls-files)
+elif [ "$1" = "--files" ]; then
+	shift
+	if [ $# -lt 1 ]; then
+		echo "Usage: $0 --files <path> [<path> ...]"
+		exit 1
+	fi
+	files=$*
 else
 	start=$1
 	end=${2:-HEAD}

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -5,29 +5,12 @@
 #
 # Author: Joerg Roedel <jroedel@suse.de>
 
-check_file_header() {
-	header_warning="Header format incorrect in $1, follow the header structure in other files"
-	IFS=$'\n'
-	arr=($(head -n 5 "$1"))
-	if  ! [[ "${arr[0]}" == "// SPDX-License-Identifier: MIT OR Apache-2.0" ||
-	         "${arr[0]}" == "// SPDX-License-Identifier: MIT" ]] ; then
-		echo "${header_warning}"
-		return 1
-	fi
-	if  ! [[ "${arr[2]}" =~ ^//[[:space:]]Copyright ]] ; then
-		echo "${header_warning}"
-		return 1
-	fi
-	if  ! [[ "${arr[4]}" =~ ^//[[:space:]]Author: ]] ; then
-		echo "${header_warning}"
-		return 1
-	fi
-	return 0
-}
-
 RET=0
+CHECK_SPDX="$(git rev-parse --show-toplevel)/scripts/check-spdx.sh"
 
-for file in `git diff --diff-filter=d --name-only --staged`; do
+staged_files=$(git diff --diff-filter=d --name-only --staged)
+
+for file in $staged_files; do
     ext=${file##*.}
     if [ "$ext" == "rs" ]; then
         rustfmt --check $file > /dev/null 2>&1
@@ -35,12 +18,12 @@ for file in `git diff --diff-filter=d --name-only --staged`; do
             echo "$file needs rustfmt checking"
             RET=1
         fi
-	check_file_header $file
-        if [ "$?" == "1" ]; then
-            RET=1
-        fi
     fi
 done
+
+if [ -n "$staged_files" ]; then
+    "$CHECK_SPDX" --files $staged_files || RET=1
+fi
 
 make clippy || exit 1
 


### PR DESCRIPTION
The pre-commit hook previously used its own check_file_header() that enforced a rigid 5-line layout (SPDX, blank comment, Copyright, blank comment, Author:) on every staged .rs file. That broke commits on unrelated changes because many existing files in the tree never had an Author: line or did not follow that exact layout — a full-tree audit found 100+ files missing Copyright or Author in the expected form.

This PR drops the Author and fixed-layout checks and reuses scripts/check-spdx.sh for SPDX validation instead of duplicating the logic. A new --files option is added to check-spdx.sh to validate a list of files; the pre-commit hook calls it for each staged file, using the same SPDX + MIT rules already applied in CI. rustfmt and clippy checks are unchanged.

It also prints an additional line _All checked file(s) contain a valid SPDX-License-Identifier header._ if header check passes for all staged files.

Reported-by: @luigix25 