### PR TITLE
rustfmt: Add edition to rustfmt.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,2 @@
+edition = "2024"
 style_edition = "2024"


### PR DESCRIPTION
Set the edition field to "2024" to match the workspace Cargo.toml edition setting. Unlike cargo fmt, standalone rustfmt does not read the edition from Cargo.toml and defaults to 2015.

Adding the edition explicitly ensures correct syntax parsing when using rustfmt directly.