### PR TITLE
irq: assume the availablity of interrupts on all systems

### DIFF
--- a/boot/bootimg/src/lib.rs
+++ b/boot/bootimg/src/lib.rs
@@ -173,9 +173,7 @@ where
         ap_start_context_addr: boot_image_params.ap_start_context_addr,
         use_alternate_injection: boot_image_params.boot_params.use_alternate_injection != 0,
         kernel_page_table_vaddr: kernel_page_tables.root_vaddr(),
-        suppress_svsm_interrupts: false,
         vmsa_in_kernel_heap,
-        _reserved: Default::default(),
     };
     add_page_contents(add_page_data, launch_info_paddr, launch_info.as_bytes())?;
 

--- a/boot/defs/src/boot_params.rs
+++ b/boot/defs/src/boot_params.rs
@@ -128,9 +128,6 @@ pub struct BootParamBlock {
     /// Indicates whether the guest can support alternate injection.
     pub use_alternate_injection: u8,
 
-    /// Indicates whether SVSM should suppress interrupts when running on SEV-SNP.
-    pub suppress_svsm_interrupts_on_snp: u8,
-
     /// Indicates whether SVSM can assume that the qemu testdev device exists to assist testing.
     pub has_qemu_testdev: u8,
 
@@ -143,6 +140,8 @@ pub struct BootParamBlock {
     /// Indicates whether the VMSA is placed at the top of the kernel GPA
     /// range.
     pub vmsa_in_kernel_range: u8,
+
+    pub _reserved: u8,
 
     /// Metadata containing information about the firmware image embedded in the
     /// IGVM file.

--- a/boot/defs/src/kernel_launch.rs
+++ b/boot/defs/src/kernel_launch.rs
@@ -39,8 +39,6 @@ pub struct KernelLaunchInfo {
     pub debug_serial_port: u16,
     pub vmsa_in_kernel_heap: bool,
     pub use_alternate_injection: bool,
-    pub suppress_svsm_interrupts: bool,
-    pub _reserved: [bool; 7],
 }
 
 pub const INITIAL_KERNEL_STACK_WORDS: usize = 3;

--- a/kernel/src/boot_params.rs
+++ b/kernel/src/boot_params.rs
@@ -461,10 +461,6 @@ impl BootParams<'_> {
         self.boot_param_block.use_alternate_injection != 0
     }
 
-    pub fn suppress_svsm_interrupts_on_snp(&self) -> bool {
-        self.boot_param_block.suppress_svsm_interrupts_on_snp != 0
-    }
-
     pub fn has_qemu_testdev(&self) -> bool {
         self.boot_param_block.has_qemu_testdev != 0
     }

--- a/kernel/src/cpu/ipi.rs
+++ b/kernel/src/cpu/ipi.rs
@@ -10,7 +10,6 @@ use super::idt::common::IPI_VECTOR;
 use super::percpu::{PERCPU_AREAS, PerCpuShared, this_cpu};
 use super::x86::apic_post_irq;
 use crate::error::SvsmError;
-use crate::platform::SVSM_PLATFORM;
 use crate::types::{TPR_IPI, TPR_SYNCH};
 use crate::utils::{ScopedMut, ScopedRef};
 
@@ -18,7 +17,8 @@ use core::cell::{Cell, UnsafeCell};
 use core::mem;
 use core::mem::MaybeUninit;
 use core::ptr;
-use core::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
+use core::sync::atomic::AtomicUsize;
+use core::sync::atomic::Ordering;
 use cpuarch::x86apic::ApicIcr;
 use cpuarch::x86apic::IcrDestFmt;
 
@@ -326,8 +326,6 @@ impl Default for IpiBoard {
 // is consumed as a dynamic dispatch trait to avoid explosion due to multiple
 // generic message implementations.
 fn send_ipi(target_set: IpiTarget<'_>, ipi_helper: &mut dyn IpiHelper) {
-    assert!(ipi_available());
-
     let sender_cpu_index = this_cpu().get_cpu_index();
 
     // Raise TPR to synch level to prevent reentrant attempts to send an IPI.
@@ -619,45 +617,9 @@ pub fn send_unicast_ipi<M: IpiMessageMut>(cpu_index: usize, ipi_message: &mut M)
     send_ipi(IpiTarget::Single(cpu_index), &mut ipi_helper);
 }
 
-/// The count of CPUs that have not yet requested blocking of IPI usage.  This
-/// is initially set to 1 to count the BSP, and each AP that starts will
-/// increment the count.
-static IPI_AVAILABLE_CPU_COUNT: AtomicU32 = AtomicU32::new(1);
-
-/// Indicates whether use of IPIs is currently available.
-pub fn ipi_available() -> bool {
-    IPI_AVAILABLE_CPU_COUNT.load(Ordering::Acquire) != 0
-}
-
-/// Request IPI blocking on the current CPU and wait until all other CPUs have
-/// done the same.
-pub fn wait_for_ipi_block() {
-    // Mark this CPU as wanting to block IPIs and wait until all other CPUs
-    // have done the same.  Note that while waiting, additional IPIs may still
-    // be received, which is necessary because other CPUs may not have yet
-    // gotten to the point that they are willing to stop using IPIs.
-    IPI_AVAILABLE_CPU_COUNT.fetch_sub(1, Ordering::Release);
-    while ipi_available() {
-        core::hint::spin_loop();
-    }
-
-    // If this platform cannot make use of interrupts generally, then block
-    // interrupts from this point now that all CPUs have agreed to stop using
-    // IPIs.
-    if !SVSM_PLATFORM.use_interrupts() {
-        this_cpu().disable_interrupt_use();
-    }
-}
-
-/// Count the startup of another AP for IPI blocking purposes.
-pub fn ipi_start_cpu() {
-    IPI_AVAILABLE_CPU_COUNT.fetch_add(1, Ordering::Release);
-}
-
 #[cfg(test)]
 mod tests {
     use crate::cpu::ipi::*;
-    use crate::platform::SVSM_PLATFORM;
 
     #[derive(Debug)]
     struct TestIpi<'a> {
@@ -711,34 +673,26 @@ mod tests {
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn test_ipi() {
-        // IPI testing is only possible on platforms that support SVSM
-        // interrupts.
-        if ipi_available() {
-            let mut drop_count: usize = 0;
-            let message = TestIpi::new(4, &mut drop_count);
-            send_multicast_ipi(IpiTarget::All, &message);
-            drop(message);
-            // Verify that `drop()` was called exactly once on thie IPI
-            // message.
-            assert_eq!(drop_count, 1);
-        }
+        let mut drop_count: usize = 0;
+        let message = TestIpi::new(4, &mut drop_count);
+        send_multicast_ipi(IpiTarget::All, &message);
+        drop(message);
+        // Verify that `drop()` was called exactly once on thie IPI
+        // message.
+        assert_eq!(drop_count, 1);
     }
 
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn test_mut_ipi() {
-        // IPI testing is only possible on platforms that support SVSM
-        // interrupts.
-        if ipi_available() {
-            let mut drop_count: usize = 0;
-            let mut message = TestIpi::new(4, &mut drop_count);
-            send_unicast_ipi(0, &mut message);
-            assert_eq!(message.value, 5);
-            drop(message);
-            // Verify that `drop()` was called exactly once on thie IPI
-            // message.
-            assert_eq!(drop_count, 1);
-        }
+        let mut drop_count: usize = 0;
+        let mut message = TestIpi::new(4, &mut drop_count);
+        send_unicast_ipi(0, &mut message);
+        assert_eq!(message.value, 5);
+        drop(message);
+        // Verify that `drop()` was called exactly once on thie IPI
+        // message.
+        assert_eq!(drop_count, 1);
     }
 
     struct AtomicIpi {
@@ -762,22 +716,18 @@ mod tests {
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn test_atomic_ipi() {
-        // IPI testing is only possible on platforms that support SVSM
-        // interrupts.
-        if SVSM_PLATFORM.use_interrupts() {
-            let all_message = AtomicIpi {
-                cpu_count: AtomicUsize::new(0),
-            };
-            send_multicast_ipi(IpiTarget::All, &all_message);
-            let all_count = all_message.cpu_count.load(Ordering::Relaxed);
-            assert!(all_count > 0);
+        let all_message = AtomicIpi {
+            cpu_count: AtomicUsize::new(0),
+        };
+        send_multicast_ipi(IpiTarget::All, &all_message);
+        let all_count = all_message.cpu_count.load(Ordering::Relaxed);
+        assert!(all_count > 0);
 
-            let abs_message = AtomicIpi {
-                cpu_count: AtomicUsize::new(0),
-            };
-            send_multicast_ipi(IpiTarget::AllButSelf, &abs_message);
-            let abs_count = abs_message.cpu_count.load(Ordering::Relaxed);
-            assert_eq!(abs_count + 1, all_count);
-        }
+        let abs_message = AtomicIpi {
+            cpu_count: AtomicUsize::new(0),
+        };
+        send_multicast_ipi(IpiTarget::AllButSelf, &abs_message);
+        let abs_count = abs_message.cpu_count.load(Ordering::Relaxed);
+        assert_eq!(abs_count + 1, all_count);
     }
 }

--- a/kernel/src/cpu/irq_state.rs
+++ b/kernel/src/cpu/irq_state.rs
@@ -375,8 +375,6 @@ impl Drop for TprGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cpu::ipi::ipi_available;
-    use crate::platform::SVSM_PLATFORM;
 
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
@@ -427,42 +425,38 @@ mod tests {
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn tpr_test() {
-        if SVSM_PLATFORM.use_interrupts() || ipi_available() {
-            assert_eq!(raw_get_tpr(), 0);
-            raise_tpr(7);
-            assert_eq!(raw_get_tpr(), 7);
-            raise_tpr(8);
-            assert_eq!(raw_get_tpr(), 8);
-            lower_tpr(8);
-            assert_eq!(raw_get_tpr(), 7);
-            lower_tpr(7);
-            assert_eq!(raw_get_tpr(), 0);
-        }
+        assert_eq!(raw_get_tpr(), 0);
+        raise_tpr(7);
+        assert_eq!(raw_get_tpr(), 7);
+        raise_tpr(8);
+        assert_eq!(raw_get_tpr(), 8);
+        lower_tpr(8);
+        assert_eq!(raw_get_tpr(), 7);
+        lower_tpr(7);
+        assert_eq!(raw_get_tpr(), 0);
     }
 
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn tpr_guard_test() {
-        if SVSM_PLATFORM.use_interrupts() || ipi_available() {
-            assert_eq!(raw_get_tpr(), 0);
-            // Test in-order raise/lower.
-            let g1 = TprGuard::raise(8);
-            assert_eq!(raw_get_tpr(), 8);
-            let g2 = TprGuard::raise(9);
-            assert_eq!(raw_get_tpr(), 9);
-            drop(g2);
-            assert_eq!(raw_get_tpr(), 8);
-            drop(g1);
-            assert_eq!(raw_get_tpr(), 0);
-            // Test out-of-order raise/lower.
-            let g1 = TprGuard::raise(8);
-            assert_eq!(raw_get_tpr(), 8);
-            let g2 = TprGuard::raise(9);
-            assert_eq!(raw_get_tpr(), 9);
-            drop(g1);
-            assert_eq!(raw_get_tpr(), 9);
-            drop(g2);
-            assert_eq!(raw_get_tpr(), 0);
-        }
+        assert_eq!(raw_get_tpr(), 0);
+        // Test in-order raise/lower.
+        let g1 = TprGuard::raise(8);
+        assert_eq!(raw_get_tpr(), 8);
+        let g2 = TprGuard::raise(9);
+        assert_eq!(raw_get_tpr(), 9);
+        drop(g2);
+        assert_eq!(raw_get_tpr(), 8);
+        drop(g1);
+        assert_eq!(raw_get_tpr(), 0);
+        // Test out-of-order raise/lower.
+        let g1 = TprGuard::raise(8);
+        assert_eq!(raw_get_tpr(), 8);
+        let g2 = TprGuard::raise(9);
+        assert_eq!(raw_get_tpr(), 9);
+        drop(g1);
+        assert_eq!(raw_get_tpr(), 9);
+        drop(g2);
+        assert_eq!(raw_get_tpr(), 0);
     }
 }

--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -14,6 +14,9 @@ use super::msr::write_msr;
 use super::shadow_stack::{ISST_ADDR, init_shadow_stack, is_cet_ss_enabled};
 use super::tss::{IST_DF, X86Tss};
 use crate::address::{Address, PhysAddr, VirtAddr};
+use crate::cpu::IrqState;
+use crate::cpu::LocalApic;
+use crate::cpu::ShadowStackInit;
 use crate::cpu::control_regs::{read_cr0, read_cr4};
 use crate::cpu::efer::read_efer;
 use crate::cpu::idt::common::INT_INJ_VECTOR;
@@ -21,7 +24,6 @@ use crate::cpu::tss::TSS_LIMIT;
 use crate::cpu::vmsa::{init_guest_vmsa, init_svsm_vmsa};
 use crate::cpu::vmsa::{svsm_code_segment, svsm_data_segment, svsm_gdt_segment, svsm_idt_segment};
 use crate::cpu::x86::{ApicAccess, X86Apic};
-use crate::cpu::{IrqGuard, IrqState, LocalApic, ShadowStackInit};
 use crate::error::{ApicError, SvsmError};
 use crate::hyperv::HypercallPagesGuard;
 use crate::hyperv::{self, HypercallPage};
@@ -1205,12 +1207,6 @@ impl PerCpu {
         let task = self.runqueue_mut().schedule_init();
         self.set_current_stack(task.stack_bounds());
         task
-    }
-
-    pub fn disable_interrupt_use(&self) {
-        let guard = IrqGuard::new();
-        self.irq_state.set_restore_state(false);
-        drop(guard);
     }
 
     pub fn schedule_prepare(&self, reschedule: bool) -> Option<(TaskPointer, TaskPointer)> {

--- a/kernel/src/cpu/smp.rs
+++ b/kernel/src/cpu/smp.rs
@@ -8,7 +8,6 @@ use super::idt::load_static_idt;
 use crate::acpi::tables::ACPICPUInfo;
 use crate::address::PhysAddr;
 use crate::address::{Address, VirtAddr};
-use crate::cpu::ipi::ipi_start_cpu;
 use crate::cpu::percpu::{PERCPU_AREAS, PerCpu, PerCpuShared, this_cpu, this_cpu_shared};
 use crate::cpu::shadow_stack::{MODE_64BIT, S_CET, SCetFlags, is_cet_ss_enabled};
 use crate::cpu::sse::sse_init;
@@ -211,9 +210,6 @@ extern "C" fn start_ap() -> ! {
 
     // Send a life-sign
     log::info!("CPU {} is online", this_cpu().get_cpu_index());
-
-    // Mark this CPU as participating in IPI usage.
-    ipi_start_cpu();
 
     // Set CPU online so that BSP can proceed
     this_cpu_shared().set_online();

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -246,9 +246,6 @@ pub trait SvsmPlatform: Sync {
     /// Queries the state of APIC registration on this system.
     fn query_apic_registration_state(&self) -> bool;
 
-    /// Determines whether the platform supports interrupts to the SVSM.
-    fn use_interrupts(&self) -> bool;
-
     /// Determines whether a given interrupt vector was invoked as an external
     /// interrupt.
     fn is_external_interrupt(&self, vector: usize) -> bool;
@@ -300,17 +297,11 @@ pub enum SvsmPlatformCell {
 }
 
 impl SvsmPlatformCell {
-    pub fn new(suppress_svsm_interrupts: bool) -> Self {
+    pub fn new() -> Self {
         match *SVSM_PLATFORM_TYPE {
-            SvsmPlatformType::Native => {
-                SvsmPlatformCell::Native(NativePlatform::new(suppress_svsm_interrupts))
-            }
-            SvsmPlatformType::Snp => {
-                SvsmPlatformCell::Snp(SnpPlatform::new(suppress_svsm_interrupts))
-            }
-            SvsmPlatformType::Tdp => {
-                SvsmPlatformCell::Tdp(TdpPlatform::new(suppress_svsm_interrupts))
-            }
+            SvsmPlatformType::Native => SvsmPlatformCell::Native(NativePlatform::new()),
+            SvsmPlatformType::Snp => SvsmPlatformCell::Snp(SnpPlatform::new()),
+            SvsmPlatformType::Tdp => SvsmPlatformCell::Tdp(TdpPlatform::new()),
         }
     }
 
@@ -345,6 +336,12 @@ impl SvsmPlatformCell {
             SvsmPlatformCell::Snp(_) => SvsmPlatformType::Snp,
             SvsmPlatformCell::Tdp(_) => SvsmPlatformType::Tdp,
         }
+    }
+}
+
+impl Default for SvsmPlatformCell {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -50,12 +50,18 @@ use bootdefs::platform::SvsmPlatformType;
 pub struct NativePlatform {}
 
 impl NativePlatform {
-    pub fn new(_suppress_svsm_interrupts: bool) -> Self {
+    pub fn new() -> Self {
         // Execution is not possible unless X2APIC is supported.
         if !cpu_has_feat(Feature::X2Apic) {
             panic!("X2APIC is not supported");
         }
         Self {}
+    }
+}
+
+impl Default for NativePlatform {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -204,10 +210,6 @@ impl SvsmPlatform for NativePlatform {
 
     fn query_apic_registration_state(&self) -> bool {
         false
-    }
-
-    fn use_interrupts(&self) -> bool {
-        true
     }
 
     fn is_external_interrupt(&self, _vector: usize) -> bool {

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -106,16 +106,12 @@ impl From<PageValidateOp> for PvalidateOp {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
-pub struct SnpPlatform {
-    can_use_interrupts: bool,
-}
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SnpPlatform {}
 
 impl SnpPlatform {
-    pub fn new(suppress_svsm_interrupts: bool) -> Self {
-        Self {
-            can_use_interrupts: !suppress_svsm_interrupts,
-        }
+    pub fn new() -> Self {
+        Self {}
     }
 }
 
@@ -409,10 +405,6 @@ impl SvsmPlatform for SnpPlatform {
 
     fn query_apic_registration_state(&self) -> bool {
         APIC_EMULATION_REG_COUNT.load(Ordering::Relaxed) > 0
-    }
-
-    fn use_interrupts(&self) -> bool {
-        self.can_use_interrupts
     }
 
     fn is_external_interrupt(&self, _vector: usize) -> bool {

--- a/kernel/src/platform/tdp.rs
+++ b/kernel/src/platform/tdp.rs
@@ -45,11 +45,11 @@ use bootdefs::platform::SvsmPlatformType;
 static GHCI_IO_DRIVER: GHCIIOPort = GHCIIOPort::new();
 static VTOM: ImmutAfterInitCell<usize> = ImmutAfterInitCell::uninit();
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct TdpPlatform {}
 
 impl TdpPlatform {
-    pub fn new(_suppress_svsm_interrupts: bool) -> Self {
+    pub fn new() -> Self {
         Self {}
     }
 }
@@ -214,10 +214,6 @@ impl SvsmPlatform for TdpPlatform {
 
     fn query_apic_registration_state(&self) -> bool {
         false
-    }
-
-    fn use_interrupts(&self) -> bool {
-        true
     }
 
     fn is_external_interrupt(&self, vector: usize) -> bool {

--- a/kernel/src/requests.rs
+++ b/kernel/src/requests.rs
@@ -4,7 +4,6 @@
 //
 // Author: Joerg Roedel <jroedel@suse.de>
 
-use crate::cpu::ipi::wait_for_ipi_block;
 use crate::cpu::percpu::{PERCPU_AREAS, this_cpu};
 use crate::protocols::apic::apic_protocol_request;
 use crate::protocols::core::core_protocol_request;
@@ -110,10 +109,6 @@ fn request_loop_main(cpu_index: usize) {
     set_affinity(cpu_index);
 
     log::info!("Launching request-processing task on CPU {cpu_index}");
-
-    // Suppress the use of IPIs before entering the guest, and ensure that all
-    // other CPUs have done the same.
-    wait_for_ipi_block();
 
     let mut output = RequestOutput::new();
 

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -319,7 +319,7 @@ unsafe fn svsm_start(
     // the address space.
     let debug_serial_port = launch_info.debug_serial_port;
 
-    let mut platform_cell = SvsmPlatformCell::new(launch_info.suppress_svsm_interrupts);
+    let mut platform_cell = SvsmPlatformCell::new();
     let platform = platform_cell.platform_mut();
 
     // SAFETY: the CPUID and secrets page addresses were allocated in the

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -602,7 +602,7 @@ pub fn scheduler_idle() {
 
 fn preemption_checks() {
     assert!(irq_nesting_count() == 0);
-    assert!(raw_get_tpr() == 0 || !SVSM_PLATFORM.use_interrupts());
+    assert!(raw_get_tpr() == 0);
 }
 
 /// # Safety

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -44,7 +44,6 @@ use crate::mm::{
     PageBox, SVSM_PERTASK_BASE, SVSM_PERTASK_END, USER_MEM_END, USER_MEM_START, VMMappingGuard,
     mappings::create_anon_mapping, mappings::create_file_mapping,
 };
-use crate::platform::SVSM_PLATFORM;
 use crate::syscall::{Obj, ObjError, ObjHandle};
 use crate::types::{SVSM_USER_CS, SVSM_USER_DS};
 use crate::utils::{MemoryRegion, is_aligned};
@@ -767,13 +766,7 @@ impl Task {
         xsa_addr: usize,
     ) -> Result<(Mapping, MemoryRegion<VirtAddr>, usize), SvsmError> {
         let (mapping, bounds) = Task::allocate_stack_common()?;
-        // Do not run user-mode with IRQs enabled on platforms which are not
-        // ready for it.
-        let iret_rflags: usize = if SVSM_PLATFORM.use_interrupts() {
-            2 | EFLAGS_IF
-        } else {
-            2
-        };
+        let iret_rflags: usize = 2 | EFLAGS_IF;
 
         let percpu_mapping = cpu.new_mapping(mapping.clone())?;
 

--- a/tools/igvmbuilder/src/igvm_builder.rs
+++ b/tools/igvmbuilder/src/igvm_builder.rs
@@ -225,11 +225,6 @@ impl IgvmBuilder {
             GuestFwInfoBlock::default()
         };
 
-        let suppress_svsm_interrupts_on_snp = match self.options.hypervisor {
-            Hypervisor::Qemu | Hypervisor::Vanadium => 1,
-            _ => 0,
-        };
-
         let has_qemu_testdev = match self.options.hypervisor {
             Hypervisor::Qemu | Hypervisor::Vanadium => 1,
             _ => 0,
@@ -275,10 +270,10 @@ impl IgvmBuilder {
             kernel_min_size: self.gpa_map.kernel_min_size,
             kernel_max_size: self.gpa_map.kernel_max_size,
             use_alternate_injection: u8::from(self.options.alt_injection),
-            suppress_svsm_interrupts_on_snp,
             has_qemu_testdev,
             has_fw_cfg_port,
             has_test_iorequests,
+            _reserved: Default::default(),
         })
     }
 


### PR DESCRIPTION
Now that SNP requires the use of restricted injection, it is safe to assume that all all platforms support the use of SVSM interrupts, and all abstractions can be removed.