### PR TITLE
Update verus to 0.2026.06.28.1847ab3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2475,15 +2475,15 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "verus_builtin"
-version = "0.0.0-2026-04-12-0118"
+version = "0.0.0-2026-05-17-0151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a46cb431066009ad2035f6bca936b1c2b7e293bffec93a2090fead0f35ab4276"
+checksum = "cab9266bfb5cf45a080f425c560b0e0be2bf81194f0e80258990c49c1829d8b9"
 
 [[package]]
 name = "verus_builtin_macros"
-version = "0.0.0-2026-04-12-0118"
+version = "0.0.0-2026-07-12-0122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a4db9c476e75215dc079b3b9a740099ae26e318b410a0063b3c97c624bba991"
+checksum = "3fb60e3a141ababe618fbdb759f14aa8544f6346a98a44c1e3a7dbe20b1f2892"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2502,9 +2502,9 @@ dependencies = [
 
 [[package]]
 name = "verus_prettyplease"
-version = "0.0.0-2026-04-12-0118"
+version = "0.0.0-2026-05-31-0205"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b246e61b068e807cb05a030fc1d7efa83d2a0d227eaf67921661419edfe8e83"
+checksum = "3ffdc94c89109a67c59646f6b6e71b49de394020f45294247dd716470523245b"
 dependencies = [
  "proc-macro2",
  "verus_syn",
@@ -2512,9 +2512,9 @@ dependencies = [
 
 [[package]]
 name = "verus_state_machines_macros"
-version = "0.0.0-2026-04-05-0114"
+version = "0.0.0-2026-06-14-0213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e799e4fb96bff36ea1356624d8b633887a46b3558f34cc20e8e228d0d7bcac2b"
+checksum = "6704a9ce586a5027f87933d9a84817411c937804090a9585c28bf335ac37eefc"
 dependencies = [
  "indexmap",
  "proc-macro2",
@@ -2533,9 +2533,9 @@ dependencies = [
 
 [[package]]
 name = "verus_syn"
-version = "0.0.0-2026-04-05-0114"
+version = "0.0.0-2026-05-31-0205"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "285b554a87b470ee705634ea1cdc92c14ba088a7b8bdacbb9116b32e832fe272"
+checksum = "030b774330d5ec618691c2cd6fba8bbb13bd538f3884a1143450baec25749706"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2599,9 +2599,9 @@ dependencies = [
 
 [[package]]
 name = "vstd"
-version = "0.0.0-2026-04-12-0118"
+version = "0.0.0-2026-07-12-0122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fd22791c5bc9db0227a3be72721e969ac0165028ffa40c9479558b7a73006c5"
+checksum = "dd0a0d328e1d6382af99a65f71677cf4b9200ec24e09fcafa7b1a3af8c8f5111"
 dependencies = [
  "verus_builtin",
  "verus_builtin_macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,10 +104,10 @@ zerocopy = { version = "0.8.2", features = ["derive"] }
 zeroize = { version = "1.8.2", default-features = false }
 
 # Verus repos
-verus_builtin = { version = "=0.0.0-2026-04-12-0118", default-features = false }
-verus_builtin_macros = { version = "=0.0.0-2026-04-12-0118", features = ["vpanic"], default-features = false }
-verus_state_machines_macros = { version = "=0.0.0-2026-04-05-0114", default-features = false }
-vstd = { version = "=0.0.0-2026-04-12-0118", features = ["alloc", "allow_panic"], default-features = false }
+verus_builtin = { version = "=0.0.0-2026-05-17-0151", default-features = false }
+verus_builtin_macros = { version = "=0.0.0-2026-07-12-0122", features = ["vpanic"], default-features = false }
+verus_state_machines_macros = { version = "=0.0.0-2026-06-14-0213", default-features = false }
+vstd = { version = "=0.0.0-2026-07-12-0122", features = ["alloc", "allow_panic"], default-features = false }
 
 # Verification libs
 verify_proof = { path = "verification/verify_proof", default-features = false  }

--- a/kernel/src/address.verus.rs
+++ b/kernel/src/address.verus.rs
@@ -298,11 +298,11 @@ impl SpecVAddrImpl for VirtAddr {
     #[verifier(opaque)]
     open spec fn region_to_dom(&self, size: nat) -> Set<int> {
         if self.is_canonical() {
-            Set::new(
+            Set::<int>::range(0, usize::MAX + 1).filter(
                 |v: int|
                     exists|addr: VirtAddr|
-                        addr@ == v && v <= usize::MAX && addr.is_canonical() && self.offset()
-                            <= addr.offset() < self.offset() + size,
+                        addr@ == v && addr.is_canonical() && self.offset() <= addr.offset()
+                            < self.offset() + size,
             )
         } else {
             Set::empty()

--- a/kernel/src/address.verus.rs
+++ b/kernel/src/address.verus.rs
@@ -9,7 +9,7 @@ use crate::utils::util::{
 };
 use verify_external::convert::{exists_into, forall_into};
 use verify_external::hw_spec::SpecVAddrImpl;
-use vstd::raw_ptr::{ptr_from_data, ptr_mut_from_data, PtrData};
+use vstd::raw_ptr::{PtrData, ptr_from_data, ptr_mut_from_data};
 use vstd::set_lib::set_int_range;
 use vstd::std_specs::cmp::PartialOrdSpec;
 use vstd::std_specs::convert::{FromSpec, IntoSpec};

--- a/kernel/src/address.verus.rs
+++ b/kernel/src/address.verus.rs
@@ -309,11 +309,11 @@ impl SpecVAddrImpl for VirtAddr {
         }
     }
 
-    #[verus_verify(spinoff_prover)]
+    #[verifier(spinoff_prover)]
     proof fn lemma_unique(v1: &Self, v2: &Self) {
     }
 
-    #[verus_verify(spinoff_prover)]
+    #[verifier(spinoff_prover)]
     proof fn lemma_vaddr_region_len(&self, size: nat)
         ensures
             self.is_canonical() ==> self.region_to_dom(size).len() > 0,
@@ -329,14 +329,14 @@ impl SpecVAddrImpl for VirtAddr {
         vstd::set_lib::lemma_len_subset(self.region_to_dom(1), self.region_to_dom(size));
     }
 
-    #[verus_verify(spinoff_prover)]
+    #[verifier(spinoff_prover)]
     proof fn lemma_valid_small_size(&self, size1: nat, size2: nat) {
         reveal(<VirtAddr as SpecVAddrImpl>::region_to_dom);
     }
 }
 
 impl VirtAddr {
-    #[verus_verify(spinoff_prover)]
+    #[verifier(spinoff_prover)]
     pub proof fn lemma_region_to_dom_merge(self, size1: nat, vaddr2: VirtAddr, size2: nat)
         requires
             self.is_canonical() && vaddr2.is_canonical(),

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -13,6 +13,11 @@
     reexport_test_harness_main = "test_main"
 )]
 #![cfg_attr(verus_keep_ghost, feature(proc_macro_hygiene))]
+#![cfg_attr(verus_keep_ghost, verifier::allow(unknown_automatic_derive))]
+#![cfg_attr(
+    verus_keep_ghost,
+    allow(macro_expanded_macro_exports_accessed_by_absolute_paths)
+)]
 
 pub mod acpi;
 pub mod address;

--- a/kernel/src/mm/alloc.rs
+++ b/kernel/src/mm/alloc.rs
@@ -538,12 +538,12 @@ struct HeapMemoryRegion {
 #[verus_verify]
 impl HeapMemoryRegion {
     /// Creates a new [`HeapMemoryRegion`] with default values.
+    #[verus_verify(external_body)]
     #[verus_spec(ret =>
         ensures
             ret.wf_next_pages(),
             ret.page_count == 0,
     )]
-    #[verus_verify(external_body)]
     const fn new() -> Self {
         Self {
             start_phys: PhysAddr::null(),
@@ -650,11 +650,11 @@ impl HeapMemoryRegion {
     /// # Panics
     ///
     /// Panics if the page frame number is invalid.
+    #[verus_verify(spinoff_prover)]
     #[verus_spec(
         ensures pfn < self.page_count
         no_unwind when pfn < self.page_count
     )]
-    #[verus_verify(spinoff_prover)]
     fn check_pfn(&self, pfn: usize) {
         if pfn >= self.page_count {
             panic!("Invalid Page Number {}", pfn);
@@ -687,6 +687,7 @@ impl HeapMemoryRegion {
     }
 
     /// Reads page information for a given page frame number.
+    #[verus_verify(spinoff_prover)]
     #[verus_spec(ret =>
         requires
             self.req_read_any_info(),
@@ -694,7 +695,6 @@ impl HeapMemoryRegion {
         ensures
             self.ens_read_page_info(pfn, ret),
     )]
-    #[verus_verify(spinoff_prover)]
     fn read_page_info(&self, pfn: usize) -> PageInfo {
         self.check_pfn(pfn);
 
@@ -761,6 +761,7 @@ impl HeapMemoryRegion {
     }
 
     /// Gets the next available page frame number for a given order.
+    #[verus_verify(spinoff_prover)]
     #[verus_spec(ret =>
         with Tracked(perm): Tracked<&mut PgUnitPerm<DeallocUnit>>
         requires
@@ -769,7 +770,6 @@ impl HeapMemoryRegion {
         ensures
             old(self).ens_get_next_page(&*final(self), order, ret, *final(perm)),
     )]
-    #[verus_verify(spinoff_prover)]
     fn get_next_page(&mut self, order: usize) -> Result<usize, AllocError> {
         let pfn = self.next_page[order];
 
@@ -804,6 +804,7 @@ impl HeapMemoryRegion {
     }
 
     /// Marks a compound page and updates page information for neighboring pages.
+    #[verus_verify(spinoff_prover)]
     #[verus_spec(
         with Tracked(perms): Tracked<&mut Map<usize, PInfoPerm>>
         requires
@@ -811,7 +812,6 @@ impl HeapMemoryRegion {
         ensures
             old(self).ens_mark_compound_page(*final(self), pfn, order, *old(perms), *final(perms)),
     )]
-    #[verus_verify(spinoff_prover)]
     fn mark_compound_page(&mut self, pfn: usize, order: usize) {
         let nr_pages: usize = 1 << order;
         let compound = PageInfo::Compound(CompoundInfo { order });
@@ -862,6 +862,7 @@ impl HeapMemoryRegion {
     }
 
     /// Splits a page into two pages of the next lower order.
+    #[verus_verify(spinoff_prover, rlimit(3))]
     #[verus_spec(ret =>
         with Tracked(perm): Tracked<PgUnitPerm<DeallocUnit>>
         requires
@@ -870,7 +871,6 @@ impl HeapMemoryRegion {
             old(self).ens_split_page_ok(&*final(self), pfn, order),
             ret.is_ok(),
     )]
-    #[verus_verify(spinoff_prover, rlimit(3))]
     fn split_page(&mut self, pfn: usize, order: usize) -> Result<(), AllocError> {
         if !(1..MAX_ORDER).contains(&order) {
             proof! {assert(false);} // unreachable
@@ -1099,13 +1099,13 @@ impl HeapMemoryRegion {
     }
 
     /// Finds the neighboring page frame number for a compound page.
+    #[verus_verify(spinoff_prover)]
     #[verus_spec(ret =>
         requires
             self.valid_pfn_order(pfn, order),
         ensures
             self.ens_compound_neighbor(pfn, order, ret),
     )]
-    #[verus_verify(spinoff_prover)]
     fn compound_neighbor(&self, pfn: usize, order: usize) -> Result<usize, AllocError> {
         proof! {
             // replace assert_eq! with a proof.
@@ -1127,6 +1127,7 @@ impl HeapMemoryRegion {
     }
 
     /// Merges two pages of the same order into a new compound page.
+    #[verus_verify(spinoff_prover, rlimit(2))]
     #[verus_spec(ret =>
         with Tracked(perm): Tracked<&mut PgUnitPerm<DeallocUnit>>, Tracked(p2): Tracked<PgUnitPerm<DeallocUnit>>
         requires
@@ -1134,7 +1135,6 @@ impl HeapMemoryRegion {
         ensures
             old(self).ens_merge_pages(&*final(self), pfn1, pfn2, order, ret, *final(perm)),
     )]
-    #[verus_verify(spinoff_prover, rlimit(2))]
     fn merge_pages(&mut self, pfn1: usize, pfn2: usize, order: usize) -> Result<usize, AllocError> {
         if order >= MAX_ORDER - 1 {
             return Err(AllocError::InvalidPageOrder(order));
@@ -1201,6 +1201,7 @@ impl HeapMemoryRegion {
     /// # Panics
     ///
     /// Panics if `order` is greater than [`MAX_ORDER`].
+    #[verus_verify(spinoff_prover, rlimit(2))]
     #[verus_spec(ret =>
         with Tracked(perm): Tracked<&mut PgUnitPerm<DeallocUnit>>
         requires
@@ -1209,7 +1210,6 @@ impl HeapMemoryRegion {
             ret.is_ok() ==> old(self).ens_allocate_pfn(&*final(self), pfn, order, *final(perm)),
             !ret.is_ok() ==> *old(self) === *final(self),
     )]
-    #[verus_verify(spinoff_prover, rlimit(2))]
     fn allocate_pfn(&mut self, pfn: usize, order: usize) -> Result<(), AllocError> {
         proof_decl! {
             let ghost mut idx_ = self@.free.next_lists()[order as int].len() - 1;
@@ -1307,6 +1307,7 @@ impl HeapMemoryRegion {
     /// # Panics
     ///
     /// Panics if `order` is greater than [`MAX_ORDER`].
+    #[verus_verify(spinoff_prover, rlimit(2))]
     #[verus_spec(
         with Tracked(perm): Tracked<PgUnitPerm<DeallocUnit>>
         requires
@@ -1314,7 +1315,6 @@ impl HeapMemoryRegion {
         ensures
             old(self).ens_free_page_raw(&*final(self), pfn, order),
     )]
-    #[verus_verify(spinoff_prover, rlimit(2))]
     fn free_page_raw(&mut self, pfn: usize, order: usize) {
         let old_next = self.next_page[order];
         proof_decl! {
@@ -1340,6 +1340,7 @@ impl HeapMemoryRegion {
     /// Attempts to merge a given page with its neighboring page.
     /// If successful, returns the new page frame number after merging.
     /// If unsuccessful, the page remains unmerged, and an error is returned.
+    #[verus_verify(spinoff_prover, rlimit(2))]
     #[verus_spec(ret =>
         with Tracked(perm): Tracked<&mut PgUnitPerm<DeallocUnit>>
         requires
@@ -1347,7 +1348,6 @@ impl HeapMemoryRegion {
         ensures
             old(self).ens_try_to_merge_page(&*final(self), pfn, order, ret,  *old(perm), *final(perm)),
     )]
-    #[verus_verify(spinoff_prover, rlimit(2))]
     fn try_to_merge_page(&mut self, pfn: usize, order: usize) -> Result<usize, AllocError> {
         let neighbor_pfn = self.compound_neighbor(pfn, order)?;
         let neighbor_page = self.read_page_info(neighbor_pfn);
@@ -1376,6 +1376,7 @@ impl HeapMemoryRegion {
     /// Frees a page of a specific order. If merging is successful, it
     /// continues merging until merging is no longer possible. If merging
     /// fails, the page is marked as a free page.
+    #[verus_verify(external_body)]
     #[verus_spec(
         with Tracked(perm): Tracked<PgUnitPerm<DeallocUnit>>
         requires
@@ -1385,7 +1386,6 @@ impl HeapMemoryRegion {
         decreases
             MAX_ORDER - order,
     )]
-    #[verus_verify(external_body)]
     fn free_page_order(&mut self, mut pfn: usize, mut order: usize) {
         proof_decl! {
             let tracked mut perm = perm;

--- a/kernel/src/mm/alloc.rs
+++ b/kernel/src/mm/alloc.rs
@@ -608,8 +608,8 @@ impl HeapMemoryRegion {
             old(self).wf_params(),
             pfn < old(self).page_count,
         ensures
-            ret == self@.page_info_ptr(pfn),
-            *self == *old(self),
+            ret == final(self)@.page_info_ptr(pfn),
+            *final(self) == *old(self),
     )]
     #[expect(clippy::needless_pass_by_ref_mut)]
     fn page_info_mut_ptr(&mut self, pfn: usize) -> *mut PageStorageType {
@@ -668,7 +668,7 @@ impl HeapMemoryRegion {
             pi.spec_order() < MAX_ORDER,
             old(self).writable_page_info(pfn, *old(perm)),
         ensures
-            old(self).ens_write_page_info(*self, pfn, pi, *old(perm), *perm),
+            old(self).ens_write_page_info(*final(self), pfn, pi, *old(perm), *final(perm)),
     )]
     fn write_page_info(&mut self, pfn: usize, pi: PageInfo) {
         proof! {
@@ -767,7 +767,7 @@ impl HeapMemoryRegion {
             order < MAX_ORDER,
             old(self).wf_next_pages(),
         ensures
-            old(self).ens_get_next_page(&*self, order, ret, *perm),
+            old(self).ens_get_next_page(&*final(self), order, ret, *final(perm)),
     )]
     #[verus_verify(spinoff_prover)]
     fn get_next_page(&mut self, order: usize) -> Result<usize, AllocError> {
@@ -809,7 +809,7 @@ impl HeapMemoryRegion {
         requires
             old(self).req_mark_compound_page(pfn, order, *old(perms)),
         ensures
-            old(self).ens_mark_compound_page(*self, pfn, order, *old(perms), *perms),
+            old(self).ens_mark_compound_page(*final(self), pfn, order, *old(perms), *final(perms)),
     )]
     #[verus_verify(spinoff_prover)]
     fn mark_compound_page(&mut self, pfn: usize, order: usize) {
@@ -842,7 +842,7 @@ impl HeapMemoryRegion {
         requires
             old(self).req_init_compound_page(pfn, order, next_pfn, *old(perms)),
         ensures
-            old(self).ens_init_compound_page(*self, pfn, order, next_pfn, *old(perms), *perms),
+            old(self).ens_init_compound_page(*final(self), pfn, order, next_pfn, *old(perms), *final(perms)),
     )]
     fn init_compound_page(&mut self, pfn: usize, order: usize, next_pfn: usize) {
         let head = PageInfo::Free(FreeInfo {
@@ -867,7 +867,7 @@ impl HeapMemoryRegion {
         requires
             old(self).req_split_page(pfn, order, perm),
         ensures
-            old(self).ens_split_page_ok(&*self, pfn, order),
+            old(self).ens_split_page_ok(&*final(self), pfn, order),
             ret.is_ok(),
     )]
     #[verus_verify(spinoff_prover, rlimit(3))]
@@ -917,7 +917,7 @@ impl HeapMemoryRegion {
             old(self).wf_next_pages(),
             0 <= order <= MAX_ORDER,
         ensures
-            old(self).ens_refill_page_list(*self, ret.is_ok(), order),
+            old(self).ens_refill_page_list(*final(self), ret.is_ok(), order),
         decreases
             MAX_ORDER - order,
     )]
@@ -959,11 +959,11 @@ impl HeapMemoryRegion {
 
     /// Allocates pages with a specific order and page information.
     #[verus_spec(ret =>
-        with Tracked(ret_perm): Tracked<&mut Option<UnitDeallocPerm>>
+        with Tracked(ret_perm): Tracked<&mut Tracked<Option<UnitDeallocPerm>>>
         requires
             old(self).req_allocate_pages_info(order, pg),
         ensures
-            old(self).ens_allocate_pages_info(self, order, pg, ret, *ret_perm),
+            old(self).ens_allocate_pages_info(&*final(self), order, pg, ret, **final(ret_perm)),
     )]
     fn allocate_pages_info(&mut self, order: usize, pg: PageInfo) -> Result<VirtAddr, AllocError> {
         proof_decl! {
@@ -986,12 +986,12 @@ impl HeapMemoryRegion {
 
     /// Allocates pages with a specific order.
     #[verus_spec(ret =>
-        with Tracked(perm): Tracked<&mut Option<UnitDeallocPerm>>
+        with Tracked(perm): Tracked<&mut Tracked<Option<UnitDeallocPerm>>>
         requires
             old(self).wf_next_pages(),
             order < MAX_ORDER,
         ensures
-            old(self).ens_allocate_pages_info(self, order, PageInfo::Allocated(AllocatedInfo { order }), ret, *perm),
+            old(self).ens_allocate_pages_info(&*final(self), order, PageInfo::Allocated(AllocatedInfo { order }), ret, **final(perm)),
     )]
     fn allocate_pages(&mut self, order: usize) -> Result<VirtAddr, AllocError> {
         let pg = PageInfo::Allocated(AllocatedInfo { order });
@@ -1001,11 +1001,11 @@ impl HeapMemoryRegion {
 
     /// Allocates a single page.
     #[verus_spec(ret =>
-        with Tracked(perm): Tracked<&mut Option<UnitDeallocPerm>>
+        with Tracked(perm): Tracked<&mut Tracked<Option<UnitDeallocPerm>>>
         requires
             old(self).wf_next_pages(),
         ensures
-            old(self).ens_allocate_pages_info(self, 0, PageInfo::Allocated(AllocatedInfo { order: 0 }), ret, *perm),
+            old(self).ens_allocate_pages_info(&*final(self), 0, PageInfo::Allocated(AllocatedInfo { order: 0 }), ret, **final(perm)),
     )]
     fn allocate_page(&mut self) -> Result<VirtAddr, AllocError> {
         proof_with!(Tracked(perm));
@@ -1029,14 +1029,14 @@ impl HeapMemoryRegion {
 
     /// Allocates a slab page.
     #[verus_spec(ret =>
-        with Tracked(perm): Tracked<&mut Option<UnitDeallocPerm>>
+        with Tracked(perm): Tracked<&mut Tracked<Option<UnitDeallocPerm>>>
         requires
             old(self).wf_next_pages(),
             N as u64 <= PageStorageType::SLAB_MASK,
         ensures
-            old(self).ens_allocate_pages_info(self, 0, PageInfo::Slab(SlabPageInfo {
+            old(self).ens_allocate_pages_info(&*final(self), 0, PageInfo::Slab(SlabPageInfo {
                 item_size: N as u64,
-            }) , ret, *perm),
+            }) , ret, **final(perm)),
     )]
     fn allocate_slab_page<const N: usize>(&mut self) -> Result<VirtAddr, AllocError> {
         let pg = PageInfo::Slab(SlabPageInfo {
@@ -1048,11 +1048,11 @@ impl HeapMemoryRegion {
 
     /// Allocates a file page with initial reference count.
     #[verus_spec(ret =>
-        with Tracked(perm): Tracked<&mut Option<UnitDeallocPerm>>
+        with Tracked(perm): Tracked<&mut Tracked<Option<UnitDeallocPerm>>>
         requires
             old(self).wf_next_pages(),
         ensures
-            old(self).ens_allocate_pages_info(self, 0, PageInfo::File(FileInfo::spec_new(1)), ret, *perm),
+            old(self).ens_allocate_pages_info(&*final(self), 0, PageInfo::File(FileInfo::spec_new(1)), ret, **final(perm)),
     )]
     fn allocate_file_page(&mut self) -> Result<VirtAddr, AllocError> {
         let pg = PageInfo::File(FileInfo::new(1));
@@ -1132,7 +1132,7 @@ impl HeapMemoryRegion {
         requires
             old(self).req_merge_pages(pfn1, pfn2, order, *old(perm), p2),
         ensures
-            old(self).ens_merge_pages(self, pfn1, pfn2, order, ret, *perm),
+            old(self).ens_merge_pages(&*final(self), pfn1, pfn2, order, ret, *final(perm)),
     )]
     #[verus_verify(spinoff_prover, rlimit(2))]
     fn merge_pages(&mut self, pfn1: usize, pfn2: usize, order: usize) -> Result<usize, AllocError> {
@@ -1206,8 +1206,8 @@ impl HeapMemoryRegion {
         requires
             old(self).req_allocate_pfn(pfn, order)
         ensures
-            ret.is_ok() ==> old(self).ens_allocate_pfn(self, pfn, order, *perm),
-            !ret.is_ok() ==> *old(self) === *self,
+            ret.is_ok() ==> old(self).ens_allocate_pfn(&*final(self), pfn, order, *final(perm)),
+            !ret.is_ok() ==> *old(self) === *final(self),
     )]
     #[verus_verify(spinoff_prover, rlimit(2))]
     fn allocate_pfn(&mut self, pfn: usize, order: usize) -> Result<(), AllocError> {
@@ -1312,7 +1312,7 @@ impl HeapMemoryRegion {
         requires
             old(self).req_free_page_raw(pfn, order, perm)
         ensures
-            old(self).ens_free_page_raw(self, pfn, order),
+            old(self).ens_free_page_raw(&*final(self), pfn, order),
     )]
     #[verus_verify(spinoff_prover, rlimit(2))]
     fn free_page_raw(&mut self, pfn: usize, order: usize) {
@@ -1345,7 +1345,7 @@ impl HeapMemoryRegion {
         requires
             old(self).req_try_to_merge_page(pfn, order, *old(perm)),
         ensures
-            old(self).ens_try_to_merge_page(self, pfn, order, ret,  *old(perm), *perm),
+            old(self).ens_try_to_merge_page(&*final(self), pfn, order, ret,  *old(perm), *final(perm)),
     )]
     #[verus_verify(spinoff_prover, rlimit(2))]
     fn try_to_merge_page(&mut self, pfn: usize, order: usize) -> Result<usize, AllocError> {
@@ -1381,7 +1381,7 @@ impl HeapMemoryRegion {
         requires
             old(self).req_try_to_merge_page(pfn, order, perm),
         ensures
-            old(self).ens_free_page_order(self, pfn, order),
+            old(self).ens_free_page_order(&*final(self), pfn, order),
         decreases
             MAX_ORDER - order,
     )]
@@ -1414,7 +1414,7 @@ impl HeapMemoryRegion {
             old(self).wf_next_pages(),
             alloced_perm.with_vaddr(vaddr),
         ensures
-            old(self).ens_free_page(self, vaddr, alloced_perm),
+            old(self).ens_free_page(&*final(self), vaddr, alloced_perm),
     )]
     fn free_page(&mut self, vaddr: VirtAddr) {
         let Ok(pfn) = self.get_pfn(vaddr) else {

--- a/kernel/src/mm/alloc.verus.rs
+++ b/kernel/src/mm/alloc.verus.rs
@@ -35,8 +35,7 @@ mod alloc_spec { include!("alloc_inner.verus.rs");  }
 use alloc_spec::*;
 
 broadcast group set_len_group {
-    verify_proof::set::lemma_len_filter,
-    verify_proof::set::lemma_len_subset,
+    verify_proof::set::group_set_usize,
 }
 
 broadcast group alloc_broadcast_group {
@@ -101,7 +100,7 @@ impl HeapMemoryRegion {
             0 <= order < MAX_ORDER ==> info.nr_page(order) == (
             #[trigger] self.nr_pages[order as int])
         &&& self@.free.nr_free() =~= self.free_pages@
-        &&& info.dom() =~= Set::new(|idx| 0 <= idx < self.page_count)
+        &&& info.dom() =~= Set::range(0, self.page_count)
         &&& self.page_count == self@.npages()
     }
 
@@ -640,7 +639,7 @@ macro_rules! lemma_split_pre {
             use_type_invariant(&$perm.info);
             grant_info_write!($mr, $perm => $mem, $reserved2, $id);
 
-            let tracked mut $reserved = $reserved2.tracked_remove_keys(Set::new(|i: usize| $pfn1 <= i < $pfn2));
+            let tracked mut $reserved = $reserved2.tracked_remove_keys(Set::range($pfn1, $pfn2));
 
             // Prove the next page is valid.
             $mr.perms.borrow().free.tracked_next($new_order);

--- a/kernel/src/mm/alloc.verus.rs
+++ b/kernel/src/mm/alloc.verus.rs
@@ -824,7 +824,7 @@ macro_rules! lemma_alloc_pages_info_post {
 
             // Return the memory permission with a readonly share of info.
             let tracked perm = PgUnitPerm {$mem, info, typ: arbitrary()};
-            *$ret_perm = Some(UnitDeallocPerm(perm));
+            *$ret_perm = Tracked(Some(UnitDeallocPerm(perm)));
 
             // Prove the relationship between vaddr and pfn.
             // assert(pfn == self.spec_get_pfn(vaddr).unwrap()) by {

--- a/kernel/src/mm/alloc_free.verus.rs
+++ b/kernel/src/mm/alloc_free.verus.rs
@@ -153,7 +153,7 @@ impl MRFreePerms {
             0 <= o < MAX_ORDER,
             0 <= order < MAX_ORDER,
         ensures
-            *perm == *old(perm),
+            *final(perm) == *old(perm),
             forall|i: int|
                 #![trigger self.avail[o as int][i]]
                 0 <= i < len ==> order_disjoint(self.avail[o as int][i].pfn(), o, pfn, order),
@@ -181,7 +181,7 @@ impl MRFreePerms {
             0 <= order < MAX_ORDER,
             0 <= max_order <= MAX_ORDER,
         ensures
-            *perm == *old(perm),
+            *final(perm) == *old(perm),
             forall|o: usize, i: int|
                 #![trigger self.avail[o as int][i].pfn()]
                 0 <= o < max_order && 0 <= i < self.avail[o as int].len() ==> order_disjoint(
@@ -210,7 +210,7 @@ impl MRFreePerms {
             old(perm).wf_pfn_order(self.mr_map(), pfn, order),
             0 <= order < MAX_ORDER,
         ensures
-            *perm == *old(perm),
+            *final(perm) == *old(perm),
             forall|o: usize, i: int|
                 #![trigger self.avail[o as int][i].pfn()]
                 0 <= o < MAX_ORDER && 0 <= i < self.avail[o as int].len() ==> order_disjoint(
@@ -232,8 +232,13 @@ impl MRFreePerms {
             0 <= i < old(self).avail[o1 as int].len() as int,
             0 <= j < old(self).avail[o2 as int].len() as int,
         ensures
-            *self == *old(self),
-            order_disjoint(self.avail[o1 as int][i].pfn(), o1, self.avail[o2 as int][j].pfn(), o2),
+            *final(self) == *old(self),
+            order_disjoint(
+                final(self).avail[o1 as int][i].pfn(),
+                o1,
+                final(self).avail[o2 as int][j].pfn(),
+                o2,
+            ),
     {
         reveal(MRFreePerms::wf_at);
         use_type_invariant(&*self);
@@ -270,11 +275,11 @@ impl MRFreePerms {
         requires
             0 <= o < MAX_ORDER,
         ensures
-            *self == *old(self),
-            self.next_lists()[o as int].no_duplicates(),
-            self.avail[o as int].len() <= self.pg_params().page_count,
-            self.avail[o as int].len() * (1usize << o) <= self.pg_params().page_count + (1usize
-                << o) - 1,
+            *final(self) == *old(self),
+            final(self).next_lists()[o as int].no_duplicates(),
+            final(self).avail[o as int].len() <= final(self).pg_params().page_count,
+            final(self).avail[o as int].len() * (1usize << o) <= final(self).pg_params().page_count
+                + (1usize << o) - 1,
     {
         reveal(MRFreePerms::wf_at);
         use_type_invariant(&*self);
@@ -290,13 +295,13 @@ impl MRFreePerms {
             0 <= o < MAX_ORDER,
             0 <= start <= end <= old(self).avail[o as int].len(),
         ensures
-            *self == *old(self),
+            *final(self) == *old(self),
             forall|i, j|
-                #![trigger self.avail[o as int][i], self.avail[o as int][j]]
+                #![trigger final(self).avail[o as int][i], final(self).avail[o as int][j]]
                 start <= i < end && start <= j < end && i != j ==> order_disjoint(
-                    self.avail[o as int][i].pfn(),
+                    final(self).avail[o as int][i].pfn(),
                     o,
-                    self.avail[o as int][j].pfn(),
+                    final(self).avail[o as int][j].pfn(),
                     o,
                 ),
         decreases end - start,
@@ -332,14 +337,14 @@ impl MRFreePerms {
             perm.wf_pfn_order(old(self).mr_map, pfn, order),
             perm.page_type() == PageType::Free,
         ensures
-            self.avail == old(self).avail.update(
+            final(self).avail == old(self).avail.update(
                 order as int,
                 old(self).avail[order as int].insert(idx, perm),
             ),
-            self.avail[order as int] == old(self).avail[order as int].insert(idx, perm),
-            self.mr_map() == old(self).mr_map(),
-            self.pg_params() == old(self).pg_params(),
-            self.nr_free() == old(self).nr_free().update(
+            final(self).avail[order as int] == old(self).avail[order as int].insert(idx, perm),
+            final(self).mr_map() == old(self).mr_map(),
+            final(self).pg_params() == old(self).pg_params(),
+            final(self).nr_free() == old(self).nr_free().update(
                 order as int,
                 (old(self).nr_free()[order as int] + 1) as usize,
             ),
@@ -402,13 +407,13 @@ impl MRFreePerms {
                 PageInfo::Free(FreeInfo { order, next_page: old(self).next_page(order) }),
             ),
         ensures
-            self.avail == old(self).avail.update(
+            final(self).avail == old(self).avail.update(
                 order as int,
                 old(self).avail[order as int].push(perm),
             ),
-            self.mr_map() == old(self).mr_map(),
-            self.pg_params() == old(self).pg_params(),
-            self.nr_free() == old(self).nr_free().update(
+            final(self).mr_map() == old(self).mr_map(),
+            final(self).pg_params() == old(self).pg_params(),
+            final(self).nr_free() == old(self).nr_free().update(
                 order as int,
                 (old(self).nr_free()[order as int] + 1) as usize,
             ),
@@ -416,7 +421,7 @@ impl MRFreePerms {
             old(self).nr_free()[order as int] * (1usize << order) <= old(
                 self,
             ).pg_params().page_count - 1,
-            self.wf_strict(),
+            final(self).wf_strict(),
     {
         reveal(MRFreePerms::wf_strict);
         reveal(MRFreePerms::wf_at);
@@ -437,14 +442,17 @@ impl MRFreePerms {
             !spec_pfn_is_oob(old(self).next_page(order)),
             old(self).wf_strict(),
         ensures
-            self.wf_strict(),
-            self.avail == old(self).avail.update(order as int, self.avail[order as int]),
-            self.avail[order as int] == old(self).avail[order as int].take(
+            final(self).wf_strict(),
+            final(self).avail == old(self).avail.update(
+                order as int,
+                final(self).avail[order as int],
+            ),
+            final(self).avail[order as int] == old(self).avail[order as int].take(
                 old(self).avail[order as int].len() - 1,
             ),
             old(self).ens_perm_strict(order, old(self).avail[order as int].len() - 1, perm),
-            self.mr_map() == old(self).mr_map(),
-            self.nr_free() == old(self).nr_free().update(
+            final(self).mr_map() == old(self).mr_map(),
+            final(self).nr_free() == old(self).nr_free().update(
                 order as int,
                 (old(self).nr_free()[order as int] - 1) as usize,
             ),
@@ -496,17 +504,21 @@ impl MRFreePerms {
             0 <= order < MAX_ORDER,
             0 <= idx < old(self).avail[order as int].len(),
         ensures
-            self.avail == old(self).avail.update(order as int, self.avail[order as int]),
-            self.avail[order as int] == old(self).avail[order as int].remove(idx),
+            final(self).avail == old(self).avail.update(
+                order as int,
+                final(self).avail[order as int],
+            ),
+            final(self).avail[order as int] == old(self).avail[order as int].remove(idx),
             old(self).ens_perm_valid(order, idx, perm),
-            self.mr_map() == old(self).mr_map(),
-            self.nr_free() == old(self).nr_free().update(
+            final(self).mr_map() == old(self).mr_map(),
+            final(self).nr_free() == old(self).nr_free().update(
                 order as int,
                 (old(self).nr_free()[order as int] - 1) as usize,
             ),
             old(self).nr_free()[order as int] > 0,
             old(self).wf_strict() ==> old(self).ens_perm_strict(order, idx, perm),
-            old(self).wf_strict() ==> (idx == self.avail[order as int].len() ==> self.wf_strict()),
+            old(self).wf_strict() ==> (idx == final(self).avail[order as int].len()
+                ==> final(self).wf_strict()),
     {
         reveal(MRFreePerms::wf_at);
         use_type_invariant(&*self);

--- a/kernel/src/mm/alloc_info.verus.rs
+++ b/kernel/src/mm/alloc_info.verus.rs
@@ -12,7 +12,7 @@
 // shared status.
 use verify_proof::frac_ptr::tracked_map_merge_right_shares;
 use verify_proof::frac_ptr::tracked_map_shares;
-use verify_proof::set::{lemma_set_usize_range, set_usize_range};
+use verify_proof::set::{group_set_usize, lemma_set_usize_range, set_usize_range};
 use vstd::raw_ptr::PtrData;
 
 verus! {
@@ -182,7 +182,7 @@ impl PageInfoDb {
         let end = unit_start + (1usize << order);
         &&& end <= usize::MAX + 1
         &&& !reserved.dom().is_empty()
-        &&& reserved.dom() =~= Set::new(|k| unit_start <= k < end)
+        &&& reserved.dom() =~= set_usize_range(unit_start, end)
         &&& item.is_head()
     }
 
@@ -678,10 +678,19 @@ impl PageInfoDb {
     {
         reveal(PageInfoDb::restrict);
         self.lemma_restrict(i);
-        lemma_set_usize_range(i, i + self@[i].size());
-        broadcast use lemma_set_usize_range;
+        broadcast use group_set_usize;
 
+        lemma_set_usize_range(i, i + self@[i].size());
         self.lemma_remove(i);
+        let removed = self.remove(i);
+        assert forall|idx: usize| #![trigger removed@[idx]] removed@.dom().contains(idx) implies {
+            &&& removed@[idx] == self@[idx]
+            &&& removed@[idx].is_head() ==> removed.restrict(idx).wf_unit()
+        } by {
+            if removed@[idx].is_head() {
+                self.lemma_remove_restrict(i, idx);
+            }
+        }
     }
 
     #[verifier(spinoff_prover)]
@@ -743,7 +752,7 @@ impl PageInfoDb {
         requires
             order < MAX_ORDER,
             unit_start + (1usize << order) <= usize::MAX + 1,
-            reserved.dom() =~= Set::new(|k| unit_start <= k < unit_start + (1usize << order)),
+            reserved.dom() =~= set_usize_range(unit_start, unit_start + (1usize << order)),
             reserved[unit_start].is_head(),
             reserved[unit_start].order() == order,
             PageInfoDb::new_unit_requires(reserved, id, unit_start, order),
@@ -852,7 +861,7 @@ impl PageInfoDb {
         requires
             order < MAX_ORDER,
             unit_start + (1usize << order) <= usize::MAX + 1,
-            reserved.dom() =~= Set::new(|k| unit_start <= k < unit_start + (1usize << order)),
+            reserved.dom() =~= set_usize_range(unit_start, unit_start + (1usize << order)),
             reserved[unit_start].is_head(),
             reserved[unit_start].order() == order,
             PageInfoDb::new_unit_requires(reserved, id, unit_start, order),

--- a/kernel/src/mm/alloc_info.verus.rs
+++ b/kernel/src/mm/alloc_info.verus.rs
@@ -766,13 +766,13 @@ impl PageInfoDb {
             old(self).dom().contains(idx),
             old(self).is_head(idx),
         ensures
-            old(self).ens_split(*self, unit),
-            self@ == old(self)@.remove_keys(unit@.dom()),
-            self.id() == old(self).id(),
-            self.npages() == old(self).npages() - old(self)@[idx].size(),
+            old(self).ens_split(*final(self), unit),
+            final(self)@ == old(self)@.remove_keys(unit@.dom()),
+            final(self).id() == old(self).id(),
+            final(self).npages() == old(self).npages() - old(self)@[idx].size(),
             unit.is_unit(),
             unit.unit_start() == idx,
-            old(self).ens_add_nr_pages(*self, unit),
+            old(self).ens_add_nr_pages(*final(self), unit),
     {
         use_type_invariant(&*self);
         reveal(PageInfoDb::restrict);
@@ -805,17 +805,19 @@ impl PageInfoDb {
             old(unit).is_unit(),
             old(unit).id().ptr_data == old(self).id().ptr_data,
         ensures
-            unit.is_unit(),
-            unit.npages() == old(unit).npages(),
-            unit.unit_start() == old(unit).unit_start(),
-            unit.id() == old(unit).id().update_shares(
+            final(unit).is_unit(),
+            final(unit).npages() == old(unit).npages(),
+            final(unit).unit_start() == old(unit).unit_start(),
+            final(unit).id() == old(unit).id().update_shares(
                 old(unit).id().shares + old(self).id().shares,
             ),
-            unit.unit_head()@ == old(unit).unit_head()@.update_shares(unit.id().shares),
-            forall|order: usize| #[trigger] old(unit).nr_page(order) == unit.nr_page(order),
-            self@ == old(self)@.remove_keys(unit@.dom()),
-            self.id() == old(self).id(),
-            old(self).ens_add_unit_nr_pages(*self, unit.order()),
+            final(unit).unit_head()@ == old(unit).unit_head()@.update_shares(
+                final(unit).id().shares,
+            ),
+            forall|order: usize| #[trigger] old(unit).nr_page(order) == final(unit).nr_page(order),
+            final(self)@ == old(self)@.remove_keys(final(unit)@.dom()),
+            final(self).id() == old(self).id(),
+            old(self).ens_add_unit_nr_pages(*final(self), final(unit).order()),
     {
         let idx = unit.unit_start();
         use_type_invariant(&*self);
@@ -863,10 +865,10 @@ impl PageInfoDb {
             unit.unit_head()@ == reserved[unit_start]@.update_shares(unit.id().shares),
             unit.unit_start() == unit_start,
             unit.npages() == (1usize << order),
-            self.id() == old(self).id(),
-            self@.dom() == old(self)@.dom() + reserved.dom(),
-            self@ =~= old(self)@.union_prefer_right(self@.restrict(reserved.dom())),
-            self.ens_add_unit_nr_pages(*old(self), order),
+            final(self).id() == old(self).id(),
+            final(self)@.dom() == old(self)@.dom() + reserved.dom(),
+            final(self)@ =~= old(self)@.union_prefer_right(final(self)@.restrict(reserved.dom())),
+            final(self).ens_add_unit_nr_pages(*old(self), order),
     {
         let tracked mut info = PageInfoDb::tracked_new_unit(order, unit_start, id, reserved);
         self.tracked_insert_shares(&mut info);
@@ -881,17 +883,21 @@ impl PageInfoDb {
             old(self).dom().disjoint(old(unit).dom()),
             old(self).id() == old(unit).id().update_shares(old(self).id().shares),
         ensures
-            unit.is_unit(),
-            unit.unit_head()@ == old(unit).unit_head()@.update_shares(unit.id().shares),
-            unit.id() == old(unit).id().update_shares(
+            final(unit).is_unit(),
+            final(unit).unit_head()@ == old(unit).unit_head()@.update_shares(
+                final(unit).id().shares,
+            ),
+            final(unit).id() == old(unit).id().update_shares(
                 (old(unit).id().shares - old(self).id().shares) as nat,
             ),
-            unit.unit_start() == old(unit).unit_start(),
-            self.id() == old(self).id(),
-            self@.dom() == old(self)@.dom() + old(unit)@.dom(),
-            self@ =~= old(self)@.union_prefer_right(self@.restrict(unit@.dom())),
-            forall|order: usize| #[trigger] old(unit).nr_page(order) == unit.nr_page(order),
-            self.ens_add_unit_nr_pages(*old(self), unit.order()),
+            final(unit).unit_start() == old(unit).unit_start(),
+            final(self).id() == old(self).id(),
+            final(self)@.dom() == old(self)@.dom() + old(unit)@.dom(),
+            final(self)@ =~= old(self)@.union_prefer_right(
+                final(self)@.restrict(final(unit)@.dom()),
+            ),
+            forall|order: usize| #[trigger] old(unit).nr_page(order) == final(unit).nr_page(order),
+            final(self).ens_add_unit_nr_pages(*old(self), final(unit).order()),
     {
         use_type_invariant(&*unit);
         unit.tracked_unit_nr_pages();
@@ -912,16 +918,20 @@ impl PageInfoDb {
             old(self).is_unit(),
             0 < shares < old(self).id().shares,
         ensures
-            self.is_unit(),
-            self.unit_head()@ == old(self).unit_head()@.update_shares(self.id().shares),
+            final(self).is_unit(),
+            final(self).unit_head()@ == old(self).unit_head()@.update_shares(
+                final(self).id().shares,
+            ),
             unit.unit_head()@ == old(self).unit_head()@.update_shares(shares),
-            self.unit_start() == old(self).unit_start() == unit.unit_start(),
-            old(self).npages() == self.npages() == unit.npages(),
-            self.id() == old(self).id().update_shares((old(self).id().shares - shares) as nat),
+            final(self).unit_start() == old(self).unit_start() == unit.unit_start(),
+            old(self).npages() == final(self).npages() == unit.npages(),
+            final(self).id() == old(self).id().update_shares(
+                (old(self).id().shares - shares) as nat,
+            ),
             unit.is_unit(),
             unit.id() == old(self).id().update_shares(shares),
             forall|order: usize| #[trigger]
-                old(self).nr_page(order) == self.nr_page(order) == unit.nr_page(order),
+                old(self).nr_page(order) == final(self).nr_page(order) == unit.nr_page(order),
     {
         use_type_invariant(&*self);
         self.proof_unit_nr_page();

--- a/kernel/src/mm/alloc_inner.verus.rs
+++ b/kernel/src/mm/alloc_inner.verus.rs
@@ -5,9 +5,9 @@
 // Author: Ziqiao Zhou <ziqiaozhou@microsoft.com>
 //
 // Spec and proofs that does not need private types in alloc.rs
-use crate::mm::alloc::VirtAddr;
 use crate::mm::LinearMap;
-use crate::types::{lemma_page_size, PAGE_SIZE};
+use crate::mm::alloc::VirtAddr;
+use crate::types::{PAGE_SIZE, lemma_page_size};
 use crate::utils::util::spec_align_up;
 
 use crate::mm::alloc::MAX_ORDER;
@@ -353,7 +353,11 @@ impl MemRegionMapping {
             perm2.wf_pfn_order(*self, p2, order),
             old(perm1).wf_pfn_order(*self, p1, order),
         ensures
-            perm1.wf_pfn_order(*self, min(p1 as int, p2 as int) as usize, (order + 1) as usize),
+            final(perm1).wf_pfn_order(
+                *self,
+                min(p1 as int, p2 as int) as usize,
+                (order + 1) as usize,
+            ),
     {
         use_type_invariant(self);
         broadcast use lemma_bit_usize_shl_values;
@@ -431,7 +435,7 @@ impl MemRegionMapping {
             perm2.wf_pfn_order(*self, p2, o2),
         ensures
             order_disjoint(p1, o1, p2, o2),
-            *old(perm1) == *perm1,
+            *old(perm1) == *final(perm1),
     {
         broadcast use lemma_bit_usize_shl_values;
 

--- a/kernel/src/mm/alloc_perms.verus.rs
+++ b/kernel/src/mm/alloc_perms.verus.rs
@@ -238,7 +238,7 @@ impl MemoryRegionPerms {
         let info = self.info;
         &&& info.is_readonly_allocator_shares()
         &&& self.npages() == info.npages()
-        &&& info@.dom() =~= Set::new(|idx| 0 <= idx < self.npages())
+        &&& info@.dom() =~= Set::range(0, self.npages())
         &&& self.wf_base_ptr()
     }
 

--- a/kernel/src/utils/tcb_ptr.rs
+++ b/kernel/src/utils/tcb_ptr.rs
@@ -33,7 +33,7 @@ use verify_proof::frac_ptr::FracTypedPerm;
         old(perm).writable(),
         old(perm).valid(),
     ensures
-        perm@ == old(perm)@.update_value(vstd::simple_pptr::MemContents::Init(v)),
+        final(perm)@ == old(perm)@.update_value(vstd::simple_pptr::MemContents::Init(v)),
     opens_invariants none
     no_unwind
 )]

--- a/scripts/vinstall.sh
+++ b/scripts/vinstall.sh
@@ -9,13 +9,13 @@ set -e
 trap 'echo "Error at line $LINENO: $BASH_COMMAND"' ERR
 
 # Verus release version and commit hash
-VERUS_VERSION=0.2026.04.12.f1166c4
-VERUS_REV=f1166c42c3decd42c1cca2916ef2880d27cfb7d9
-VERUS_RUST_VERSION=1.94.0
+VERUS_VERSION=0.2026.07.12.0b42f4c
+VERUS_REV=0b42f4cee92a178937608cf55e512371d2fd8cd4
+VERUS_RUST_VERSION=1.96.0
 
 # Verusfmt version and commit hash
-VERUSFMT_VERSION=v0.5.7
-VERUSFMT_REV=beff2fa686d856d5e60df368fd027d94ead11ac5 # v0.5.7
+VERUSFMT_VERSION=v0.7.2
+VERUSFMT_REV=610d4ee7fa4d5a8f0132aad70f8df07fd64adc87 # 0.7.2
 
 # Z3 version and commit hash
 VERUS_Z3_VERSION=4.12.5

--- a/verification/verify_external/src/hw_spec/mm.verus.rs
+++ b/verification/verify_external/src/hw_spec/mm.verus.rs
@@ -26,7 +26,6 @@ pub trait SpecVAddrImpl {
             self.spec_int_addr().is_some(),
             size > 0,
         ensures
-            self.region_to_dom(size).finite(),
             self.region_to_dom(1).len() > 0 <==> self.region_to_dom(1).contains(
                 self.spec_int_addr().unwrap(),
             ),

--- a/verification/verify_proof/src/frac_perm.rs
+++ b/verification/verify_proof/src/frac_perm.rs
@@ -288,11 +288,11 @@ impl<T> FracPerm<T> {
             0 < n < old(self).shares(),
         ensures
             ret@ == old(self)@,
-            self@ == old(self)@,
-            self.id() == old(self).id(),
-            self.total() == old(self).total(),
+            final(self)@ == old(self)@,
+            final(self).id() == old(self).id(),
+            final(self).total() == old(self).total(),
             ret.id() == old(self).id(),
-            ret.shares() + self.shares() == old(self).shares(),
+            ret.shares() + final(self).shares() == old(self).shares(),
             ret.shares() == n,
             ret.total() == old(self).total(),
     {
@@ -316,11 +316,11 @@ impl<T> FracPerm<T> {
             other.valid(),
             old(self).id() == other.id(),
         ensures
-            self@ == old(self)@,
-            self.shares() == old(self).shares() + other.shares(),
-            self.total() == old(self).total(),
-            self.id() == old(self).id(),
-            self.valid(),
+            final(self)@ == old(self)@,
+            final(self).shares() == old(self).shares() + other.shares(),
+            final(self).total() == old(self).total(),
+            final(self).id() == old(self).id(),
+            final(self).valid(),
     {
         use_type_invariant(&*self);
         use_type_invariant(&other);
@@ -337,11 +337,11 @@ impl<T> FracPerm<T> {
             !old(self).valid(),
             old(self).shares() == old(self).total(),
         ensures
-            self.valid(),
-            self@ == Some(v),
-            self.id() == old(self).id(),
-            self.shares() == old(self).shares(),
-            self.total() == old(self).total(),
+            final(self).valid(),
+            final(self)@ == Some(v),
+            final(self).id() == old(self).id(),
+            final(self).shares() == old(self).shares(),
+            final(self).total() == old(self).total(),
     {
         use_type_invariant(&*self);
         let tracked mut perm = FracPerm::empty(self.total());
@@ -375,10 +375,10 @@ impl<T> FracPerm<T> {
             old(self).shares() == old(self).total(),
         ensures
             Some(ret) == old(self)@,
-            self.id() == old(self).id(),
-            !self.valid(),
-            self.shares() == old(self).total(),
-            self.total() == old(self).total(),
+            final(self).id() == old(self).id(),
+            !final(self).valid(),
+            final(self).shares() == old(self).total(),
+            final(self).total() == old(self).total(),
     {
         use_type_invariant(&*self);
         let tracked mut perm = FracPerm::empty(self.total());

--- a/verification/verify_proof/src/frac_ptr.rs
+++ b/verification/verify_proof/src/frac_ptr.rs
@@ -20,10 +20,10 @@ use vstd::multiset::Multiset;
 
 tokenized_state_machine!(addr_unique {
     fields {
-        #[sharding(map)]
-        pub addr_to: Map<int, Option<InstanceId>>,
-        #[sharding(map)]
-        pub to_addr: Map<InstanceId, Option<int>>,
+        #[sharding(imap)]
+        pub addr_to: IMap<int, Option<InstanceId>>,
+        #[sharding(imap)]
+        pub to_addr: IMap<InstanceId, Option<int>>,
 
         #[sharding(multiset)]
         pub ptr_readers: Multiset<(int, InstanceId)>,
@@ -37,8 +37,8 @@ tokenized_state_machine!(addr_unique {
 
     #[invariant]
     pub fn dom_cover_all(&self) -> bool {
-        self.addr_to.dom() =~= Set::full() &&
-        self.to_addr.dom() =~= Set::full()
+        self.addr_to.dom() =~= ISet::full() &&
+        self.to_addr.dom() =~= ISet::full()
     }
 
     #[invariant]
@@ -70,15 +70,15 @@ tokenized_state_machine!(addr_unique {
 
     init!{
         empty() {
-            init addr_to = Map::new(|addr| true, |addr|None);
-            init to_addr = Map::new(|id| true, |addr|None);
+            init addr_to = IMap::new(|addr| true, |addr|None);
+            init to_addr = IMap::new(|id| true, |addr|None);
             init ptr_readers = Multiset::empty();
         }
     }
 
     #[inductive(empty)]
     fn empty_inductive(post: Self) {
-        assert(post.addr_to =~= Map::new(|addr| true, |addr|None));
+        assert(post.addr_to =~= IMap::new(|addr| true, |addr|None));
     }
 
     transition!{
@@ -433,7 +433,6 @@ pub proof fn tracked_map_shares<Idx, T>(
     shares: nat,
 ) -> (tracked ret: Map<Idx, FracTypedPerm<T>>)
     requires
-        old(m).dom().finite(),
         shares > 0,
         forall|i|
             old(m).dom().contains(i) ==> shares < (#[trigger] old(m)[i]).shares() && old(
@@ -466,7 +465,6 @@ pub proof fn _tracked_map_shares<Idx, T>(
         forall|i| #[trigger] s.contains(i) ==> old(m).contains_key(i),
         forall|i| s.contains(i) ==> (#[trigger] old(m)[i]).valid(),
         forall|i| s.contains(i) ==> shares < (#[trigger] old(m)[i]).shares(),
-        s.finite(),
     ensures
         forall|i: Idx|
             #![trigger final(m)[i]]
@@ -503,7 +501,6 @@ pub proof fn tracked_map_merge_right_shares<Idx, T>(
 )
     requires
         right.dom().subset_of(old(m).dom()),
-        right.dom().finite(),
         forall|i|
             right.contains_key(i) ==> (#[trigger] old(m)[i]).valid() && old(m)[i].ptr()
                 == right[i].ptr(),

--- a/verification/verify_proof/src/frac_ptr.rs
+++ b/verification/verify_proof/src/frac_ptr.rs
@@ -346,9 +346,9 @@ impl<T> FracTypedPerm<T> {
             old(self).writable(),
         ensures
             Some(ret@) == old(self).points_to(),
-            ret.ptr() as int == self.addr(),
-            !self.valid(),
-            self@ == old(self)@.update_points_to(None),
+            ret.ptr() as int == final(self).addr(),
+            !final(self).valid(),
+            final(self)@ == old(self)@.update_points_to(None),
     {
         use_type_invariant(&*self);
         self.p.take()
@@ -360,7 +360,7 @@ impl<T> FracTypedPerm<T> {
             (val@.ptr as int) == old(self).addr(),
             !old(self).valid(),
         ensures
-            self@ === old(self)@.update_points_to(Some(val@)),
+            final(self)@ === old(self)@.update_points_to(Some(val@)),
     {
         use_type_invariant(&*self);
         use_type_invariant(&self.p);
@@ -382,7 +382,7 @@ impl<T> FracTypedPerm<T> {
             old(self).valid(),
             0 < shares < old(self).shares(),
         ensures
-            self@ === old(self)@.update_shares((old(self).shares() - shares) as nat),
+            final(self)@ === old(self)@.update_shares((old(self).shares() - shares) as nat),
             ret@ === old(self)@.update_shares(shares),
     {
         use_type_invariant(&*self);
@@ -404,7 +404,7 @@ impl<T> FracTypedPerm<T> {
             old(self).valid(),
             old(self).ptr() == other.ptr(),
         ensures
-            self@ === old(self)@.update_shares(old(self).shares() + other.shares()),
+            final(self)@ === old(self)@.update_shares(old(self).shares() + other.shares()),
             old(self).shares() + other.shares() <= old(self).total(),
     {
         use_type_invariant(&*self);
@@ -422,8 +422,8 @@ pub proof fn raw_perm_is_disjoint(tracked p1: &mut PointsToRaw, p2: &PointsToRaw
     requires
         old(p1).dom().len() > 0,
     ensures
-        *old(p1) == *p1,
-        p1.dom().disjoint(p2.dom()),
+        *old(p1) == *final(p1),
+        final(p1).dom().disjoint(p2.dom()),
 {
     admit();
 }
@@ -440,12 +440,12 @@ pub proof fn tracked_map_shares<Idx, T>(
                 m,
             )[i].valid(),
     ensures
-        ret.dom() == m.dom(),
-        m.dom() == old(m).dom(),
+        ret.dom() == final(m).dom(),
+        final(m).dom() == old(m).dom(),
         forall|i: Idx|
-            #![trigger m[i]]
+            #![trigger final(m)[i]]
             #![trigger old(m)[i]]
-            m.contains_key(i) ==> m[i]@ == old(m)[i]@.update_shares(
+            final(m).contains_key(i) ==> final(m)[i]@ == old(m)[i]@.update_shares(
                 (old(m)[i].shares() - shares) as nat,
             ),
         forall|i: Idx|
@@ -469,13 +469,13 @@ pub proof fn _tracked_map_shares<Idx, T>(
         s.finite(),
     ensures
         forall|i: Idx|
-            #![trigger m[i]]
+            #![trigger final(m)[i]]
             #![trigger old(m)[i]]
-            s.contains(i) ==> m[i]@ == old(m)[i]@.update_shares(
+            s.contains(i) ==> final(m)[i]@ == old(m)[i]@.update_shares(
                 (old(m)[i].shares() - shares) as nat,
             ),
-        *m =~= old(m).union_prefer_right(m.restrict(s)),
-        m.dom() =~= old(m).dom(),
+        *final(m) =~= old(m).union_prefer_right(final(m).restrict(s)),
+        final(m).dom() =~= old(m).dom(),
         ret.dom() =~= s,
         forall|i: Idx| s.contains(i) ==> (#[trigger] ret[i])@ == old(m)[i]@.update_shares(shares),
     decreases s.len(),
@@ -510,12 +510,12 @@ pub proof fn tracked_map_merge_right_shares<Idx, T>(
         forall|i| right.contains_key(i) ==> (#[trigger] right[i]).valid(),
     ensures
         forall|i: Idx|
-            #![trigger m[i]]
+            #![trigger final(m)[i]]
             #![trigger old(m)[i]]
-            old(m).contains_key(i) && right.contains_key(i) ==> m[i]@ == old(m)[i]@.update_shares(
+            old(m).contains_key(i) && right.contains_key(i) ==> final(m)[i]@ == old(m)[i]@.update_shares(
                 (old(m)[i].shares() + right[i].shares()) as nat,
             ),
-        m.dom() =~= old(m).dom(),
+        final(m).dom() =~= old(m).dom(),
     decreases right.dom().len(),
 {
     let s = right.dom();

--- a/verification/verify_proof/src/lib.rs
+++ b/verification/verify_proof/src/lib.rs
@@ -26,9 +26,4 @@ verus! {
 
 global size_of usize == 8;
 
-#[cfg_attr(verus_keep_ghost, verifier::broadcast_use_by_default_when_this_crate_is_imported)]
-pub broadcast group group_axioms {
-    set::lemma_set_usize_finite,
-}
-
 } // verus!

--- a/verification/verify_proof/src/set.rs
+++ b/verification/verify_proof/src/set.rs
@@ -4,61 +4,89 @@
 //
 // Author: Ziqiao Zhou <ziqiaozhou@microsoft.com>
 use vstd::prelude::*;
+use vstd::set_lib::range_set_properties;
 
 verus! {
 
-pub open spec fn set_usize_range(start: usize, end: int) -> Set<usize> {
-    Set::new(|i| start <= i < end)
+/// The finite set of usizes in the half-open range [start, end).
+///
+/// `end` is an `int` so the range can be empty (`end == start`) or cover the
+/// full `usize` space (`end == usize::MAX + 1`), neither of which a `usize`
+/// upper bound can express. It is built from vstd's `Set::range`
+/// (`[start, end)`) for the common case and `Set::range_inclusive` for the full
+/// case, so finiteness, membership, and length all come from vstd's
+/// `range_set_properties` broadcast. Membership is re-exported unconditionally
+/// through [`lemma_set_usize_range_contains`] (and [`group_set_usize`]); the
+/// length is given by [`lemma_set_usize_range`].
+pub closed spec fn set_usize_range(start: usize, end: int) -> Set<usize> {
+    if end <= start {
+        Set::<usize>::range(start, start)
+    } else if end <= usize::MAX {
+        Set::<usize>::range(start, end as usize)
+    } else {
+        Set::<usize>::range_inclusive(start, usize::MAX)
+    }
 }
 
+/// Unconditional membership of [`set_usize_range`].
+pub broadcast proof fn lemma_set_usize_range_contains(start: usize, end: int, k: usize)
+    ensures
+        (#[trigger] set_usize_range(start, end).contains(k)) <==> start <= k < end,
+{
+    broadcast use vstd::set::group_set_lemmas;
+
+    if end <= start {
+        range_set_properties::<usize>(start, start);
+    } else if end <= usize::MAX {
+        assert((end as usize) as int == end);
+        range_set_properties::<usize>(start, end as usize);
+    } else {
+        range_set_properties::<usize>(start, usize::MAX);
+    }
+}
+
+/// Establishes the length of [`set_usize_range`].
 pub broadcast proof fn lemma_set_usize_range(start: usize, end: int)
     requires
         start <= end,
         end <= usize::MAX + 1,
     ensures
-        (#[trigger] set_usize_range(start, end)).finite(),
-        set_usize_range(start, end).len() == end - start,
-    decreases end - start,
+        (#[trigger] set_usize_range(start, end)).len() == end - start,
 {
-    if end > start {
-        let e2 = (end - 1) as usize;
-        let s1 = set_usize_range(start, end);
-        let s2 = set_usize_range(start, e2 as int);
-        lemma_set_usize_range(start, e2 as int);
-        assert(s1 =~= s2.insert(e2));
+    if end <= start {
+    } else if end <= usize::MAX {
+        range_set_properties::<usize>(start, end as usize);
     } else {
-        assert(set_usize_range(start, end) =~= Set::empty());
+        // end == usize::MAX + 1: range_inclusive adds the top element, which is
+        // not already in the half-open range, so the length is one larger.
+        range_set_properties::<usize>(start, usize::MAX);
+        assert(!Set::<usize>::range(start, usize::MAX).contains(usize::MAX));
     }
 }
 
-pub broadcast proof fn lemma_set_usize_finite(s: Set<usize>)
-    ensures
-        #[trigger] s.finite(),
-{
-    let maxset = set_usize_range(0, usize::MAX + 1);
-    lemma_set_usize_range(0, usize::MAX + 1);
-    assert(s.subset_of(maxset));
-}
-
 pub broadcast proof fn lemma_len_filter<A>(s: Set<A>, f: spec_fn(A) -> bool)
-    requires
-        s.finite(),
     ensures
-        (#[trigger] s.filter(f)).finite(),
-        s.filter(f).len() <= s.len(),
+        (#[trigger] s.filter(f)).len() <= s.len(),
 {
     s.lemma_len_filter(f)
 }
 
 pub broadcast proof fn lemma_len_subset<A>(s1: Set<A>, s2: Set<A>)
     requires
-        s2.finite(),
         #[trigger] s1.subset_of(s2),
     ensures
         s1.len() <= s2.len(),
-        s1.finite(),
 {
     vstd::set_lib::lemma_len_subset(s1, s2)
+}
+
+/// Broadcast group restoring the ergonomics of the (now finite) `Set` over
+/// `usize` ranges: unconditional membership of [`set_usize_range`] plus the
+/// filter/subset length lemmas.
+pub broadcast group group_set_usize {
+    lemma_set_usize_range_contains,
+    lemma_len_filter,
+    lemma_len_subset,
 }
 
 } // verus!


### PR DESCRIPTION
Fixes #1143.

There are several breaking changes in Verus between April - Jun.
1. Improved support of &mut which requires final() vs old() for &mut ret.
2. Macro improvement for #[verus_verify] and #[verus_spec] to avoid duplicated macro expansion.
3. vstd::set library is updated to distinguish Set vs ISet. In old version, Set is an infinite Set and need to be proved to finite; In the latest version, Set is finite.