### PR TITLE
Move ELF loading into context of new task

### DIFF
--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -51,7 +51,7 @@ pub fn load_static_idt() {
 }
 
 unsafe extern "C" {
-    pub fn return_new_task();
+    pub fn thread_entry_asm();
     pub fn default_return();
     fn asm_entry_de();
     fn asm_entry_db();

--- a/kernel/src/cpu/idt/svsm_entry.S
+++ b/kernel/src/cpu/idt/svsm_entry.S
@@ -378,6 +378,11 @@ thread_entry_asm:
 	movq %r15, %rsi
 	movq %r14, %rdi
 
+	// Move pointer to X86ExceptionContext to %rdx - Only present and used
+	// for user-tasks
+	movq %rsp, %rdx
+	addq $16, %rdx
+
 	// Fetch thread entry function pointer - do not touch stack pointer to
 	// keep stack alignment
 	movq (%rsp), %rax

--- a/kernel/src/cpu/idt/svsm_entry.S
+++ b/kernel/src/cpu/idt/svsm_entry.S
@@ -369,10 +369,23 @@ return_user:
 	// Put user-mode specific return code here
 	jmp	return_all_paths
 
-.globl return_new_task
-return_new_task:
-	call	setup_user_task
-	jmp	default_return
+.globl thread_entry_asm
+thread_entry_asm:
+	// Call common thread setup function
+	call complete_new_thread
+
+	// Move thread fn and start parameter
+	movq %r15, %rsi
+	movq %r14, %rdi
+
+	// Fetch thread entry function pointer - do not touch stack pointer to
+	// keep stack alignment
+	movq (%rsp), %rax
+	call *%rax
+
+	// Skip to return addr
+	addq $8, %rsp
+	ret
 
 // #DE Divide-by-Zero-Error Exception (Vector 0)
 default_entry_no_ist	name=de		handler=terminate			error_code=0	vector=0

--- a/kernel/src/cpu/shadow_stack.rs
+++ b/kernel/src/cpu/shadow_stack.rs
@@ -97,7 +97,9 @@ pub enum ShadowStackInit {
         /// The address of the first instruction that will be executed by the task.
         entry_return: usize,
         /// The address of the function that's executed when the task exits.
-        exit_return: Option<usize>,
+        exit_return: usize,
+        /// Whether there is an iret frame on the bottom of the stack.
+        iret_frame: bool,
     },
     /// A shadow stack to be used during context switches.
     ///
@@ -116,58 +118,63 @@ pub fn init_shadow_stack(
     init: ShadowStackInit,
 ) -> (Option<VirtAddr>, VirtAddr) {
     // Initialize the shadow stack.
-    let mut chunk = [0; 24];
-    let (base_token_addr, ssp) = match init {
+    let mut chunk = [0; 32];
+    let (base_token_addr, ssp, len) = match init {
         ShadowStackInit::Normal {
             entry_return,
             exit_return,
+            iret_frame,
         } => {
-            // If exit return is empty, then this thread will be used as a
-            // user task stack.  In that case, place a busy token at the
-            // base of the shadow stack.
             let base_token_addr = top_of_sstack - 8;
-            let base_token = match exit_return {
-                Some(addr) => addr,
-                None => base_token_addr.bits() + BUSY,
-            };
-
             let (token_bytes, rip_bytes) = chunk.split_at_mut(8);
 
+            let len: usize = if iret_frame { 32 } else { 24 };
+
             // Create a shadow stack restore token.
-            let token_addr = top_of_sstack - 24;
+            let token_addr = top_of_sstack - len;
             let token = (token_addr + 8).bits() + MODE_64BIT;
             token_bytes.copy_from_slice(&token.to_ne_bytes());
 
             let (entry_bytes, base_bytes) = rip_bytes.split_at_mut(8);
             entry_bytes.copy_from_slice(&entry_return.to_ne_bytes());
-            base_bytes.copy_from_slice(&base_token.to_ne_bytes());
 
-            (Some(base_token_addr), token_addr)
+            let (exit_bytes, bottom_bytes) = base_bytes.split_at_mut(8);
+            exit_bytes.copy_from_slice(&exit_return.to_ne_bytes());
+
+            if iret_frame {
+                // If iret_frame is true, then this thread will be used as a
+                // user task stack.  In that case, place a busy token at the
+                // base of the shadow stack.
+                let base_token = base_token_addr.bits() + BUSY;
+                bottom_bytes.copy_from_slice(&base_token.to_ne_bytes());
+            }
+
+            (Some(base_token_addr), token_addr, len)
         }
         ShadowStackInit::ContextSwitch => {
-            let (_, token_bytes) = chunk.split_at_mut(16);
+            let (_, token_bytes) = chunk.split_at_mut(24);
 
             // Create a shadow stack restore token.
             let token_addr = top_of_sstack - 8;
             let token = (token_addr + 8).bits() + MODE_64BIT;
             token_bytes.copy_from_slice(&token.to_ne_bytes());
 
-            (None, token_addr)
+            (None, token_addr, 32)
         }
         ShadowStackInit::Exception => {
-            let (_, token_bytes) = chunk.split_at_mut(16);
+            let (_, token_bytes) = chunk.split_at_mut(24);
 
             // Create a supervisor shadow stack token.
             let token_addr = top_of_sstack - 8;
             let token = token_addr.bits();
             token_bytes.copy_from_slice(&token.to_ne_bytes());
 
-            (None, token_addr)
+            (None, token_addr, 32)
         }
-        ShadowStackInit::Init => (None, top_of_sstack - 8),
+        ShadowStackInit::Init => (None, top_of_sstack - 8, 24),
     };
 
-    page.write(PAGE_SIZE - chunk.len(), &chunk);
+    page.write(PAGE_SIZE - len, &chunk[..len]);
 
     (base_token_addr, ssp)
 }

--- a/kernel/src/cpu/shadow_stack.rs
+++ b/kernel/src/cpu/shadow_stack.rs
@@ -112,69 +112,69 @@ pub enum ShadowStackInit {
     Exception,
 }
 
+struct ShadowStackInitializer<'a> {
+    page: &'a PageRef,
+    top_of_stack: VirtAddr,
+    stack_ptr: usize,
+}
+
+impl<'a> ShadowStackInitializer<'a> {
+    fn new(page: &'a PageRef, top_of_stack: VirtAddr) -> Self {
+        Self {
+            page,
+            top_of_stack,
+            stack_ptr: PAGE_SIZE,
+        }
+    }
+
+    fn push(&mut self, value: usize) {
+        let buf = value.to_ne_bytes();
+        self.stack_ptr -= buf.len();
+        self.page.write(self.stack_ptr, &buf);
+    }
+
+    fn push_token(&mut self, offset: usize, mask: usize) -> VirtAddr {
+        let token_offset = PAGE_SIZE - self.stack_ptr + size_of::<usize>();
+        let token_addr = self.top_of_stack - token_offset;
+        let token = (token_addr + offset).bits() | mask;
+        self.push(token);
+        token_addr
+    }
+}
+
 pub fn init_shadow_stack(
     page: &PageRef,
     top_of_sstack: VirtAddr,
     init: ShadowStackInit,
 ) -> (Option<VirtAddr>, VirtAddr) {
     // Initialize the shadow stack.
-    let mut chunk = [0; 32];
-    let (base_token_addr, ssp, len) = match init {
+    let mut shadow_stack = ShadowStackInitializer::new(page, top_of_sstack);
+    match init {
         ShadowStackInit::Normal {
             entry_return,
             exit_return,
             iret_frame,
         } => {
-            let base_token_addr = top_of_sstack - 8;
-            let (token_bytes, rip_bytes) = chunk.split_at_mut(8);
+            let base_token_addr = match iret_frame {
+                true => Some(shadow_stack.push_token(0, BUSY)),
+                false => Some(top_of_sstack - 8),
+            };
 
-            let len: usize = if iret_frame { 32 } else { 24 };
+            shadow_stack.push(exit_return);
+            shadow_stack.push(entry_return);
 
-            // Create a shadow stack restore token.
-            let token_addr = top_of_sstack - len;
-            let token = (token_addr + 8).bits() + MODE_64BIT;
-            token_bytes.copy_from_slice(&token.to_ne_bytes());
+            let token_addr = shadow_stack.push_token(size_of::<usize>(), MODE_64BIT);
 
-            let (entry_bytes, base_bytes) = rip_bytes.split_at_mut(8);
-            entry_bytes.copy_from_slice(&entry_return.to_ne_bytes());
-
-            let (exit_bytes, bottom_bytes) = base_bytes.split_at_mut(8);
-            exit_bytes.copy_from_slice(&exit_return.to_ne_bytes());
-
-            if iret_frame {
-                // If iret_frame is true, then this thread will be used as a
-                // user task stack.  In that case, place a busy token at the
-                // base of the shadow stack.
-                let base_token = base_token_addr.bits() + BUSY;
-                bottom_bytes.copy_from_slice(&base_token.to_ne_bytes());
-            }
-
-            (Some(base_token_addr), token_addr, len)
+            (base_token_addr, token_addr)
         }
         ShadowStackInit::ContextSwitch => {
-            let (_, token_bytes) = chunk.split_at_mut(24);
-
-            // Create a shadow stack restore token.
-            let token_addr = top_of_sstack - 8;
-            let token = (token_addr + 8).bits() + MODE_64BIT;
-            token_bytes.copy_from_slice(&token.to_ne_bytes());
-
-            (None, token_addr, 32)
+            let token_addr = shadow_stack.push_token(size_of::<usize>(), MODE_64BIT);
+            (None, token_addr)
         }
         ShadowStackInit::Exception => {
-            let (_, token_bytes) = chunk.split_at_mut(24);
-
-            // Create a supervisor shadow stack token.
-            let token_addr = top_of_sstack - 8;
-            let token = token_addr.bits();
-            token_bytes.copy_from_slice(&token.to_ne_bytes());
-
-            (None, token_addr, 32)
+            let token_addr = shadow_stack.push_token(0, 0);
+            (None, token_addr)
         }
-        ShadowStackInit::Init => (None, top_of_sstack - 8, 24),
-    };
-
-    page.write(PAGE_SIZE - len, &chunk[..len]);
-
-    (base_token_addr, ssp)
+        ShadowStackInit::Init => (None, top_of_sstack - 8),
+    }
 }

--- a/kernel/src/task/exec.rs
+++ b/kernel/src/task/exec.rs
@@ -10,15 +10,29 @@ use super::TaskPointer;
 use crate::address::{Address, VirtAddr};
 use crate::error::SvsmError;
 use crate::fs::{Directory, open_read};
-use crate::mm::USER_MEM_END;
 use crate::mm::vm::VMFileMappingFlags;
+use crate::mm::{USER_MEM_END, mmap_user};
 use crate::task::{create_user_task, current_task, finish_user_task, schedule};
 use crate::types::PAGE_SIZE;
 use crate::utils::align_up;
+use alloc::boxed::Box;
 use alloc::sync::Arc;
 use elf::{Elf64File, Elf64PhdrFlags};
 
 use alloc::string::String;
+
+#[derive(Debug)]
+pub struct UserExecInfo {
+    binary: String,
+}
+
+impl UserExecInfo {
+    pub fn new(b: &str) -> Self {
+        Self {
+            binary: String::from(b),
+        }
+    }
+}
 
 fn convert_elf_phdr_flags(flags: Elf64PhdrFlags) -> VMFileMappingFlags {
     let mut vm_flags = VMFileMappingFlags::Fixed;
@@ -44,20 +58,22 @@ fn task_name(binary: &str) -> String {
     }
 }
 
-/// Loads and executes an ELF binary in user-mode.
+/// Loads and executes an user-mode ELF binary into the current tasks address
+/// space.
 ///
 /// # Arguments
 ///
-/// * binary: Path to file in the file-system
+/// * info: Instance of [`UserExecInfo`] describing the user-mode task.
 ///
 /// # Returns
 ///
 /// [`Ok(TaskPointer)`] on success, [`Err(SvsmError)`] on failure.
-pub fn exec_user(binary: &str, root: Arc<dyn Directory>) -> Result<TaskPointer, SvsmError> {
-    let fh = open_read(binary)?;
+pub fn exec(info: UserExecInfo) -> Result<u64, SvsmError> {
+    let fh = open_read(&info.binary)?;
     let file_size = fh.size();
 
     let current_task = current_task();
+
     let vstart = current_task.mmap_kernel_guard(
         VirtAddr::new(0),
         Some(&fh),
@@ -65,6 +81,7 @@ pub fn exec_user(binary: &str, root: Arc<dyn Directory>) -> Result<TaskPointer, 
         file_size,
         VMFileMappingFlags::Read,
     )?;
+
     // SAFETY: `vstart` has just been mapped using `file_size` as the size,
     // so it is safe to create a slice of the same size.
     let buf = unsafe { vstart.to_slice::<u8>(file_size) };
@@ -73,8 +90,6 @@ pub fn exec_user(binary: &str, root: Arc<dyn Directory>) -> Result<TaskPointer, 
     let alloc_info = elf_bin.image_load_vaddr_alloc_info();
     let virt_base = alloc_info.range.vaddr_begin;
     let entry = elf_bin.get_entry(virt_base);
-
-    let new_task = create_user_task(entry.try_into().unwrap(), root, task_name(binary))?;
 
     for seg in elf_bin.image_load_segment_iter(virt_base) {
         let virt_start = VirtAddr::from(seg.vaddr_range.vaddr_begin);
@@ -93,16 +108,16 @@ pub fn exec_user(binary: &str, root: Arc<dyn Directory>) -> Result<TaskPointer, 
             let start_aligned = virt_start.page_align();
             let offset = file_offset - virt_start.page_offset();
             let size = file_size + virt_start.page_offset();
-            new_task.mmap_user(start_aligned, Some(&fh), offset, size, flags)?;
+            mmap_user(start_aligned, Some(&fh), offset, size, flags)?;
 
             let size_aligned = align_up(size, PAGE_SIZE);
             if size_aligned < len {
                 let start_anon = start_aligned.const_add(size_aligned);
                 let remaining_len = len - size_aligned;
-                new_task.mmap_user(start_anon, None, 0, remaining_len, flags)?;
+                mmap_user(start_anon, None, 0, remaining_len, flags)?;
             }
         } else {
-            new_task.mmap_user(virt_start, None, 0, len, flags)?;
+            mmap_user(virt_start, None, 0, len, flags)?;
         }
     }
 
@@ -113,7 +128,24 @@ pub fn exec_user(binary: &str, root: Arc<dyn Directory>) -> Result<TaskPointer, 
     let user_stack_size: usize = 64 * 1024;
     let stack_flags: VMFileMappingFlags = VMFileMappingFlags::Fixed | VMFileMappingFlags::Write;
     let stack_addr = USER_MEM_END - user_stack_size;
-    new_task.mmap_user(stack_addr, None, 0, user_stack_size, stack_flags)?;
+    mmap_user(stack_addr, None, 0, user_stack_size, stack_flags)?;
+
+    Ok(entry)
+}
+
+/// Starts a new task and sets it up for loading and executing a user-mode
+/// binary.
+///
+/// # Arguments
+///
+/// * binary: Path to file in the file-system
+///
+/// # Returns
+///
+/// [`Ok(TaskPointer)`] on success, [`Err(SvsmError)`] on failure.
+pub fn exec_user(binary: &str, root: Arc<dyn Directory>) -> Result<TaskPointer, SvsmError> {
+    let info = Box::new(UserExecInfo::new(binary));
+    let new_task = create_user_task(info, root, task_name(binary))?;
 
     finish_user_task(new_task.clone());
     schedule();

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -21,5 +21,5 @@ pub use tasks::{
     TaskExitStatus, TaskListAdapter, TaskPointer, TaskRunListAdapter, TaskState, is_task_fault,
 };
 
-pub use exec::exec_user;
+pub use exec::{UserExecInfo, exec_user};
 pub use waiting::WaitQueue;

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -39,6 +39,7 @@ use super::tasks::TASK_CUR_CPU_OFFSET;
 use super::tasks::TaskExitStatus;
 use super::{
     INITIAL_TASK_ID, KernelThreadStartInfo, Task, TaskListAdapter, TaskPointer, TaskRunListAdapter,
+    UserExecInfo,
 };
 use crate::address::{Address, VirtAddr};
 use crate::cpu::IrqGuard;
@@ -60,6 +61,7 @@ use crate::fs::Directory;
 use crate::locking::SpinLock;
 use crate::mm::SVSM_CONTEXT_SWITCH_SHADOW_STACK;
 use crate::platform::SVSM_PLATFORM;
+use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::sync::Arc;
 use core::arch::global_asm;
@@ -366,12 +368,12 @@ pub fn start_kernel_thread(start_info: KernelThreadStartInfo) -> Result<TaskPoin
 ///
 /// A new instance of [`TaskPointer`] on success, [`SvsmError`] on failure.
 pub fn create_user_task(
-    user_entry: usize,
+    info: Box<UserExecInfo>,
     root: Arc<dyn Directory>,
     name: String,
 ) -> Result<TaskPointer, SvsmError> {
     let cpu = this_cpu();
-    Task::create_user(cpu, user_entry, root, name)
+    Task::create_user(cpu, info, root, name)
 }
 
 /// Finished user-space task creation by putting the task on the global

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -721,13 +721,41 @@ impl Task {
         Ok(())
     }
 
-    fn allocate_stack_common() -> Result<(Mapping, MemoryRegion<VirtAddr>), SvsmError> {
+    fn allocate_stack_common<T>(
+        cpu: &PerCpu,
+        context: &T,
+    ) -> Result<(Mapping, MemoryRegion<VirtAddr>, usize), SvsmError>
+    where
+        T: Sized + Copy,
+    {
         let stack = VMKernelStack::new()?;
         let bounds = stack.bounds(VirtAddr::from(0u64));
 
         let mapping = Arc::new(stack);
+        let percpu_mapping = cpu.new_mapping(mapping.clone())?;
 
-        Ok((mapping, bounds))
+        // We need to setup a context on the stack that matches the stack layout
+        // defined in switch_context below.
+        let stack_tos = percpu_mapping.virt_addr() + bounds.end().bits();
+
+        // Make space for the task termination handler
+        let stack_offset = size_of::<T>();
+        let stack_ptr = stack_tos
+            .checked_sub(stack_offset)
+            .unwrap()
+            .as_mut_ptr::<T>();
+
+        // Make sure there is room for T
+        debug_assert!(
+            (percpu_mapping.virt_addr() + bounds.start().bits()) <= VirtAddr::from(stack_ptr)
+        );
+
+        // 'Push' the task frame onto the stack
+        //
+        // SAFETY: We ensure that T can be written to valid memory.
+        unsafe { stack_ptr.write(*context) };
+
+        Ok((mapping, bounds, stack_offset))
     }
 
     fn allocate_ktask_stack(
@@ -737,25 +765,6 @@ impl Task {
         xsa_addr: usize,
         start_parameter: usize,
     ) -> Result<(Mapping, MemoryRegion<VirtAddr>, usize), SvsmError> {
-        let (mapping, bounds) = Task::allocate_stack_common()?;
-
-        let percpu_mapping = cpu.new_mapping(mapping.clone())?;
-
-        // We need to setup a context on the stack that matches the stack layout
-        // defined in switch_context below.
-        let stack_tos = percpu_mapping.virt_addr() + bounds.end().bits();
-        // Make space for the task termination handler
-        let stack_offset = size_of::<KernelTaskContext>();
-        let stack_ptr = stack_tos
-            .checked_sub(stack_offset)
-            .unwrap()
-            .as_mut_ptr::<u8>();
-
-        // Make sure there is room for TaskContext
-        debug_assert!(
-            (percpu_mapping.virt_addr() + bounds.start().bits()) <= VirtAddr::from(stack_ptr)
-        );
-
         let task_context = KernelTaskContext {
             task_context: TaskContext {
                 regs: X86TaskSwitchRegs {
@@ -769,17 +778,7 @@ impl Task {
             exit_addr: task_exit as *const () as u64,
         };
 
-        // 'Push' the task frame onto the stack
-        //
-        // SAFETY: we ensure that both `TaskContext` and the function pointer
-        // can be written to valid memory. The address storing the function
-        // pointer is always 8b-aligned.
-        unsafe {
-            let stack_task_context = stack_ptr.cast::<KernelTaskContext>();
-            *stack_task_context = task_context;
-        }
-
-        Ok((mapping, bounds, stack_offset))
+        Self::allocate_stack_common(cpu, &task_context)
     }
 
     fn allocate_utask_stack(
@@ -787,26 +786,7 @@ impl Task {
         user_entry: usize,
         xsa_addr: usize,
     ) -> Result<(Mapping, MemoryRegion<VirtAddr>, usize), SvsmError> {
-        let (mapping, bounds) = Task::allocate_stack_common()?;
         let iret_rflags: usize = 2 | EFLAGS_IF;
-
-        let percpu_mapping = cpu.new_mapping(mapping.clone())?;
-
-        // We need to setup a context on the stack that matches the stack layout
-        // defined in switch_context below.
-        let stack_tos = percpu_mapping.virt_addr() + bounds.end().bits();
-        // Make space for the IRET frame
-        let stack_offset = size_of::<UserTaskContext>();
-        let stack_ptr = stack_tos
-            .checked_sub(stack_offset)
-            .unwrap()
-            .as_mut_ptr::<u8>();
-
-        // Make sure there is room for TaskContext
-        debug_assert!(
-            (percpu_mapping.virt_addr() + bounds.start().bits()) <= VirtAddr::from(stack_ptr)
-        );
-
         let task_context = UserTaskContext {
             task_context: TaskContext {
                 regs: X86TaskSwitchRegs {
@@ -834,16 +814,7 @@ impl Task {
 
         debug_assert!(is_aligned(task_context.excp_context.frame.rsp + 8, 16));
 
-        // 'Push' the task frame onto the stack
-        //
-        // SAFETY: we ensure that both `X86ExceptionContext` and `TaskContext`
-        // can be written to valid memory.
-        unsafe {
-            let stack_task_context = stack_ptr.cast::<UserTaskContext>();
-            *stack_task_context = task_context;
-        }
-
-        Ok((mapping, bounds, stack_offset))
+        Self::allocate_stack_common(cpu, &task_context)
     }
 
     fn allocate_xsave_area() -> PageBox<[u8]> {

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -22,7 +22,7 @@ use crate::address::{Address, VirtAddr};
 use crate::cpu::IrqGuard;
 use crate::cpu::ShadowStackInit;
 use crate::cpu::features::{Feature, cpu_has_feat};
-use crate::cpu::idt::svsm::return_new_task;
+use crate::cpu::idt::svsm::{default_return, thread_entry_asm};
 use crate::cpu::irq_state::EFLAGS_IF;
 use crate::cpu::irqs_enable;
 use crate::cpu::irqs_enabled;
@@ -264,6 +264,7 @@ pub struct TaskContext {
 #[derive(Default, Debug, Clone, Copy)]
 struct KernelTaskContext {
     pub task_context: TaskContext,
+    pub thread_routine: u64,
     pub exit_addr: u64,
 }
 
@@ -271,6 +272,8 @@ struct KernelTaskContext {
 #[derive(Default, Debug, Clone, Copy)]
 struct UserTaskContext {
     pub task_context: TaskContext,
+    pub thread_routine: u64,
+    pub exit_addr: u64,
     pub excp_context: X86ExceptionContext,
 }
 
@@ -278,15 +281,12 @@ struct UserTaskContext {
 // so that (%rsp + 8) is 16b-aligned after the ret instruction in
 // switch_context
 const _: () = assert!(
-    (size_of::<KernelTaskContext>() - offset_of!(KernelTaskContext, task_context.ret_addr)) % 16
+    ((size_of::<KernelTaskContext>() - offset_of!(KernelTaskContext, task_context.ret_addr)) % 16)
+        - 8
         == 0
 );
-
-// User-task return to return_new_task which is asm code, so %rsp must be
-// 16b-aligned after the ret instruction in switch_context to ensure stack
-// frames are 16b-aligned
 const _: () = assert!(
-    (size_of::<UserTaskContext>() - offset_of!(UserTaskContext, task_context.ret_addr) - 8) % 16
+    ((size_of::<UserTaskContext>() - offset_of!(UserTaskContext, task_context.ret_addr)) % 16) - 8
         == 0
 );
 
@@ -478,11 +478,10 @@ impl Task {
 
         // Determine which kernel-mode entry/exit routines will be used for
         // this task.
-        let (entry_return, exit_return) = match args.start_info {
-            ThreadStartInfo::User(_) => (return_new_task as *const () as usize, None),
-            ThreadStartInfo::Kernel(ref info) => {
-                (info.start_routine, Some(task_exit as *const () as usize))
-            }
+        let entry_return = thread_entry_asm as *const () as usize;
+        let (exit_return, iret_frame) = match args.start_info {
+            ThreadStartInfo::User(_) => (default_return as *const () as usize, true),
+            ThreadStartInfo::Kernel(_) => (task_exit as *const () as usize, false),
         };
 
         let mut shadow_stack_offset = VirtAddr::null();
@@ -506,6 +505,7 @@ impl Task {
                 ShadowStackInit::Normal {
                     entry_return,
                     exit_return,
+                    iret_frame,
                 },
             );
 
@@ -768,13 +768,15 @@ impl Task {
         let task_context = KernelTaskContext {
             task_context: TaskContext {
                 regs: X86TaskSwitchRegs {
-                    rsi: entry,
-                    rdx: xsa_addr,
-                    rcx: start_parameter,
+                    rsi: xsa_addr,
+                    // Put these into callee-saved registers
+                    r14: entry,
+                    r15: start_parameter,
                     ..Default::default()
                 },
-                ret_addr: start_routine as u64,
+                ret_addr: thread_entry_asm as *const () as u64,
             },
+            thread_routine: start_routine as u64,
             exit_addr: task_exit as *const () as u64,
         };
 
@@ -793,11 +795,13 @@ impl Task {
                     rsi: xsa_addr, // XSAVE area addr
                     ..Default::default()
                 },
-                ret_addr: VirtAddr::from(return_new_task as *const ())
-                    .bits()
-                    .try_into()
-                    .unwrap(),
+                ret_addr: thread_entry_asm as *const () as u64,
             },
+            thread_routine: run_user_task as *const () as u64,
+            exit_addr: VirtAddr::from(default_return as *const ())
+                .bits()
+                .try_into()
+                .unwrap(),
             // Setup IRQ return frame.  User-mode tasks always run with
             // interrupts enabled.
             excp_context: X86ExceptionContext {
@@ -1044,23 +1048,14 @@ fn task_attach_console() {
         .expect("Failed to attach console");
 }
 
-/// Runs the first time a new task is scheduled, in the context of the new
-/// task. Any first-time initialization and setup work for a new task that
-/// needs to happen in its context must be done here.
-/// # Safety
-/// The caller is required to verify the correctness of the save area address.
+/// Finished the setup of a new thread by doing all setup work which needs to
+/// happen in the context of the new thread.
+///
+/// Right now this is mostly work done also in the switch_to() function after
+/// the task switch happened, as new threads do not go through this path when they
+/// first run.
 #[unsafe(no_mangle)]
-unsafe fn setup_user_task(prev: usize, xsa_addr: u64) {
-    // SAFETY: caller needs to make sure that the previous task pointer and
-    // xsa_addr are valid.
-    unsafe {
-        // Needs to be the first function called here.
-        setup_new_task_common(xsa_addr, complete_task_switch(prev));
-    }
-    task_attach_console();
-}
-
-unsafe fn setup_new_task_common(xsa_addr: u64, prev_task: Option<TaskPointer>) {
+unsafe fn complete_new_thread(prev: usize, xsa_addr: u64) {
     // Re-enable IRQs here, as they are still disabled from the
     // schedule()/sched_init() functions. After the context switch the IrqGuard
     // from the previous task is not dropped, which causes IRQs to stay
@@ -1069,6 +1064,9 @@ unsafe fn setup_new_task_common(xsa_addr: u64, prev_task: Option<TaskPointer>) {
     // subsequent task switches will go through schedule() and there the guard
     // is dropped, re-enabling IRQs.
     irqs_enable();
+
+    // SAFETY: the scheduler passes the correct pointer to the previous task.
+    let prev_task = unsafe { complete_task_switch(prev) };
 
     // Drop the previous task reference now that interrupts are reenabled.
     // This ensures that the task destructor will run with interrupts enabled.
@@ -1081,25 +1079,22 @@ unsafe fn setup_new_task_common(xsa_addr: u64, prev_task: Option<TaskPointer>) {
     }
 }
 
+/// Runs the first time a new task is scheduled, in the context of the new
+/// task. Any first-time initialization specific to user-tasks need to happen
+/// here.
+/// # Safety
+/// This is called from assembly code. The caller needs to ensure the
+/// parameters are passed correctly.
+#[unsafe(no_mangle)]
+unsafe fn run_user_task() {
+    task_attach_console();
+}
+
 /// # Safety
 /// This function must only be invoked as a thread start function, and must
 /// be invoked according to the start parameter data type expected by the entry
 /// point.
-unsafe fn run_kernel_task<T: KernelThreadStartParameter>(
-    prev: usize,
-    entry: fn(T),
-    xsa_addr: u64,
-    start_parameter: usize,
-) {
-    // SAFETY: the scheduler passes the correct pointer to the previous task.
-    let prev_task = unsafe { complete_task_switch(prev) };
-
-    // SAFETY: the save area address is provided by the context switch assembly
-    // code.
-    unsafe {
-        setup_new_task_common(xsa_addr, prev_task);
-    }
-
+unsafe fn run_kernel_task<T: KernelThreadStartParameter>(entry: fn(T), start_parameter: usize) {
     // SAFETY: the `usize` start parameter was generated from an earlier call
     // to `KernelThreadStartParameter::to_usize` when the start argument was
     // prepared for use in the initial stack context, and therefore the safety

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -262,6 +262,13 @@ pub struct TaskContext {
 
 #[repr(C)]
 #[derive(Default, Debug, Clone, Copy)]
+struct KernelTaskContext {
+    pub task_context: TaskContext,
+    pub exit_addr: u64,
+}
+
+#[repr(C)]
+#[derive(Default, Debug, Clone, Copy)]
 struct UserTaskContext {
     pub task_context: TaskContext,
     pub excp_context: X86ExceptionContext,
@@ -722,7 +729,7 @@ impl Task {
         // defined in switch_context below.
         let stack_tos = percpu_mapping.virt_addr() + bounds.end().bits();
         // Make space for the task termination handler
-        let stack_offset = size_of::<u64>();
+        let stack_offset = size_of::<KernelTaskContext>();
         let stack_ptr = stack_tos
             .checked_sub(stack_offset)
             .unwrap()
@@ -736,13 +743,24 @@ impl Task {
                 .unwrap()
                 .is_aligned(16)
         );
+
         // Make sure there is room for TaskContext
         debug_assert!(
-            (percpu_mapping.virt_addr() + bounds.start().bits())
-                <= VirtAddr::from(stack_ptr)
-                    .checked_sub(size_of::<TaskContext>())
-                    .unwrap()
+            (percpu_mapping.virt_addr() + bounds.start().bits()) <= VirtAddr::from(stack_ptr)
         );
+
+        let task_context = KernelTaskContext {
+            task_context: TaskContext {
+                regs: X86TaskSwitchRegs {
+                    rsi: entry,
+                    rdx: xsa_addr,
+                    rcx: start_parameter,
+                    ..Default::default()
+                },
+                ret_addr: start_routine as u64,
+            },
+            exit_addr: task_exit as *const () as u64,
+        };
 
         // 'Push' the task frame onto the stack
         //
@@ -750,21 +768,11 @@ impl Task {
         // can be written to valid memory. The address storing the function
         // pointer is always 8b-aligned.
         unsafe {
-            let task_context = stack_ptr
-                .sub(size_of::<TaskContext>())
-                .cast::<TaskContext>();
-            // ret_addr
-            (*task_context).regs.rsi = entry;
-            // xsave area addr
-            (*task_context).regs.rdx = xsa_addr;
-            // start argument parameter.
-            (*task_context).regs.rcx = start_parameter;
-            (*task_context).ret_addr = start_routine as u64;
-            // Task termination handler for when entry point returns
-            stack_ptr.cast::<u64>().write(task_exit as *const () as u64);
+            let stack_task_context = stack_ptr.cast::<KernelTaskContext>();
+            *stack_task_context = task_context;
         }
 
-        Ok((mapping, bounds, stack_offset + size_of::<TaskContext>()))
+        Ok((mapping, bounds, stack_offset))
     }
 
     fn allocate_utask_stack(

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -6,6 +6,7 @@
 
 extern crate alloc;
 
+use alloc::boxed::Box;
 use alloc::collections::btree_map::BTreeMap;
 use alloc::string::String;
 use alloc::sync::Arc;
@@ -45,16 +46,18 @@ use crate::mm::{
     mappings::create_anon_mapping, mappings::create_file_mapping,
 };
 use crate::syscall::{Obj, ObjError, ObjHandle};
-use crate::types::{SVSM_USER_CS, SVSM_USER_DS};
+use crate::types::{SVSM_USER_CPL, SVSM_USER_CS, SVSM_USER_DS};
 use crate::utils::{MemoryRegion, is_aligned};
 use intrusive_collections::{LinkedListAtomicLink, intrusive_adapter};
 
-use super::WaitQueue;
+use super::exec::exec;
 use super::schedule::complete_task_switch;
 use super::schedule::terminate;
 use super::task_mm::{TaskKernelMapping, TaskMM};
+use super::{UserExecInfo, WaitQueue};
 
 pub const INITIAL_TASK_ID: u32 = 1;
+pub const EFLAGS_INIT: usize = 2;
 
 /// This trait is used to describe a type that can be used as the start
 /// parameter for a kernel thread.  The thread start path requires that all
@@ -128,7 +131,7 @@ impl KernelThreadStartInfo {
 #[derive(Debug)]
 enum ThreadStartInfo {
     Kernel(KernelThreadStartInfo),
-    User(usize),
+    User(*const UserExecInfo),
 }
 
 #[derive(PartialEq, Debug, Copy, Clone, Default)]
@@ -520,7 +523,7 @@ impl Task {
 
         // Call the correct stack creation routine for this task.
         let (stack, raw_bounds, rsp_offset) = match args.start_info {
-            ThreadStartInfo::User(entry) => Self::allocate_utask_stack(cpu, entry, xsa_addr)?,
+            ThreadStartInfo::User(info_ptr) => Self::allocate_utask_stack(cpu, info_ptr, xsa_addr)?,
             ThreadStartInfo::Kernel(ref info) => Self::allocate_ktask_stack(
                 cpu,
                 info.entry,
@@ -582,7 +585,7 @@ impl Task {
 
     pub fn create_user(
         cpu: &PerCpu,
-        user_entry: usize,
+        info: Box<UserExecInfo>,
         root: Arc<dyn Directory>,
         name: String,
     ) -> Result<TaskPointer, SvsmError> {
@@ -592,14 +595,23 @@ impl Task {
         unsafe {
             vm_user_range.initialize_lazy()?;
         }
+
+        // Destroy the Box and get the pointer to the raw data
+        let info_ptr = Box::into_raw(info);
+
         let create_args = CreateTaskArguments {
-            start_info: ThreadStartInfo::User(user_entry),
+            start_info: ThreadStartInfo::User(info_ptr),
             name,
             vm_user_range: Some(vm_user_range),
             rootdir: root,
             thread_of: None,
         };
-        Self::create_common(cpu, create_args)
+        Self::create_common(cpu, create_args).inspect_err(|_| {
+            // In error case, make sure info gets freed
+            // SAFETY: info_ptr was created above from a Box and not
+            // dropped in the create_common call-path.
+            drop(unsafe { Box::from_raw(info_ptr) });
+        })
     }
 
     /// Create a new thread for an existing task.
@@ -785,14 +797,14 @@ impl Task {
 
     fn allocate_utask_stack(
         cpu: &PerCpu,
-        user_entry: usize,
+        info_ptr: *const UserExecInfo,
         xsa_addr: usize,
     ) -> Result<(Mapping, MemoryRegion<VirtAddr>, usize), SvsmError> {
-        let iret_rflags: usize = 2 | EFLAGS_IF;
         let task_context = UserTaskContext {
             task_context: TaskContext {
                 regs: X86TaskSwitchRegs {
-                    rsi: xsa_addr, // XSAVE area addr
+                    rsi: xsa_addr,          // XSAVE area addr
+                    r14: info_ptr as usize, // New task launch info
                     ..Default::default()
                 },
                 ret_addr: thread_entry_asm as *const () as u64,
@@ -804,19 +816,8 @@ impl Task {
                 .unwrap(),
             // Setup IRQ return frame.  User-mode tasks always run with
             // interrupts enabled.
-            excp_context: X86ExceptionContext {
-                frame: X86InterruptFrame {
-                    rip: user_entry,
-                    cs: (SVSM_USER_CS | 3).into(),
-                    flags: iret_rflags,
-                    rsp: (USER_MEM_END - 8).into(),
-                    ss: (SVSM_USER_DS | 3).into(),
-                },
-                ..Default::default()
-            },
+            excp_context: X86ExceptionContext::default(),
         };
-
-        debug_assert!(is_aligned(task_context.excp_context.frame.rsp + 8, 16));
 
         Self::allocate_stack_common(cpu, &task_context)
     }
@@ -1082,11 +1083,42 @@ unsafe fn complete_new_thread(prev: usize, xsa_addr: u64) {
 /// Runs the first time a new task is scheduled, in the context of the new
 /// task. Any first-time initialization specific to user-tasks need to happen
 /// here.
+///
+/// # Arguments:
+///
+/// * `info_ptr` - Pointer to a UserExecInfo structure.
+/// * `_unused` - Unused parameter, is the start parameter for kernel tasks
+/// * `ctxt` - Mutable reference to a struct X86ExceptionContext which must be
+///   prepared for the return-to-user path.
+///
 /// # Safety
+///
 /// This is called from assembly code. The caller needs to ensure the
 /// parameters are passed correctly.
 #[unsafe(no_mangle)]
-unsafe fn run_user_task() {
+unsafe fn run_user_task(info_ptr: *mut UserExecInfo, _unused: u64, ctxt: &mut X86ExceptionContext) {
+    // SAFETY: The raw pointer was extracted from a Box in
+    // allocate_utask_stack() to move ownership to a new process.
+    let info = unsafe { Box::from_raw(info_ptr) };
+
+    let entry = match exec(*info) {
+        Ok(e) => e,
+        Err(e) => {
+            log::error!("Failed to load ELF binary: {e:?}");
+            terminate(None);
+        }
+    };
+
+    ctxt.frame = X86InterruptFrame {
+        rip: entry as usize,
+        cs: (SVSM_USER_CS | SVSM_USER_CPL).into(),
+        flags: EFLAGS_INIT | EFLAGS_IF,
+        rsp: (USER_MEM_END - 8).into(),
+        ss: (SVSM_USER_DS | SVSM_USER_CPL).into(),
+    };
+
+    debug_assert!(is_aligned(ctxt.frame.rsp + 8, 16));
+
     task_attach_console();
 }
 

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -274,6 +274,22 @@ struct UserTaskContext {
     pub excp_context: X86ExceptionContext,
 }
 
+// To ensure stack frames are 16b-aligned, ret_addr must be 16b-aligned
+// so that (%rsp + 8) is 16b-aligned after the ret instruction in
+// switch_context
+const _: () = assert!(
+    (size_of::<KernelTaskContext>() - offset_of!(KernelTaskContext, task_context.ret_addr)) % 16
+        == 0
+);
+
+// User-task return to return_new_task which is asm code, so %rsp must be
+// 16b-aligned after the ret instruction in switch_context to ensure stack
+// frames are 16b-aligned
+const _: () = assert!(
+    (size_of::<UserTaskContext>() - offset_of!(UserTaskContext, task_context.ret_addr) - 8) % 16
+        == 0
+);
+
 #[repr(C)]
 struct TaskSchedState {
     /// Whether this is an idle task
@@ -734,15 +750,6 @@ impl Task {
             .checked_sub(stack_offset)
             .unwrap()
             .as_mut_ptr::<u8>();
-        // To ensure stack frames are 16b-aligned, ret_addr must be 16b-aligned
-        // so that (%rsp + 8) is 16b-aligned after the ret instruction in
-        // switch_context
-        debug_assert!(
-            VirtAddr::from(stack_ptr)
-                .checked_sub(8)
-                .unwrap()
-                .is_aligned(16)
-        );
 
         // Make sure there is room for TaskContext
         debug_assert!(
@@ -794,10 +801,7 @@ impl Task {
             .checked_sub(stack_offset)
             .unwrap()
             .as_mut_ptr::<u8>();
-        // return_new_task is asm code, so %rsp must be 16b-aligned after the
-        // ret instruction in switch_context to ensure stack frames are
-        // 16b-aligned
-        debug_assert!(VirtAddr::from(stack_ptr).is_aligned(16));
+
         // Make sure there is room for TaskContext
         debug_assert!(
             (percpu_mapping.virt_addr() + bounds.start().bits()) <= VirtAddr::from(stack_ptr)

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -21,7 +21,6 @@ use core::sync::atomic::Ordering;
 use crate::address::{Address, VirtAddr};
 use crate::cpu::IrqGuard;
 use crate::cpu::ShadowStackInit;
-use crate::cpu::X86ExceptionContext;
 use crate::cpu::features::{Feature, cpu_has_feat};
 use crate::cpu::idt::svsm::return_new_task;
 use crate::cpu::irq_state::EFLAGS_IF;
@@ -33,6 +32,7 @@ use crate::cpu::percpu::this_cpu;
 use crate::cpu::shadow_stack::init_shadow_stack;
 use crate::cpu::sse::sse_restore_context;
 use crate::cpu::sse::xsave_area_size;
+use crate::cpu::{X86ExceptionContext, X86InterruptFrame};
 use crate::error::SvsmError;
 use crate::fs::{Directory, FileHandle, opendir, stdout_open};
 use crate::locking::RWLock;
@@ -258,6 +258,13 @@ pub struct X86TaskSwitchRegs {
 pub struct TaskContext {
     pub regs: X86TaskSwitchRegs,
     pub ret_addr: u64,
+}
+
+#[repr(C)]
+#[derive(Default, Debug, Clone, Copy)]
+struct UserTaskContext {
+    pub task_context: TaskContext,
+    pub excp_context: X86ExceptionContext,
 }
 
 #[repr(C)]
@@ -774,7 +781,7 @@ impl Task {
         // defined in switch_context below.
         let stack_tos = percpu_mapping.virt_addr() + bounds.end().bits();
         // Make space for the IRET frame
-        let stack_offset = size_of::<X86ExceptionContext>();
+        let stack_offset = size_of::<UserTaskContext>();
         let stack_ptr = stack_tos
             .checked_sub(stack_offset)
             .unwrap()
@@ -785,32 +792,11 @@ impl Task {
         debug_assert!(VirtAddr::from(stack_ptr).is_aligned(16));
         // Make sure there is room for TaskContext
         debug_assert!(
-            (percpu_mapping.virt_addr() + bounds.start().bits())
-                <= VirtAddr::from(stack_ptr)
-                    .checked_sub(size_of::<TaskContext>())
-                    .unwrap()
+            (percpu_mapping.virt_addr() + bounds.start().bits()) <= VirtAddr::from(stack_ptr)
         );
 
-        // 'Push' the task frame onto the stack
-        //
-        // SAFETY: we ensure that both `X86ExceptionContext` and `TaskContext`
-        // can be written to valid memory.
-        unsafe {
-            // Setup IRQ return frame.  User-mode tasks always run with
-            // interrupts enabled.
-            let mut iret_frame = X86ExceptionContext::default();
-            iret_frame.frame.rip = user_entry;
-            iret_frame.frame.cs = (SVSM_USER_CS | 3).into();
-            iret_frame.frame.flags = iret_rflags;
-            iret_frame.frame.rsp = (USER_MEM_END - 8).into();
-            iret_frame.frame.ss = (SVSM_USER_DS | 3).into();
-            debug_assert!(is_aligned(iret_frame.frame.rsp + 8, 16));
-
-            // Copy IRET frame to stack
-            let stack_iret_frame = stack_ptr.cast::<X86ExceptionContext>();
-            *stack_iret_frame = iret_frame;
-
-            let task_context = TaskContext {
+        let task_context = UserTaskContext {
+            task_context: TaskContext {
                 regs: X86TaskSwitchRegs {
                     rsi: xsa_addr, // XSAVE area addr
                     ..Default::default()
@@ -819,15 +805,33 @@ impl Task {
                     .bits()
                     .try_into()
                     .unwrap(),
-            };
+            },
+            // Setup IRQ return frame.  User-mode tasks always run with
+            // interrupts enabled.
+            excp_context: X86ExceptionContext {
+                frame: X86InterruptFrame {
+                    rip: user_entry,
+                    cs: (SVSM_USER_CS | 3).into(),
+                    flags: iret_rflags,
+                    rsp: (USER_MEM_END - 8).into(),
+                    ss: (SVSM_USER_DS | 3).into(),
+                },
+                ..Default::default()
+            },
+        };
 
-            let stack_task_context = stack_ptr
-                .sub(size_of::<TaskContext>())
-                .cast::<TaskContext>();
+        debug_assert!(is_aligned(task_context.excp_context.frame.rsp + 8, 16));
+
+        // 'Push' the task frame onto the stack
+        //
+        // SAFETY: we ensure that both `X86ExceptionContext` and `TaskContext`
+        // can be written to valid memory.
+        unsafe {
+            let stack_task_context = stack_ptr.cast::<UserTaskContext>();
             *stack_task_context = task_context;
         }
 
-        Ok((mapping, bounds, stack_offset + size_of::<TaskContext>()))
+        Ok((mapping, bounds, stack_offset))
     }
 
     fn allocate_xsave_area() -> PageBox<[u8]> {

--- a/kernel/src/types.rs
+++ b/kernel/src/types.rs
@@ -40,6 +40,7 @@ impl From<PageSize> for usize {
 #[expect(clippy::identity_op)]
 pub const SVSM_CS: u16 = 1 * 8;
 pub const SVSM_DS: u16 = 2 * 8;
+pub const SVSM_USER_CPL: u16 = 3;
 pub const SVSM_USER_CS: u16 = 3 * 8;
 pub const SVSM_USER_DS: u16 = 4 * 8;
 pub const SVSM_TSS: u16 = 6 * 8;


### PR DESCRIPTION
Cleanup the task setup and launch process and move loading of the ELF file for a user-space process into the context of the user-mode task.