### PR TITLE
Fix Guestmem label and page-fault handler

### DIFF
--- a/elf/src/program_header.rs
+++ b/elf/src/program_header.rs
@@ -15,7 +15,7 @@ use bitflags::bitflags;
 bitflags! {
 /// Attributes of an ELF64 program header, to specify whether
 /// the segment is readable, writable, and/or executable
-    #[derive(Debug)]
+    #[derive(Copy, Clone, Debug)]
     pub struct Elf64PhdrFlags : Elf64Word {
         const EXECUTE = 0x01;
         const WRITE   = 0x02;
@@ -24,7 +24,7 @@ bitflags! {
 }
 
 /// Program header entry in an ELF64 file
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct Elf64Phdr {
     /// Type of the program header entry
     pub p_type: Elf64Word,

--- a/elf/src/section_header.rs
+++ b/elf/src/section_header.rs
@@ -16,7 +16,7 @@ use bitflags::bitflags;
 bitflags! {
     /// Flags associated with ELF64 section header (e.g.,
     /// writable, contains null-terminated string, etc.
-    #[derive(Debug)]
+    #[derive(Copy, Clone, Debug)]
     pub struct Elf64ShdrFlags : Elf64Xword {
         const WRITE            = 0x001;
         const ALLOC            = 0x002;
@@ -33,7 +33,7 @@ bitflags! {
 }
 
 /// An ELF64 section header
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct Elf64Shdr {
     pub sh_name: Elf64Word,
     pub sh_type: Elf64Word,

--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -277,34 +277,29 @@ extern "C" fn ex_handler_page_fault(ctxt: &mut X86ExceptionContext, vector: usiz
     let err = ctxt.error_code;
     let vaddr = VirtAddr::from(cr2);
 
-    if user_mode(ctxt) {
-        let kill_task: bool = if is_task_fault(vaddr) {
-            current_task()
-                .fault(vaddr, (err & PageFaultError::W.bits() as usize) != 0)
-                .is_err()
-        } else {
-            true
-        };
+    let resolved = if is_task_fault(vaddr) {
+        current_task()
+            .fault(vaddr, (err & PageFaultError::W.bits() as usize) != 0)
+            .is_ok()
+    } else {
+        this_cpu()
+            .handle_pf(vaddr, (err & PageFaultError::W.bits() as usize) != 0)
+            .is_ok()
+    };
 
-        if kill_task {
+    if !resolved {
+        if user_mode(ctxt) {
             log::error!(
                 "Unexpected user-mode page-fault at RIP {rip:#018x} CR2: {cr2:#018x} error code: {err:#018x} - Terminating task"
             );
             terminate(Some(TaskExitStatus::Exception));
+        } else if !handle_exception_table(ctxt) {
+            handle_debug_exception(ctxt, vector);
+            panic!(
+                "Unhandled Page-Fault at RIP {:#018x} CR2: {:#018x} error code: {:#018x}",
+                rip, cr2, err
+            );
         }
-    } else if this_cpu()
-        .handle_pf(
-            VirtAddr::from(cr2),
-            (err & PageFaultError::W.bits() as usize) != 0,
-        )
-        .is_err()
-        && !handle_exception_table(ctxt)
-    {
-        handle_debug_exception(ctxt, vector);
-        panic!(
-            "Unhandled Page-Fault at RIP {:#018x} CR2: {:#018x} error code: {:#018x}",
-            rip, cr2, err
-        );
     }
 }
 

--- a/kernel/src/mm/guestmem.rs
+++ b/kernel/src/mm/guestmem.rs
@@ -249,8 +249,7 @@ unsafe fn copy_bytes(src: *const u8, dst: *mut u8, size: usize) -> Result<(), Sv
     // SAFETY: Safe as long as the function's safety requirements are met. Any
     // fault that might happen is handled via the exception handlers.
     unsafe {
-        asm!("1:cld
-                rep movsb
+        asm!("1: rep movsb
               2:
              .pushsection \"__exception_table\",\"a\"
              .balign 16


### PR DESCRIPTION
Fix two issues and add missing `Copy + Clone` annotations to ELF code. The issues fixes here:

* Fix the faulting label in `copy_bytes()` so it points to the instruction that will fault.
* Fix the page-fault handler so that it correctly handles and resolves faults when kernel mode accesses user-mode addresses.