### PR TITLE
aproxy: Update anyhow dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "aproxy"

--- a/tools/aproxy/Cargo.toml
+++ b/tools/aproxy/Cargo.toml
@@ -8,7 +8,7 @@ reqwest = { version = "0.12.9", default-features = false, features = ["blocking"
 kbs-types.workspace = true
 
 [dependencies]
-anyhow = "1.0.93"
+anyhow = "1.0.103"
 base64 = { workspace = true, features = ["std"] }
 clap = { version = "4.5", features = ["derive"] }
 const_format = "0.2"


### PR DESCRIPTION
The cargo audit tool reported a vulnerability in `anyhow` (RUSTSEC-2026-0190). Update the dependency to include the fix.