### PR TITLE
bldr: exclude from workspace clippy and simplify build script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ CARGO ?= cargo
 CLIPPY_OPTIONS ?= --all-features
 CLIPPY_ARGS ?= -D warnings
 
+# Packages that require --target x86_64-unknown-none
+BARE_METAL_MEMBERS := svsm stage1
+BARE_METAL_EXCLUDES := $(addprefix --exclude ,$(BARE_METAL_MEMBERS))
+
 ifdef CARGO_HACK
 CARGO = cargo hack
 CLIPPY_OPTIONS = --each-feature
@@ -162,11 +166,11 @@ endif
 	touch ${FS_BIN}
 
 clippy:
-	${CARGO} clippy ${CLIPPY_OPTIONS} --workspace --exclude svsm --exclude stage1 --exclude svsm-fuzz --exclude uapi_tester -- ${CLIPPY_ARGS}
+	${CARGO} clippy ${CLIPPY_OPTIONS} --workspace $(BARE_METAL_EXCLUDES) --exclude svsm-fuzz --exclude uapi_tester -- ${CLIPPY_ARGS}
 	RUSTFLAGS="--cfg fuzzing" ${CARGO} clippy ${CLIPPY_OPTIONS} --package svsm-fuzz -- ${CLIPPY_ARGS}
-	${CARGO} clippy ${CLIPPY_OPTIONS} --package svsm --target x86_64-unknown-none -- ${CLIPPY_ARGS}
-	${CARGO} clippy ${CLIPPY_OPTIONS} --package bldr --target x86_64-unknown-none -- ${CLIPPY_ARGS}
-	${CARGO} clippy ${CLIPPY_OPTIONS} --package stage1 --target x86_64-unknown-none -- ${CLIPPY_ARGS}
+	for pkg in $(BARE_METAL_MEMBERS); do \
+		${CARGO} clippy ${CLIPPY_OPTIONS} --package $$pkg --target x86_64-unknown-none -- ${CLIPPY_ARGS} || exit 1; \
+	done
 	${CARGO} clippy ${CLIPPY_OPTIONS} --workspace --tests --exclude svsm -- ${CLIPPY_ARGS}
 	${CARGO} clippy ${CLIPPY_OPTIONS} --package svsm --tests -- ${CLIPPY_ARGS}
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ CLIPPY_OPTIONS ?= --all-features
 CLIPPY_ARGS ?= -D warnings
 
 # Packages that require --target x86_64-unknown-none
-BARE_METAL_MEMBERS := svsm stage1
+BARE_METAL_MEMBERS := svsm bldr stage1
 BARE_METAL_EXCLUDES := $(addprefix --exclude ,$(BARE_METAL_MEMBERS))
 
 ifdef CARGO_HACK

--- a/boot/bldr/build.rs
+++ b/boot/bldr/build.rs
@@ -5,12 +5,7 @@
 // Author: Joerg Roedel <jroedel@suse.de>
 
 fn main() {
-    let target = std::env::var("TARGET").unwrap();
-
-    if target == "x86_64-unknown-none" {
-        println!("cargo:rustc-link-arg=--build-id=none");
-    }
-
+    println!("cargo:rustc-link-arg=--build-id=none");
     println!("cargo:rustc-link-arg=-nostdlib");
     println!("cargo:rustc-link-arg=-Tboot/bldr/src/bldr.lds");
     println!("cargo:rustc-link-arg=-no-pie");


### PR DESCRIPTION
- Remove bldr from clippy workspace, as it targets " x86_64-unknown-linux-gnu" and this is not necessary as the bootloader is always compiled targeting "x86_64-unknown-none"
- In the bldr `build.rs` file, there is a check on the target, remove it for the same reason as above.


cc @armenon-rh