### PR TITLE
xbuild/test: Replace dashes in package name

### DIFF
--- a/xbuild/src/cargo.rs
+++ b/xbuild/src/cargo.rs
@@ -20,9 +20,28 @@ enum CargoMessage {
     Other,
 }
 
+/// The kind of a cargo target as reported in `compiler-artifact` messages.
+#[derive(Deserialize, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+enum ArtifactKind {
+    Bin,
+    Lib,
+    Rlib,
+    Dylib,
+    Cdylib,
+    Staticlib,
+    ProcMacro,
+    Test,
+    Bench,
+    Example,
+    #[serde(other)]
+    Other,
+}
+
 #[derive(Deserialize)]
 struct ArtifactTarget {
     name: String,
+    kind: Vec<ArtifactKind>,
 }
 
 #[derive(Deserialize)]
@@ -34,9 +53,8 @@ struct ArtifactProfile {
 /// the path to the test executable produced for package `pkg`.
 ///
 /// Cargo emits one JSON object per line. Look for the `compiler-artifact`
-/// record whose target name matches `pkg`, was built in test mode, and has
-/// an `executable` path. If cargo produces several such records (e.g. lib +
-/// integration tests) the last one wins.
+/// record whose target name matches `pkg`, is a lib target, was built in test
+/// mode, and has an `executable` path.
 pub fn find_test_executable(stdout: &[u8], pkg: &str) -> Option<PathBuf> {
     std::str::from_utf8(stdout)
         .ok()?
@@ -47,7 +65,12 @@ pub fn find_test_executable(stdout: &[u8], pkg: &str) -> Option<PathBuf> {
                 target,
                 profile,
                 executable,
-            } if target.name == pkg && profile.test => executable,
+            } if target.name == pkg.replace('-', "_")
+                && target.kind.contains(&ArtifactKind::Lib)
+                && profile.test =>
+            {
+                executable
+            }
             _ => None,
         })
         .next_back()


### PR DESCRIPTION
When specifying `--message-format=json-render-diagnostics`, Cargo produces an output where potential '-' in target.name are converted in '_' for lib crates. [1]

This seems to be the expected behavior. [2]

Update `find_test_executable` to account for that.

[1] https://github.com/rust-lang/cargo/issues/13867
[2] https://github.com/rust-lang/cargo/pull/13887

**note**: I discovered this when trying to use `kapi-tester` as crate name instead of `kapi_tester` in #926. 
For `test-in-svsm`, is it correct to assume that the `target.crate_types` will only contain `lib` as bin is tagged with `test=false`? Otherwise, the match guard should be changed to account for other cases