### PR TITLE
kernel/platform: allow unused_unsafe on __cpuid_count call

### DIFF
--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -186,8 +186,13 @@ pub trait SvsmPlatform: Sync {
     where
         Self: Sized,
     {
+        // Stable clippy and the nightly rust compiler disagree on the safety
+        // of __cpuid_count(). Silence both until this is resolved.
+        #[allow(unused_unsafe)]
         // SAFETY: CPUID is always safe
-        unsafe { Some(__cpuid_count(eax, ecx)) }
+        unsafe {
+            Some(__cpuid_count(eax, ecx))
+        }
     }
 
     /// Write a host-owned MSR.


### PR DESCRIPTION
`__cpuid_count` is safe on nightly but unsafe on stable. This causes an unused_unsafe warning when running test-in-svsm that uses nightly.

Add #[allow(unused_unsafe)] to satisfy both toolchains.