### PR TITLE
clippy: followup on allowing `new_without_default`

### DIFF
--- a/elf/src/relocation.rs
+++ b/elf/src/relocation.rs
@@ -163,12 +163,6 @@ impl Elf64X86RelocProcessor {
     }
 }
 
-impl Default for Elf64X86RelocProcessor {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Elf64RelocProcessor for Elf64X86RelocProcessor {
     /// Applies a relocation operation for x86_64 ELF files.
     ///


### PR DESCRIPTION
Commit bb4ad3ef ("clippy: allow `new_without_default`") suppressed clippy warnings related to `new_without_default` lint. With that merged, we can remove one more unused `default()` implementation, in this case for `Elf64X86RelocProcessor`.