### PR TITLE
boot_params: get debug com port from IGVM command line

### DIFF
--- a/boot/bootimg/src/lib.rs
+++ b/boot/bootimg/src/lib.rs
@@ -169,11 +169,11 @@ where
         idt_vaddr,
         boot_params_virt_addr: boot_params_vaddr,
         vtom: boot_image_params.vtom,
-        debug_serial_port: boot_image_params.boot_params.debug_serial_port,
         ap_start_context_addr: boot_image_params.ap_start_context_addr,
         use_alternate_injection: boot_image_params.boot_params.use_alternate_injection != 0,
         kernel_page_table_vaddr: kernel_page_tables.root_vaddr(),
         vmsa_in_kernel_heap,
+        _reserved: Default::default(),
     };
     add_page_contents(add_page_data, launch_info_paddr, launch_info.as_bytes())?;
 

--- a/boot/defs/src/boot_params.rs
+++ b/boot/defs/src/boot_params.rs
@@ -118,12 +118,13 @@ pub struct BootParamBlock {
     /// of the memory map (which is in IGVM format).
     pub memory_map_offset: u32,
 
+    /// The offset, in bytes, of the command line, or zero if no command line
+    /// is present.
+    pub command_line_offset: u32,
+
     /// The offset, in bytes, of the guest context, or zero if no guest
     /// context is present.
     pub guest_context_offset: u32,
-
-    /// The port number of the serial port to use for debugging.
-    pub debug_serial_port: u16,
 
     /// Indicates whether the guest can support alternate injection.
     pub use_alternate_injection: u8,
@@ -141,7 +142,7 @@ pub struct BootParamBlock {
     /// range.
     pub vmsa_in_kernel_range: u8,
 
-    pub _reserved: u8,
+    pub _reserved: [u8; 7],
 
     /// Metadata containing information about the firmware image embedded in the
     /// IGVM file.

--- a/boot/defs/src/boot_params.rs
+++ b/boot/defs/src/boot_params.rs
@@ -125,12 +125,13 @@ pub struct BootParamBlock {
     /// of the memory map (which is in IGVM format).
     pub memory_map_offset: u32,
 
+    /// The offset, in bytes, of the command line, or zero if no command line
+    /// is present.
+    pub command_line_offset: u32,
+
     /// The offset, in bytes, of the guest context, or zero if no guest
     /// context is present.
     pub guest_context_offset: u32,
-
-    /// The port number of the serial port to use for debugging.
-    pub debug_serial_port: u16,
 
     /// Indicates whether the guest can support alternate injection.
     pub use_alternate_injection: u8,
@@ -144,8 +145,6 @@ pub struct BootParamBlock {
     /// Indicates whether the VMSA is placed at the top of the kernel GPA
     /// range.
     pub vmsa_in_kernel_range: u8,
-
-    pub _reserved: [u8; 2],
 
     /// Metadata containing information about the firmware image embedded in the
     /// IGVM file.

--- a/boot/defs/src/kernel_launch.rs
+++ b/boot/defs/src/kernel_launch.rs
@@ -36,9 +36,9 @@ pub struct KernelLaunchInfo {
     pub vtom: u64,
     pub kernel_page_table_vaddr: u64,
     pub ap_start_context_addr: u32,
-    pub debug_serial_port: u16,
     pub vmsa_in_kernel_heap: bool,
     pub use_alternate_injection: bool,
+    pub _reserved: [bool; 2],
 }
 
 pub const INITIAL_KERNEL_STACK_WORDS: usize = 3;

--- a/configs/all-targets.json
+++ b/configs/all-targets.json
@@ -18,7 +18,6 @@
                 "vsm"
             ],
             "policy": "0x30000",
-            "comport": "3",
             "measure": "print"
         },
         "vanadium": {

--- a/configs/hyperv-target.json
+++ b/configs/hyperv-target.json
@@ -8,7 +8,6 @@
                 "vsm"
             ],
             "policy": "0x30000",
-            "comport": "3",
             "measure": "print"
         }
     },

--- a/configs/test/hyperv-test-target.json
+++ b/configs/test/hyperv-test-target.json
@@ -8,7 +8,6 @@
                 "vsm"
             ],
             "policy": "0x30000",
-            "comport": "3",
             "measure": "print"
         }
     },

--- a/kernel/src/boot_params.rs
+++ b/kernel/src/boot_params.rs
@@ -38,6 +38,7 @@ pub struct BootParams<'a> {
     boot_param_block: &'a BootParamBlock,
     igvm_param_page: &'a IgvmParamPage,
     igvm_memory_map: &'a IgvmMemoryMap,
+    igvm_cmdline: Option<&'a [u8]>,
     igvm_madt: &'a [u8],
     guest_context: Option<&'a InitialGuestContext>,
 }
@@ -58,6 +59,19 @@ impl BootParams<'_> {
         let madt = unsafe {
             slice::from_raw_parts(madt_address.as_ptr::<u8>(), param_block.madt_size as usize)
         };
+        let cmdline = if param_block.command_line_offset != 0 {
+            // SAFETY: the parameter block correctly specifies the address of
+            // the command line, which is limited to a single page.
+            unsafe {
+                let cmdline_address = addr + param_block.command_line_offset as usize;
+                let bytes = slice::from_raw_parts(cmdline_address.as_ptr::<u8>(), PAGE_SIZE);
+                let end = bytes.iter().position(|&b| b == 0).unwrap_or(bytes.len());
+                let (cmdline, _) = bytes.split_at(end);
+                Some(cmdline)
+            }
+        } else {
+            None
+        };
         let guest_context = if param_block.guest_context_offset != 0 {
             let offset = usize::try_from(param_block.guest_context_offset).unwrap();
             Some(Self::try_aligned_ref::<InitialGuestContext>(addr + offset)?)
@@ -70,6 +84,7 @@ impl BootParams<'_> {
             igvm_param_page: param_page,
             igvm_memory_map: memory_map,
             igvm_madt: madt,
+            igvm_cmdline: cmdline,
             guest_context,
         })
     }
@@ -284,8 +299,69 @@ impl BootParams<'_> {
         self.boot_param_block.firmware.size != 0
     }
 
+    fn get_cmdline_parameter(&self, param: &[u8]) -> Option<&[u8]> {
+        self.igvm_cmdline.and_then(|cmdline| {
+            if cmdline.len() <= param.len() {
+                return None;
+            } else {
+                // Scan the command line up through the last point where the
+                // parameter string could be present.
+                let scan_len = cmdline.len() - param.len();
+                for i in 0..scan_len {
+                    // Check to see whether this command line position holds
+                    // the first character of the requested parameter name.  If
+                    // so, loop over every character in the requested parameter
+                    // as long as it matches the string found in the command
+                    // line.
+                    let mut j: usize = 0;
+                    while cmdline[i + j] == param[j] {
+                        j += 1;
+                        if j == param.len() {
+                            // The parameter matches.  Generate a substring
+                            // that contains the entire command line that
+                            // follows the parameter string, and then break it
+                            // at the first space.
+                            let (_, substr) = cmdline.split_at(i + j);
+                            let end = substr
+                                .iter()
+                                .position(|&b| b == b' ')
+                                .unwrap_or(substr.len());
+                            let (val, _) = substr.split_at(end);
+                            return Some(val);
+                        }
+                    }
+                }
+            }
+            None
+        })
+    }
+
+    fn param_as_u32(param: &[u8]) -> Option<u32> {
+        let mut val: u32 = 0;
+        for b in param.iter() {
+            if *b < b'0' {
+                return None;
+            }
+            if *b > b'9' {
+                return None;
+            }
+            // TODO: check for overflow.
+            val = 10 * val + (*b - b'0') as u32;
+        }
+        Some(val)
+    }
+
     pub fn debug_serial_port(&self) -> u16 {
-        self.boot_param_block.debug_serial_port
+        let comport = self
+            .get_cmdline_parameter(b"CONSOLEPORT=")
+            .and_then(Self::param_as_u32);
+        match comport {
+            Some(2) => 0x2f8,
+            Some(3) => 0x3e8,
+            Some(4) => 0x2e8,
+            // All invalid port numbers are treated as COM1.
+            _ => 0x3f8,
+        }
     }
 
     pub fn get_fw_metadata(&self) -> Option<SevFWMetaData> {

--- a/kernel/src/boot_params.rs
+++ b/kernel/src/boot_params.rs
@@ -38,6 +38,7 @@ pub struct BootParams<'a> {
     boot_param_block: &'a BootParamBlock,
     igvm_param_page: &'a IgvmParamPage,
     igvm_memory_map: &'a IgvmMemoryMap,
+    igvm_cmdline: Option<&'a [u8]>,
     igvm_madt: &'a [u8],
     igvm_device_tree: &'a [u8],
     guest_context: Option<&'a InitialGuestContext>,
@@ -65,6 +66,20 @@ impl BootParams<'_> {
             slice::from_raw_parts(dt_address.as_ptr::<u8>(), param_block.dt_size as usize)
         };
 
+        let cmdline = if param_block.command_line_offset != 0 {
+            // SAFETY: the parameter block correctly specifies the address of
+            // the command line, which is limited to a single page.
+            unsafe {
+                let cmdline_address = addr + param_block.command_line_offset as usize;
+                let bytes = slice::from_raw_parts(cmdline_address.as_ptr::<u8>(), PAGE_SIZE);
+                let end = bytes.iter().position(|&b| b == 0).unwrap_or(bytes.len());
+                let (cmdline, _) = bytes.split_at(end);
+                Some(cmdline)
+            }
+        } else {
+            None
+        };
+
         let guest_context = if param_block.guest_context_offset != 0 {
             let offset = usize::try_from(param_block.guest_context_offset).unwrap();
             Some(Self::try_aligned_ref::<InitialGuestContext>(addr + offset)?)
@@ -78,6 +93,7 @@ impl BootParams<'_> {
             igvm_memory_map: memory_map,
             igvm_madt: madt,
             igvm_device_tree: device_tree,
+            igvm_cmdline: cmdline,
             guest_context,
         })
     }
@@ -298,8 +314,69 @@ impl BootParams<'_> {
         self.boot_param_block.firmware.size != 0
     }
 
+    fn get_cmdline_parameter(&self, param: &[u8]) -> Option<&[u8]> {
+        self.igvm_cmdline.and_then(|cmdline| {
+            if cmdline.len() <= param.len() {
+                return None;
+            } else {
+                // Scan the command line up through the last point where the
+                // parameter string could be present.
+                let scan_len = cmdline.len() - param.len();
+                for i in 0..scan_len {
+                    // Check to see whether this command line position holds
+                    // the first character of the requested parameter name.  If
+                    // so, loop over every character in the requested parameter
+                    // as long as it matches the string found in the command
+                    // line.
+                    let mut j: usize = 0;
+                    while cmdline[i + j] == param[j] {
+                        j += 1;
+                        if j == param.len() {
+                            // The parameter matches.  Generate a substring
+                            // that contains the entire command line that
+                            // follows the parameter string, and then break it
+                            // at the first space.
+                            let (_, substr) = cmdline.split_at(i + j);
+                            let end = substr
+                                .iter()
+                                .position(|&b| b == b' ')
+                                .unwrap_or(substr.len());
+                            let (val, _) = substr.split_at(end);
+                            return Some(val);
+                        }
+                    }
+                }
+            }
+            None
+        })
+    }
+
+    fn param_as_u32(param: &[u8]) -> Option<u32> {
+        let mut val: u32 = 0;
+        for b in param.iter() {
+            if *b < b'0' {
+                return None;
+            }
+            if *b > b'9' {
+                return None;
+            }
+            // TODO: check for overflow.
+            val = 10 * val + (*b - b'0') as u32;
+        }
+        Some(val)
+    }
+
     pub fn debug_serial_port(&self) -> u16 {
-        self.boot_param_block.debug_serial_port
+        let comport = self
+            .get_cmdline_parameter(b"CONSOLEPORT=")
+            .and_then(Self::param_as_u32);
+        match comport {
+            Some(2) => 0x2f8,
+            Some(3) => 0x3e8,
+            Some(4) => 0x2e8,
+            // All invalid port numbers are treated as COM1.
+            _ => 0x3f8,
+        }
     }
 
     pub fn get_fw_metadata(&self) -> Option<SevFWMetaData> {

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -156,6 +156,7 @@ global_asm!(
 /// heap.
 unsafe fn memory_init(
     launch_info: &mut KernelLaunchInfo,
+    boot_params: &BootParams<'_>,
     platform: &dyn SvsmPlatform,
     platform_type: SvsmPlatformType,
 ) {
@@ -163,28 +164,23 @@ unsafe fn memory_init(
 
     // Determine the size of the full kernel region as determined from the
     // boot parameters, including the initial memory map.
-    let heap_adjust_pages: isize = if launch_info.vmsa_in_kernel_heap
-        && (platform_type == SvsmPlatformType::Snp)
-    {
-        // On an SNP system, the VMSA might be located within the kernel heap
-        // area.  If so, it is at the last page within the heap range, so the
-        // heap range must be reduced so there is no attempt to validate the
-        // VMSA page and so that the VMSA page is not reallocated.  If this
-        // VMSA is present, then the heap cannot be dynamically expanded.
-        -1
-    } else {
-        // SAFETY: The launch info block is trusted to hold a valid virtual
-        // address for the boot parameters.
-        let boot_params =
-            unsafe { BootParams::new(VirtAddr::from(launch_info.boot_params_virt_addr)).unwrap() };
-        let kernel_region = boot_params
-            .find_kernel_region()
-            .expect("Failed to find memory region for SVSM kernel");
-        full_kernel_region = Some(kernel_region);
+    let heap_adjust_pages: isize =
+        if launch_info.vmsa_in_kernel_heap && (platform_type == SvsmPlatformType::Snp) {
+            // On an SNP system, the VMSA might be located within the kernel heap
+            // area.  If so, it is at the last page within the heap range, so the
+            // heap range must be reduced so there is no attempt to validate the
+            // VMSA page and so that the VMSA page is not reallocated.  If this
+            // VMSA is present, then the heap cannot be dynamically expanded.
+            -1
+        } else {
+            let kernel_region = boot_params
+                .find_kernel_region()
+                .expect("Failed to find memory region for SVSM kernel");
+            full_kernel_region = Some(kernel_region);
 
-        let region_end = u64::from(kernel_region.end());
-        ((region_end - launch_info.kernel_region_phys_end) as usize / PAGE_SIZE) as isize
-    };
+            let region_end = u64::from(kernel_region.end());
+            ((region_end - launch_info.kernel_region_phys_end) as usize / PAGE_SIZE) as isize
+        };
 
     // Calculate the physical and virtual bounds of the kernel heap, which sits
     // within the direct map.
@@ -315,10 +311,6 @@ unsafe fn svsm_start(
         early_idt_init(&mut idt);
     }
 
-    // Capture the debug serial port before the launch info disappears from
-    // the address space.
-    let debug_serial_port = launch_info.debug_serial_port;
-
     let mut platform_cell = SvsmPlatformCell::new();
     let platform = platform_cell.platform_mut();
 
@@ -338,6 +330,14 @@ unsafe fn svsm_start(
     cr0_init();
     cr4_init();
 
+    // SAFETY: The launch info block is trusted to hold a valid virtual
+    // address for the boot parameters.
+    let boot_params =
+        unsafe { BootParams::new(VirtAddr::from(launch_info.boot_params_virt_addr)).unwrap() };
+
+    // Obtain the debug console port from the boot parameters.
+    let debug_serial_port = boot_params.debug_serial_port();
+
     install_console_logger("SVSM").expect("Console logger already initialized");
     platform
         .env_setup(debug_serial_port, launch_info.vtom.try_into().unwrap())
@@ -356,7 +356,7 @@ unsafe fn svsm_start(
     // SAFETY: THe launch info is assumed to correctly specify the initial
     // state of memory.
     unsafe {
-        memory_init(launch_info.as_mut(), platform, platform_type);
+        memory_init(launch_info.as_mut(), &boot_params, platform, platform_type);
     }
 
     // SAFETY: the current page table was was placed into the kernel heap as

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -150,6 +150,7 @@ global_asm!(
 /// heap.
 unsafe fn memory_init(
     launch_info: &mut KernelLaunchInfo,
+    boot_params: &BootParams<'_>,
     platform: &dyn SvsmPlatform,
     platform_type: SvsmPlatformType,
 ) {
@@ -157,28 +158,24 @@ unsafe fn memory_init(
 
     // Determine the size of the full kernel region as determined from the
     // boot parameters, including the initial memory map.
-    let heap_adjust_pages: isize = if launch_info.vmsa_in_kernel_heap
-        && (platform_type == SvsmPlatformType::Snp)
-    {
-        // On an SNP system, the VMSA might be located within the kernel heap
-        // area.  If so, it is at the last page within the heap range, so the
-        // heap range must be reduced so there is no attempt to validate the
-        // VMSA page and so that the VMSA page is not reallocated.  If this
-        // VMSA is present, then the heap cannot be dynamically expanded.
-        -1
-    } else {
-        // SAFETY: The launch info block is trusted to hold a valid virtual
-        // address for the boot parameters.
-        let boot_params =
-            unsafe { BootParams::new(VirtAddr::from(launch_info.boot_params_virt_addr)).unwrap() };
-        let kernel_region = boot_params
-            .find_kernel_region()
-            .expect("Failed to find memory region for SVSM kernel");
-        full_kernel_region = Some(kernel_region);
+    let heap_adjust_pages: isize =
+        if launch_info.vmsa_in_kernel_heap && (platform_type == SvsmPlatformType::Snp) {
+            // On an SNP system, the VMSA might be located within the kernel
+            // heap area.  If so, it is at the last page within the heap range,
+            // so the heap range must be reduced so there is no attempt to
+            // validate the VMSA page and so that the VMSA page is not
+            // reallocated.  If this VMSA is present, then the heap cannot be
+            // dynamically expanded.
+            -1
+        } else {
+            let kernel_region = boot_params
+                .find_kernel_region()
+                .expect("Failed to find memory region for SVSM kernel");
+            full_kernel_region = Some(kernel_region);
 
-        let region_end = u64::from(kernel_region.end());
-        ((region_end - launch_info.kernel_region_phys_end) as usize / PAGE_SIZE) as isize
-    };
+            let region_end = u64::from(kernel_region.end());
+            ((region_end - launch_info.kernel_region_phys_end) as usize / PAGE_SIZE) as isize
+        };
 
     // Calculate the physical and virtual bounds of the kernel heap, which sits
     // within the direct map.
@@ -309,10 +306,6 @@ unsafe fn svsm_start(
         early_idt_init(&mut idt);
     }
 
-    // Capture the debug serial port before the launch info disappears from
-    // the address space.
-    let debug_serial_port = launch_info.debug_serial_port;
-
     let mut platform_cell = SvsmPlatformCell::new();
     let platform = platform_cell.platform_mut();
 
@@ -332,6 +325,14 @@ unsafe fn svsm_start(
     cr0_init();
     cr4_init();
 
+    // SAFETY: The launch info block is trusted to hold a valid virtual
+    // address for the boot parameters.
+    let boot_params =
+        unsafe { BootParams::new(VirtAddr::from(launch_info.boot_params_virt_addr)).unwrap() };
+
+    // Obtain the debug console port from the boot parameters.
+    let debug_serial_port = boot_params.debug_serial_port();
+
     platform
         .env_setup(debug_serial_port, launch_info.vtom.try_into().unwrap())
         .expect("Early environment setup failed");
@@ -349,7 +350,7 @@ unsafe fn svsm_start(
     // SAFETY: THe launch info is assumed to correctly specify the initial
     // state of memory.
     unsafe {
-        memory_init(launch_info.as_mut(), platform, platform_type);
+        memory_init(launch_info.as_mut(), &boot_params, platform, platform_type);
     }
 
     // SAFETY: the current page table was was placed into the kernel heap as

--- a/tools/igvmbuilder/src/boot_params.rs
+++ b/tools/igvmbuilder/src/boot_params.rs
@@ -11,6 +11,7 @@ pub enum BootParamType {
     General,
     MemoryMap,
     Madt,
+    CommandLine,
     GuestContext,
 }
 
@@ -19,6 +20,7 @@ pub struct BootParamLayout {
     general_param_offset: u32,
     memory_map_offset: u32,
     madt_offset: u32,
+    command_line_offset: u32,
     guest_context_offset: u32,
     guest_context_size: u32,
     total_size: u32,
@@ -36,12 +38,14 @@ impl BootParamLayout {
         };
         let general_param_offset = page_size + guest_context_size;
         let madt_offset = general_param_offset + page_size;
-        let memory_map_offset = madt_offset + page_size;
+        let command_line_offset = madt_offset + page_size;
+        let memory_map_offset = command_line_offset + page_size;
         let total_size = memory_map_offset + page_size;
         Self {
             general_param_offset,
             memory_map_offset,
             madt_offset,
+            command_line_offset,
             guest_context_offset,
             guest_context_size,
             total_size,
@@ -58,6 +62,7 @@ impl BootParamLayout {
             BootParamType::MemoryMap => self.memory_map_offset,
             BootParamType::Madt => self.madt_offset,
             BootParamType::GuestContext => self.guest_context_offset,
+            BootParamType::CommandLine => self.command_line_offset,
         }
     }
 

--- a/tools/igvmbuilder/src/boot_params.rs
+++ b/tools/igvmbuilder/src/boot_params.rs
@@ -12,6 +12,7 @@ pub enum BootParamType {
     MemoryMap,
     Madt,
     DeviceTree,
+    CommandLine,
     GuestContext,
 }
 
@@ -22,6 +23,7 @@ pub struct BootParamLayout {
     madt_offset: u32,
     device_tree_offset: u32,
     device_tree_size: u32,
+    command_line_offset: u32,
     guest_context_offset: u32,
     guest_context_size: u32,
     total_size: u32,
@@ -41,6 +43,7 @@ impl BootParamLayout {
         let madt_offset = general_param_offset + page_size;
         let memory_map_offset = madt_offset + page_size;
         let device_tree_offset = memory_map_offset + page_size;
+        let command_line_offset = madt_offset + page_size;
         let total_size = device_tree_offset + page_size;
         Self {
             general_param_offset,
@@ -48,6 +51,7 @@ impl BootParamLayout {
             madt_offset,
             device_tree_offset,
             device_tree_size: page_size,
+            command_line_offset,
             guest_context_offset,
             guest_context_size,
             total_size,
@@ -65,6 +69,7 @@ impl BootParamLayout {
             BootParamType::Madt => self.madt_offset,
             BootParamType::DeviceTree => self.device_tree_offset,
             BootParamType::GuestContext => self.guest_context_offset,
+            BootParamType::CommandLine => self.command_line_offset,
         }
     }
 

--- a/tools/igvmbuilder/src/cmd_options.rs
+++ b/tools/igvmbuilder/src/cmd_options.rs
@@ -32,10 +32,6 @@ pub struct CmdOptions {
     #[arg(short, long)]
     pub output: String,
 
-    /// COM port to use for the SVSM console. Valid values are 1-4
-    #[arg(short, long, default_value_t = 1, value_parser = clap::value_parser!(i32).range(1..=4))]
-    pub comport: i32,
-
     /// Hypervisor to generate IGVM file for
     #[arg(value_enum)]
     pub hypervisor: Hypervisor,
@@ -79,18 +75,6 @@ pub struct CmdOptions {
     /// Use Alternate Injection if available
     #[arg(long, default_value_t = false)]
     pub alt_injection: bool,
-}
-
-impl CmdOptions {
-    pub fn get_port_address(&self) -> u16 {
-        match self.comport {
-            1 => 0x3f8,
-            2 => 0x2f8,
-            3 => 0x3e8,
-            4 => 0x2e8,
-            _ => 0,
-        }
-    }
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]

--- a/tools/igvmbuilder/src/igvm_builder.rs
+++ b/tools/igvmbuilder/src/igvm_builder.rs
@@ -58,7 +58,8 @@ pub static COMPATIBILITY_MASK: PlatformMask = PlatformMask::new();
 const IGVM_GENERAL_PARAMS_PA: u32 = 0;
 const IGVM_MEMORY_MAP_PA: u32 = 1;
 const IGVM_MADT_PA: u32 = 2;
-const IGVM_PARAMETER_COUNT: u32 = 3;
+const IGVM_COMMAND_LINE_PA: u32 = 3;
+const IGVM_PARAMETER_COUNT: u32 = 4;
 
 const _: () = assert!(size_of::<BootParamBlock>() as u64 <= PAGE_SIZE_4K);
 const _: () = assert!(size_of::<InitialGuestContext>() as u64 <= PAGE_SIZE_4K);
@@ -259,11 +260,14 @@ impl IgvmBuilder {
                 .gpa_map
                 .boot_param_layout
                 .get_param_size(BootParamType::Madt),
+            command_line_offset: self
+                .gpa_map
+                .boot_param_layout
+                .get_param_offset(BootParamType::CommandLine),
             guest_context_offset: self
                 .gpa_map
                 .boot_param_layout
                 .get_param_size(BootParamType::GuestContext),
-            debug_serial_port: self.options.get_port_address(),
             firmware: fw_info,
             vmsa_in_kernel_range: self.gpa_map.vmsa_in_kernel_range as u8,
             kernel_base: self.gpa_map.kernel.get_start(),
@@ -513,6 +517,14 @@ impl IgvmBuilder {
             number_of_bytes: self
                 .gpa_map
                 .boot_param_layout
+                .get_param_size(BootParamType::CommandLine) as u64,
+            parameter_area_index: IGVM_COMMAND_LINE_PA,
+            initial_data: vec![],
+        });
+        self.directives.push(IgvmDirectiveHeader::ParameterArea {
+            number_of_bytes: self
+                .gpa_map
+                .boot_param_layout
                 .get_param_size(BootParamType::General) as u64,
             parameter_area_index: IGVM_GENERAL_PARAMS_PA,
             initial_data: vec![],
@@ -530,6 +542,11 @@ impl IgvmBuilder {
         self.directives
             .push(IgvmDirectiveHeader::Madt(IGVM_VHS_PARAMETER {
                 parameter_area_index: IGVM_MADT_PA,
+                byte_offset: 0,
+            }));
+        self.directives
+            .push(IgvmDirectiveHeader::CommandLine(IGVM_VHS_PARAMETER {
+                parameter_area_index: IGVM_COMMAND_LINE_PA,
                 byte_offset: 0,
             }));
         self.directives
@@ -555,6 +572,16 @@ impl IgvmBuilder {
                     .get_param_gpa(image_layout.boot_params_gpa, BootParamType::Madt),
                 compatibility_mask: COMPATIBILITY_MASK.get(),
                 parameter_area_index: IGVM_MADT_PA,
+            },
+        ));
+        self.directives.push(IgvmDirectiveHeader::ParameterInsert(
+            IGVM_VHS_PARAMETER_INSERT {
+                gpa: self
+                    .gpa_map
+                    .boot_param_layout
+                    .get_param_gpa(image_layout.boot_params_gpa, BootParamType::CommandLine),
+                compatibility_mask: COMPATIBILITY_MASK.get(),
+                parameter_area_index: IGVM_COMMAND_LINE_PA,
             },
         ));
         self.directives.push(IgvmDirectiveHeader::ParameterInsert(

--- a/tools/igvmbuilder/src/igvm_builder.rs
+++ b/tools/igvmbuilder/src/igvm_builder.rs
@@ -59,7 +59,8 @@ const IGVM_GENERAL_PARAMS_PA: u32 = 0;
 const IGVM_MEMORY_MAP_PA: u32 = 1;
 const IGVM_MADT_PA: u32 = 2;
 const IGVM_DT_PA: u32 = 3;
-const IGVM_PARAMETER_COUNT: u32 = 4;
+const IGVM_COMMAND_LINE_PA: u32 = 4;
+const IGVM_PARAMETER_COUNT: u32 = 5;
 
 const _: () = assert!(size_of::<BootParamBlock>() as u64 <= PAGE_SIZE_4K);
 const _: () = assert!(size_of::<InitialGuestContext>() as u64 <= PAGE_SIZE_4K);
@@ -263,11 +264,14 @@ impl IgvmBuilder {
                 .gpa_map
                 .boot_param_layout
                 .get_param_size(BootParamType::DeviceTree),
+            command_line_offset: self
+                .gpa_map
+                .boot_param_layout
+                .get_param_offset(BootParamType::CommandLine),
             guest_context_offset: self
                 .gpa_map
                 .boot_param_layout
                 .get_param_size(BootParamType::GuestContext),
-            debug_serial_port: self.options.get_port_address(),
             firmware: fw_info,
             vmsa_in_kernel_range: self.gpa_map.vmsa_in_kernel_range as u8,
             kernel_base: self.gpa_map.kernel.get_start(),
@@ -276,7 +280,6 @@ impl IgvmBuilder {
             use_alternate_injection: u8::from(self.options.alt_injection),
             has_qemu_testdev,
             has_test_iorequests,
-            _reserved: Default::default(),
         })
     }
 
@@ -525,6 +528,14 @@ impl IgvmBuilder {
             number_of_bytes: self
                 .gpa_map
                 .boot_param_layout
+                .get_param_size(BootParamType::CommandLine) as u64,
+            parameter_area_index: IGVM_COMMAND_LINE_PA,
+            initial_data: vec![],
+        });
+        self.directives.push(IgvmDirectiveHeader::ParameterArea {
+            number_of_bytes: self
+                .gpa_map
+                .boot_param_layout
                 .get_param_size(BootParamType::General) as u64,
             parameter_area_index: IGVM_GENERAL_PARAMS_PA,
             initial_data: vec![],
@@ -548,6 +559,11 @@ impl IgvmBuilder {
         self.directives
             .push(IgvmDirectiveHeader::DeviceTree(IGVM_VHS_PARAMETER {
                 parameter_area_index: IGVM_DT_PA,
+                byte_offset: 0,
+            }));
+        self.directives
+            .push(IgvmDirectiveHeader::CommandLine(IGVM_VHS_PARAMETER {
+                parameter_area_index: IGVM_COMMAND_LINE_PA,
                 byte_offset: 0,
             }));
         self.directives
@@ -584,6 +600,16 @@ impl IgvmBuilder {
                     .get_param_gpa(image_layout.boot_params_gpa, BootParamType::DeviceTree),
                 compatibility_mask: COMPATIBILITY_MASK.get(),
                 parameter_area_index: IGVM_DT_PA,
+            },
+        ));
+        self.directives.push(IgvmDirectiveHeader::ParameterInsert(
+            IGVM_VHS_PARAMETER_INSERT {
+                gpa: self
+                    .gpa_map
+                    .boot_param_layout
+                    .get_param_gpa(image_layout.boot_params_gpa, BootParamType::CommandLine),
+                compatibility_mask: COMPATIBILITY_MASK.get(),
+                parameter_area_index: IGVM_COMMAND_LINE_PA,
             },
         ));
         self.directives.push(IgvmDirectiveHeader::ParameterInsert(

--- a/xbuild/src/igvm.rs
+++ b/xbuild/src/igvm.rs
@@ -78,8 +78,6 @@ struct IgvmTargetConfig {
     /// See help for `igvmbuilder --policy`
     #[serde(default = "IgvmTargetConfig::default_policy")]
     policy: String,
-    /// See help for `igvmbuilder --comport`.
-    comport: Option<String>,
     /// Platform flags for igvmbuilder
     #[serde(default = "IgvmTargetConfig::default_platforms")]
     platforms: Vec<IgvmPlatform>,
@@ -136,9 +134,6 @@ impl IgvmTargetConfig {
         }
         if let Some(fs) = parts.fs.as_ref() {
             cmd.arg("--filesystem").arg(fs);
-        }
-        if let Some(comport) = self.comport.as_ref() {
-            cmd.arg("--comport").arg(comport);
         }
         if args.verbose {
             cmd.arg("--verbose");


### PR DESCRIPTION
The IGVM command line is intended to convey debug configuration options, so obtain the debug com port identifier from the command line instead of relying on a static configuration in the IGVM file.  This eliminates one more hypervisor-specific difference from the IGVM file.  If the command line is not specified (QEMU does not specify a command line), then the com port defaults to 1, which is the value that QEMU expects, thus ensuring that QEMU can get the correct behavior without requiring a command line to be specified.