### PR TITLE
userspace: Introduce log crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2434,6 +2434,7 @@ dependencies = [
 name = "userlib"
 version = "0.1.0"
 dependencies = [
+ "log",
  "syscall",
  "test",
 ]

--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,6 @@ TARGET_PATH=debug
 OBJCOPY_ELF_ARGS := --strip-debug
 endif
 
-ifeq ($(DISABLE_CONSOLE_LOG),)
-SVSM_ARGS += --features enable-console-log
-XBUILD_ARGS += -f enable-console-log
-endif
-
 ifdef OFFLINE
 CARGO_ARGS += --locked --offline
 endif

--- a/kernel/src/log_buffer.rs
+++ b/kernel/src/log_buffer.rs
@@ -51,13 +51,7 @@ fn lb_write(args: fmt::Arguments<'_>) {
 }
 
 #[derive(Clone, Copy, Debug)]
-struct BufferLogger {}
-
-impl BufferLogger {
-    const fn new() -> Self {
-        Self {}
-    }
-}
+struct BufferLogger;
 
 impl log::Log for BufferLogger {
     fn enabled(&self, _metadata: &log::Metadata<'_>) -> bool {
@@ -94,24 +88,21 @@ impl log::Log for BufferLogger {
     fn flush(&self) {}
 }
 
-static BUFFER_LOGGER: ImmutAfterInitCell<BufferLogger> = ImmutAfterInitCell::uninit();
+static BUFFER_LOGGER: BufferLogger = BufferLogger;
 
+/// Set the log buffer as logger. This function will panic if it is
+/// called more than once.
 pub fn install_buffer_logger() {
     let logbuf = SpinLock::new(LogBuffer::new());
-    let _res = LOGGER.init(logbuf).map_err(|_| SvsmError::LogError);
+    LOGGER
+        .init(logbuf)
+        .expect("Failed to initialize log buffer");
 
-    BUFFER_LOGGER
-        .init_from_ref(&BufferLogger::new())
-        .expect("log init error");
-
-    if let Err(e) = log::set_logger(&*BUFFER_LOGGER) {
-        // Failed to install the ConsoleLogger, presumably because something had
-        // installed another logger before. No logs will appear at the console.
-        // Print an error string.
-        _print(format_args!(
-            "ERROR: failed to install console logger: {e:?}"
-        ));
-    }
+    // As described in the `log` crate, this function can be called only once
+    // and successive calls will return an error. Panic on that error.
+    // Essentially, it handles initialization in the same way as `immut_after_init`,
+    // so we can avoid using it. Therefore, the logger will be immutable after initialization.
+    log::set_logger(&BUFFER_LOGGER).expect("Failed to install the BufferLogger");
 
     // Log levels are to be configured via the log's library feature configuration.
     log::set_max_level(log::LevelFilter::Trace);

--- a/user/init/src/main.rs
+++ b/user/init/src/main.rs
@@ -9,7 +9,7 @@ use userlib::*;
 declare_main!(main);
 
 fn main() -> u32 {
-    println!("COCONUT-SVSM init process starting");
+    log::info!("COCONUT-SVSM init process starting");
 
     0
 }

--- a/user/lib/Cargo.toml
+++ b/user/lib/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 
 [dependencies]
 syscall.workspace = true
+log = { workspace = true, features = ["max_level_info", "release_max_level_info"] }
 
 [target."x86_64-unknown-none".dependencies]
 test = { workspace = true, optional = true }

--- a/user/lib/src/lib.rs
+++ b/user/lib/src/lib.rs
@@ -40,6 +40,6 @@ macro_rules! declare_main {
 #[cfg(all(not(test), target_os = "none"))]
 #[panic_handler]
 fn panic(info: &core::panic::PanicInfo<'_>) -> ! {
-    println!("Panic: {}", info);
+    log::error!("Panic: {}", info);
     exit(!0);
 }

--- a/user/lib/src/lib.rs
+++ b/user/lib/src/lib.rs
@@ -15,6 +15,8 @@ pub use locking::*;
 pub use log_buffer::*;
 pub use syscall::*;
 
+pub use log;
+
 #[cfg(all(feature = "test_runner", not(test), target_os = "none"))]
 pub mod testing;
 #[cfg(all(feature = "test_runner", not(test), target_os = "none"))]
@@ -26,6 +28,7 @@ macro_rules! declare_main {
         const _: () = {
             #[unsafe(export_name = "_start")]
             pub extern "C" fn launch_module() -> ! {
+                $crate::install_logger();
                 let main_fn: fn() -> u32 = $path;
                 let ret = main_fn();
                 $crate::exit(ret);

--- a/user/lib/src/lib.rs
+++ b/user/lib/src/lib.rs
@@ -28,7 +28,7 @@ macro_rules! declare_main {
             pub extern "C" fn launch_module() -> ! {
                 let main_fn: fn() -> u32 = $path;
                 let ret = main_fn();
-                exit(ret);
+                $crate::exit(ret);
             }
         };
     };

--- a/user/lib/src/log_buffer.rs
+++ b/user/lib/src/log_buffer.rs
@@ -7,6 +7,7 @@
 use crate::SpinLock;
 use crate::console_print;
 use core::fmt;
+use log::{Level, LevelFilter, Metadata, Record};
 use syscall::SysCallError;
 use syscall::write_log;
 
@@ -47,4 +48,53 @@ macro_rules! print {
 macro_rules! println {
     () => ($crate::print!("\n"));
     ($($arg:tt)*) => ($crate::print!("{}\n", format_args!($($arg)*)));
+}
+
+struct UserLogger;
+
+impl log::Log for UserLogger {
+    fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+        true
+    }
+
+    fn log(&self, record: &Record<'_>) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+
+        // The logger being uninitialized is impossible, as that would mean it
+        // wouldn't have been registered with the log library.
+        // Log format/detail depends on the level.
+        match record.metadata().level() {
+            Level::Error | Level::Warn => {
+                println!("{}: {}", record.metadata().level().as_str(), record.args());
+            }
+            Level::Info => {
+                println!("{}", record.args());
+            }
+
+            Level::Debug | Level::Trace => {
+                println!(
+                    "[{}] {} {}",
+                    record.target(),
+                    record.metadata().level().as_str(),
+                    record.args()
+                );
+            }
+        };
+    }
+
+    fn flush(&self) {}
+}
+
+static LOGGER: UserLogger = UserLogger;
+
+/// Install the logger. This function is called automatically at start up
+/// in `declare_main` macro. Subsequent calls will cause a panic.
+pub fn install_logger() {
+    // This can be called a single time, additional calls will
+    // generate an error (internal behaviour of log crate)
+    log::set_logger(&LOGGER).expect("Logger already initialized");
+    // Log levels are to be configured via the log's library feature configuration.
+    log::set_max_level(LevelFilter::Trace);
 }

--- a/user/lib/src/log_buffer.rs
+++ b/user/lib/src/log_buffer.rs
@@ -40,11 +40,11 @@ pub fn log_msg(args: fmt::Arguments<'_>) {
 
 #[macro_export]
 macro_rules! print {
-        ($($arg:tt)*) => (log_msg(format_args!($($arg)*)))
+        ($($arg:tt)*) => ($crate::log_msg(format_args!($($arg)*)))
 }
 
 #[macro_export]
 macro_rules! println {
-    () => (print!("\n"));
-    ($($arg:tt)*) => (print!("{}\n", format_args!($($arg)*)));
+    () => ($crate::print!("\n"));
+    ($($arg:tt)*) => ($crate::print!("{}\n", format_args!($($arg)*)));
 }

--- a/user/lib/src/testing.rs
+++ b/user/lib/src/testing.rs
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //
 
-use crate::println;
 use test::ShouldPanic;
 
 pub fn svsm_usermodule_test_runner(test_cases: &[&test::TestDescAndFn]) {
-    println!("running {} user tests", test_cases.len());
+    log::info!("running {} user tests", test_cases.len());
     for mut test_case in test_cases.iter().copied().copied() {
         if test_case.desc.should_panic == ShouldPanic::Yes {
             test_case.desc.ignore = true;
@@ -17,16 +16,16 @@ pub fn svsm_usermodule_test_runner(test_cases: &[&test::TestDescAndFn]) {
 
         if test_case.desc.ignore {
             if let Some(message) = test_case.desc.ignore_message {
-                println!("test {} ... ignored, {message}", test_case.desc.name.0);
+                log::info!("test {} ... ignored, {message}", test_case.desc.name.0);
             } else {
-                println!("test {} ... ignored", test_case.desc.name.0);
+                log::info!("test {} ... ignored", test_case.desc.name.0);
             }
             continue;
         }
 
-        println!("test {} ...", test_case.desc.name.0);
+        log::info!("test {} ...", test_case.desc.name.0);
         (test_case.testfn.0)();
     }
 
-    println!("Usermodule tests in svsm passed!");
+    log::info!("Usermodule tests in svsm passed!");
 }

--- a/user/lib/src/testing.rs
+++ b/user/lib/src/testing.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //
 
-use crate::{log_msg, print, println};
+use crate::println;
 use test::ShouldPanic;
 
 pub fn svsm_usermodule_test_runner(test_cases: &[&test::TestDescAndFn]) {


### PR DESCRIPTION
Introduce `log` crate in `userlib` and make it available for user binaries. `log::set_logger` behaves internally as `immut_after_init` when initializing, so there is no need to introduce that and successive calls will return an error. Call the `install_logger` function before entering main. This function causes a panic on multiple calls.

Reduce log level so that `log::debug` are available in the binary. The minimum log level can still be set at runtime.

~~Depends on https://github.com/coconut-svsm/svsm/pull/1165: only the last two commits here are related to this PR~~

other fixes:
- introduce `$crate` in macros
- remove `DISABLE_CONSOLE_LOG`