### PR TITLE
virtio/mmio: account for page offset in transport size

### DIFF
--- a/kernel/src/virtio/mmio.rs
+++ b/kernel/src/virtio/mmio.rs
@@ -99,8 +99,11 @@ pub fn probe_mmio_slots(boot_params: &BootParams<'_>) -> MmioSlots {
         // SAFETY: The address is valid, mapped by `map_global_range_4k_shared`, and verified
         // to be VirtIOHeader-aligned by the guard above.
         // The memory region has the same lifetime of the MmioSlot structure which will be consumed by the driver.
-        // Note: QEMU places each MMIO slot on its own page for us, thus mmio_size = PAGE_SIZE.
-        let Ok(transport) = (unsafe { MmioTransport::new(header, PAGE_SIZE) }) else {
+        // TODO: Currently the hypervisor does not advertise the size of the mmio space (header + config space).
+        //       The size will be provided by the device tree. For now, let's just make sure we don't go past
+        //       the boundaries of the allocated space.
+        let Ok(transport) = (unsafe { MmioTransport::new(header, mem.size() - page_offset) })
+        else {
             // Currently QEMU advertises _all_ slots, regardless they are empty or not.
             log::debug!("MmioSlots: {addr:x} empty");
             continue;


### PR DESCRIPTION
Since commit https://github.com/luigix25/svsm/commit/a109b5d55e7b52aa2c35a225c3ce41902178f855 ("virtio/mmio: handle
non-page-aligned MMIO device addresses") added support for unaligned
MMIO slots, the assumption that each slot occupies exactly one page no
longer holds, making the comment about QEMU placing each slot on its
own page obsolete.

This also means that using a whole page for `MmioTransport` is wrong:
if the offset is non-zero and the header starts at page_base + offset,
passing PAGE_SIZE as the size causes the transport to go past the
boundaries of the allocated region.

Fix this by subtracting the page offset from the total size.

Also use `mem.size()` instead of `PAGE_SIZE`. This is not a functional
change, but makes code easier to maintain as the size is derived from
the mapped region rather than repeated as a literal.

/cc @osteffenrh 