### PR TITLE
kernel: fs: do not clone task name on stdout open

### DIFF
--- a/kernel/src/fs/buffer.rs
+++ b/kernel/src/fs/buffer.rs
@@ -153,9 +153,9 @@ pub struct LineBuffer {
 }
 
 impl LineBuffer {
-    pub fn new(component: String, is_console: bool) -> Self {
+    pub fn new<S: AsRef<str>>(component: S, is_console: bool) -> Self {
         let mut prefix = String::from("[");
-        prefix.push_str(component.as_str());
+        prefix.push_str(component.as_ref());
         prefix.push_str("] ");
         Self {
             prefix,

--- a/kernel/src/fs/log_buffer.rs
+++ b/kernel/src/fs/log_buffer.rs
@@ -11,8 +11,8 @@ use crate::error::SvsmError;
 use crate::fs::*;
 use crate::locking::SpinLock;
 use crate::syscall::Obj;
-use alloc::string::String;
 use alloc::sync::Arc;
+
 pub fn initialize_log_buffer() -> Result<usize, SvsmError> {
     mkdir("Log").map_err(|_| SvsmError::LogError)?;
     let _handle = create("Log/logfile").map_err(|_| SvsmError::LogError)?;
@@ -36,7 +36,7 @@ struct LogFile {
 }
 
 impl LogFile {
-    fn new(component: String, is_console: bool) -> Self {
+    fn new<S: AsRef<str>>(component: S, is_console: bool) -> Self {
         Self {
             lb: SpinLock::new(LineBuffer::new(component, is_console)),
         }
@@ -69,9 +69,9 @@ impl File for LogFile {
     }
 }
 
-pub fn stdout_open(taskname: String) -> (Arc<dyn Obj>, Arc<dyn Obj>) {
-    let console_file: Arc<dyn File> = Arc::new(LogFile::new(taskname.clone(), true));
-    let log_file: Arc<dyn File> = Arc::new(LogFile::new(taskname.clone(), false));
+pub fn stdout_open(taskname: &str) -> (Arc<dyn Obj>, Arc<dyn Obj>) {
+    let console_file: Arc<dyn File> = Arc::new(LogFile::new(taskname, true));
+    let log_file: Arc<dyn File> = Arc::new(LogFile::new(taskname, false));
 
     // Stdout is write-only.
     (
@@ -84,6 +84,7 @@ pub fn stdout_open(taskname: String) -> (Arc<dyn Obj>, Arc<dyn Obj>) {
 mod tests {
     use super::*;
     use crate::task::{KernelThreadStartInfo, start_kernel_task, wait_for_termination};
+    use alloc::string::String;
 
     fn log_reset() -> Result<usize, SvsmError> {
         let handle = open_write("Log/logfile").map_err(|_| SvsmError::LogError)?;

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -1041,9 +1041,9 @@ impl Task {
 
     fn attach_stdout(&self) {
         let name = if self.name == "idle" {
-            String::from("SVSM")
+            "SVSM"
         } else {
-            self.name.clone()
+            self.name.as_str()
         };
 
         let (fh_console, fh_log) = stdout_open(name);


### PR DESCRIPTION
When creating the stdout files, the task name is cloned so that the log prefix can be preformatted. However, the prefix itself is heap-allocated, so a simple &str is enough.