### PR TITLE
kernel: remove more unnecessary allocations

### DIFF
--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -61,7 +61,6 @@ use crate::types::{
 use crate::utils::MemoryRegion;
 use crate::utils::immut_after_init::ImmutAfterInitCell;
 use alloc::boxed::Box;
-use alloc::string::String;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::arch::asm;
@@ -886,7 +885,7 @@ impl PerCpu {
     }
 
     fn setup_idle_task_internal(&self, start_info: KernelThreadStartInfo) -> Result<(), SvsmError> {
-        let idle_task = Task::create(self, start_info, String::from("idle"))?;
+        let idle_task = Task::create(self, start_info, Arc::from("idle"))?;
         self.runqueue_mut().set_idle_task(idle_task);
         Ok(())
     }

--- a/kernel/src/fs/api.rs
+++ b/kernel/src/fs/api.rs
@@ -17,6 +17,7 @@ use crate::mm::PageRef;
 use packit::PackItError;
 
 pub type FileName = String;
+pub type FileNameRef<'a> = &'a str;
 
 /// Represents the type of error occurred
 /// while doing SVSM filesystem operations.
@@ -204,7 +205,7 @@ pub trait Directory: Debug + Send + Sync {
     /// [`Result<DirEntry, SvsmError>`]: A [`Result`] containing the [`DirEntry`]
     /// corresponding to the entry being looked up in the directory if present, or
     /// an [`SvsmError`] if not present.
-    fn lookup_entry(&self, name: &FileName) -> Result<DirEntry, SvsmError>;
+    fn lookup_entry(&self, name: FileNameRef<'_>) -> Result<DirEntry, SvsmError>;
 
     /// Used to create a new file in the directory.
     ///
@@ -240,7 +241,7 @@ pub trait Directory: Debug + Send + Sync {
     ///
     /// [`Result<(), SvsmError>`]: A [`Result`] containing the empty
     /// value on success, or an [`SvsmError`] on failure
-    fn unlink(&self, name: &FileName) -> Result<(), SvsmError>;
+    fn unlink(&self, name: FileNameRef<'_>) -> Result<(), SvsmError>;
 }
 
 /// Represents a directory entry which could

--- a/kernel/src/fs/buffer.rs
+++ b/kernel/src/fs/buffer.rs
@@ -153,9 +153,9 @@ pub struct LineBuffer {
 }
 
 impl LineBuffer {
-    pub fn new(component: String, is_console: bool) -> Self {
+    pub fn new<S: AsRef<str>>(component: S, is_console: bool) -> Self {
         let mut prefix = String::from("[");
-        prefix.push_str(component.as_str());
+        prefix.push_str(component.as_ref());
         prefix.push_str("] ");
         Self {
             prefix,

--- a/kernel/src/fs/filesystem.rs
+++ b/kernel/src/fs/filesystem.rs
@@ -415,8 +415,7 @@ where
     let mut current_dir = dir;
 
     for item in path_items {
-        let dir_name = FileName::from(item);
-        let dir_entry = current_dir.lookup_entry(&dir_name)?;
+        let dir_entry = current_dir.lookup_entry(item)?;
         current_dir = match dir_entry {
             DirEntry::File(_) => return Err(SvsmError::FileSystem(FsError::file_not_found())),
             DirEntry::Directory(dir) => dir,
@@ -507,10 +506,10 @@ pub fn open_root(
     write: bool,
 ) -> Result<FileHandle, SvsmError> {
     let mut path_items = split_path(path)?;
-    let file_name = FileName::from(path_items.next_back().unwrap());
+    let file_name = path_items.next_back().unwrap();
     let current_dir = walk_path(root_dir, path_items)?;
 
-    let dir_entry = current_dir.lookup_entry(&file_name)?;
+    let dir_entry = current_dir.lookup_entry(file_name)?;
 
     match dir_entry {
         DirEntry::Directory(_) => Err(SvsmError::FileSystem(FsError::file_not_found())),
@@ -713,11 +712,11 @@ pub fn mkdir(path: &str) -> Result<(), SvsmError> {
 /// value if successful,  [`SvsmError`] otherwise.
 pub fn unlink_root(root_dir: Arc<dyn Directory>, path: &str) -> Result<(), SvsmError> {
     let mut path_items = split_path(path)?;
-    let entry_name = FileName::from(path_items.next_back().unwrap());
+    let entry_name = path_items.next_back().unwrap();
     let dir = walk_path(root_dir, path_items)?;
 
-    match dir.lookup_entry(&entry_name)? {
-        DirEntry::File(_) => dir.unlink(&entry_name),
+    match dir.lookup_entry(entry_name)? {
+        DirEntry::File(_) => dir.unlink(entry_name),
         DirEntry::Directory(_) => Err(SvsmError::FileSystem(FsError::is_dir())),
     }
 }
@@ -754,14 +753,14 @@ pub fn unlink(path: &str) -> Result<(), SvsmError> {
 /// in progress.
 pub fn rmdir_root(root_dir: Arc<dyn Directory>, path: &str) -> Result<(), SvsmError> {
     let mut path_items = split_path(path)?;
-    let entry_name = FileName::from(path_items.next_back().unwrap());
+    let entry_name = path_items.next_back().unwrap();
     let dir = walk_path(root_dir, path_items)?;
 
-    match dir.lookup_entry(&entry_name)? {
+    match dir.lookup_entry(entry_name)? {
         DirEntry::File(_) => Err(SvsmError::FileSystem(FsError::is_file())),
         DirEntry::Directory(target) => {
             target.prepare_remove()?;
-            dir.unlink(&entry_name)
+            dir.unlink(entry_name)
         }
     }
 }

--- a/kernel/src/fs/filesystem.rs
+++ b/kernel/src/fs/filesystem.rs
@@ -930,7 +930,7 @@ mod tests {
 
         // Check if it appears in the listing
         let root_list = list_dir("").unwrap();
-        assert!(root_list.contains(&FileName::from("test1")));
+        assert!(root_list.iter().any(|f| f == "test1"));
 
         // Try again - should succeed now
         create("test1/file1").unwrap();
@@ -949,7 +949,7 @@ mod tests {
 
         // Check if it appears in the listing
         let root_list = list_dir("").unwrap();
-        assert!(root_list.contains(&FileName::from("test1")));
+        assert!(root_list.iter().any(|f| f == "test1"));
 
         // Try creating again as file - should fail
         create("test1").unwrap_err();
@@ -965,8 +965,8 @@ mod tests {
 
         // Check if it is removed from the listing
         let root_list = list_dir("").unwrap();
-        assert!(!root_list.contains(&FileName::from("test1")));
-        assert!(root_list.contains(&FileName::from("test2")));
+        assert!(!root_list.iter().any(|f| f == "test1"));
+        assert!(root_list.iter().any(|f| f == "test2"));
 
         // Cleanup
         rmdir("test2").unwrap();
@@ -988,14 +988,14 @@ mod tests {
 
         // Check if it appears in the listing
         let list = list_dir("test1/").unwrap();
-        assert_eq!(list, [FileName::from("test2")]);
+        assert_eq!(list, ["test2"]);
 
         // Try again - should succeed now
         create("test1/test2/file1").unwrap();
 
         // Check if it appears in the listing
         let list = list_dir("test1/test2/").unwrap();
-        assert_eq!(list, [FileName::from("file1")]);
+        assert_eq!(list, ["file1"]);
 
         // Cleanup
         unlink("test1/test2/file1").unwrap();
@@ -1017,7 +1017,7 @@ mod tests {
 
         // Check if they appears in the listing
         let list = list_dir("test1").unwrap();
-        assert_eq!(list, [FileName::from("file1"), FileName::from("file2")]);
+        assert_eq!(list, ["file1", "file2"]);
 
         // Unlink non-existent file
         unlink("test2").unwrap_err();
@@ -1027,7 +1027,7 @@ mod tests {
 
         // Check if it is removed from the listing
         let list = list_dir("test1").unwrap();
-        assert_eq!(list, [FileName::from("file2")]);
+        assert_eq!(list, ["file2"]);
 
         // Cleanup
         unlink("test1/file2").unwrap();

--- a/kernel/src/fs/init.rs
+++ b/kernel/src/fs/init.rs
@@ -11,8 +11,7 @@ use packit::PackItArchiveDecoder;
 
 use super::*;
 
-extern crate alloc;
-use alloc::slice;
+use core::slice;
 
 /// Used to create a SVSM RAM filesystem from a filesystem archive.
 ///

--- a/kernel/src/fs/log_buffer.rs
+++ b/kernel/src/fs/log_buffer.rs
@@ -11,8 +11,8 @@ use crate::error::SvsmError;
 use crate::fs::*;
 use crate::locking::SpinLock;
 use crate::syscall::Obj;
-use alloc::string::String;
 use alloc::sync::Arc;
+
 pub fn initialize_log_buffer() -> Result<usize, SvsmError> {
     mkdir("Log").map_err(|_| SvsmError::LogError)?;
     let _handle = create("Log/logfile").map_err(|_| SvsmError::LogError)?;
@@ -36,7 +36,7 @@ struct LogFile {
 }
 
 impl LogFile {
-    fn new(component: String, is_console: bool) -> Self {
+    fn new<S: AsRef<str>>(component: S, is_console: bool) -> Self {
         Self {
             lb: SpinLock::new(LineBuffer::new(component, is_console)),
         }
@@ -69,9 +69,9 @@ impl File for LogFile {
     }
 }
 
-pub fn stdout_open(taskname: String) -> (Arc<dyn Obj>, Arc<dyn Obj>) {
-    let console_file: Arc<dyn File> = Arc::new(LogFile::new(taskname.clone(), true));
-    let log_file: Arc<dyn File> = Arc::new(LogFile::new(taskname.clone(), false));
+pub fn stdout_open(taskname: &str) -> (Arc<dyn Obj>, Arc<dyn Obj>) {
+    let console_file: Arc<dyn File> = Arc::new(LogFile::new(taskname, true));
+    let log_file: Arc<dyn File> = Arc::new(LogFile::new(taskname, false));
 
     // Stdout is write-only.
     (
@@ -84,6 +84,7 @@ pub fn stdout_open(taskname: String) -> (Arc<dyn Obj>, Arc<dyn Obj>) {
 mod tests {
     use super::*;
     use crate::task::{KernelThreadStartInfo, start_kernel_task, wait_for_termination};
+    use alloc::string::String;
 
     fn log_reset() -> Result<usize, SvsmError> {
         let handle = open_write("Log/logfile").map_err(|_| SvsmError::LogError)?;

--- a/kernel/src/fs/log_buffer.rs
+++ b/kernel/src/fs/log_buffer.rs
@@ -84,7 +84,6 @@ pub fn stdout_open(taskname: &str) -> (Arc<dyn Obj>, Arc<dyn Obj>) {
 mod tests {
     use super::*;
     use crate::task::{KernelThreadStartInfo, start_kernel_task, wait_for_termination};
-    use alloc::string::String;
 
     fn log_reset() -> Result<usize, SvsmError> {
         let handle = open_write("Log/logfile").map_err(|_| SvsmError::LogError)?;
@@ -109,10 +108,10 @@ mod tests {
     fn test_log_buffer_multiple_tasks() {
         let _ = log_reset();
         log::info!("in test task");
-        let task1 = start_kernel_task(KernelThreadStartInfo::new(task1, 1), String::from("task1"))
+        let task1 = start_kernel_task(KernelThreadStartInfo::new(task1, 1), "task1")
             .expect("Failed to launch request processing task");
         wait_for_termination(task1);
-        let task2 = start_kernel_task(KernelThreadStartInfo::new(task2, 2), String::from("task2"))
+        let task2 = start_kernel_task(KernelThreadStartInfo::new(task2, 2), "task2")
             .expect("Failed to launch request processing task");
         wait_for_termination(task2);
         let expected = "[SVSM test task] in test task\n[task1] in task1\n[task2] in task2\n";

--- a/kernel/src/fs/ramfs.rs
+++ b/kernel/src/fs/ramfs.rs
@@ -558,7 +558,7 @@ mod tests {
             .expect("Failed to create directory");
 
         let list = ram_dir.list();
-        assert_eq!(list, [f_name.clone(), d_name.clone()]);
+        assert_eq!(list, [f_name.as_str(), d_name.as_str()]);
 
         let entry = ram_dir
             .lookup_entry(&f_name)

--- a/kernel/src/fs/ramfs.rs
+++ b/kernel/src/fs/ramfs.rs
@@ -367,9 +367,9 @@ impl RawRamDirectory {
         }
     }
 
-    fn lookup_entry(&self, name: &FileName) -> Result<DirEntry, SvsmError> {
+    fn lookup_entry(&self, name: FileNameRef<'_>) -> Result<DirEntry, SvsmError> {
         for e in self.entries.iter() {
-            if &e.name == name {
+            if e.name == name {
                 return Ok(e.entry.clone());
             }
         }
@@ -407,9 +407,8 @@ impl RawRamDirectory {
         Ok(new_dir)
     }
 
-    fn unlink(&mut self, name: &FileName) -> Result<(), SvsmError> {
-        let pos = self.entries.iter().position(|e| &e.name == name);
-
+    fn unlink(&mut self, name: FileNameRef<'_>) -> Result<(), SvsmError> {
+        let pos = self.entries.iter().position(|e| e.name == name);
         match pos {
             Some(idx) => {
                 self.entries.swap_remove(idx);
@@ -444,7 +443,7 @@ impl Directory for RamDirectory {
         self.directory.lock_write().prepare_remove()
     }
 
-    fn lookup_entry(&self, name: &FileName) -> Result<DirEntry, SvsmError> {
+    fn lookup_entry(&self, name: FileNameRef<'_>) -> Result<DirEntry, SvsmError> {
         self.directory.lock_read().lookup_entry(name)
     }
 
@@ -456,7 +455,7 @@ impl Directory for RamDirectory {
         self.directory.lock_write().create_directory(name)
     }
 
-    fn unlink(&self, name: &FileName) -> Result<(), SvsmError> {
+    fn unlink(&self, name: FileNameRef<'_>) -> Result<(), SvsmError> {
         self.directory.lock_write().unlink(name)
     }
 }

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -7,8 +7,6 @@
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(not(test), no_main)]
 
-extern crate alloc;
-
 use bootdefs::kernel_launch::KernelLaunchInfo;
 use bootdefs::platform::SvsmPlatformType;
 use core::arch::global_asm;
@@ -76,7 +74,6 @@ use svsm::virtio::probe_mmio_slots;
 #[cfg(all(feature = "vtpm", not(test)))]
 use svsm::vtpm::vtpm_init;
 
-use alloc::string::String;
 use release::COCONUT_VERSION;
 
 #[cfg(feature = "attest")]
@@ -583,7 +580,7 @@ fn svsm_init(launch_info: &KernelLaunchInfo) {
         }
         let _ = start_kernel_task(
             KernelThreadStartInfo::new(test_in_svsm_task, 0),
-            String::from("SVSM test task"),
+            "SVSM test task",
         );
     }
 
@@ -602,7 +599,7 @@ fn svsm_init(launch_info: &KernelLaunchInfo) {
         if SVSM_PLATFORM.start_svsm_request_loop() {
             start_kernel_task(
                 KernelThreadStartInfo::new(request_loop_start, 0),
-                String::from("request-loop on CPU 0"),
+                "request-loop on CPU 0",
             )
             .expect("Failed to launch request loop task");
         }

--- a/kernel/src/syscall/class0.rs
+++ b/kernel/src/syscall/class0.rs
@@ -31,7 +31,7 @@ pub fn sys_exec(file: usize, root: usize, _flags: usize) -> Result<u64, SysCallE
     let file_str = user_file_ptr.read_c_string()?;
     let root_str = user_root_ptr.read_c_string()?;
     let real_root = find_dir(current_task().rootdir(), &root_str)?;
-    let tid = exec_user(&file_str, real_root)?;
+    let tid = exec_user(file_str, real_root)?;
 
     Ok(tid.get_task_id().into())
 }

--- a/kernel/src/task/exec.rs
+++ b/kernel/src/task/exec.rs
@@ -28,10 +28,8 @@ pub struct UserExecInfo {
 }
 
 impl UserExecInfo {
-    pub fn new(b: &str) -> Self {
-        Self {
-            binary: String::from(b),
-        }
+    pub fn new(binary: String) -> Self {
+        Self { binary }
     }
 }
 
@@ -163,13 +161,18 @@ pub fn exec(info: UserExecInfo) -> Result<u64, SvsmError> {
 /// # Arguments
 ///
 /// * binary: Path to file in the file-system
+/// * root: Root directory associated with the new task
 ///
 /// # Returns
 ///
 /// [`Ok(TaskPointer)`] on success, [`Err(SvsmError)`] on failure.
-pub fn exec_user(binary: &str, root: Arc<dyn Directory>) -> Result<TaskPointer, SvsmError> {
-    let info = Box::new(UserExecInfo::new(binary));
-    let new_task = create_user_task(info, root, task_name(binary))?;
+pub fn exec_user<S: Into<String>>(
+    binary: S,
+    root: Arc<dyn Directory>,
+) -> Result<TaskPointer, SvsmError> {
+    let info = Box::new(UserExecInfo::new(binary.into()));
+    let name = Arc::from(task_name(&info.binary));
+    let new_task = create_user_task(info, root, name)?;
 
     finish_user_task(new_task.clone());
     schedule();

--- a/kernel/src/task/exec.rs
+++ b/kernel/src/task/exec.rs
@@ -51,11 +51,11 @@ fn convert_elf_phdr_flags(flags: Elf64PhdrFlags) -> VMFileMappingFlags {
 
 /// Returns the name of the binary file without preceeding directories. This is
 /// used as the official task name.
-fn task_name(binary: &str) -> String {
+fn task_name(binary: &str) -> &str {
     let mut items = binary.split('/').filter(|x| !x.is_empty());
     match items.nth_back(0) {
-        Some(p) => String::from(p),
-        None => String::from("unknown"),
+        Some(p) => p,
+        None => "unknown",
     }
 }
 

--- a/kernel/src/task/schedule.rs
+++ b/kernel/src/task/schedule.rs
@@ -62,7 +62,6 @@ use crate::locking::SpinLock;
 use crate::mm::SVSM_CONTEXT_SWITCH_SHADOW_STACK;
 use crate::platform::SVSM_PLATFORM;
 use alloc::boxed::Box;
-use alloc::string::String;
 use alloc::sync::Arc;
 use core::arch::global_asm;
 use core::mem::offset_of;
@@ -306,16 +305,17 @@ pub static TASKLIST: SpinLock<TaskList> = SpinLock::new(TaskList::new());
 /// # Arguments
 ///
 /// * entry: The function to run as the new tasks main function
+/// * name: The name for the task
 ///
 /// # Returns
 ///
 /// A new instance of [`TaskPointer`] on success, [`SvsmError`] on failure.
-pub fn start_kernel_task(
+pub fn start_kernel_task<S: Into<Arc<str>>>(
     start_info: KernelThreadStartInfo,
-    name: String,
+    name: S,
 ) -> Result<TaskPointer, SvsmError> {
     let cpu = this_cpu();
-    let task = Task::create(cpu, start_info, name)?;
+    let task = Task::create(cpu, start_info, name.into())?;
     TASKLIST.lock().list().push_back(task.clone());
 
     // Put task on the runqueue of this CPU
@@ -363,17 +363,18 @@ pub fn start_kernel_thread(start_info: KernelThreadStartInfo) -> Result<TaskPoin
 /// # Arguments
 ///
 /// * user_entry: The user-space entry point.
+/// * name: The name for the task
 ///
 /// # Returns
 ///
 /// A new instance of [`TaskPointer`] on success, [`SvsmError`] on failure.
-pub fn create_user_task(
+pub fn create_user_task<S: Into<Arc<str>>>(
     info: Box<UserExecInfo>,
     root: Arc<dyn Directory>,
-    name: String,
+    name: S,
 ) -> Result<TaskPointer, SvsmError> {
     let cpu = this_cpu();
-    Task::create_user(cpu, info, root, name)
+    Task::create_user(cpu, info, root, name.into())
 }
 
 /// Finished user-space task creation by putting the task on the global
@@ -902,13 +903,11 @@ const CONTEXT_SWITCH_RESTORE_TOKEN: VirtAddr = SVSM_CONTEXT_SWITCH_SHADOW_STACK.
 
 #[cfg(all(test, test_in_svsm))]
 mod test {
-    extern crate alloc;
     use super::KernelThreadStartInfo;
     use super::set_affinity;
     use super::start_kernel_task;
     use super::wait_for_termination;
     use crate::cpu::percpu::{PERCPU_AREAS, this_cpu};
-    use alloc::string::String;
     use core::sync::atomic::AtomicU32;
     use core::sync::atomic::Ordering;
 
@@ -930,7 +929,7 @@ mod test {
         // Start a task that will immediately terminate.
         start_kernel_task(
             KernelThreadStartInfo::new(empty_task, 0),
-            String::from("test termination task"),
+            "test termination task",
         )
         .expect("Failed to start test termination task");
     }
@@ -945,7 +944,7 @@ mod test {
         // and will then terminate.
         let task = start_kernel_task(
             KernelThreadStartInfo::new(empty_task, 1),
-            String::from("test termination task"),
+            "test termination task",
         )
         .expect("Failed to start test termination task");
 

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -8,7 +8,6 @@ extern crate alloc;
 
 use alloc::boxed::Box;
 use alloc::collections::btree_map::BTreeMap;
-use alloc::string::String;
 use alloc::sync::Arc;
 use core::fmt;
 use core::mem::offset_of;
@@ -367,7 +366,7 @@ pub struct Task {
     sched_state: TaskSchedState,
 
     /// User-visible name of task
-    name: String,
+    name: Arc<str>,
 
     /// ID of the task
     id: u32,
@@ -445,7 +444,7 @@ struct CreateTaskArguments {
     start_info: ThreadStartInfo,
 
     // The name of the task.
-    name: String,
+    name: Arc<str>,
 
     // For a user task, supplies the `VMR` that will represent the user-mode
     // address space.
@@ -575,7 +574,7 @@ impl Task {
     pub fn create(
         cpu: &PerCpu,
         start_info: KernelThreadStartInfo,
-        name: String,
+        name: Arc<str>,
     ) -> Result<TaskPointer, SvsmError> {
         let create_args = CreateTaskArguments {
             start_info: ThreadStartInfo::Kernel(start_info),
@@ -591,7 +590,7 @@ impl Task {
         cpu: &PerCpu,
         info: Box<UserExecInfo>,
         root: Arc<dyn Directory>,
-        name: String,
+        name: Arc<str>,
     ) -> Result<TaskPointer, SvsmError> {
         let vm_user_range = VMR::new(USER_MEM_START, USER_MEM_END, PTEntryFlags::USER)?;
         // SAFETY: the user address range is fully aligned to top-level paging
@@ -635,7 +634,7 @@ impl Task {
     pub fn create_thread(
         cpu: &PerCpu,
         start_info: KernelThreadStartInfo,
-        name: String,
+        name: Arc<str>,
         thread: TaskPointer,
     ) -> Result<TaskPointer, SvsmError> {
         let create_args = CreateTaskArguments {
@@ -652,7 +651,7 @@ impl Task {
         self.stack_bounds
     }
 
-    pub fn get_task_name(&self) -> &String {
+    pub fn get_task_name(&self) -> &Arc<str> {
         &self.name
     }
 
@@ -1040,10 +1039,10 @@ impl Task {
     }
 
     fn attach_stdout(&self) {
-        let name = if self.name == "idle" {
+        let name = if &*self.name == "idle" {
             "SVSM"
         } else {
-            self.name.as_str()
+            &self.name
         };
 
         let (fh_console, fh_log) = stdout_open(name);
@@ -1155,9 +1154,7 @@ fn task_exit() {
 
 #[cfg(all(test, test_in_svsm))]
 mod tests {
-    extern crate alloc;
     use crate::task::{KernelThreadStartInfo, start_kernel_task, wait_for_termination};
-    use alloc::string::String;
     use core::arch::asm;
     use core::arch::global_asm;
 
@@ -1248,7 +1245,7 @@ mod tests {
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn test_fpu_context_switch() {
-        let task1 = start_kernel_task(KernelThreadStartInfo::new(task1, 1), String::from("task1"))
+        let task1 = start_kernel_task(KernelThreadStartInfo::new(task1, 1), "task1")
             .expect("Failed to launch request processing task");
 
         wait_for_termination(task1);
@@ -1262,7 +1259,7 @@ mod tests {
             asm!("call test_fpu", options(att_syntax));
         }
 
-        let task2 = start_kernel_task(KernelThreadStartInfo::new(task2, 2), String::from("task2"))
+        let task2 = start_kernel_task(KernelThreadStartInfo::new(task2, 2), "task2")
             .expect("Failed to launch request processing task");
 
         wait_for_termination(task2);

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -1041,9 +1041,9 @@ impl Task {
 
     fn attach_stdout(&self) {
         let name = if self.name == "idle" {
-            String::from("SVSM")
+            "SVSM"
         } else {
-            self.name.clone()
+            self.name.as_str()
         };
 
         let (fh_console, fh_log) = stdout_open(name);

--- a/kernel/src/testing.rs
+++ b/kernel/src/testing.rs
@@ -105,7 +105,7 @@ pub fn user_tests_in_svsm() {
 
     for file in files {
         log::info!("Running tests in svsm for {file}");
-        let task = exec_user(&format!("test/{file}"), opendir("/").unwrap()).unwrap();
+        let task = exec_user(format!("test/{file}"), opendir("/").unwrap()).unwrap();
         wait_for_termination(task.clone());
         let exit_status = task.get_exit_status().unwrap();
         assert_eq!(


### PR DESCRIPTION
In preparation to introduce fallible allocations, remove more unnecessary allocations, as these will introduce extra points of failure without good reason. This will also minimize the diff when switching to the new infrastructure:
* Do not ask for an owned `String` when creating a new `LineBuffer`.
* Store task names in `Arc<str>`, which allows cloning the name without allocating.
* Allow reusing a `String` allocation in `exec_user()`.
* Allow using some `Directory` methods without an owned `FileName` (which aliases to `String`).
* Remove unnecessary uses of `FileName` in some tests.