### PR TITLE
docs/RELEASE-TESTPLAN: small fixes plus more details for boot tests

### DIFF
--- a/Documentation/docs/developer/RELEASE-TESTPLAN.md
+++ b/Documentation/docs/developer/RELEASE-TESTPLAN.md
@@ -91,6 +91,7 @@ Run the formal verification included in the project.
 Commands:
 
 ```
+./scripts/vinstall.sh --use-prebuilt
 cd kernel
 cargo verify
 ```

--- a/Documentation/docs/developer/RELEASE-TESTPLAN.md
+++ b/Documentation/docs/developer/RELEASE-TESTPLAN.md
@@ -100,7 +100,7 @@ cargo verify
 In the Linux guest OS, check that a TPM2 is available.
 
 ```
-systemd-analyze has-tpm2`
+systemd-analyze has-tpm2
 ```
 
 ### `make clippy CARGO_HACK=1`

--- a/Documentation/docs/developer/RELEASE-TESTPLAN.md
+++ b/Documentation/docs/developer/RELEASE-TESTPLAN.md
@@ -4,6 +4,16 @@
 
 Here is the list of tests performed for each monthly development release.
 
+### Environment Setup
+
+Set the following environment variables before running the tests:
+
+```
+export FW_FILE=/usr/share/edk2/ovmf/OVMF.amdsev.fd
+export QEMU=/path/to/qemu-system-x86_64
+export IMAGE=/path/to/guest.qcow2
+```
+
 ### Build all targets
 
 Build all targets in the `configs/` directory.
@@ -16,17 +26,37 @@ cargo xbuild configs/*.json configs/test/*.json
 
 Build with debug flag enabled and boot VM under SEV-SNP to Linux prompt.
 
+```
+cargo xbuild configs/qemu-target.json
+./scripts/launch_guest.sh
+```
+
 ### Development Build + Native boot test
 
 Build with debug flag enabled and boot COCONUT-SVSM in a non-confidential VM.
+
+```
+cargo xbuild configs/qemu-target.json
+./scripts/launch_guest.sh --nocc
+```
 
 ### Release Build + SNP boot test
 
 Build with release flag enabled and boot VM under SEV-SNP to Linux prompt.
 
+```
+cargo xbuild --release configs/qemu-target.json
+./scripts/launch_guest.sh
+```
+
 ### Release Build + Native boot test
 
 Build with release flag enabled and boot COCONUT-SVSM in a non-confidential VM.
+
+```
+cargo xbuild --release configs/qemu-target.json
+./scripts/launch_guest.sh --nocc
+```
 
 ### Fuzzers
 

--- a/Documentation/docs/developer/RELEASE-TESTPLAN.md
+++ b/Documentation/docs/developer/RELEASE-TESTPLAN.md
@@ -64,35 +64,8 @@ Run all the fuzzers included in the project for an extended period of time.
 Given that failures in the past usually showed up in the first minute of
 fuzzing, for releases the fuzzer runs for a minimum of 10 minutes.
 
-
-#### Fuzzer: `alloc`
-
 ```
-RUSTFLAGS="-Clinker=clang -Clink-arg=-fuse-ld=lld" cargo +nightly fuzz run alloc --strip-dead-code -- -max_total_time=600
-```
-
-#### Fuzzer: `bitmap_allocator`
-
-```
-RUSTFLAGS="-Clinker=clang -Clink-arg=-fuse-ld=lld" cargo +nightly fuzz run bitmap_allocator --strip-dead-code -- -max_total_time=600
-```
-
-#### Fuzzer: `fs`
-
-```
-RUSTFLAGS="-Clinker=clang -Clink-arg=-fuse-ld=lld" cargo +nightly fuzz run fs --strip-dead-code -- -max_total_time=600
-```
-
-#### Fuzzer: `insn`
-
-```
-RUSTFLAGS="-Clinker=clang -Clink-arg=-fuse-ld=lld" cargo +nightly fuzz run insn --strip-dead-code -- -max_total_time=600
-```
-
-#### Fuzzer: `page_alloc`
-
-```
-RUSTFLAGS="-Clinker=clang -Clink-arg=-fuse-ld=lld" cargo +nightly fuzz run page_alloc --strip-dead-code -- -max_total_time=600
+./scripts/run-fuzzers.sh
 ```
 
 ### `make test`


### PR DESCRIPTION
While I was testing the test plans for the next release, I found a few things that need to be fixed, plus some additional examples for the boot tests and replace the individual fuzzer sections with a loop.