### PR TITLE
virtio: remove shared page

### DIFF
--- a/kernel/src/block/virtio_blk.rs
+++ b/kernel/src/block/virtio_blk.rs
@@ -23,7 +23,7 @@ use alloc::boxed::Box;
 
 pub struct VirtIOBlkDriver {
     device: SpinLock<VirtIOBlk<SvsmHal, MmioTransport<'static>>>,
-    _mmio_space: GlobalRangeGuard,
+    _mmio_space: Option<GlobalRangeGuard>,
 }
 
 impl core::fmt::Debug for VirtIOBlkDriver {

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -32,6 +32,7 @@ use crate::cpu::tlb::{TlbFlushScope, flush_tlb};
 use crate::error::SvsmError;
 use crate::hyperv;
 use crate::io::IOPort;
+use crate::mm::GlobalRangeGuard;
 use crate::mm::alloc::free_page;
 use crate::utils::MemoryRegion;
 use crate::utils::immut_after_init::ImmutAfterInitCell;
@@ -267,6 +268,19 @@ pub trait SvsmPlatform: Sync {
     fn start_svsm_request_loop(&self) -> bool {
         false
     }
+
+    /// Map an MMIO region for use with virtio devices.
+    ///
+    /// Returns the virtual address to use for MMIO access and an optional
+    /// [`GlobalRangeGuard`] that keeps the mapping alive. Platforms that
+    /// access MMIO through a side-channel (e.g. GHCB) may return `None` for
+    /// the guard and encode the physical address directly in the returned
+    /// [`VirtAddr`].
+    fn virtio_mmio_init(
+        &self,
+        paddr: PhysAddr,
+        size: usize,
+    ) -> Result<(VirtAddr, Option<GlobalRangeGuard>), SvsmError>;
 
     /// Perfrom a write to a memory-mapped IO area
     ///

--- a/kernel/src/platform/native.rs
+++ b/kernel/src/platform/native.rs
@@ -40,8 +40,10 @@ use core::arch::asm;
 use core::mem::MaybeUninit;
 use syscall::GlobalFeatureFlags;
 
+use crate::mm::pagetable::PTEntryFlags;
 #[cfg(debug_assertions)]
 use crate::mm::virt_to_phys;
+use crate::mm::{GlobalRangeGuard, map_global_range_4k_shared};
 
 #[cfg(test)]
 use bootdefs::platform::SvsmPlatformType;
@@ -240,6 +242,16 @@ impl SvsmPlatform for NativePlatform {
         apic_post_irq(sipi_icr.into());
 
         Ok(())
+    }
+
+    fn virtio_mmio_init(
+        &self,
+        paddr: PhysAddr,
+        size: usize,
+    ) -> Result<(VirtAddr, Option<GlobalRangeGuard>), SvsmError> {
+        let guard = map_global_range_4k_shared(paddr, size, PTEntryFlags::data())?;
+        let vaddr = guard.addr();
+        Ok((vaddr, Some(guard)))
     }
 
     /// Perform a write to a memory-mapped IO area

--- a/kernel/src/platform/snp.rs
+++ b/kernel/src/platform/snp.rs
@@ -33,6 +33,7 @@ use crate::error::SvsmError;
 use crate::greq::driver::guest_request_driver_init;
 use crate::hyperv;
 use crate::io::IOPort;
+use crate::mm::GlobalRangeGuard;
 use crate::mm::PAGE_SIZE;
 use crate::mm::PAGE_SIZE_2M;
 use crate::mm::PerCPUPageMappingGuard;
@@ -431,15 +432,26 @@ impl SvsmPlatform for SnpPlatform {
         true
     }
 
+    fn virtio_mmio_init(
+        &self,
+        paddr: PhysAddr,
+        _size: usize,
+    ) -> Result<(VirtAddr, Option<GlobalRangeGuard>), SvsmError> {
+        // SNP MMIO goes through the GHCB, so no virtual mapping is needed.
+        // Encode the physical address directly in the returned VirtAddr.
+        Ok((VirtAddr::from(paddr.bits()), None))
+    }
+
     /// Perfrom a write to a memory-mapped IO area
     ///
     /// # Safety
     ///
-    /// Caller must ensure that `vaddr` points to a properly aligned memory location and the
-    /// memory accessed is part of a valid MMIO range.
+    /// Caller must ensure that `vaddr` encodes a valid physical MMIO address
+    /// and that data is properly aligned.
     unsafe fn mmio_write(&self, vaddr: VirtAddr, data: &[u8]) -> Result<(), SvsmError> {
-        let paddr = this_cpu().get_pgtable().phys_addr(vaddr)?;
-
+        // MMIO accesses go through the GHCB, so no virtual mapping is created;
+        // virtual addresses are physical addresses.
+        let paddr = PhysAddr::from(vaddr.bits());
         // SAFETY: We are trusting the caller to ensure validity of `paddr` and alignment of data.
         unsafe { crate::cpu::percpu::current_ghcb().mmio_write(paddr, data) }
     }
@@ -448,14 +460,16 @@ impl SvsmPlatform for SnpPlatform {
     ///
     /// # Safety
     ///
-    /// Caller must ensure that `vaddr` points to a properly aligned memory location and the
-    /// memory accessed is part of a valid MMIO range.
+    /// Caller must ensure that `vaddr` encodes a valid physical MMIO address
+    /// and that data is properly aligned.
     unsafe fn mmio_read(
         &self,
         vaddr: VirtAddr,
         data: &mut [MaybeUninit<u8>],
     ) -> Result<(), SvsmError> {
-        let paddr = this_cpu().get_pgtable().phys_addr(vaddr)?;
+        // MMIO accesses go through the GHCB, so no virtual mapping is created;
+        // virtual addresses are physical addresses.
+        let paddr = PhysAddr::from(vaddr.bits());
         // SAFETY: We are trusting the caller to ensure validity of `paddr` and alignment of data.
         unsafe { crate::cpu::percpu::current_ghcb().mmio_read(paddr, data) }
     }

--- a/kernel/src/platform/tdp.rs
+++ b/kernel/src/platform/tdp.rs
@@ -22,7 +22,7 @@ use crate::error::SvsmError;
 use crate::hyperv;
 use crate::hyperv::hyperv_start_cpu;
 use crate::io::IOPort;
-use crate::mm::PerCPUMapping;
+use crate::mm::{GlobalRangeGuard, PerCPUMapping};
 use crate::platform::IrqGuard;
 use crate::tdx::apic::TDX_APIC_ACCESSOR;
 use crate::tdx::tdcall::{
@@ -265,6 +265,14 @@ impl SvsmPlatform for TdpPlatform {
         }
 
         Ok(())
+    }
+
+    fn virtio_mmio_init(
+        &self,
+        _paddr: PhysAddr,
+        _size: usize,
+    ) -> Result<(VirtAddr, Option<GlobalRangeGuard>), SvsmError> {
+        unimplemented!()
     }
 
     unsafe fn mmio_write(&self, _vaddr: VirtAddr, _data: &[u8]) -> Result<(), SvsmError> {

--- a/kernel/src/virtio/mmio.rs
+++ b/kernel/src/virtio/mmio.rs
@@ -14,7 +14,7 @@ use virtio_drivers::transport::{DeviceType, Transport, mmio::MmioTransport};
 use crate::address::{Address, PhysAddr};
 use crate::boot_params::BootParams;
 use crate::fw_cfg::FwCfg;
-use crate::mm::{GlobalRangeGuard, map_global_range_4k_shared, pagetable::PTEntryFlags};
+use crate::mm::GlobalRangeGuard;
 use crate::platform::SVSM_PLATFORM;
 use crate::types::PAGE_SIZE;
 
@@ -31,7 +31,7 @@ pub struct MmioSlot {
     // TODO: The destruction order should be expressed via code rather than
     // relying on field ordering. This should be addressed when moving to
     // the upstream virtio-drivers crate.
-    pub mmio_range: GlobalRangeGuard,
+    pub mmio_range: Option<GlobalRangeGuard>,
 }
 
 #[derive(Debug, Default)]
@@ -93,22 +93,20 @@ pub fn probe_mmio_slots(boot_params: &BootParams<'_>) -> MmioSlots {
         // If multiple devices reside in the same page, each gets its own
         // mapping, which is slightly wasteful but avoids shared-ownership
         // complexity.
-        let Ok(mem) = map_global_range_4k_shared(page_base, PAGE_SIZE, PTEntryFlags::data()) else {
+        let Ok((vbase, guard)) = SVSM_PLATFORM.virtio_mmio_init(page_base, PAGE_SIZE) else {
             log::warn!("MmioSlots: Failed to map MMIO region at {addr:x}");
             continue;
         };
 
-        // Not expected to fail, because mem exists.
-        let header = NonNull::new((mem.addr() + page_offset).as_mut_ptr()).unwrap();
+        // Not expected to fail, because vbase is non-null.
+        let header = NonNull::new((vbase + page_offset).as_mut_ptr()).unwrap();
 
-        // SAFETY: The address is valid, mapped by `map_global_range_4k_shared`, and verified
-        // to be VirtIOHeader-aligned by the guard above.
+        // SAFETY: The address is valid and verified to be VirtIOHeader-aligned by the guard above.
         // The memory region has the same lifetime of the MmioSlot structure which will be consumed by the driver.
         // TODO: Currently the hypervisor does not advertise the size of the mmio space (header + config space).
         //       The size will be provided by the device tree. For now, let's just make sure we don't go past
         //       the boundaries of the allocated space.
-        let Ok(transport) = (unsafe { MmioTransport::new(header, mem.size() - page_offset) })
-        else {
+        let Ok(transport) = (unsafe { MmioTransport::new(header, PAGE_SIZE - page_offset) }) else {
             // Currently QEMU advertises _all_ slots, regardless they are empty or not.
             log::debug!("MmioSlots: {addr:x} empty");
             continue;
@@ -118,7 +116,7 @@ pub fn probe_mmio_slots(boot_params: &BootParams<'_>) -> MmioSlots {
 
         let slot_type = MmioSlot {
             transport,
-            mmio_range: mem,
+            mmio_range: guard,
         };
 
         slots.push(slot_type);

--- a/kernel/src/virtio/mmio.rs
+++ b/kernel/src/virtio/mmio.rs
@@ -75,6 +75,11 @@ pub fn probe_mmio_slots(boot_params: &BootParams<'_>) -> MmioSlots {
         let page_base = phys_addr.page_align();
         let page_offset = phys_addr.page_offset();
 
+        if phys_addr.is_null() {
+            log::warn!("MmioSlots: MMIO device address is null");
+            continue;
+        }
+
         if !phys_addr.is_aligned_to::<VirtIOHeader>() {
             log::warn!("MmioSlots: MMIO device at {phys_addr:x} is not properly aligned");
             continue;

--- a/kernel/src/vsock/virtio_vsock.rs
+++ b/kernel/src/vsock/virtio_vsock.rs
@@ -26,7 +26,7 @@ use virtio_drivers::transport::mmio::MmioTransport;
 
 pub struct VirtIOVsockDriver {
     device: SpinLock<VsockConnectionManager<SvsmHal, MmioTransport<'static>>>,
-    _mmio_space: GlobalRangeGuard,
+    _mmio_space: Option<GlobalRangeGuard>,
 }
 
 impl core::fmt::Debug for VirtIOVsockDriver {


### PR DESCRIPTION
Currently a shared page is created, on all platforms, for the MMIO header + config space.
This is not really necessary, because all the mmio reads and writes on SNP go through the GHCB, therefore no mapping is needed. It is only required for native mode.

This PR moves the mapping creation to the `SvsmPlatform` trait. In this way it's only created when necessary.

/cc @osteffenrh who came up this idea during an offline discussion.