### PR TITLE
igvmmeasure: Customize image_id provided in id_block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1235,7 +1235,6 @@ dependencies = [
 name = "igvmmeasure"
 version = "0.1.0"
 dependencies = [
- "base64",
  "clap",
  "hex",
  "igvm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1235,7 +1235,9 @@ dependencies = [
 name = "igvmmeasure"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "clap",
+ "hex",
  "igvm",
  "igvm_defs",
  "p384",

--- a/tools/igvmmeasure/Cargo.toml
+++ b/tools/igvmmeasure/Cargo.toml
@@ -6,8 +6,10 @@ edition.workspace = true
 # specify dependencies' target to avoid feature unification with SVSM
 # see https://doc.rust-lang.org/cargo/reference/features.html#feature-unification
 [target.'cfg(all(target_os = "linux"))'.dependencies]
+base64 = { workspace = true, features = ["alloc"] }
 clap = { workspace = true, default-features = true, features = ["derive"] }
 sha2 = { workspace = true, default-features = true }
+hex = { version = "0.4.3", features = ["alloc"] }
 igvm.workspace = true
 igvm_defs.workspace = true
 p384.workspace = true

--- a/tools/igvmmeasure/Cargo.toml
+++ b/tools/igvmmeasure/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 # specify dependencies' target to avoid feature unification with SVSM
 # see https://doc.rust-lang.org/cargo/reference/features.html#feature-unification
 [target.'cfg(all(target_os = "linux"))'.dependencies]
-base64 = { workspace = true, features = ["alloc"] }
 clap = { workspace = true, default-features = true, features = ["derive"] }
 sha2 = { workspace = true, default-features = true }
 hex = { version = "0.4.3", features = ["alloc"] }

--- a/tools/igvmmeasure/README.md
+++ b/tools/igvmmeasure/README.md
@@ -93,6 +93,10 @@ sign
 
         The author key is option. See the SEV-SNP documentation for more
         information.
+
+      --image-id <IMAGE_ID>
+          The image ID to store in the ID block (16 bytes). Accepts a
+          hex string or a base64 encoded string.
 ```
 
 ## Example signing process

--- a/tools/igvmmeasure/README.md
+++ b/tools/igvmmeasure/README.md
@@ -96,7 +96,7 @@ sign
 
       --image-id <IMAGE_ID>
           The image ID to store in the ID block (16 bytes). Accepts a
-          hex string or a base64 encoded string.
+          hex string.
 ```
 
 ## Example signing process

--- a/tools/igvmmeasure/src/cmd_options.rs
+++ b/tools/igvmmeasure/src/cmd_options.rs
@@ -82,7 +82,7 @@ pub enum Commands {
         author_key: Option<String>,
 
         /// The image ID to store in the ID block (16 bytes). Accepts a
-        /// hex string or a base64 encoded string.
+        /// hex string.
         #[arg(long)]
         image_id: Option<String>,
     },

--- a/tools/igvmmeasure/src/cmd_options.rs
+++ b/tools/igvmmeasure/src/cmd_options.rs
@@ -80,6 +80,11 @@ pub enum Commands {
         /// information.
         #[arg(long)]
         author_key: Option<String>,
+
+        /// The image ID to store in the ID block (16 bytes). Accepts a
+        /// hex string or a base64 encoded string.
+        #[arg(long)]
+        image_id: Option<String>,
     },
 }
 

--- a/tools/igvmmeasure/src/id_block.rs
+++ b/tools/igvmmeasure/src/id_block.rs
@@ -7,6 +7,9 @@
 use std::error::Error;
 use std::fs;
 
+use base64::Engine;
+use base64::prelude::BASE64_STANDARD;
+use hex;
 use igvm::{IgvmDirectiveHeader, IgvmFile};
 use igvm_defs::{
     IGVM_VHS_SNP_ID_BLOCK_PUBLIC_KEY, IGVM_VHS_SNP_ID_BLOCK_SIGNATURE, IgvmPlatformType,
@@ -38,7 +41,11 @@ pub struct SevIdBlockBuilder {
 }
 
 impl SevIdBlockBuilder {
-    pub fn build(igvm: &IgvmFile, measure: &IgvmMeasure) -> Result<Self, Box<dyn Error>> {
+    pub fn build(
+        igvm: &IgvmFile,
+        measure: &IgvmMeasure,
+        image_id: &Option<String>,
+    ) -> Result<Self, Box<dyn Error>> {
         let compatibility_mask = get_compatibility_mask(igvm, IgvmPlatformType::SEV_SNP).ok_or(
             String::from("IGVM file is not compatible with the specified platform."),
         )?;
@@ -48,16 +55,35 @@ impl SevIdBlockBuilder {
         let mut ld = [0u8; 48];
         ld.copy_from_slice(measure.digest());
 
+        let image_id = match image_id {
+            Some(image_id) => Self::parse_image_id(image_id)?,
+            None => Default::default(),
+        };
+
         Ok(Self {
             compatibility_mask,
             id_block: SevIdBlock {
                 ld,
                 family_id: Default::default(),
-                image_id: Default::default(),
+                image_id,
                 version: 1,
                 guest_svn: Default::default(),
                 policy,
             },
+        })
+    }
+
+    fn parse_image_id(image_id: &str) -> Result<[u8; 16], Box<dyn Error>> {
+        let bytes = if let Ok(bytes) = hex::decode(image_id) {
+            bytes
+        } else if let Ok(bytes) = BASE64_STANDARD.decode(image_id) {
+            bytes
+        } else {
+            return Err("Image ID must be a valid hex or base64 string.".into());
+        };
+
+        bytes.try_into().map_err(|bytes: Vec<u8>| {
+            format!("Image ID must be exactly 16 bytes, got {}.", bytes.len()).into()
         })
     }
 

--- a/tools/igvmmeasure/src/id_block.rs
+++ b/tools/igvmmeasure/src/id_block.rs
@@ -7,8 +7,6 @@
 use std::error::Error;
 use std::fs;
 
-use base64::Engine;
-use base64::prelude::BASE64_STANDARD;
 use hex;
 use igvm::{IgvmDirectiveHeader, IgvmFile};
 use igvm_defs::{
@@ -76,10 +74,8 @@ impl SevIdBlockBuilder {
     fn parse_image_id(image_id: &str) -> Result<[u8; 16], Box<dyn Error>> {
         let bytes = if let Ok(bytes) = hex::decode(image_id) {
             bytes
-        } else if let Ok(bytes) = BASE64_STANDARD.decode(image_id) {
-            bytes
         } else {
-            return Err("Image ID must be a valid hex or base64 string.".into());
+            return Err("Image ID must be a valid hex string.".into());
         };
 
         bytes.try_into().map_err(|bytes: Vec<u8>| {

--- a/tools/igvmmeasure/src/main.rs
+++ b/tools/igvmmeasure/src/main.rs
@@ -59,11 +59,12 @@ fn main() -> Result<(), Box<dyn Error>> {
             output,
             id_key,
             author_key,
+            image_id,
         } => {
             if options.platform != Platform::SevSnp {
                 return Err("Signing is only supported for SEV-SNP".into());
             }
-            sign_command(&output, &id_key, &author_key, &igvm, &measure)?;
+            sign_command(&output, &id_key, &author_key, &image_id, &igvm, &measure)?;
         }
     }
 
@@ -103,10 +104,11 @@ fn sign_command(
     output: &String,
     id_key: &String,
     author_key: &Option<String>,
+    image_id: &Option<String>,
     igvm: &IgvmFile,
     measure: &IgvmMeasure,
 ) -> Result<(), Box<dyn Error>> {
-    let id_block = SevIdBlockBuilder::build(igvm, measure)?;
+    let id_block = SevIdBlockBuilder::build(igvm, measure, image_id)?;
     let id_block_directive = id_block.sign(id_key, author_key)?;
 
     let mut directives = igvm.directives().to_vec();


### PR DESCRIPTION
I tend to modify the `image_id` provided in `id_block` for my own use-cases, and it seems like `igvmmeasure` sets a default zero-initialized field for `image_id`: 
https://github.com/coconut-svsm/svsm/blob/main/tools/igvmmeasure/src/id_block.rs#L56

Add an optional argument so that callers can specify an image id that can be passed in as a hex string. This mirrors the approach in https://github.com/virtee/snpguest/blob/main/src/preattestation.rs#L282-L284

# Testing
Builds fine on my box:
```
$ cargo build -p igvmmeasure --release
    Finished `release` profile [optimized] target(s) in 0.16s
```

I launched this with [cloud-hypervisor](https://github.com/cloud-hypervisor/cloud-hypervisor) which recently gained SEV-SNP support with IGVM files.

My CVM has `snpguest`, so I use this to verify the image id:
```
# Generate the id key first
$ openssl ecparam -name secp384r1 -genkey -noout -out id_key.pem

$ ./igvmmeasure -n ./unsigned_cvm.igvm sign --output signed_cvm.igvm --id-key id_key.pem --image-id 012345678
9abcdef0123456789abcdef
Successfully created signed file: signed_cvm.igvm
./cloud-hypervisor -v --platform sev_snp=on --igvm ./signed_cvm.igvm --kernel ./vmlinuz --cpus boot=24 --memory size=4G --disk path=./rootfs.img,image_type=raw --cmdline console=ttyS0 root=/dev/mapper/root rootfstype=btrfs ro roothash=207fa8d44e3728413f33e6ea43a025b22d706d83c4b47c8358ec5b74163551a2 systemd.verity_root_data=/dev/disk/by-partlabel/cvm_rfs_ro systemd.verity_root_hash=/dev/disk/by-partlabel/cvm_metadata systemd.volatile=overlay pci=realloc,nocrs module_load=ecdsa_generic,ecdh_generic watchdog_thresh=360 init_on_alloc=1 net.ifnames=0 biosdevname=0 --serial tty --fw-cfg-config e820=on,kernel=on,cmdline=on,initramfs=on,acpi_table=on --initramfs ./cvm-initrd.cpio.gz
root@cvm-disk:~# /usr/local/bin/snpguest report foo bar -r
root@cvm-disk:~# /usr/local/bin/snpguest display report foo
...
Image ID:
01 23 45 67 89 AB CD EF 01 23 45 67 89 AB CD EF
```

When no `image-id` is passed, `image_id` reverts to a zero-initialized field:
```
# No --image-id is passed
$ ./igvmmeasure -n ./unsigned_cvm.igvm sign --output signed_cvm.igvm --id-key id_key.pem 
Successfully created signed file: signed_cvm.igvm

./cloud-hypervisor -v --platform sev_snp=on --igvm ./signed_cvm.igvm --kernel ./vmlinuz --cpus boot=24 --memory size=4G --disk path=./rootfs.img,image_type=raw --cmdline console=ttyS0 root=/dev/mapper/root rootfstype=btrfs ro roothash=207fa8d44e3728413f33e6ea43a025b22d706d83c4b47c8358ec5b74163551a2 systemd.verity_root_data=/dev/disk/by-partlabel/cvm_rfs_ro systemd.verity_root_hash=/dev/disk/by-partlabel/cvm_metadata systemd.volatile=overlay pci=realloc,nocrs module_load=ecdsa_generic,ecdh_generic watchdog_thresh=360 init_on_alloc=1 net.ifnames=0 biosdevname=0 --serial tty --fw-cfg-config e820=on,kernel=on,cmdline=on,initramfs=on,acpi_table=on --initramfs ./cvm-initrd.cpio.gz
...
Image ID:
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
```

If the wrong amount of bytes are provided, verify that it errors:
```
$ ./igvmmeasure -n ./unsigned_cvm.igvm sign --output signed_cvm.igvm --id-key id_key.pem --image-id 0123456789abcdef0123456789abcdefff1231
Error: "Image ID must be exactly 16 bytes, got 19."
```