### PR TITLE
docs/RELEASE-TESTPLAN: extend TPM test section and add attestation tests

### DIFF
--- a/Documentation/docs/developer/RELEASE-TESTPLAN.md
+++ b/Documentation/docs/developer/RELEASE-TESTPLAN.md
@@ -99,14 +99,6 @@ cd kernel
 cargo verify
 ```
 
-### TPM Test
-
-In the Linux guest OS, check that a TPM2 is available.
-
-```
-systemd-analyze has-tpm2
-```
-
 ### `make clippy CARGO_HACK=1`
 
 Run `clippy` for a wider set of configurations.
@@ -121,4 +113,76 @@ Check the projects dependency tree for known vulnerabilities.
 
 ```
 cargo audit
+```
+
+### TPM Tests
+
+Start a Linux guest OS
+
+```
+cargo xbuild configs/qemu-target.json
+./scripts/launch_guest.sh
+```
+
+and run the following TPM2 tests:
+
+#### Check TPM2 availability
+
+```
+systemd-analyze has-tpm2
+```
+
+#### Seal/Unseal
+
+```
+pushd $(mktemp -d)
+
+SECRET="secret"
+tpm2_createprimary -c primary.ctx
+
+echo "sealing '$SECRET' without PCRs"
+echo "$SECRET" | tpm2_create -C primary.ctx -i - -u seal.pub -r seal.priv
+tpm2_load -C primary.ctx -u seal.pub -r seal.priv -c seal.ctx
+unsealed=$(tpm2_unseal -c seal.ctx)
+echo "unsealed: '$unsealed'"
+[ "$unsealed" != "$SECRET" ] && echo "FAILED: unseal without PCRs: expected '$SECRET'" && false
+
+echo "sealing '$SECRET' with PCRs"
+tpm2_pcrread -Q -o pcr.bin sha256:0,1,2,3
+tpm2_createpolicy --policy-pcr -l sha256:0,1,2,3 -f pcr.bin -L pcr.policy
+echo "$SECRET" | tpm2_create -C primary.ctx -L pcr.policy -i - -u seal.pub -r seal.priv
+tpm2_load -C primary.ctx -u seal.pub -r seal.priv -c seal.ctx
+unsealed=$(tpm2_unseal -c seal.ctx -p pcr:sha256:0,1,2,3)
+echo "unsealed: '$unsealed'"
+[ "$unsealed" != "$SECRET" ] && echo "FAILED: unseal with PCRs: expected '$SECRET'" && false
+
+popd
+```
+
+#### Self Test
+
+```
+tpm2_selftest -f
+```
+
+#### Event Log
+
+Check that OVMF recorded EFI events in the TPM event log.
+
+```
+tpm2_eventlog /sys/kernel/security/tpm0/binary_bios_measurements | \
+    grep EV_EFI_BOOT_SERVICES_APPLICATION || { echo "FAILED: no EFI boot services events"; false; }
+```
+
+#### vTPM Attestation
+
+Test SEV-SNP vTPM service attestation via Linux configfs-tsm.
+
+```
+# Fedora/RHEL: dnf install -y git cargo tpm2-tss-devel
+# Debian/Ubuntu: apt install -y git cargo libtss2-dev
+# openSUSE/SUSE: zypper install -y git cargo tpm2-0-tss-devel
+git clone https://github.com/hpe-security-lab/svsm-vtpm-test.git
+cd svsm-vtpm-test
+cargo run
 ```

--- a/Documentation/docs/developer/RELEASE-TESTPLAN.md
+++ b/Documentation/docs/developer/RELEASE-TESTPLAN.md
@@ -186,3 +186,59 @@ git clone https://github.com/hpe-security-lab/svsm-vtpm-test.git
 cd svsm-vtpm-test
 cargo run
 ```
+
+### Attestation Tests
+
+Test SVSM attestation via KBS using both transport methods. See
+[ATTESTATION.md](ATTESTATION.md) for full details.
+
+If attestation fails, SVSM will panic and the VM will not boot.
+On success, `[SVSM] attestation successful` appears in the boot logs.
+
+#### Build SVSM and proxy
+
+```
+cargo xbuild -f attest,vsock,attest-serial,virtio-drivers configs/qemu-target.json
+make aproxy
+```
+
+#### Start the kbs-test server
+
+In a separate terminal:
+
+```
+SVSM=/path/to/svsm
+
+git clone https://github.com/coconut-svsm/kbs-test.git
+cd kbs-test
+MEASUREMENT="$($SVSM/bin/igvmmeasure --check-kvm $SVSM/bin/coconut-qemu.igvm measure -b)"
+cargo run -- --measurement $MEASUREMENT
+```
+
+#### vsock transport
+
+Start the proxy in another terminal:
+
+```
+bin/aproxy --protocol kbs --url http://0.0.0.0:8080 --vsock
+```
+
+Launch the guest:
+
+```
+./scripts/launch_guest.sh --vsock 3
+```
+
+#### Serial transport
+
+Start the proxy in another terminal:
+
+```
+bin/aproxy --protocol kbs --url http://0.0.0.0:8080 --unix /tmp/svsm-proxy.sock --force
+```
+
+Launch the guest:
+
+```
+./scripts/launch_guest.sh --aproxy /tmp/svsm-proxy.sock
+```


### PR DESCRIPTION
Add seal/unseal tests (with and without PCRs), TPM self test, event log verification, and vTPM attestation test via svsm-vtpm-test.

Add attestation test steps using kbs-test server for both vsock and serial transport methods.