### PR TITLE
kernel/vsock: fix flaky double_connect test

### DIFF
--- a/.github/workflows/qemu.yml
+++ b/.github/workflows/qemu.yml
@@ -126,9 +126,6 @@ jobs:
       - name: Install TPM 2.0 Reference Implementation build dependencies
         run: sudo apt install -y build-essential cmake pkg-config
 
-      - name: Install netcat used by test-in-svsm for vsock tests
-        run: sudo apt install -y ncat
-
       - name: Set up KVM permissions
         run: sudo chmod 666 /dev/kvm
 

--- a/kernel/src/vsock/stream.rs
+++ b/kernel/src/vsock/stream.rs
@@ -178,7 +178,14 @@ mod tests {
 
         let remote_port = start_vsock_server_host();
 
-        VsockStream::connect(remote_port, VMADDR_CID_HOST).expect("connection failed");
+        let mut stream =
+            VsockStream::connect(remote_port, VMADDR_CID_HOST).expect("connection failed");
+
+        // Read the message to ensure the server has accepted the connection
+        // and closed its listening socket before we attempt the second connect.
+        let mut buffer = [0u8; 11];
+        stream.read(&mut buffer).expect("read failed");
+        drop(stream);
 
         VsockStream::connect(remote_port, VMADDR_CID_HOST)
             .expect_err("The second connection operation was expected to fail, but it succeeded.");

--- a/scripts/test-in-svsm.sh
+++ b/scripts/test-in-svsm.sh
@@ -30,7 +30,7 @@ check_required_tools() {
 
 # Only the non-coreutils binaries are listed here, since coreutils is assumed to
 # be installed. Add any future non-coreutils dependencies to this list.
-check_required_tools ncat xxd ss
+check_required_tools python3 xxd
 
 test_io(){
     PIPE_IN=$1
@@ -56,27 +56,7 @@ test_io(){
             #                          to the guest and a "hello_world" string to SVSM
             #                          using the vsock socket
             "03")
-              # virtio-vsock in svsm does not handle half duplex connections.
-              # This is why we need to use `--no-shutdown` that prevents ncat from sending a
-              # partial shutdown after it has no more bytes to send.
-              echo -n "hello_world" | ncat --no-shutdown -l --vsock -p $TEST_VSOCK_PORT > /dev/null &
-              echo $! >> "$NCAT_PIDS_FILE"
-              NCAT_READY=false
-              # Wait until ncat is ready for listening
-              for _ in $(seq 1 50); do
-                  if ss --numeric --listening --no-header --vsock | grep -q ":$TEST_VSOCK_PORT"; then
-                      NCAT_READY=true
-                      break
-                  fi
-                  sleep 0.1
-              done
-              if [ "$NCAT_READY" = false ]; then
-                  echo "ncat failed to start listening on vsock port $TEST_VSOCK_PORT"
-                  # use VMADDR_PORT_ANY to signal the guest that an error has occurred
-                  TEST_VSOCK_PORT=$((0xFFFFFFFF))
-              fi
-              # write port number as a zero-padded 8-char hex string
-              printf '%08x' "$TEST_VSOCK_PORT" | xxd -p -r > "$PIPE_IN"
+              python3 "$SCRIPT_DIR/test_vsock_server.py" "$TEST_VSOCK_PORT" "$PIPE_IN"
               ;;
             "")
                 # skip EOF
@@ -89,7 +69,6 @@ test_io(){
 }
 
 TEST_DIR=$(mktemp -d -q)
-NCAT_PIDS_FILE="$TEST_DIR/ncat_pids"
 mkfifo $TEST_DIR/pipe.in
 mkfifo $TEST_DIR/pipe.out
 # Create a raw disk image (512kB in size) for virtio-blk tests containing random data
@@ -158,14 +137,6 @@ else
 fi
 
 kill $TEST_IO_PID 2> /dev/null || true
-# Kill ncat processes spawned by test_io. NCAT_PID was set inside a
-# subshell (test_io runs in background) so it is not visible here.
-# Read the PIDs from the file instead.
-if [ -f "$NCAT_PIDS_FILE" ]; then
-    while read -r pid; do
-        kill "$pid" 2> /dev/null || true
-    done < "$NCAT_PIDS_FILE"
-fi
 rm -rf $TEST_DIR
 
 exit $exit_value

--- a/scripts/test_vsock_server.py
+++ b/scripts/test_vsock_server.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""
+Simple vsock server for SVSM integration tests.
+
+Start a vsock server that accepts one connection, sends the port to the
+guest through a named pipe (e.g. connected to a QEMU serial port) so it
+knows where to connect, and sends "hello_world" on the vsock connection.
+
+Usage: test_vsock_server.py <port> <guest-pipe>
+"""
+
+import socket
+import struct
+import sys
+
+
+def main():
+    port = int(sys.argv[1])
+    pipe_in = sys.argv[2]
+
+    with open(pipe_in, "wb") as pipe:
+        try:
+            sock = socket.socket(socket.AF_VSOCK, socket.SOCK_STREAM)
+            sock.bind((socket.VMADDR_CID_ANY, port))
+            sock.listen(1)
+        except Exception as e:
+            print(f"vsock server failed: {e}", file=sys.stderr)
+            # use VMADDR_PORT_ANY to signal the guest that an error has occurred
+            pipe.write(struct.pack(">I", socket.VMADDR_PORT_ANY))
+            sys.exit(0)
+        # send the port to the guest as big-endian u32 so it knows where to connect
+        pipe.write(struct.pack(">I", port))
+
+    conn, _ = sock.accept()
+    sock.close()
+
+    try:
+        conn.sendall(b"hello_world")
+        # virtio-vsock in SVSM does not handle half-duplex connections,
+        # so keep the connection open until the peer closes it.
+        while conn.recv(1024):
+            pass
+    except OSError:
+        pass
+
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Replace ncat with an inline python vsock server that gives us direct control over the listening socket lifecycle.
This is in preparation of the fix for the test_virtio_vsock_double_connect test that was flaky because it relied on timing for the second connect() to fail, assuming the server had already closed its listening socket by the time the guest attempted the second connection:
```
        test vsock::stream::tests::test_virtio_vsock_double_connect ...
        ERROR: Panic on CPU[3]! COCONUT-SVSM Version: 2026.06-devel-120-g54cd9681
        ERROR: Info: panicked at kernel/src/vsock/stream.rs:184:14:
        The second connection operation was expected to fail, but it succeeded.: VsockStream { local_port: 1025, r
emote_port: 12345, remote_cid: 2 }
        ---BACKTRACE---:
          [ffffff8000092792] core::panicking::panic_bounds_check+0x0
          [ffffff8000042d24] svsm::vsock::stream::tests::test_virtio_vsock_double_connect+0xf4
          [ffffff800001d8f9] <svsm::vsock::stream::tests::test_virtio_vsock_double_connect::{closure#0} as core::ops::function::FnOnce<()>>::call_once+0x9
          [ffffff8000011f66] svsm::testing::svsm_kernel_test_runner+0xc6
          [ffffff8000052109] svsm::svsm_bin::test_in_svsm_task+0x19
          [ffffff80000953d4] @ thread_entry_asm+0x18
        ---END---
```