### PR TITLE
kernel/protocols: Reserve OCP number

### DIFF
--- a/kernel/src/protocols/mod.rs
+++ b/kernel/src/protocols/mod.rs
@@ -21,6 +21,7 @@ pub const SVSM_ATTEST_PROTOCOL: u32 = 1;
 pub const SVSM_VTPM_PROTOCOL: u32 = 2;
 pub const SVSM_APIC_PROTOCOL: u32 = 3;
 pub const SVSM_UEFI_MM_PROTOCOL: u32 = 4;
+pub const SVSM_OBSERVABILITY_CONFIGURATION_PROTOCOL: u32 = 5;
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct RequestParams {


### PR DESCRIPTION
The new protocol enables SVSM to receive observability and configuration requests from the guest.

Reserve the protocol number.

