### PR TITLE
kernel/attest: add some unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SVSM_ARGS += --features ${FEATURES}
 XBUILD_ARGS += -f ${FEATURES}
 endif
 
-FEATURES_TEST ?= vtpm,virtio-drivers,block,vsock,uefivars,secureboot,enable-console-log
+FEATURES_TEST ?= vtpm,virtio-drivers,block,vsock,uefivars,secureboot,enable-console-log,attest
 SVSM_ARGS_TEST += --no-default-features
 ifneq ($(FEATURES_TEST),)
 SVSM_ARGS_TEST += --features ${FEATURES_TEST}

--- a/kernel/src/attest.rs
+++ b/kernel/src/attest.rs
@@ -422,3 +422,75 @@ fn hash(
 
     try_to_vec(&sha.finalize()).or(Err(AttestationError::VecAlloc))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+    use cocoon_tpm_tpm2_interface::{Tpm2bEccParameter, TpmBuffer};
+
+    fn make_ecc_point(x: &[u8], y: &[u8]) -> TpmsEccPoint<'static> {
+        TpmsEccPoint {
+            x: Tpm2bEccParameter {
+                buffer: TpmBuffer::Owned(x.to_vec()),
+            },
+            y: Tpm2bEccParameter {
+                buffer: TpmBuffer::Owned(y.to_vec()),
+            },
+        }
+    }
+
+    mod negotiation_hash {
+        use super::*;
+
+        // The challenge size is server-dictated; 48 is an arbitrary choice.
+        const CHALLENGE_LEN: usize = 48;
+        // P-521 coordinate size.
+        const COORD_LEN: usize = 66;
+
+        /// hash() feeds NegotiationParams into SHA-512 in the order they
+        /// appear in `response.params`. Verify that [Challenge, EcPublicKeyBytes]
+        /// and [EcPublicKeyBytes, Challenge] each produce the correct digest and
+        /// that the two digests differ — the server-negotiated ordering must
+        /// affect the resulting attestation evidence.
+        #[test]
+        fn hash_respects_param_ordering() {
+            let challenge = vec![0xdd; CHALLENGE_LEN];
+            let x = vec![0x10; COORD_LEN];
+            let y = vec![0x20; COORD_LEN];
+            let pub_key = make_ecc_point(&x, &y);
+
+            let response_chal_first = NegotiationResponse {
+                challenge: challenge.clone(),
+                params: vec![
+                    NegotiationParam::Challenge,
+                    NegotiationParam::EcPublicKeyBytes,
+                ],
+            };
+            let response_key_first = NegotiationResponse {
+                challenge: challenge.clone(),
+                params: vec![
+                    NegotiationParam::EcPublicKeyBytes,
+                    NegotiationParam::Challenge,
+                ],
+            };
+
+            let result_chal_first = hash(&response_chal_first, &pub_key).unwrap();
+            let result_key_first = hash(&response_key_first, &pub_key).unwrap();
+
+            let mut sha = Sha512::new();
+            sha.update(&challenge);
+            sha.update(&x);
+            sha.update(&y);
+            assert_eq!(result_chal_first, sha.finalize().as_slice());
+
+            let mut sha = Sha512::new();
+            sha.update(&x);
+            sha.update(&y);
+            sha.update(&challenge);
+            assert_eq!(result_key_first, sha.finalize().as_slice());
+
+            assert_ne!(result_chal_first, result_key_first);
+        }
+    }
+}

--- a/kernel/src/attest.rs
+++ b/kernel/src/attest.rs
@@ -398,3 +398,75 @@ fn hash(
 
     try_to_vec(&sha.finalize()).or(Err(AttestationError::VecAlloc))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+    use cocoon_tpm_tpm2_interface::{Tpm2bEccParameter, TpmBuffer};
+
+    fn make_ecc_point(x: &[u8], y: &[u8]) -> TpmsEccPoint<'static> {
+        TpmsEccPoint {
+            x: Tpm2bEccParameter {
+                buffer: TpmBuffer::Owned(x.to_vec()),
+            },
+            y: Tpm2bEccParameter {
+                buffer: TpmBuffer::Owned(y.to_vec()),
+            },
+        }
+    }
+
+    mod negotiation_hash {
+        use super::*;
+
+        // The challenge size is server-dictated; 48 is an arbitrary choice.
+        const CHALLENGE_LEN: usize = 48;
+        // P-521 coordinate size.
+        const COORD_LEN: usize = 66;
+
+        /// hash() feeds NegotiationParams into SHA-512 in the order they
+        /// appear in `response.params`. Verify that [Challenge, EcPublicKeyBytes]
+        /// and [EcPublicKeyBytes, Challenge] each produce the correct digest and
+        /// that the two digests differ — the server-negotiated ordering must
+        /// affect the resulting attestation evidence.
+        #[test]
+        fn hash_respects_param_ordering() {
+            let challenge = vec![0xdd; CHALLENGE_LEN];
+            let x = vec![0x10; COORD_LEN];
+            let y = vec![0x20; COORD_LEN];
+            let pub_key = make_ecc_point(&x, &y);
+
+            let response_chal_first = NegotiationResponse {
+                challenge: challenge.clone(),
+                params: vec![
+                    NegotiationParam::Challenge,
+                    NegotiationParam::EcPublicKeyBytes,
+                ],
+            };
+            let response_key_first = NegotiationResponse {
+                challenge: challenge.clone(),
+                params: vec![
+                    NegotiationParam::EcPublicKeyBytes,
+                    NegotiationParam::Challenge,
+                ],
+            };
+
+            let result_chal_first = hash(&response_chal_first, &pub_key).unwrap();
+            let result_key_first = hash(&response_key_first, &pub_key).unwrap();
+
+            let mut sha = Sha512::new();
+            sha.update(&challenge);
+            sha.update(&x);
+            sha.update(&y);
+            assert_eq!(result_chal_first, sha.finalize().as_slice());
+
+            let mut sha = Sha512::new();
+            sha.update(&x);
+            sha.update(&y);
+            sha.update(&challenge);
+            assert_eq!(result_key_first, sha.finalize().as_slice());
+
+            assert_ne!(result_chal_first, result_key_first);
+        }
+    }
+}

--- a/kernel/src/protocols/attest.rs
+++ b/kernel/src/protocols/attest.rs
@@ -197,6 +197,24 @@ impl AttestServicesOp {
     }
 }
 
+// Compile-time ABI layout guard: any change to field order or padding that
+// breaks the wire format with the guest will be caught here.
+const _: () = assert!(
+    core::mem::offset_of!(AttestServicesOp, report_gpa) == 0x00
+        && core::mem::offset_of!(AttestServicesOp, report_size) == 0x08
+        && core::mem::offset_of!(AttestServicesOp, reserved_1) == 0x0c
+        && core::mem::offset_of!(AttestServicesOp, nonce_gpa) == 0x10
+        && core::mem::offset_of!(AttestServicesOp, nonce_size) == 0x18
+        && core::mem::offset_of!(AttestServicesOp, reserved_2) == 0x1a
+        && core::mem::offset_of!(AttestServicesOp, manifest_gpa) == 0x20
+        && core::mem::offset_of!(AttestServicesOp, manifest_size) == 0x28
+        && core::mem::offset_of!(AttestServicesOp, reserved_3) == 0x2c
+        && core::mem::offset_of!(AttestServicesOp, certificate_gpa) == 0x30
+        && core::mem::offset_of!(AttestServicesOp, certificate_size) == 0x38
+        && core::mem::offset_of!(AttestServicesOp, reserved_4) == 0x3c
+        && core::mem::size_of::<AttestServicesOp>() == 0x40
+);
+
 #[derive(Clone)]
 struct GuidTableEntry {
     guid: uuid::Uuid,
@@ -331,6 +349,16 @@ impl AttestSingleServiceOp {
         self.op.is_extended_report()
     }
 }
+
+// Compile-time ABI layout guard for the extended single-service structure
+// that wraps AttestServicesOp.
+const _: () = assert!(
+    core::mem::offset_of!(AttestSingleServiceOp, op) == 0x00
+        && core::mem::offset_of!(AttestSingleServiceOp, guid) == 0x40
+        && core::mem::offset_of!(AttestSingleServiceOp, manifest_ver) == 0x50
+        && core::mem::offset_of!(AttestSingleServiceOp, reserved_5) == 0x54
+        && core::mem::size_of::<AttestSingleServiceOp>() == 0x58
+);
 
 fn get_attestation_report_standard(nonce: &[u8]) -> Result<Box<SnpReportResponse>, SvsmReqError> {
     let mut resp = SnpReportResponse::new_box_zeroed()
@@ -554,5 +582,111 @@ pub fn attest_protocol_request(
         SVSM_ATTEST_SERVICES => attest_multiple_services(params),
         SVSM_ATTEST_SINGLE_SERVICE => attest_single_service_handler(params),
         _ => Err(SvsmReqError::unsupported_protocol()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocols::errors::SvsmResultCode;
+    use core::mem::offset_of;
+    use zerocopy::FromZeros;
+
+    fn is_invalid_parameter(err: &SvsmReqError) -> bool {
+        matches!(
+            err,
+            SvsmReqError::RequestError(SvsmResultCode::INVALID_PARAMETER)
+        )
+    }
+
+    mod attest_services {
+        use super::*;
+
+        fn base_op() -> AttestServicesOp {
+            AttestServicesOp::new_zeroed()
+        }
+
+        /// Parsing must reject requests with non-zero reserved fields
+        /// to enforce forward-compatibility with future spec revisions.
+        #[test]
+        fn check_valid_rejects_nonzero_reserved() {
+            for offset in [
+                offset_of!(AttestServicesOp, reserved_1),
+                offset_of!(AttestServicesOp, reserved_2),
+                offset_of!(AttestServicesOp, reserved_3),
+                offset_of!(AttestServicesOp, reserved_4),
+            ] {
+                let mut bytes = base_op().as_bytes().to_vec();
+                bytes[offset] = 1;
+                let op = AttestServicesOp::ref_from_bytes(&bytes).unwrap();
+                let err = op.check_valid().unwrap_err();
+                assert!(
+                    is_invalid_parameter(&err),
+                    "should reject nonzero reserved at offset {offset:#x}"
+                );
+            }
+        }
+
+        /// The certificate region is optional (size == 0 means absent).
+        /// When present, it must enforce MAX_CERTIFICATE_SIZE as an upper
+        /// bound to prevent guests from requesting unbounded allocations.
+        #[test]
+        fn certificate_region_boundary() {
+            let mut op = base_op();
+            assert!(op.get_certificate_region().unwrap().is_none());
+
+            // 0x4000 is an arbitrary page-aligned GPA; any page-aligned
+            // value would work here.
+            op.certificate_gpa = 0x4000;
+            op.certificate_size = MAX_CERTIFICATE_SIZE as u32;
+            assert!(op.get_certificate_region().unwrap().is_some());
+
+            op.certificate_size = (MAX_CERTIFICATE_SIZE + 1) as u32;
+            let err = op.get_certificate_region().unwrap_err();
+            assert!(is_invalid_parameter(&err));
+        }
+
+        /// The certificate GPA must be page-aligned when a certificate
+        /// region is requested.
+        #[test]
+        fn certificate_region_rejects_unaligned_gpa() {
+            let mut op = base_op();
+            op.certificate_gpa = 0x4001; // not page-aligned
+            op.certificate_size = MAX_CERTIFICATE_SIZE as u32;
+            let err = op.get_certificate_region().unwrap_err();
+            assert!(is_invalid_parameter(&err));
+        }
+    }
+
+    mod attest_single_service {
+        use super::*;
+
+        fn base_op() -> AttestSingleServiceOp {
+            AttestSingleServiceOp::new_zeroed()
+        }
+
+        /// Only manifest version 0 is currently defined by the protocol.
+        /// Parsing must reject any other version to prevent silent
+        /// misinterpretation of the manifest payload.
+        #[test]
+        fn check_valid_rejects_invalid_manifest_version() {
+            let mut bytes = base_op().as_bytes().to_vec();
+            bytes[offset_of!(AttestSingleServiceOp, manifest_ver)] = 1;
+            let op = AttestSingleServiceOp::ref_from_bytes(&bytes).unwrap();
+            let err = op.check_valid().unwrap_err();
+            assert!(is_invalid_parameter(&err));
+        }
+
+        /// check_valid() must reject a non-zero reserved_5. The reserved fields
+        /// of the embedded AttestServicesOp are already covered by the
+        /// attest_services::check_valid_rejects_nonzero_reserved test.
+        #[test]
+        fn check_valid_rejects_nonzero_reserved() {
+            let mut bytes = base_op().as_bytes().to_vec();
+            bytes[offset_of!(AttestSingleServiceOp, reserved_5)] = 1;
+            let op = AttestSingleServiceOp::ref_from_bytes(&bytes).unwrap();
+            let err = op.check_valid().unwrap_err();
+            assert!(is_invalid_parameter(&err));
+        }
     }
 }

--- a/kernel/src/protocols/attest.rs
+++ b/kernel/src/protocols/attest.rs
@@ -197,6 +197,24 @@ impl AttestServicesOp {
     }
 }
 
+// Compile-time ABI layout guard: any change to field order or padding that
+// breaks the wire format with the guest will be caught here.
+const _: () = assert!(
+    core::mem::offset_of!(AttestServicesOp, report_gpa) == 0x00
+        && core::mem::offset_of!(AttestServicesOp, report_size) == 0x08
+        && core::mem::offset_of!(AttestServicesOp, reserved_1) == 0x0c
+        && core::mem::offset_of!(AttestServicesOp, nonce_gpa) == 0x10
+        && core::mem::offset_of!(AttestServicesOp, nonce_size) == 0x18
+        && core::mem::offset_of!(AttestServicesOp, reserved_2) == 0x1a
+        && core::mem::offset_of!(AttestServicesOp, manifest_gpa) == 0x20
+        && core::mem::offset_of!(AttestServicesOp, manifest_size) == 0x28
+        && core::mem::offset_of!(AttestServicesOp, reserved_3) == 0x2c
+        && core::mem::offset_of!(AttestServicesOp, certificate_gpa) == 0x30
+        && core::mem::offset_of!(AttestServicesOp, certificate_size) == 0x38
+        && core::mem::offset_of!(AttestServicesOp, reserved_4) == 0x3c
+        && core::mem::size_of::<AttestServicesOp>() == 0x40
+);
+
 #[derive(Clone)]
 struct GuidTableEntry {
     guid: uuid::Uuid,
@@ -331,6 +349,16 @@ impl AttestSingleServiceOp {
         self.op.is_extended_report()
     }
 }
+
+// Compile-time ABI layout guard for the extended single-service structure
+// that wraps AttestServicesOp.
+const _: () = assert!(
+    core::mem::offset_of!(AttestSingleServiceOp, op) == 0x00
+        && core::mem::offset_of!(AttestSingleServiceOp, guid) == 0x40
+        && core::mem::offset_of!(AttestSingleServiceOp, manifest_ver) == 0x50
+        && core::mem::offset_of!(AttestSingleServiceOp, reserved_5) == 0x54
+        && core::mem::size_of::<AttestSingleServiceOp>() == 0x58
+);
 
 fn get_attestation_report_standard(nonce: &[u8]) -> Result<Box<SnpReportResponse>, SvsmReqError> {
     let mut resp = SnpReportResponse::new_box_zeroed()
@@ -554,5 +582,111 @@ pub fn attest_protocol_request(
         SVSM_ATTEST_SERVICES => attest_multiple_services(params),
         SVSM_ATTEST_SINGLE_SERVICE => attest_single_service_handler(params),
         _ => Err(SvsmReqError::unsupported_protocol()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocols::errors::SvsmResultCode;
+    use core::mem::offset_of;
+    use zerocopy::FromZeros;
+
+    fn is_invalid_parameter(err: &SvsmReqError) -> bool {
+        matches!(
+            err,
+            SvsmReqError::RequestError(SvsmResultCode::INVALID_PARAMETER)
+        )
+    }
+
+    mod attest_services {
+        use super::*;
+
+        fn base_op() -> AttestServicesOp {
+            AttestServicesOp::new_zeroed()
+        }
+
+        /// Parsing must reject requests with non-zero reserved fields
+        /// to enforce forward-compatibility with future spec revisions.
+        #[test]
+        fn check_valid_rejects_nonzero_reserved() {
+            for offset in [
+                offset_of!(AttestServicesOp, reserved_1),
+                offset_of!(AttestServicesOp, reserved_2),
+                offset_of!(AttestServicesOp, reserved_3),
+                offset_of!(AttestServicesOp, reserved_4),
+            ] {
+                let mut bytes = base_op().as_bytes().to_vec();
+                bytes[offset] = 1;
+                let op = AttestServicesOp::ref_from_bytes(&bytes).unwrap();
+                let err = op.check_valid().unwrap_err();
+                assert!(
+                    is_invalid_parameter(&err),
+                    "should reject nonzero reserved at offset {offset:#x}"
+                );
+            }
+        }
+
+        /// The certificate region is optional (size == 0 means absent).
+        /// When present, it must enforce MAX_CERTIFICATE_SIZE as an upper
+        /// bound to prevent guests from requesting unbounded allocations.
+        #[test]
+        fn certificate_region_boundary() {
+            let mut op = base_op();
+            assert!(op.get_certificate_region().unwrap().is_none());
+
+            // 0x4000 is an arbitrary page-aligned GPA; any page-aligned
+            // value would work here.
+            op.certificate_gpa = 0x4000;
+            op.certificate_size = MAX_CERTIFICATE_SIZE as u32;
+            assert!(op.get_certificate_region().unwrap().is_some());
+
+            op.certificate_size = (MAX_CERTIFICATE_SIZE + 1) as u32;
+            let err = op.get_certificate_region().unwrap_err();
+            assert!(is_invalid_parameter(&err));
+        }
+
+        /// The certificate GPA must be page-aligned when a certificate
+        /// region is requested.
+        #[test]
+        fn certificate_region_rejects_unaligned_gpa() {
+            let mut op = base_op();
+            op.certificate_gpa = 0x4001; // not page-aligned
+            op.certificate_size = MAX_CERTIFICATE_SIZE as u32;
+            let err = op.get_certificate_region().unwrap_err();
+            assert!(is_invalid_parameter(&err));
+        }
+    }
+
+    mod attest_single_service {
+        use super::*;
+
+        fn base_op() -> AttestSingleServiceOp {
+            AttestSingleServiceOp::new_zeroed()
+        }
+
+        /// Only manifest version 0 is currently defined by the protocol.
+        /// Parsing must reject any other version to prevent silent
+        /// misinterpretation of the manifest payload.
+        #[test]
+        fn check_valid_rejects_invalid_manifest_version() {
+            let mut bytes = base_op().as_bytes().to_vec();
+            bytes[offset_of!(AttestSingleServiceOp, manifest_ver)] = 1;
+            let op = AttestSingleServiceOp::ref_from_bytes(&bytes).unwrap();
+            let err = op.check_valid().unwrap_err();
+            assert!(is_invalid_parameter(&err));
+        }
+
+        /// AttestSingleServiceOp embeds an AttestServicesOp. Parsing must
+        /// validate the reserved fields of the inner struct too, not just
+        /// its own reserved_5.
+        #[test]
+        fn check_valid_rejects_nonzero_inner_reserved() {
+            let mut bytes = base_op().as_bytes().to_vec();
+            bytes[offset_of!(AttestServicesOp, reserved_1)] = 1;
+            let op = AttestSingleServiceOp::ref_from_bytes(&bytes).unwrap();
+            let err = op.check_valid().unwrap_err();
+            assert!(is_invalid_parameter(&err));
+        }
     }
 }

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -13,8 +13,6 @@ use core::arch::global_asm;
 use core::panic::PanicInfo;
 use core::ptr::NonNull;
 use svsm::address::{Address, PhysAddr, VirtAddr};
-#[cfg(feature = "attest")]
-use svsm::attest::AttestationDriver;
 use svsm::boot_params::BootParamBox;
 use svsm::boot_params::BootParams;
 use svsm::cpu::control_regs::{cr0_init, cr4_init};
@@ -77,9 +75,6 @@ use svsm::virtio::probe_mmio_slots;
 use svsm::vtpm::vtpm_init;
 
 use release::COCONUT_VERSION;
-
-#[cfg(feature = "attest")]
-use kbs_types::Tee;
 
 unsafe extern "C" {
     static bsp_stack: u64;
@@ -551,8 +546,11 @@ fn svsm_init(launch_info: &KernelLaunchInfo) {
     #[cfg(feature = "virtio-drivers")]
     initialize_virtio_mmio(&boot_params).expect("Failed to initialize virtio-mmio drivers");
 
-    #[cfg(feature = "attest")]
+    #[cfg(all(feature = "attest", not(test_in_svsm)))]
     {
+        use kbs_types::Tee;
+        use svsm::attest::AttestationDriver;
+
         // Obtain the persistence metadata first. It's not the case yet,
         // but it likely will be needed as input to the attestation.
         #[cfg(feature = "persistence")]


### PR DESCRIPTION
This PR adds some unit tests for the attestation protocol and early boot attestation. More details in the commit messages. This is a rework of the PR #1002 

I dropped commit "test/attest: add kbs-test flow for SNP attestation" as the doc changes are already available. For the script, that takes care of setting up attestation infrastructure, I'll open a followup PR. 

I dropped some tests:
- `rejects_unknown_request` it had a really low value
- `reserved_clear_rejects_each_field` was doing the same work of `check_valid_rejects_nonzero_reserved`
- guidtable tests: even though the table is part of the svsm spec, it was testing rust's internal implementation.

All commit messages have been reworded and fixed clippy and cargo fmt checks