### PR TITLE
kernel/virtio: update safe-mmio to version 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1855,8 +1855,9 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "safe-mmio"
-version = "0.3.0"
-source = "git+https://github.com/google/safe-mmio?rev=89f584caaf32fcd4341a5a716c97d67be83edb9c#89f584caaf32fcd4341a5a716c97d67be83edb9c"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce5e4ed477d6ebc07e01ce97b87fe319e6b62d0ab2564594db6a8c4cdc29ffd9"
 dependencies = [
  "zerocopy",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ libfuzzer-sys = "0.4"
 log = "0.4.17"
 p384 = { version = "0.13.0" }
 rustc-demangle = { version = "0.1.26" }
-safe-mmio = { version = "0.3", features = ["custom-mmio"] }
+safe-mmio = { version = "0.3.1", features = ["custom-mmio"] }
 serde = { version = "1.0.215", default-features = false }
 serde_json = { version = "1.0", default-features = false }
 sha2 = { version = "0.10.8", default-features = false }
@@ -122,12 +122,6 @@ vstd = { version = "=0.0.0-2026-07-12-0122", features = [
 # Verification libs
 verify_proof = { path = "verification/verify_proof", default-features = false }
 verify_external = { path = "verification/verify_external", default-features = false }
-
-[patch.crates-io]
-# Force all dependencies to use the same version of safe-mmio, which has
-# the new custom-mmio feature, so that injecting our MMIO backend works.
-# This can be removed once the feature has been released on creates.io.
-safe-mmio = { git = "https://github.com/google/safe-mmio", rev = "89f584caaf32fcd4341a5a716c97d67be83edb9c" }
 
 [profile.release]
 panic = 'abort'

--- a/kernel/src/virtio/hal.rs
+++ b/kernel/src/virtio/hal.rs
@@ -185,9 +185,7 @@ unsafe impl virtio_drivers::Hal for SvsmHal {
 /// safe-mmio backend implementation
 struct SvsmMmio;
 
-// SAFETY: Each method performs a single MMIO access of the indicated width
-// via the platform's GHCB-based MMIO helpers.
-unsafe impl safe_mmio::custom_mmio::MmioOps for SvsmMmio {
+impl safe_mmio::MmioOps for SvsmMmio {
     unsafe fn read_u8(src: *const u8) -> u8 {
         let mut data = MaybeUninit::<u8>::uninit();
         // SAFETY: src is a valid, aligned MMIO pointer per MmioOps contract.


### PR DESCRIPTION
safe-mmio version 0.3.1 includes the `custom-mmio` feature that we need. This allows us to drop the `[patch.crates-io]` section and consume the crate directly from crates.io.

This new version removed the custom_mmio submodule and re-exports MmioOps directly from the crate root. The trait is also no longer unsafe to implement, so drop the unsafe qualifier.