### PR TITLE
cargo: bump dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,9 +183,9 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bindgen"
-version = "0.71.1"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags",
  "cexpr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,17 +207,6 @@ checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
 name = "bitfield-struct"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc0846593a56638b74e136a45610f9934c052e14761bebca6b092d5522599e3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "bitfield-struct"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2be5a46ba01b60005ae2c51a36a29cfe134bcacae2dd5cedcd4615fbaad1494b"
@@ -232,6 +221,17 @@ name = "bitfield-struct"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8769c4854c5ada2852ddf6fd09d15cf43d4c2aaeccb4de6432f5402f08a6003b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "bitfield-struct"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ca6739863c590881f038d033a146c51ddae239186a4327014839fd864f44ed5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -320,7 +320,7 @@ dependencies = [
 name = "cbit"
 version = "0.1.0"
 dependencies = [
- "bitfield-struct 0.6.2",
+ "bitfield-struct 0.13.0",
 ]
 
 [[package]]
@@ -562,7 +562,7 @@ dependencies = [
 name = "cpuarch"
 version = "0.1.0"
 dependencies = [
- "bitfield-struct 0.6.2",
+ "bitfield-struct 0.13.0",
  "bitflags",
  "zerocopy",
 ]
@@ -2075,7 +2075,7 @@ version = "0.1.0"
 dependencies = [
  "aes-gcm",
  "aes-kw",
- "bitfield-struct 0.6.2",
+ "bitfield-struct 0.13.0",
  "bitflags",
  "bootdefs",
  "bootimg",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1278,12 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "intrusive-collections"
-version = "0.9.7"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
-dependencies = [
- "memoffset",
-]
+checksum = "4275b20e6057cd7733fd8df8a5a31701e4fe44497dad0f3fa0e1c4fb971506be"
 
 [[package]]
 name = "ipnet"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ gdbstub = { version = "0.7.10", default-features = false }
 gdbstub_arch = { version = "0.3.3" }
 igvm = { version = "0.4.0", default-features = false }
 igvm_defs = { version = "0.4.0", default-features = false }
-intrusive-collections = "0.9.6"
+intrusive-collections = "0.10.0"
 kbs-types = { version = "0.14.0", default-features = false }
 libfuzzer-sys = "0.4"
 log = "0.4.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ aes-kw = { version = "0.3.1", default-features = false }
 arbitrary = "1.3.0"
 base64 = { version = "0.22.1", default-features = false }
 bindgen = { version = "0.71.0", default-features = false }
-bitfield-struct = "0.6.2"
+bitfield-struct = "0.13.0"
 bitflags = "2.6"
 clap = { version = "4.4.14", default-features = false }
 cocoon-tpm-crypto = { version = "0.1.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ aes-gcm = { version = "0.10.3", default-features = false }
 aes-kw = { version = "0.3.1", default-features = false }
 arbitrary = "1.3.0"
 base64 = { version = "0.22.1", default-features = false }
-bindgen = { version = "0.71.0", default-features = false }
+bindgen = { version = "0.72.0", default-features = false }
 bitfield-struct = "0.13.0"
 bitflags = "2.6"
 clap = { version = "4.4.14", default-features = false }

--- a/kernel/src/mm/vm/mapping/api.rs
+++ b/kernel/src/mm/vm/mapping/api.rs
@@ -150,7 +150,7 @@ pub struct VMM {
     mapping: Mapping,
 }
 
-intrusive_adapter!(pub VMMAdapter = Box<VMM>: VMM { link: AtomicLink });
+intrusive_adapter!(pub VMMAdapter = Box<VMM>: VMM { link => AtomicLink });
 
 impl<'a> KeyAdapter<'a> for VMMAdapter {
     type Key = usize;

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -407,8 +407,8 @@ unsafe impl Sync for Task {}
 
 pub type TaskPointer = Arc<Task>;
 
-intrusive_adapter!(pub TaskRunListAdapter = TaskPointer: Task { runlist_link: LinkedListAtomicLink });
-intrusive_adapter!(pub TaskListAdapter = TaskPointer: Task { list_link: LinkedListAtomicLink });
+intrusive_adapter!(pub TaskRunListAdapter = TaskPointer: Task { runlist_link => LinkedListAtomicLink });
+intrusive_adapter!(pub TaskListAdapter = TaskPointer: Task { list_link => LinkedListAtomicLink });
 
 impl PartialEq for Task {
     fn eq(&self, other: &Self) -> bool {


### PR DESCRIPTION
bump some dependencies to their latest version.

This came up while packaging svsm for fedora, as older crate version are no longer available in the package manager.