### PR TITLE
kernel/sec/ghcb: add missing tlb flush in GhcbPage::drop.

### DIFF
--- a/kernel/src/sev/ghcb.rs
+++ b/kernel/src/sev/ghcb.rs
@@ -176,6 +176,7 @@ impl Drop for GhcbPage {
             .get_pgtable()
             .set_encrypted_4k(vaddr)
             .expect("Could not re-encrypt page");
+        flush_tlb_global_sync_page(vaddr, PageSize::Regular);
 
         // Unregister GHCB PA
         // SAFETY: mapping the GHCB at physical address 0 is safe.


### PR DESCRIPTION
Security issue without the fix:

If the page is allocated again for other purpose, the CPU may see a stale TLB cache and causes unexpected behavior (e.g., write unencrypted content to a private page).