### PR TITLE
Verus: cleanup spec

### DIFF
--- a/kernel/src/mm/address_space_spec.verus.rs
+++ b/kernel/src/mm/address_space_spec.verus.rs
@@ -20,10 +20,6 @@ pub ghost struct LinearMap {
 }
 
 impl LinearMap {
-    pub open spec fn is_identity_map(&self) -> bool {
-        self.virt_start@ == VirtAddr::from_spec(self.phys_start as usize)@
-    }
-
     pub open spec fn spec_phys_to_virt(&self, paddr: int) -> Option<VirtAddr> {
         let offset = paddr - self.phys_start;
         if 0 <= offset < self.size && (self.virt_start.offset() + offset < VADDR_RANGE_SIZE) {

--- a/kernel/src/mm/alloc.verus.rs
+++ b/kernel/src/mm/alloc.verus.rs
@@ -323,7 +323,6 @@ impl HeapMemoryRegion {
     }
 
     spec fn req_split_page(&self, pfn: usize, order: usize, perm: PgUnitPerm<DeallocUnit>) -> bool {
-        let new_size = (1usize << (order - 1) as usize);
         &&& self.wf_next_pages()
         &&& perm.wf_pfn_order(self@.mr_map, pfn, order)
         &&& perm.page_type() == PageType::Free
@@ -332,7 +331,6 @@ impl HeapMemoryRegion {
     }
 
     spec fn ens_split_page_ok(&self, new: &Self, pfn: usize, order: usize) -> bool {
-        let rhs_pfn = (pfn + (1usize << order) / 2) as usize;
         let new_order = order - 1;
         let order = order as int;
         &&& new.wf_next_pages()
@@ -543,7 +541,6 @@ impl HeapMemoryRegion {
     }
 
     spec fn ens_free_page_raw(&self, new: &Self, pfn: usize, order: usize) -> bool {
-        let end = pfn + (1usize << order);
         &&& new.wf_next_pages()
         &&& self.with_same_mapping(new)
     }

--- a/kernel/src/mm/alloc.verus.rs
+++ b/kernel/src/mm/alloc.verus.rs
@@ -521,10 +521,6 @@ impl HeapMemoryRegion {
 
     }
 
-    spec fn req_free_page(&self, vaddr: VirtAddr, perm: AllocatedPagesPerm) -> bool {
-        &&& self.wf_next_pages()
-    }
-
     spec fn ens_free_page(&self, new: &Self, vaddr: VirtAddr, perm: AllocatedPagesPerm) -> bool {
         self@.mr_map@ == new@.mr_map@
     }

--- a/kernel/src/mm/alloc_info.verus.rs
+++ b/kernel/src/mm/alloc_info.verus.rs
@@ -151,11 +151,6 @@ impl PageInfoDb {
         self.id().ptr(idx)
     }
 
-    #[verifier::inline]
-    spec fn share_total(&self) -> (nat, nat) {
-        (self.id().shares, self.id().total)
-    }
-
     #[verifier(inline)]
     spec fn end(&self) -> int {
         self.unit_start + (1usize << self@[self.unit_start()].order())
@@ -341,10 +336,6 @@ impl PageInfoDb {
     #[verifier(opaque)]
     spec fn nr_page(&self, order: usize) -> nat {
         self._info_dom(order).len()
-    }
-
-    spec fn _info_head_dom(&self, order: usize) -> Set<usize> {
-        self@.dom().filter(|i| self@[i].order() == order && self@[i].is_head())
     }
 
     /// Prove that for any two orders: `order` and `order2`,
@@ -797,12 +788,6 @@ impl PageInfoDb {
         assert(old(self).ens_split_inner(*self, ret));
         old(self).proof_split_nr_page(*self, ret);
         ret
-    }
-
-    spec fn ens_unshare_for_write(&self, new: Self, unit: &PageInfoDb) -> bool {
-        &&& new@ == self@.remove_keys(unit@.dom())
-        &&& new.id() == self.id()
-        &&& self.ens_add_unit_nr_pages(new, unit.order())
     }
 
     /// Remove the permission for the specified unit from the `PageInfoDb` and merge

--- a/kernel/src/mm/alloc_inner.verus.rs
+++ b/kernel/src/mm/alloc_inner.verus.rs
@@ -35,8 +35,6 @@ pub spec const ALLOCATOR_PGINFO_SHARES: nat = 1;
 
 pub spec const DEALLOC_PGINFO_SHARES: nat = 1;
 
-pub uninterp spec fn allocator_provenance() -> Provenance;
-
 pub proof fn tracked_empty_seq_of_seq<T>(n: nat) -> (tracked ret: Seq<Seq<T>>)
     requires
         n >= 0,

--- a/kernel/src/mm/alloc_perms.verus.rs
+++ b/kernel/src/mm/alloc_perms.verus.rs
@@ -7,19 +7,6 @@
 // Defines memory region permissions.
 verus! {
 
-spec fn spec_map_page_info_addr(map: LinearMap, pfn: usize) -> VirtAddr {
-    let reserved_unit_size = size_of::<PageStorageType>();
-    let start = map.virt_start;
-    VirtAddr::from_spec((start@ + (pfn * reserved_unit_size)) as usize)
-}
-
-spec fn spec_map_page_info_ptr(map: LinearMap, pfn: usize) -> *const PageStorageType {
-    let addr = spec_map_page_info_addr(map, pfn)@;
-    vstd::raw_ptr::ptr_from_data(
-        vstd::raw_ptr::PtrData { addr, provenance: allocator_provenance(), metadata: () },
-    )
-}
-
 /// Defines ghost tracked memory region permissions.
 ///
 /// `info` is a readonly share of reserved memory storing PageInfo which allows
@@ -152,10 +139,6 @@ impl<T: UnitType> PgUnitPerm<T> {
         pageinfo.spec_type()
     }
 
-    pub closed spec fn from_mr(&self, map: MemRegionMapping, pfn: usize, order: usize) -> bool {
-        self.wf_pfn_order(map, pfn, order)
-    }
-
     pub closed spec fn wf_pfn_order(
         &self,
         map: MemRegionMapping,
@@ -222,15 +205,6 @@ impl MemoryRegionPerms {
     #[verifier(inline)]
     spec fn get_info(&self, pfn: usize) -> Option<PageInfo> {
         self.info@[pfn].page_info()
-    }
-
-    #[verifier(inline)]
-    spec fn get_free_info(&self, pfn: usize) -> Option<FreeInfo> {
-        self.info@[pfn].page_info().unwrap().spec_get_free()
-    }
-
-    spec fn get_page_storage_type(&self, pfn: usize) -> Option<PageStorageType> {
-        self.info@[pfn].page_storage()
     }
 
     /** Invariants for page info **/

--- a/kernel/src/mm/alloc_types.verus.rs
+++ b/kernel/src/mm/alloc_types.verus.rs
@@ -256,7 +256,6 @@ impl SpecDecoderProof<PageStorageType> for FreeInfo {
         let mem = PageType::Free as u64;
         let bit1 = PageStorageType::TYPE_SHIFT;
         let bit2 = (PageStorageType::NEXT_SHIFT - PageStorageType::TYPE_SHIFT) as u64;
-        let bit3 = (u64::BITS - PageStorageType::NEXT_SHIFT) as u64;
         lemma_u64_and_bitmask_lower(order, bit2);
         broadcast use lemma_bit_u64_shr_bound;
 
@@ -379,7 +378,6 @@ impl SpecDecoderProof<PageStorageType> for FileInfo {
     {
         PageType::File.lemma_encode_decode();
         let ref_count = self.ref_count as u64;
-        let tbits = PageStorageType::TYPE_SHIFT;
         let bits = (u64::BITS - PageStorageType::TYPE_SHIFT) as u64;
         let mem = self.spec_encode().unwrap().0;
         lemma_bit_u64_extract_fields2(
@@ -481,7 +479,6 @@ impl SpecDecoderProof<PageStorageType> for PageInfo {
     proof fn lemma_encode_decode(&self) {
         let info = *self;
         let mem = info.spec_encode().unwrap();
-        let memval = mem.0;
         match info {
             PageInfo::Free(finfo) => {
                 finfo.lemma_encode_decode();

--- a/kernel/src/mm/alloc_types.verus.rs
+++ b/kernel/src/mm/alloc_types.verus.rs
@@ -37,16 +37,6 @@ spec fn spec_page_info(mem: MemContents<PageStorageType>) -> Option<PageInfo> {
     }
 }
 
-spec fn spec_free_info(perm: MemContents<PageStorageType>) -> Option<FreeInfo> {
-    let p_info = spec_page_info(perm);
-    if p_info.is_some() {
-        let pi = p_info.unwrap();
-        pi.spec_get_free()
-    } else {
-        None
-    }
-}
-
 impl PageType {
     spec fn spec_is_deallocatable(&self) -> bool {
         matches!(self, PageType::Allocated | PageType::SlabPage | PageType::File)
@@ -71,13 +61,6 @@ impl PageInfo {
             PageInfo::Compound(_) => PageType::Compound,
             PageInfo::File(_) => PageType::File,
             PageInfo::Reserved(_) => PageType::Reserved,
-        }
-    }
-
-    spec fn spec_get_free(&self) -> Option<FreeInfo> {
-        match *self {
-            PageInfo::Free(info) => { Some(info) },
-            _ => { None },
         }
     }
 }

--- a/verification/verify_proof/src/bits.verus.rs
+++ b/verification/verify_proof/src/bits.verus.rs
@@ -641,7 +641,6 @@ proof fn lemma_bit_u64_shl_bit_bound(x: u64, n: u64, m: u64)
     broadcast use lemma_bit_u64_shl_values;
     broadcast use vstd::bits::lemma_u64_pow2_no_overflow;
 
-    let upper = ((1u64 << m) - 1) as u64;
     vstd::bits::lemma_u64_shl_is_mul(1u64, m);
     vstd::bits::lemma_u64_shl_is_mul(1u64, n);
     vstd::bits::lemma_u64_shl_is_mul(1u64, (n + m) as u64);
@@ -699,7 +698,6 @@ pub proof fn lemma_bit_u64_extract_fields2(a: u64, b: u64, n: u64, m: u64)
 {
     let mask1 = sub(1u64 << n, 1);
     let mask2 = sub(1u64 << m, 1);
-    let field2 = (b & mask2);
     assert((b << n) <= BIT64_MASK!(m) << n) by (bit_vector)
         requires
             b <= BIT64_MASK!(m),


### PR DESCRIPTION
This PR remove unused spec functions and variables inside spec functions. They were not detected by cargo clippy since they are inside verus!. This is to address the comment in #1187 