### PR TITLE
kernel: mm/guestmem: `GuestPtr` / `UserPtr` rework

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,8 +69,8 @@ This repository integrates formal verification using **Verus**.
 
 * Follow the rules in [CONTRIBUTING.md](Documentation/docs/developer/CONTRIBUTING.md)
   and linked files.
-* Wrap accesses to guest memory with `GuestPtr`. This type makes sure that an
-  access fault is handled and returned as a regular error.
+* Wrap fault-prone pointer accesses with `TryPtr`. This type makes sure that
+  an access fault is handled and returned as a regular error.
 * Be exceedingly careful when accessing guest and host-shared memory. In
   general, shared memory may contain any bit combination and can be updated at
   any moment. We use `FromBytes` to make sure a type has no invalid bitwise
@@ -119,7 +119,7 @@ and potentially hostile.**
 
 * SVSM code must never dereference raw guest pointers directly. Any memory
   address (Guest Physical Address or GPA) provided by the guest must be wrapped
-  in `GuestPtr<T>`.
+  in `TryPtr<T>`.
 * Always validate that guest-provided buffers do not cross page boundaries
   unless explicitly handled, as page boundaries may map to disparate physical
   ranges.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,10 @@ This repository integrates formal verification using **Verus**.
 * Follow the rules in [CONTRIBUTING.md](Documentation/docs/developer/CONTRIBUTING.md)
   and linked files.
 * Wrap fault-prone pointer accesses with `TryPtr`. This type makes sure that
-  an access fault is handled and returned as a regular error.
+  an access fault is handled and returned as a regular error. For lower-VMPL
+  guest physical addresses use `GuestPtr`, which can be instantiated from a
+  `PerCPUPageMappingGuard`, and validates the physical region on construction.
+  For SVSM userspace memory use `UserPtr`.
 * Be exceedingly careful when accessing guest and host-shared memory. In
   general, shared memory may contain any bit combination and can be updated at
   any moment. We use `FromBytes` to make sure a type has no invalid bitwise
@@ -119,7 +122,8 @@ and potentially hostile.**
 
 * SVSM code must never dereference raw guest pointers directly. Any memory
   address (Guest Physical Address or GPA) provided by the guest must be wrapped
-  in `TryPtr<T>`.
+  in `GuestPtr<T>`; any address in SVSM userspace must be wrapped in
+  `UserPtr<T>`.
 * Always validate that guest-provided buffers do not cross page boundaries
   unless explicitly handled, as page boundaries may map to disparate physical
   ranges.

--- a/kernel/src/address.rs
+++ b/kernel/src/address.rs
@@ -97,6 +97,15 @@ pub trait Address: Copy + From<InnerAddr> + Into<InnerAddr> + Ord {
         self.align_up(PAGE_SIZE)
     }
 
+    fn checked_align_up(&self, align: InnerAddr) -> Option<Self> {
+        let mask = align - 1;
+        self.bits().checked_add(mask).map(|v| Self::from(v & !mask))
+    }
+
+    fn checked_page_align_up(&self) -> Option<Self> {
+        self.checked_align_up(PAGE_SIZE)
+    }
+
     #[inline]
     #[verus_spec(ret =>
         requires

--- a/kernel/src/address.rs
+++ b/kernel/src/address.rs
@@ -98,7 +98,7 @@ pub trait Address: Copy + From<InnerAddr> + Into<InnerAddr> + Ord {
     }
 
     fn checked_align_up(&self, align: InnerAddr) -> Option<Self> {
-        let mask = align - 1;
+        let mask = align.checked_sub(1)?;
         self.bits().checked_add(mask).map(|v| Self::from(v & !mask))
     }
 

--- a/kernel/src/boot_params.rs
+++ b/kernel/src/boot_params.rs
@@ -10,7 +10,7 @@ use crate::acpi::tables::{ACPICPUInfo, ACPITable, load_acpi_cpu_info};
 use crate::address::{Address, PhysAddr, VirtAddr};
 use crate::error::SvsmError;
 use crate::mm::alloc::free_multiple_pages;
-use crate::mm::{GuestPtr, PAGE_SIZE, PerCPUPageMappingGuard};
+use crate::mm::{PAGE_SIZE, PerCPUPageMappingGuard, TryPtr};
 use crate::platform::{PageStateChangeOp, PageValidateOp, SVSM_PLATFORM, SevFWMetaData};
 use crate::utils::{MemoryRegion, page_align_up, round_to_pages};
 use alloc::vec::Vec;
@@ -245,7 +245,7 @@ impl BootParams<'_> {
         }
 
         // Generate a guest pointer range to hold the memory map.
-        let mem_map = GuestPtr::new(mem_map_va + mem_map_gpa.page_offset());
+        let mem_map = TryPtr::new(mem_map_va + mem_map_gpa.page_offset());
 
         for (i, entry) in map.iter().enumerate() {
             // SAFETY: mem_map_va points to newly mapped memory, whose physical

--- a/kernel/src/boot_params.rs
+++ b/kernel/src/boot_params.rs
@@ -245,40 +245,41 @@ impl BootParams<'_> {
         }
 
         // Generate a guest pointer range to hold the memory map.
-        let mem_map =
-            TryPtr::<IGVM_VHS_MEMORY_MAP_ENTRY>::new(mem_map_va + mem_map_gpa.page_offset());
+        let mem_map_addr = mem_map_va + mem_map_gpa.page_offset();
+        let mem_map = TryPtr::<[IGVM_VHS_MEMORY_MAP_ENTRY]>::new(mem_map_addr, max_entries);
 
         for (i, entry) in map.iter().enumerate() {
             // SAFETY: mem_map_va points to newly mapped memory, whose physical
-            // address is defined in the IGVM config.
+            // address is defined in the IGVM config; i < map.len() <= max_entries.
             unsafe {
-                mem_map
-                    .offset(i as isize)
-                    .write(IGVM_VHS_MEMORY_MAP_ENTRY {
+                mem_map.write(
+                    i,
+                    IGVM_VHS_MEMORY_MAP_ENTRY {
                         starting_gpa_page_number: u64::from(entry.start()) / PAGE_SIZE as u64,
                         number_of_pages: (entry.len() / PAGE_SIZE) as u64,
                         entry_type: MemoryMapEntryType::default(),
                         flags: 0,
                         reserved: 0,
-                    })?;
+                    },
+                )?;
             }
         }
 
         // Write a zero page count into the last entry to terminate the list.
         let index = map.len();
         if index < max_entries {
-            // SAFETY: mem_map_va points to newly mapped memory, whose physical
-            // address is defined in the IGVM config.
+            // SAFETY: as above; index < max_entries == mem_map.len().
             unsafe {
-                mem_map
-                    .offset(index as isize)
-                    .write(IGVM_VHS_MEMORY_MAP_ENTRY {
+                mem_map.write(
+                    index,
+                    IGVM_VHS_MEMORY_MAP_ENTRY {
                         starting_gpa_page_number: 0,
                         number_of_pages: 0,
                         entry_type: MemoryMapEntryType::default(),
                         flags: 0,
                         reserved: 0,
-                    })?;
+                    },
+                )?;
             }
         }
 

--- a/kernel/src/boot_params.rs
+++ b/kernel/src/boot_params.rs
@@ -245,7 +245,8 @@ impl BootParams<'_> {
         }
 
         // Generate a guest pointer range to hold the memory map.
-        let mem_map = TryPtr::new(mem_map_va + mem_map_gpa.page_offset());
+        let mem_map =
+            TryPtr::<IGVM_VHS_MEMORY_MAP_ENTRY>::new(mem_map_va + mem_map_gpa.page_offset());
 
         for (i, entry) in map.iter().enumerate() {
             // SAFETY: mem_map_va points to newly mapped memory, whose physical

--- a/kernel/src/cpu/apic.rs
+++ b/kernel/src/cpu/apic.rs
@@ -9,7 +9,7 @@ use crate::cpu::percpu::{PERCPU_AREAS, PerCpuShared, current_ghcb, this_cpu};
 use crate::cpu::x86::apic_post_irq;
 use crate::error::ApicError::{Emulation, InvalidRegister};
 use crate::error::SvsmError;
-use crate::mm::GuestPtr;
+use crate::mm::TryPtr;
 use crate::platform::guest_cpu::GuestCpuState;
 use crate::requests::SvsmCaa;
 use crate::sev::hv_doorbell::HVExtIntStatus;
@@ -138,7 +138,7 @@ impl LocalApic {
         // reset the guest lazy EOI flag.
         if self.lazy_eoi_pending {
             if let Some(caa_ptr) = caa {
-                let calling_area = GuestPtr::<SvsmCaa>::from(caa_ptr);
+                let calling_area = TryPtr::<SvsmCaa>::from(caa_ptr);
                 // SAFETY: guest vmsa and ca are always validated before being
                 // updated (core_remap_ca(), core_create_vcpu() or
                 // prepare_fw_launch()) so they're safe to use.
@@ -169,9 +169,9 @@ impl LocalApic {
         self.get_ppr_with_tpr(cpu_state.get_tpr())
     }
 
-    fn clear_guest_eoi_pending(caa: Option<NonNull<SvsmCaa>>) -> Option<GuestPtr<SvsmCaa>> {
+    fn clear_guest_eoi_pending(caa: Option<NonNull<SvsmCaa>>) -> Option<TryPtr<SvsmCaa>> {
         let ptr = caa?;
-        let calling_area = GuestPtr::<SvsmCaa>::from(ptr);
+        let calling_area = TryPtr::<SvsmCaa>::from(ptr);
         // Ignore errors here, since nothing can be done if an error occurs.
         // SAFETY: guest vmsa and ca are always validated before being updated
         // (core_remap_ca(), core_create_vcpu() or prepare_fw_launch()) so

--- a/kernel/src/cpu/idt/common.rs
+++ b/kernel/src/cpu/idt/common.rs
@@ -12,8 +12,8 @@ use crate::cpu::registers::{X86GeneralRegs, X86InterruptFrame};
 use crate::cpu::shadow_stack::is_cet_ss_enabled;
 use crate::error::SvsmError;
 use crate::insn_decode::{InsnError, InsnMachineCtx, Register, SegRegister};
-use crate::mm::GuestPtr;
 use crate::mm::PAGE_SIZE;
+use crate::mm::TryPtr;
 use crate::mm::ro_after_init::make_ro;
 use crate::platform::SVSM_PLATFORM;
 use crate::types::{Bytes, SVSM_CS};
@@ -99,7 +99,7 @@ impl X86ExceptionContext {
 }
 
 impl InsnMachineCtx for X86ExceptionContext {
-    type Ptr<T: FromBytes + IntoBytes> = GuestPtr<T>;
+    type Ptr<T: FromBytes + IntoBytes> = TryPtr<T>;
 
     fn read_efer(&self) -> u64 {
         read_efer().bits()
@@ -181,7 +181,7 @@ impl InsnMachineCtx for X86ExceptionContext {
         if user_mode(self) {
             todo!();
         } else {
-            Ok(GuestPtr::<T>::new(VirtAddr::from(la)))
+            Ok(TryPtr::<T>::new(VirtAddr::from(la)))
         }
     }
 

--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -24,8 +24,8 @@ use crate::cpu::registers::RFlags;
 use crate::cpu::shadow_stack::IS_CET_ENABLED;
 use crate::debug::gdbstub::svsm_gdbstub::handle_debug_exception;
 use crate::error::SvsmError;
-use crate::mm::GuestPtr;
 use crate::mm::PAGE_SIZE;
+use crate::mm::TryPtr;
 use crate::platform::PageValidateOp;
 use crate::platform::SvsmPlatform;
 use crate::task::{TaskExitStatus, is_task_fault, terminate};
@@ -323,20 +323,20 @@ extern "C" fn ex_handler_control_protection(ctxt: &mut X86ExceptionContext, _vec
     match ctxt.error_code & 0x7fff {
         code @ (NEAR_RET | FAR_RET_IRET) => {
             // Read the return address on the normal stack.
-            let ret_ptr: GuestPtr<u64> = GuestPtr::new(VirtAddr::from(ctxt.frame.rsp));
+            let ret_ptr: TryPtr<u64> = TryPtr::new(VirtAddr::from(ctxt.frame.rsp));
             // SAFETY: `rsp` is a valid guest address filled by the CPU in the
             // X86InterruptFrame
             let ret = unsafe { ret_ptr.read() }.expect("Failed to read return address");
 
             // Read the return address on the shadow stack.
-            let prev_rssp_ptr: GuestPtr<u64> = GuestPtr::new(VirtAddr::from(ctxt.ssp));
+            let prev_rssp_ptr: TryPtr<u64> = TryPtr::new(VirtAddr::from(ctxt.ssp));
             // SAFETY: `ssp` is a valid guest address filled by the CPU in the
             // X86ExceptionContext
             let prev_rssp = unsafe { prev_rssp_ptr.read() }
                 .expect("Failed to read address of previous shadow stack pointer");
             // The offset to the return pointer is different for RET and IRET.
             let offset = if code == NEAR_RET { 0 } else { 8 };
-            let ret_ptr: GuestPtr<u64> = GuestPtr::new(VirtAddr::from(prev_rssp + offset));
+            let ret_ptr: TryPtr<u64> = TryPtr::new(VirtAddr::from(prev_rssp + offset));
             let ret_on_ssp =
                 // SAFETY: `ssp` is a valid guest address filled by the CPU in the
                 // X86ExceptionContext

--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -323,20 +323,20 @@ extern "C" fn ex_handler_control_protection(ctxt: &mut X86ExceptionContext, _vec
     match ctxt.error_code & 0x7fff {
         code @ (NEAR_RET | FAR_RET_IRET) => {
             // Read the return address on the normal stack.
-            let ret_ptr: TryPtr<u64> = TryPtr::new(VirtAddr::from(ctxt.frame.rsp));
+            let ret_ptr = TryPtr::<u64>::new(VirtAddr::from(ctxt.frame.rsp));
             // SAFETY: `rsp` is a valid guest address filled by the CPU in the
             // X86InterruptFrame
             let ret = unsafe { ret_ptr.read() }.expect("Failed to read return address");
 
             // Read the return address on the shadow stack.
-            let prev_rssp_ptr: TryPtr<u64> = TryPtr::new(VirtAddr::from(ctxt.ssp));
+            let prev_rssp_ptr = TryPtr::<u64>::new(VirtAddr::from(ctxt.ssp));
             // SAFETY: `ssp` is a valid guest address filled by the CPU in the
             // X86ExceptionContext
             let prev_rssp = unsafe { prev_rssp_ptr.read() }
                 .expect("Failed to read address of previous shadow stack pointer");
             // The offset to the return pointer is different for RET and IRET.
             let offset = if code == NEAR_RET { 0 } else { 8 };
-            let ret_ptr: TryPtr<u64> = TryPtr::new(VirtAddr::from(prev_rssp + offset));
+            let ret_ptr = TryPtr::<u64>::new(VirtAddr::from(prev_rssp + offset));
             let ret_on_ssp =
                 // SAFETY: `ssp` is a valid guest address filled by the CPU in the
                 // X86ExceptionContext

--- a/kernel/src/cpu/vc.rs
+++ b/kernel/src/cpu/vc.rs
@@ -191,7 +191,7 @@ fn vc_decode_insn(ctx: &X86ExceptionContext) -> Result<Option<DecodedInsnCtx>, S
     // TODO: the instruction fetch will likely to be handled differently when
     // #VC exception will be raised from CPL > 0.
 
-    let rip: TryPtr<[u8; MAX_INSN_SIZE]> = TryPtr::new(VirtAddr::from(ctx.frame.rip));
+    let rip = TryPtr::<[u8; MAX_INSN_SIZE]>::new(VirtAddr::from(ctx.frame.rip));
 
     // rip and rip+15 addresses should belong to a mapped page.
     // To ensure this, we rely on TryPtr::read() that uses the exception table

--- a/kernel/src/cpu/vc.rs
+++ b/kernel/src/cpu/vc.rs
@@ -14,7 +14,7 @@ use crate::insn_decode::DecodedInsn;
 use crate::insn_decode::DecodedInsnCtx;
 use crate::insn_decode::Instruction;
 use crate::insn_decode::MAX_INSN_SIZE;
-use crate::mm::GuestPtr;
+use crate::mm::TryPtr;
 use crate::sev::ghcb::GHCB;
 use core::fmt;
 
@@ -191,10 +191,10 @@ fn vc_decode_insn(ctx: &X86ExceptionContext) -> Result<Option<DecodedInsnCtx>, S
     // TODO: the instruction fetch will likely to be handled differently when
     // #VC exception will be raised from CPL > 0.
 
-    let rip: GuestPtr<[u8; MAX_INSN_SIZE]> = GuestPtr::new(VirtAddr::from(ctx.frame.rip));
+    let rip: TryPtr<[u8; MAX_INSN_SIZE]> = TryPtr::new(VirtAddr::from(ctx.frame.rip));
 
     // rip and rip+15 addresses should belong to a mapped page.
-    // To ensure this, we rely on GuestPtr::read() that uses the exception table
+    // To ensure this, we rely on TryPtr::read() that uses the exception table
     // to handle faults while fetching.
     // SAFETY: we trust the CPU-provided register state to be valid. Thus, RIP
     // will point to the instruction that caused #VC to be raised, so it can

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -214,6 +214,8 @@ impl From<SvsmError> for SysCallError {
             | SvsmError::InvalidBytes
             | SvsmError::InvalidUtf8 => SysCallError::EINVAL,
 
+            SvsmError::Fault => SysCallError::EFAULT,
+
             _ => SysCallError::UNKNOWN,
         }
     }

--- a/kernel/src/mm/guestmem.rs
+++ b/kernel/src/mm/guestmem.rs
@@ -20,7 +20,7 @@ use core::arch::asm;
 use core::borrow::Borrow;
 use core::ffi::c_char;
 use core::mem::{MaybeUninit, size_of};
-use core::ptr::{self, NonNull, with_exposed_provenance, with_exposed_provenance_mut};
+use core::ptr::{self, NonNull};
 use core::slice;
 use syscall::PATH_MAX;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, TryFromBytes};
@@ -617,6 +617,183 @@ impl<T: FromBytes + IntoBytes> InsnMachineMem<T> for TryPtr<T> {
     }
 }
 
+impl PerCPUPageMappingGuard {
+    /// Returns a [`GuestPtr<T>`] at `offset` bytes into the mapped region.
+    ///
+    /// # Errors
+    ///
+    /// * [`SvsmError::InvalidAddress`] if the access would exceed the mapped region or
+    ///   fall outside guest memory.
+    /// * [`SvsmError::Mem`] if integer overflow occurs.
+    pub fn guest_ptr<T>(&self, offset: usize) -> Result<GuestPtr<'_, T>, SvsmError> {
+        let start = self.phys_base().checked_add(offset).ok_or(SvsmError::Mem)?;
+        let region = checked_guest_region(start, size_of::<T>())?;
+        if !self.phys_region().contains_region(&region) {
+            return Err(SvsmError::InvalidAddress);
+        }
+        Ok(GuestPtr {
+            _guard: self,
+            ptr: TryPtr::<T>::new(self.virt_addr() + offset),
+        })
+    }
+
+    /// Returns a [`GuestPtr<[T]>`] for `len` elements at `offset` bytes into
+    /// the mapped region.
+    ///
+    /// # Errors
+    ///
+    /// * [`SvsmError::InvalidAddress`] if the access would exceed the mapped region or
+    ///   fall outside guest memory.
+    /// * [`SvsmError::Mem`] if integer overflow occurs.
+    pub fn guest_slice<T>(
+        &self,
+        offset: usize,
+        len: usize,
+    ) -> Result<GuestPtr<'_, [T]>, SvsmError> {
+        let start = self.phys_base().checked_add(offset).ok_or(SvsmError::Mem)?;
+        let size = len.checked_mul(size_of::<T>()).ok_or(SvsmError::Mem)?;
+        let region = checked_guest_region(start, size)?;
+        if !self.phys_region().contains_region(&region) {
+            return Err(SvsmError::InvalidAddress);
+        }
+        Ok(GuestPtr {
+            _guard: self,
+            ptr: TryPtr::<[T]>::new(self.virt_addr() + offset, len),
+        })
+    }
+}
+
+/// A pointer to a validated region of lower-VMPL guest memory, anchored to a
+/// [`PerCPUPageMappingGuard`] that keeps the underlying page mapping live.
+///
+/// Created via [`PerCPUPageMappingGuard::guest_ptr`] or
+/// [`PerCPUPageMappingGuard::guest_slice`].
+#[derive(Debug)]
+pub struct GuestPtr<'a, T: ?Sized> {
+    _guard: &'a PerCPUPageMappingGuard,
+    ptr: TryPtr<T>,
+}
+
+impl<T> GuestPtr<'_, T> {
+    /// Reads the value from guest memory.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SvsmError::Fault`] if the access faults unexpectedly.
+    pub fn read(&self) -> Result<T, SvsmError>
+    where
+        T: FromBytes,
+    {
+        // SAFETY: bounds were verified at construction
+        unsafe { self.ptr.read() }
+    }
+
+    /// Attempts to read the value from guest memory, validating its bit
+    /// pattern.
+    ///
+    /// # Errors
+    ///
+    /// * [`SvsmError::Fault`] if the access faults.
+    /// * [`SvsmError::Mem`] if the data is not a valid instance of `T`.
+    pub fn try_read(&self) -> Result<T, SvsmError>
+    where
+        T: TryFromBytes,
+    {
+        // SAFETY: bounds were verified at construction
+        unsafe { self.ptr.try_read() }
+    }
+
+    /// Writes `val` to guest memory.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SvsmError::Fault`] if the access faults.
+    pub fn write<B>(&self, val: B) -> Result<(), SvsmError>
+    where
+        B: Borrow<T>,
+        T: IntoBytes,
+    {
+        // SAFETY: bounds were verified at construction
+        unsafe { self.ptr.write(val) }
+    }
+}
+
+impl<T> GuestPtr<'_, [T]> {
+    /// Returns the number of elements in the slice.
+    pub const fn len(&self) -> usize {
+        self.ptr.len()
+    }
+
+    /// Returns `true` if the slice contains no elements.
+    pub const fn is_empty(&self) -> bool {
+        self.ptr.is_empty()
+    }
+
+    /// Reads element at `index`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SvsmError::InvalidAddress`] if `index >= len`, or
+    /// [`SvsmError::Fault`] if the access faults.
+    pub fn read(&self, index: usize) -> Result<T, SvsmError>
+    where
+        T: FromBytes,
+    {
+        // SAFETY: bounds were verified at construction
+        unsafe { self.ptr.read(index) }
+    }
+
+    /// Writes `val` to element at `index`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SvsmError::InvalidAddress`] if `index >= len`, or
+    /// [`SvsmError::Fault`] if the access faults.
+    pub fn write(&self, index: usize, val: T) -> Result<(), SvsmError>
+    where
+        T: IntoBytes,
+    {
+        // SAFETY: bounds were verified at construction
+        unsafe { self.ptr.write(index, val) }
+    }
+
+    /// Reads all elements and copies them into `dst`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SvsmError::Mem`] if `dst.len() != self.len()`, or
+    /// [`SvsmError::Fault`] if the copy faults.
+    pub fn read_to_slice(&self, dst: &mut [T]) -> Result<(), SvsmError>
+    where
+        T: FromBytes,
+    {
+        // SAFETY: bounds were verified at construction
+        unsafe { self.ptr.read_to_slice(dst) }
+    }
+
+    pub fn read_to_vec(&self) -> Result<Vec<T>, SvsmError>
+    where
+        T: FromBytes,
+    {
+        // SAFETY: bounds were verified at construction
+        unsafe { self.ptr.read_to_vec() }
+    }
+
+    /// Writes all elements from `src`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SvsmError::Mem`] if `src.len() != self.len()`, or
+    /// [`SvsmError::Fault`] if the copy faults.
+    pub fn write_from_slice(&self, src: &[T]) -> Result<(), SvsmError>
+    where
+        T: IntoBytes,
+    {
+        // SAFETY: bounds were verified at construction
+        unsafe { self.ptr.write_from_slice(src) }
+    }
+}
+
 struct UserAccessGuard;
 
 impl UserAccessGuard {
@@ -841,41 +1018,6 @@ fn checked_guest_region(start: PhysAddr, size: usize) -> Result<MemoryRegion<Phy
 
 /// Reads a slice of bytes from a physical address region outside of SVSM use.
 ///
-/// # Safety
-///
-/// The caller must ensure that dst..dst+size is memory that it owns.
-///
-/// # Arguments
-///
-/// * `src`: The physical address designating the start of continguous physical
-///   memory to read from.
-/// * `dst`: The pointer to the beginning of the SVSM memory range to populate.
-/// * `size`: The number of bytes to write from src to dst.
-///
-/// # Returns
-///
-/// This function returns a `Result` that indicates the success or failure of the operation.
-/// If the physical address region cannot be mapped, it returns `Err(SvsmError::Mem)`.
-/// If the physical address region cannot be read, it returns `Err(SvsmError::Fault)`.
-/// If the physical address region is not allocated to the guest, it returns
-///   `Err(SvsmError::InvalidAddress)`.
-pub unsafe fn copy_from_guest(src: PhysAddr, dst: *mut u8, size: usize) -> Result<(), SvsmError> {
-    let region = checked_guest_region(src, size)?;
-    let start = region.start().page_align();
-    // Offset will always be 0..4K, so this is infallible.
-    let offset = region.start().page_offset() as isize;
-    let end = region.end().page_align_up();
-
-    // SAFETY: Only reads data from a region outside the SVSM.
-    unsafe {
-        let guard = PerCPUPageMappingGuard::create(start, end, 0)?;
-        let source = with_exposed_provenance::<u8>(guard.virt_addr().bits()).offset(offset);
-        copy_bytes(source, dst, size)
-    }
-}
-
-/// Reads a slice of bytes from a physical address region outside of SVSM use.
-///
 /// # Arguments
 ///
 /// * `src`: The physical address designating the start of continguous physical
@@ -890,8 +1032,13 @@ pub unsafe fn copy_from_guest(src: PhysAddr, dst: *mut u8, size: usize) -> Resul
 /// If the physical address region is not allocated to the guest, it returns
 ///   `Err(SvsmError::InvalidAddress)`.
 pub fn copy_slice_from_guest(src: PhysAddr, dst: &mut [u8]) -> Result<(), SvsmError> {
-    // SAFETY: The safety property of slices ensures the memory is owned and mutable.
-    unsafe { copy_from_guest(src, dst.as_mut_ptr(), dst.len()) }
+    let src_end = src
+        .checked_add(dst.len())
+        .and_then(|end| end.checked_page_align_up())
+        .ok_or(SvsmError::Mem)?;
+    PerCPUPageMappingGuard::create(src.page_align(), src_end, 0)?
+        .guest_slice::<u8>(src.page_offset(), dst.len())?
+        .read_to_slice(dst)
 }
 
 /// Writes a slice of bytes to a physical address region outside of SVSM use.
@@ -910,20 +1057,13 @@ pub fn copy_slice_from_guest(src: PhysAddr, dst: &mut [u8]) -> Result<(), SvsmEr
 /// If the physical address region is not allocated to the guest, it returns
 ///   `Err(SvsmError::InvalidAddress)`.
 pub fn copy_slice_to_guest(src: &[u8], dst: PhysAddr) -> Result<(), SvsmError> {
-    let size = src.len();
-    let region = checked_guest_region(dst, src.len())?;
-    let start = region.start().page_align();
-    // Offset will always be 0..4K so this is infallible.
-    let offset = region.start().page_offset() as isize;
-    let end = region.end().page_align_up();
-
-    // SAFETY: Only reads data from a region outside the SVSM.
-    unsafe {
-        let guard = PerCPUPageMappingGuard::create(start, end, 0)?;
-        let destination =
-            with_exposed_provenance_mut::<u8>(guard.virt_addr().bits()).offset(offset);
-        copy_bytes(src.as_ptr(), destination, size)
-    }
+    let dst_end = dst
+        .checked_add(src.len())
+        .and_then(|end| end.checked_page_align_up())
+        .ok_or(SvsmError::Mem)?;
+    PerCPUPageMappingGuard::create(dst.page_align(), dst_end, 0)?
+        .guest_slice::<u8>(dst.page_offset(), src.len())?
+        .write_from_slice(src)
 }
 
 /// Reads a vector of bytes from a physical address region outside of SVSM use.
@@ -943,14 +1083,13 @@ pub fn copy_slice_to_guest(src: &[u8], dst: PhysAddr) -> Result<(), SvsmError> {
 /// If the physical address region is not allocated to the guest, it returns
 ///   `Err(SvsmError::InvalidAddress)`.
 pub fn read_bytes_from_guest(src: PhysAddr, size: usize) -> Result<Vec<u8>, SvsmError> {
-    let mut result = Vec::with_capacity(size);
-    // SAFETY: The vector's capacity, `size` has been populated by copy_from_guest.
-    // The translation of bytes to T are checked.
-    unsafe {
-        copy_from_guest(src, result.as_mut_ptr(), size)?;
-        result.set_len(size);
-    }
-    Ok(result)
+    let src_end = src
+        .checked_add(size)
+        .and_then(|end| end.checked_page_align_up())
+        .ok_or(SvsmError::Mem)?;
+    PerCPUPageMappingGuard::create(src.page_align(), src_end, 0)?
+        .guest_slice::<u8>(src.page_offset(), size)?
+        .read_to_vec()
 }
 
 /// Reads an instance of T from a physical address region outside of SVSM use.
@@ -969,15 +1108,13 @@ pub fn read_bytes_from_guest(src: PhysAddr, size: usize) -> Result<Vec<u8>, Svsm
 /// If the physical address region is not allocated to the guest, it returns
 ///   `Err(SvsmError::InvalidAddress)`.
 pub fn read_from_guest<T: KnownLayout + FromBytes + Sized>(src: PhysAddr) -> Result<T, SvsmError> {
-    let mut t: MaybeUninit<T> = MaybeUninit::uninit();
-    // SAFETY: copy_from_guest does not read `t`, so it's safe to take a mutable pointer.
-    // The `t` layout is known, so populating through the casted *mut u8 is safe.
-    // The size of T is allocated on the SVSM stack, so it is fully owned.
-    // copy_from_guest populates the full contents of t so it is same to assume t is initialized.
-    unsafe {
-        copy_from_guest(src, t.as_mut_ptr().cast::<u8>(), size_of::<T>())?;
-        Ok(t.assume_init())
-    }
+    let src_end = src
+        .checked_add(size_of::<T>())
+        .and_then(|end| end.checked_page_align_up())
+        .ok_or(SvsmError::Mem)?;
+    PerCPUPageMappingGuard::create(src.page_align(), src_end, 0)?
+        .guest_ptr::<T>(src.page_offset())?
+        .read()
 }
 
 /// Writes a value to a physical address region outside of SVSM use.
@@ -997,7 +1134,13 @@ pub fn read_from_guest<T: KnownLayout + FromBytes + Sized>(src: PhysAddr) -> Res
 ///   `Err(SvsmError::InvalidAddress)`.
 #[inline]
 pub fn write_to_guest<T: IntoBytes + Immutable>(v: &T, dst: PhysAddr) -> Result<(), SvsmError> {
-    copy_slice_to_guest(v.as_bytes(), dst)
+    let dst_end = dst
+        .checked_add(size_of::<T>())
+        .and_then(|end| end.checked_page_align_up())
+        .ok_or(SvsmError::Mem)?;
+    PerCPUPageMappingGuard::create(dst.page_align(), dst_end, 0)?
+        .guest_ptr::<T>(dst.page_offset())?
+        .write(v)
 }
 
 #[cfg(test)]

--- a/kernel/src/mm/guestmem.rs
+++ b/kernel/src/mm/guestmem.rs
@@ -17,6 +17,7 @@ use crate::utils::MemoryRegion;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::arch::asm;
+use core::borrow::Borrow;
 use core::ffi::c_char;
 use core::mem::{MaybeUninit, size_of};
 use core::ptr::{NonNull, with_exposed_provenance, with_exposed_provenance_mut};
@@ -393,6 +394,9 @@ impl<T> TryPtr<T> {
         }
     }
 
+    /// Writes `buf` into the memory pointed to by this `TryPtr`.
+    /// `buf` may be an owned instance of `T` or a reference.
+    ///
     /// # Safety
     ///
     /// The caller must verify not to corrupt arbitrary memory, as this function
@@ -403,32 +407,15 @@ impl<T> TryPtr<T> {
     /// Returns an error if the specified address is not mapped or is not mapped
     /// with the appropriate write permissions.
     #[inline]
-    pub unsafe fn write(&self, buf: T) -> Result<(), SvsmError>
+    pub unsafe fn write<B>(&self, buf: B) -> Result<(), SvsmError>
     where
+        B: Borrow<T>,
         T: IntoBytes,
     {
+        let src = buf.borrow();
         // SAFETY: Safe when self.ptr does not point to SVSM memory because
         // then the write can not harm memory safety.
-        unsafe { do_movsb(&raw const buf, self.ptr) }
-    }
-
-    /// # Safety
-    ///
-    /// The caller must verify not to corrupt arbitrary memory, as this function
-    /// doesn't make any checks in that regard.
-    ///
-    /// # Returns
-    ///
-    /// Returns an error if the specified address is not mapped or is not mapped
-    /// with the appropriate write permissions.
-    #[inline]
-    pub unsafe fn write_ref(&self, buf: &T) -> Result<(), SvsmError>
-    where
-        T: IntoBytes,
-    {
-        // SAFETY: Safe when self.ptr does not point to SVSM memory because
-        // then the write can not harm memory safety.
-        unsafe { do_movsb(buf, self.ptr) }
+        unsafe { do_movsb(src, self.ptr) }
     }
 
     #[inline]
@@ -530,16 +517,9 @@ impl<T> UserPtr<T> {
     }
 
     #[inline]
-    pub fn write(&self, buf: T) -> Result<(), SvsmError>
+    pub fn write<B>(&self, buf: B) -> Result<(), SvsmError>
     where
-        T: IntoBytes,
-    {
-        self.write_ref(&buf)
-    }
-
-    #[inline]
-    pub fn write_ref(&self, buf: &T) -> Result<(), SvsmError>
-    where
+        B: Borrow<T>,
         T: IntoBytes,
     {
         if !self.check_bounds() {
@@ -547,7 +527,7 @@ impl<T> UserPtr<T> {
         }
         let _guard = UserAccessGuard::new();
         // SAFETY: Target pointer is guaranteed to point to user memory.
-        unsafe { self.ptr.write_ref(buf) }
+        unsafe { self.ptr.write(buf) }
     }
 
     #[inline]

--- a/kernel/src/mm/guestmem.rs
+++ b/kernel/src/mm/guestmem.rs
@@ -474,18 +474,19 @@ pub struct UserPtr<T> {
 }
 
 impl<T> UserPtr<T> {
+    /// Constructs a `UserPtr` pointing to `v`, checking that the entire object
+    /// falls within userspace.
     #[inline]
-    pub fn new(v: VirtAddr) -> Self {
-        Self {
-            ptr: TryPtr::new(v),
+    pub fn new(v: VirtAddr) -> Result<Self, SvsmError> {
+        let userspace = MemoryRegion::from_addresses(USER_MEM_START, USER_MEM_END);
+        let region =
+            MemoryRegion::checked_new(v, size_of::<T>()).ok_or(SvsmError::InvalidAddress)?;
+        if !userspace.contains_region(&region) {
+            return Err(SvsmError::InvalidAddress);
         }
-    }
-
-    fn check_bounds(&self) -> bool {
-        let v = VirtAddr::from(self.ptr.ptr);
-
-        (USER_MEM_START..USER_MEM_END).contains(&v)
-            && (USER_MEM_START..USER_MEM_END).contains(&(v + size_of::<T>()))
+        Ok(Self {
+            ptr: TryPtr::new(v),
+        })
     }
 
     #[inline]
@@ -493,11 +494,8 @@ impl<T> UserPtr<T> {
     where
         T: FromBytes,
     {
-        if !self.check_bounds() {
-            return Err(SvsmError::InvalidAddress);
-        }
         let _guard = UserAccessGuard::new();
-        // SAFETY: Target pointer is guaranteed to point to user memory.
+        // SAFETY: bounds were verified at construction.
         unsafe { self.ptr.read() }
     }
 
@@ -508,11 +506,8 @@ impl<T> UserPtr<T> {
     where
         T: TryFromBytes,
     {
-        if !self.check_bounds() {
-            return Err(SvsmError::InvalidAddress);
-        }
         let _guard = UserAccessGuard::new();
-        // SAFETY: Target pointer is guaranteed to point to user memory.
+        // SAFETY: bounds were verified at construction.
         unsafe { self.ptr.try_read() }
     }
 
@@ -522,26 +517,20 @@ impl<T> UserPtr<T> {
         B: Borrow<T>,
         T: IntoBytes,
     {
-        if !self.check_bounds() {
-            return Err(SvsmError::InvalidAddress);
-        }
         let _guard = UserAccessGuard::new();
-        // SAFETY: Target pointer is guaranteed to point to user memory.
+        // SAFETY: bounds were verified at construction.
         unsafe { self.ptr.write(buf) }
     }
 
     #[inline]
-    pub const fn cast<N>(&self) -> UserPtr<N> {
-        UserPtr {
-            ptr: self.ptr.cast(),
-        }
+    pub fn cast<N>(&self) -> Result<UserPtr<N>, SvsmError> {
+        let vaddr = VirtAddr::from(self.ptr.ptr);
+        UserPtr::new(vaddr)
     }
 
     #[inline]
-    pub fn offset(&self, count: isize) -> UserPtr<T> {
-        UserPtr {
-            ptr: self.ptr.offset(count),
-        }
+    pub fn offset(&self, count: isize) -> Result<Self, SvsmError> {
+        Self::new(VirtAddr::from(self.ptr.offset(count).ptr))
     }
 }
 
@@ -552,7 +541,7 @@ impl UserPtr<c_char> {
         let mut buffer = Vec::new();
 
         for offset in 0..PATH_MAX {
-            let current_ptr = self.offset(offset as isize);
+            let current_ptr = self.offset(offset as isize)?;
             let char_result = current_ptr.read()?;
             match char_result {
                 0 => return String::from_utf8(buffer).map_err(|_| SvsmError::InvalidUtf8),

--- a/kernel/src/mm/guestmem.rs
+++ b/kernel/src/mm/guestmem.rs
@@ -633,7 +633,7 @@ impl Drop for UserAccessGuard {
 }
 
 #[derive(Debug)]
-pub struct UserPtr<T> {
+pub struct UserPtr<T: ?Sized> {
     ptr: TryPtr<T>,
 }
 
@@ -689,7 +689,7 @@ impl<T> UserPtr<T> {
     #[inline]
     pub fn cast<N>(&self) -> Result<UserPtr<N>, SvsmError> {
         let vaddr = VirtAddr::from(self.ptr.ptr);
-        UserPtr::new(vaddr)
+        UserPtr::<N>::new(vaddr)
     }
 
     #[inline]
@@ -716,57 +716,119 @@ impl UserPtr<c_char> {
     }
 }
 
-fn check_bounds_user(start: usize, len: usize) -> Result<(), SvsmError> {
-    let end: usize = start.checked_add(len).ok_or(SvsmError::InvalidAddress)?;
+impl<T> UserPtr<[T]> {
+    /// Constructs a `UserPtr<[T]>` pointing to `len` elements at `v`,
+    /// checking that the entire object falls within userspace.
+    #[inline]
+    pub fn new(v: VirtAddr, len: usize) -> Result<Self, SvsmError> {
+        let userspace = MemoryRegion::from_addresses(USER_MEM_START, USER_MEM_END);
+        let region = len
+            .checked_mul(size_of::<T>())
+            .and_then(|size| MemoryRegion::checked_new(v, size))
+            .ok_or(SvsmError::InvalidAddress)?;
+        if !userspace.contains_region(&region) {
+            return Err(SvsmError::InvalidAddress);
+        }
+        Ok(Self {
+            ptr: TryPtr::<[T]>::new(v, len),
+        })
+    }
 
-    if end > USER_MEM_END.bits() {
-        Err(SvsmError::InvalidAddress)
-    } else {
-        Ok(())
+    /// Returns the number of elements in the slice.
+    #[inline]
+    pub const fn len(&self) -> usize {
+        self.ptr.len()
+    }
+
+    /// Returns `true` if the slice contains no elements.
+    #[inline]
+    pub const fn is_empty(&self) -> bool {
+        self.ptr.is_empty()
+    }
+
+    /// Reads element at `index`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SvsmError::InvalidAddress`] if `index >= len`, or
+    /// [`SvsmError::Fault`] if the access faults.
+    #[inline]
+    pub fn read(&self, index: usize) -> Result<T, SvsmError>
+    where
+        T: FromBytes,
+    {
+        let _guard = UserAccessGuard::new();
+        // SAFETY: bounds were verified at construction.
+        unsafe { self.ptr.read(index) }
+    }
+
+    /// Writes `val` to element at `index`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SvsmError::InvalidAddress`] if `index >= len`, or
+    /// [`SvsmError::Fault`] if the access faults.
+    #[inline]
+    pub fn write(&self, index: usize, val: T) -> Result<(), SvsmError>
+    where
+        T: IntoBytes,
+    {
+        let _guard = UserAccessGuard::new();
+        // SAFETY: bounds were verified at construction.
+        unsafe { self.ptr.write(index, val) }
+    }
+
+    /// Copies all elements into `dst`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SvsmError::Mem`] if `dst.len() != self.len()`, or
+    /// [`SvsmError::Fault`] if the access faults.
+    #[inline]
+    pub fn read_to_slice(&self, dst: &mut [T]) -> Result<(), SvsmError>
+    where
+        T: FromBytes,
+    {
+        let _guard = UserAccessGuard::new();
+        // SAFETY: bounds were verified at construction.
+        unsafe { self.ptr.read_to_slice(dst) }
+    }
+
+    /// Copies all elements from `src` into the slice.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SvsmError::Mem`] if `src.len() != self.len()`, or
+    /// [`SvsmError::Fault`] if the access faults.
+    #[inline]
+    pub fn write_from_slice(&self, src: &[T]) -> Result<(), SvsmError>
+    where
+        T: IntoBytes,
+    {
+        let _guard = UserAccessGuard::new();
+        // SAFETY: bounds were verified at construction.
+        unsafe { self.ptr.write_from_slice(src) }
+    }
+}
+
+impl UserPtr<[u8]> {
+    pub fn zero_fill(&self) -> Result<(), SvsmError> {
+        let _guard = UserAccessGuard::new();
+        // SAFETY: bounds were verified at construction.
+        unsafe { self.ptr.zero_fill() }
     }
 }
 
 pub fn zero_user_mem(dst: VirtAddr, size: usize) -> Result<(), SvsmError> {
-    let destination = with_exposed_provenance_mut::<u8>(dst.bits());
-
-    check_bounds_user(dst.bits(), size)?;
-
-    // SAFETY: As per above check this clears only the requested memory in
-    // user-mode memory.
-    unsafe {
-        let _guard = UserAccessGuard::new();
-        clear_bytes(destination, size)
-    }
+    UserPtr::<[u8]>::new(dst, size)?.zero_fill()
 }
 
 pub fn copy_from_user(src: VirtAddr, dst: &mut [u8]) -> Result<(), SvsmError> {
-    let destination = dst.as_mut_ptr();
-    let size = dst.len();
-
-    check_bounds_user(src.bits(), size)?;
-
-    // SAFETY: Safe because the copy only happens to the memory belonging to
-    // the dst slice from user-mode memory.
-    unsafe {
-        let _guard = UserAccessGuard::new();
-        let source = with_exposed_provenance::<u8>(src.bits());
-        copy_bytes(source, destination, size)
-    }
+    UserPtr::<[u8]>::new(src, dst.len())?.read_to_slice(dst)
 }
 
 pub fn copy_to_user(src: &[u8], dst: VirtAddr) -> Result<(), SvsmError> {
-    let source = src.as_ptr();
-    let size = src.len();
-
-    check_bounds_user(dst.bits(), size)?;
-
-    // SAFETY: Only reads data from with the slice and copies to an address
-    // guaranteed to be in user-space.
-    unsafe {
-        let _guard = UserAccessGuard::new();
-        let destination = with_exposed_provenance_mut::<u8>(dst.bits());
-        copy_bytes(source, destination, size)
-    }
+    UserPtr::<[u8]>::new(dst, src.len())?.write_from_slice(src)
 }
 
 fn checked_guest_region(start: PhysAddr, size: usize) -> Result<MemoryRegion<PhysAddr>, SvsmError> {

--- a/kernel/src/mm/guestmem.rs
+++ b/kernel/src/mm/guestmem.rs
@@ -314,12 +314,13 @@ unsafe fn do_movsb<T>(src: *const T, dst: *mut T) -> Result<(), SvsmError> {
     unsafe { copy_bytes(src.cast(), dst.cast(), size) }
 }
 
+/// A pointer wrapper that safely handles faults when accessing memory.
 #[derive(Debug)]
-pub struct GuestPtr<T> {
+pub struct TryPtr<T> {
     ptr: *mut T,
 }
 
-impl<T> GuestPtr<T> {
+impl<T> TryPtr<T> {
     #[inline]
     pub fn new(v: VirtAddr) -> Self {
         Self {
@@ -340,7 +341,7 @@ impl<T> GuestPtr<T> {
     ///
     /// # Safety
     ///
-    /// See safety considerations for [`GuestPtr::read()`].
+    /// See safety considerations for [`TryPtr::read()`].
     ///
     /// # Errors
     ///
@@ -431,38 +432,36 @@ impl<T> GuestPtr<T> {
     }
 
     #[inline]
-    pub const fn cast<N>(&self) -> GuestPtr<N> {
-        GuestPtr::from_ptr(self.ptr.cast())
+    pub const fn cast<N>(&self) -> TryPtr<N> {
+        TryPtr::from_ptr(self.ptr.cast())
     }
 
     #[inline]
     pub fn offset(&self, count: isize) -> Self {
-        // SAFETY: Safe when self.ptr does not point to SVSM memory because
-        // then the write can not harm memory safety.
-        GuestPtr::from_ptr(self.ptr.wrapping_offset(count))
+        TryPtr::from_ptr(self.ptr.wrapping_offset(count))
     }
 }
 
-impl<T> From<NonNull<T>> for GuestPtr<T> {
+impl<T> From<NonNull<T>> for TryPtr<T> {
     fn from(value: NonNull<T>) -> Self {
         Self::from_ptr(value.as_ptr())
     }
 }
 
-impl<T: FromBytes + IntoBytes> InsnMachineMem<T> for GuestPtr<T> {
+impl<T: FromBytes + IntoBytes> InsnMachineMem<T> for TryPtr<T> {
     /// # Safety
     ///
-    /// See the GuestPtr's read() method documentation for safety requirements.
+    /// See the TryPtr's read() method documentation for safety requirements.
     unsafe fn mem_read(&self) -> Result<T, InsnError> {
-        // SAFETY: Safe when GuestPtr::read safety requirements are met.
+        // SAFETY: Safe when TryPtr::read safety requirements are met.
         unsafe { self.read().map_err(|_| InsnError::MemRead) }
     }
 
     /// # Safety
     ///
-    /// See the GuestPtr's write() method documentation for safety requirements.
+    /// See the TryPtr's write() method documentation for safety requirements.
     unsafe fn mem_write(&mut self, data: T) -> Result<(), InsnError> {
-        // SAFETY: Safe when GuestPtr::write safety requirements are met.
+        // SAFETY: Safe when TryPtr::write safety requirements are met.
         unsafe { self.write(data).map_err(|_| InsnError::MemWrite) }
     }
 }
@@ -484,19 +483,19 @@ impl Drop for UserAccessGuard {
 
 #[derive(Debug)]
 pub struct UserPtr<T> {
-    guest_ptr: GuestPtr<T>,
+    ptr: TryPtr<T>,
 }
 
 impl<T> UserPtr<T> {
     #[inline]
     pub fn new(v: VirtAddr) -> Self {
         Self {
-            guest_ptr: GuestPtr::new(v),
+            ptr: TryPtr::new(v),
         }
     }
 
     fn check_bounds(&self) -> bool {
-        let v = VirtAddr::from(self.guest_ptr.ptr);
+        let v = VirtAddr::from(self.ptr.ptr);
 
         (USER_MEM_START..USER_MEM_END).contains(&v)
             && (USER_MEM_START..USER_MEM_END).contains(&(v + size_of::<T>()))
@@ -512,11 +511,11 @@ impl<T> UserPtr<T> {
         }
         let _guard = UserAccessGuard::new();
         // SAFETY: Target pointer is guaranteed to point to user memory.
-        unsafe { self.guest_ptr.read() }
+        unsafe { self.ptr.read() }
     }
 
     /// Attempts to read the `T` behind the pointer, verifying it has a valid
-    /// representation in the process (see [`GuestPtr::try_read`]).
+    /// representation in the process (see [`TryPtr::try_read`]).
     #[inline]
     pub fn try_read(&self) -> Result<T, SvsmError>
     where
@@ -527,7 +526,7 @@ impl<T> UserPtr<T> {
         }
         let _guard = UserAccessGuard::new();
         // SAFETY: Target pointer is guaranteed to point to user memory.
-        unsafe { self.guest_ptr.try_read() }
+        unsafe { self.ptr.try_read() }
     }
 
     #[inline]
@@ -548,20 +547,20 @@ impl<T> UserPtr<T> {
         }
         let _guard = UserAccessGuard::new();
         // SAFETY: Target pointer is guaranteed to point to user memory.
-        unsafe { self.guest_ptr.write_ref(buf) }
+        unsafe { self.ptr.write_ref(buf) }
     }
 
     #[inline]
     pub const fn cast<N>(&self) -> UserPtr<N> {
         UserPtr {
-            guest_ptr: self.guest_ptr.cast(),
+            ptr: self.ptr.cast(),
         }
     }
 
     #[inline]
     pub fn offset(&self, count: isize) -> UserPtr<T> {
         UserPtr {
-            guest_ptr: self.guest_ptr.offset(count),
+            ptr: self.ptr.offset(count),
         }
     }
 }
@@ -844,7 +843,7 @@ mod tests {
     fn test_read_15_bytes_valid_address() {
         let test_buffer = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14];
         let test_addr = VirtAddr::from(test_buffer.as_ptr());
-        let ptr: GuestPtr<[u8; 15]> = GuestPtr::new(test_addr);
+        let ptr: TryPtr<[u8; 15]> = TryPtr::new(test_addr);
         // SAFETY: ptr points to test_buffer's virtual address
         let result = unsafe { ptr.read().unwrap() };
 
@@ -855,7 +854,7 @@ mod tests {
     #[cfg_attr(miri, ignore = "inline assembly")]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn test_read_invalid_address() {
-        let ptr: GuestPtr<u8> = GuestPtr::new(VirtAddr::new(0xDEAD_BEEF));
+        let ptr: TryPtr<u8> = TryPtr::new(VirtAddr::new(0xDEAD_BEEF));
         // SAFETY: ptr points to an invalid virtual address (0xDEADBEEF is
         // unmapped). ptr.read() will return an error but this is expected.
         let err = unsafe { ptr.read() };
@@ -867,7 +866,7 @@ mod tests {
     fn test_read_valid_bit_pattern() {
         // Valid bit pattern for `bool`
         let mut buffer = [1u8];
-        let ptr = GuestPtr::<bool>::from_ptr(buffer.as_mut_ptr().cast());
+        let ptr = TryPtr::<bool>::from_ptr(buffer.as_mut_ptr().cast());
         // SAFETY: the pointer points to a buffer on the stack with a size of 1
         // which is also the size of a bool, so we cannot read, out of bounds.
         let val = unsafe { ptr.try_read() };
@@ -879,7 +878,7 @@ mod tests {
     fn test_read_invalid_bit_pattern() {
         // Invalid bit pattern for `bool`
         let mut buffer = [2u8];
-        let ptr = GuestPtr::<bool>::from_ptr(buffer.as_mut_ptr().cast());
+        let ptr = TryPtr::<bool>::from_ptr(buffer.as_mut_ptr().cast());
         // SAFETY: the pointer points to a buffer on the stack with a size of 1
         // which is also the size of a bool, so we cannot read, out of bounds.
         let val = unsafe { ptr.try_read() };

--- a/kernel/src/mm/guestmem.rs
+++ b/kernel/src/mm/guestmem.rs
@@ -20,7 +20,7 @@ use core::arch::asm;
 use core::borrow::Borrow;
 use core::ffi::c_char;
 use core::mem::{MaybeUninit, size_of};
-use core::ptr::{NonNull, with_exposed_provenance, with_exposed_provenance_mut};
+use core::ptr::{self, NonNull, with_exposed_provenance, with_exposed_provenance_mut};
 use core::slice;
 use syscall::PATH_MAX;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, TryFromBytes};
@@ -317,7 +317,7 @@ unsafe fn do_movsb<T>(src: *const T, dst: *mut T) -> Result<(), SvsmError> {
 
 /// A pointer wrapper that safely handles faults when accessing memory.
 #[derive(Debug)]
-pub struct TryPtr<T> {
+pub struct TryPtr<T: ?Sized> {
     ptr: *mut T,
 }
 
@@ -429,6 +429,170 @@ impl<T> TryPtr<T> {
     }
 }
 
+impl<T> TryPtr<[T]> {
+    /// Creates a `TryPtr<[T]>` pointing to `len` elements starting at `v`.
+    #[inline]
+    pub fn new(v: VirtAddr, len: usize) -> Self {
+        Self {
+            ptr: ptr::slice_from_raw_parts_mut(v.as_mut_ptr::<T>(), len),
+        }
+    }
+
+    /// Returns the number of elements in the slice.
+    #[inline]
+    pub const fn len(&self) -> usize {
+        self.ptr.len()
+    }
+
+    /// Returns `true` if the slice contains no elements.
+    #[inline]
+    pub const fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Reads element at `index`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must verify that the entire slice is appropriate to read,
+    /// as this function does not validate the address range.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SvsmError::InvalidAddress`] if `index >= len`, or
+    /// [`SvsmError::Fault`] if the access faults.
+    pub unsafe fn read(&self, index: usize) -> Result<T, SvsmError>
+    where
+        T: FromBytes,
+    {
+        if index >= self.len() {
+            return Err(SvsmError::InvalidAddress);
+        }
+        // SAFETY: bounds-checked above; remaining requirements from caller.
+        unsafe { TryPtr::from_ptr((self.ptr as *mut T).wrapping_add(index)).read() }
+    }
+
+    /// Writes `val` to element at `index`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must verify that the entire slice is appropriate to write,
+    /// as this function does not validate the address range.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SvsmError::InvalidAddress`] if `index >= len`, or
+    /// [`SvsmError::Fault`] if the access faults.
+    pub unsafe fn write(&self, index: usize, val: T) -> Result<(), SvsmError>
+    where
+        T: IntoBytes,
+    {
+        if index >= self.len() {
+            return Err(SvsmError::InvalidAddress);
+        }
+        // SAFETY: bounds-checked above; remaining requirements from caller.
+        unsafe { TryPtr::from_ptr((self.ptr as *mut T).wrapping_add(index)).write(val) }
+    }
+
+    /// Reads all elements and copies them into `dst`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must verify that the entire backing memory is appropriate
+    /// to read.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SvsmError::Mem`] if `dst.len() != self.len()`, or
+    /// [`SvsmError::Fault`] if the copy faults.
+    pub unsafe fn read_to_slice(&self, dst: &mut [T]) -> Result<(), SvsmError>
+    where
+        T: FromBytes,
+    {
+        if dst.len() != self.len() {
+            return Err(SvsmError::Mem);
+        }
+        // SAFETY: dst is a valid slice; source requirements come from caller.
+        unsafe {
+            copy_bytes(
+                (self.ptr as *const T).cast::<u8>(),
+                dst.as_mut_ptr().cast::<u8>(),
+                self.len() * size_of::<T>(),
+            )
+        }
+    }
+
+    /// Reads all elements and copies them into a newly allocated `Vec`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must verify that the entire backing memory is appropriate
+    /// to read.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SvsmError::Fault`] if the copy faults.
+    pub unsafe fn read_to_vec(&self) -> Result<Vec<T>, SvsmError>
+    where
+        T: FromBytes,
+    {
+        let mut v = Vec::with_capacity(self.len());
+        let dst = v.spare_capacity_mut();
+        // SAFETY: `dst` is guaranteed to point to valid and large enough
+        // memory. If `copy_bytes()` succeeds, `self.len()` elements have
+        // been successfully initialized.
+        unsafe {
+            copy_bytes(
+                self.ptr.cast_const().cast::<u8>(),
+                dst.as_mut_ptr().cast::<u8>(),
+                self.len() * size_of::<T>(),
+            )?;
+            v.set_len(self.len());
+        }
+        Ok(v)
+    }
+
+    /// Writes all elements from `src`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must verify that the entire backing memory is appropriate
+    /// to write.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SvsmError::Mem`] if `src.len() != self.len()`, or
+    /// [`SvsmError::Fault`] if the copy faults.
+    pub unsafe fn write_from_slice(&self, src: &[T]) -> Result<(), SvsmError>
+    where
+        T: IntoBytes,
+    {
+        if src.len() != self.len() {
+            return Err(SvsmError::Mem);
+        }
+        // SAFETY: src is a valid slice; destination requirements come from caller.
+        unsafe {
+            copy_bytes(
+                src.as_ptr().cast::<u8>(),
+                (self.ptr as *mut T).cast::<u8>(),
+                self.len() * size_of::<T>(),
+            )
+        }
+    }
+}
+
+impl TryPtr<[u8]> {
+    /// # Safety
+    ///
+    /// The caller must verify that the entire backing memory is appropriate
+    /// to write.
+    pub unsafe fn zero_fill(&self) -> Result<(), SvsmError> {
+        // SAFETY: bounds limited to `self.len()`, the rest is delegated to
+        // the caller
+        unsafe { clear_bytes(self.ptr.cast::<u8>(), self.len()) }
+    }
+}
+
 impl<T> From<NonNull<T>> for TryPtr<T> {
     fn from(value: NonNull<T>) -> Self {
         Self::from_ptr(value.as_ptr())
@@ -485,7 +649,7 @@ impl<T> UserPtr<T> {
             return Err(SvsmError::InvalidAddress);
         }
         Ok(Self {
-            ptr: TryPtr::new(v),
+            ptr: TryPtr::<T>::new(v),
         })
     }
 
@@ -812,7 +976,7 @@ mod tests {
     fn test_read_15_bytes_valid_address() {
         let test_buffer = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14];
         let test_addr = VirtAddr::from(test_buffer.as_ptr());
-        let ptr: TryPtr<[u8; 15]> = TryPtr::new(test_addr);
+        let ptr = TryPtr::<[u8; 15]>::new(test_addr);
         // SAFETY: ptr points to test_buffer's virtual address
         let result = unsafe { ptr.read().unwrap() };
 
@@ -823,7 +987,7 @@ mod tests {
     #[cfg_attr(miri, ignore = "inline assembly")]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn test_read_invalid_address() {
-        let ptr: TryPtr<u8> = TryPtr::new(VirtAddr::new(0xDEAD_BEEF));
+        let ptr = TryPtr::<u8>::new(VirtAddr::new(0xDEAD_BEEF));
         // SAFETY: ptr points to an invalid virtual address (0xDEADBEEF is
         // unmapped). ptr.read() will return an error but this is expected.
         let err = unsafe { ptr.read() };

--- a/kernel/src/mm/mod.rs
+++ b/kernel/src/mm/mod.rs
@@ -20,7 +20,7 @@ pub mod virtualrange;
 pub mod vm;
 
 pub use address_space::*;
-pub use guestmem::{GuestPtr, copy_from_user, copy_to_user, zero_user_mem};
+pub use guestmem::{TryPtr, copy_from_user, copy_to_user, zero_user_mem};
 pub use memory::{valid_phys_address, valid_phys_region, writable_phys_addr};
 pub use pagebox::*;
 pub use ptguards::*;

--- a/kernel/src/mm/mod.rs
+++ b/kernel/src/mm/mod.rs
@@ -20,7 +20,7 @@ pub mod virtualrange;
 pub mod vm;
 
 pub use address_space::*;
-pub use guestmem::{TryPtr, copy_from_user, copy_to_user, zero_user_mem};
+pub use guestmem::{GuestPtr, TryPtr, copy_from_user, copy_to_user, zero_user_mem};
 pub use memory::{valid_phys_address, valid_phys_region, writable_phys_addr};
 pub use pagebox::*;
 pub use ptguards::*;

--- a/kernel/src/mm/ptguards.rs
+++ b/kernel/src/mm/ptguards.rs
@@ -48,6 +48,10 @@ impl PerCPUPageMappingGuard {
         paddr_end: PhysAddr,
         alignment: usize,
     ) -> Result<Self, SvsmError> {
+        if paddr_start >= paddr_end {
+            return Err(SvsmError::InvalidAddress);
+        }
+
         let align_mask = (PAGE_SIZE << alignment) - 1;
         let size = paddr_end - paddr_start;
         assert_eq!((size & align_mask), 0);
@@ -78,7 +82,10 @@ impl PerCPUPageMappingGuard {
     /// Creates a new [`PerCPUPageMappingGuard`] for a 4KB page at the
     /// specified physical address, or an `SvsmError` if an error occurs.
     pub fn create_4k(paddr: PhysAddr) -> Result<Self, SvsmError> {
-        Self::create(paddr, paddr + PAGE_SIZE, 0)
+        let end = paddr
+            .checked_add(PAGE_SIZE)
+            .ok_or(SvsmError::InvalidAddress)?;
+        Self::create(paddr, end, 0)
     }
 
     /// Returns the virtual address associated with the guard.

--- a/kernel/src/mm/ptguards.rs
+++ b/kernel/src/mm/ptguards.rs
@@ -85,37 +85,6 @@ impl PerCPUPageMappingGuard {
     pub fn virt_addr(&self) -> VirtAddr {
         self.mapping.region().start()
     }
-
-    /// Creates a virtual contigous mapping for the given 4k physical pages which
-    /// may not be contiguous in physical memory.
-    ///
-    /// # Arguments
-    ///
-    /// * `pages`: A slice of tuple containing `PhysAddr` objects representing the
-    ///   4k page to map and its shareability.
-    ///
-    /// # Returns
-    ///
-    /// This function returns a `Result` that contains a `PerCPUPageMappingGuard`
-    /// object on success. The `PerCPUPageMappingGuard` object represents the page
-    /// mapping that was created. If an error occurs while creating the page
-    /// mapping, it returns a `SvsmError`.
-    pub fn create_4k_pages(pages: &[(PhysAddr, bool)]) -> Result<Self, SvsmError> {
-        let mapping = VRangeAlloc::new_4k(pages.len() * PAGE_SIZE, 0)?;
-        let flags = PTEntryFlags::data();
-
-        let pgtable = this_cpu().get_pgtable();
-        for (vaddr, (paddr, shared)) in mapping
-            .region()
-            .iter_pages(PageSize::Regular)
-            .zip(pages.iter().copied())
-        {
-            assert!(paddr.is_page_aligned());
-            pgtable.map_4k(vaddr, paddr, flags, shared)?;
-        }
-
-        Ok(Self { mapping })
-    }
 }
 
 impl Drop for PerCPUPageMappingGuard {

--- a/kernel/src/mm/ptguards.rs
+++ b/kernel/src/mm/ptguards.rs
@@ -11,7 +11,7 @@ use crate::cpu::tlb::flush_tlb_global_percpu_range;
 use crate::error::SvsmError;
 use crate::mm::virtualrange::VRangeAlloc;
 use crate::types::{PAGE_SIZE, PAGE_SIZE_2M, PageSize};
-use crate::utils::align_up;
+use crate::utils::{MemoryRegion, align_up};
 use core::marker::PhantomData;
 use core::mem;
 use core::ops::{Deref, DerefMut};
@@ -22,6 +22,7 @@ use zerocopy::FromBytes;
 #[must_use = "if unused the mapping will immediately be unmapped"]
 pub struct PerCPUPageMappingGuard {
     mapping: VRangeAlloc,
+    phys_base: PhysAddr,
 }
 
 impl PerCPUPageMappingGuard {
@@ -76,7 +77,10 @@ impl PerCPUPageMappingGuard {
             range
         };
 
-        Ok(Self { mapping })
+        Ok(Self {
+            mapping,
+            phys_base: paddr_start,
+        })
     }
 
     /// Creates a new [`PerCPUPageMappingGuard`] for a 4KB page at the
@@ -91,6 +95,16 @@ impl PerCPUPageMappingGuard {
     /// Returns the virtual address associated with the guard.
     pub fn virt_addr(&self) -> VirtAddr {
         self.mapping.region().start()
+    }
+
+    /// Returns the physical base address of the mapped region.
+    pub const fn phys_base(&self) -> PhysAddr {
+        self.phys_base
+    }
+
+    /// Returns the physical address region mapped by this guard
+    pub fn phys_region(&self) -> MemoryRegion<PhysAddr> {
+        MemoryRegion::new(self.phys_base, self.mapping.region().len())
     }
 }
 

--- a/kernel/src/mm/ro_after_init.rs
+++ b/kernel/src/mm/ro_after_init.rs
@@ -62,24 +62,24 @@ mod tests {
     #[cfg(test_in_svsm)]
     fn test_make_ro_after_init() {
         use super::*;
-        use crate::mm::GuestPtr;
+        use crate::mm::TryPtr;
 
         // SAFETY: reading at ro_after_init_start doesn't break memory safety.
         let res_r =
-            unsafe { GuestPtr::<u8>::new(VirtAddr::from(&raw const ro_after_init_start)).read() };
+            unsafe { TryPtr::<u8>::new(VirtAddr::from(&raw const ro_after_init_start)).read() };
         assert!(res_r.is_ok());
 
         make_ro_after_init().expect("failed to make ro_after_init section read-only");
 
         // SAFETY: writing to ro_after_init_start is supposed to fail preventing memory safety break.
         let res_w1 = unsafe {
-            GuestPtr::<u8>::new(VirtAddr::from(&raw const ro_after_init_start)).write(0x41u8)
+            TryPtr::<u8>::new(VirtAddr::from(&raw const ro_after_init_start)).write(0x41u8)
         };
         assert!(res_w1.is_err());
 
         // SAFETY: writing up to ro_after_init_end is supposed to fail preventing memory safety break.
         let res_w2 = unsafe {
-            GuestPtr::<u8>::new(VirtAddr::from(&raw const ro_after_init_end).const_sub(1))
+            TryPtr::<u8>::new(VirtAddr::from(&raw const ro_after_init_end).const_sub(1))
                 .write(0x41u8)
         };
         assert!(res_w2.is_err());

--- a/kernel/src/protocols/core.rs
+++ b/kernel/src/protocols/core.rs
@@ -10,8 +10,8 @@ use crate::cpu::{flush_tlb_global_sync, flush_tlb_global_sync_page};
 use crate::error::SvsmError;
 use crate::locking::RWLock;
 use crate::mm::virtualrange::{VIRT_ALIGN_2M, VIRT_ALIGN_4K};
-use crate::mm::{GuestPtr, valid_phys_region, writable_phys_addr};
 use crate::mm::{PerCPUMapping, PerCPUPageMappingGuard};
+use crate::mm::{TryPtr, valid_phys_region, writable_phys_addr};
 #[cfg(all(feature = "uefivars", not(test)))]
 use crate::protocols::SVSM_UEFI_MM_PROTOCOL;
 use crate::protocols::apic::{APIC_PROTOCOL_VERSION_MAX, APIC_PROTOCOL_VERSION_MIN};
@@ -419,7 +419,7 @@ fn core_pvalidate(params: &RequestParams) -> Result<(), SvsmReqError> {
     let guard = PerCPUPageMappingGuard::create_4k(paddr)?;
     let start = guard.virt_addr();
 
-    let guest_page = GuestPtr::<PValidateRequest>::new(start + offset);
+    let guest_page = TryPtr::<PValidateRequest>::new(start + offset);
     // SAFETY: start is a new mapped page address, thus valid.
     // offset can't exceed a page size, so guest_page belongs to mapped memory.
     let mut request = unsafe { guest_page.read()? };
@@ -493,7 +493,7 @@ fn core_remap_ca(params: &RequestParams) -> Result<(), SvsmReqError> {
     let mapping_guard = PerCPUPageMappingGuard::create_4k(gpa)?;
     let vaddr = mapping_guard.virt_addr();
 
-    let pending = GuestPtr::<SvsmCaa>::new(vaddr);
+    let pending = TryPtr::<SvsmCaa>::new(vaddr);
     // SAFETY: pending points to a new allocated page
     unsafe { pending.write(SvsmCaa::zeroed())? };
 

--- a/kernel/src/protocols/core.rs
+++ b/kernel/src/protocols/core.rs
@@ -471,7 +471,7 @@ fn core_pvalidate(params: &RequestParams) -> Result<(), SvsmReqError> {
     // (untrusted), so it needs to be valid (ie. belongs to the guest and only
     // the guest). The physical address is validated by valid_phys_region()
     // called at the beginning of SVSM_CORE_PVALIDATE handler (this one).
-    if let Err(e) = unsafe { guest_page.write_ref(&request) } {
+    if let Err(e) = unsafe { guest_page.write(request) } {
         loop_result = Err(e.into());
     }
 

--- a/kernel/src/protocols/core.rs
+++ b/kernel/src/protocols/core.rs
@@ -11,7 +11,7 @@ use crate::error::SvsmError;
 use crate::locking::RWLock;
 use crate::mm::virtualrange::{VIRT_ALIGN_2M, VIRT_ALIGN_4K};
 use crate::mm::{PerCPUMapping, PerCPUPageMappingGuard};
-use crate::mm::{TryPtr, valid_phys_region, writable_phys_addr};
+use crate::mm::{valid_phys_region, writable_phys_addr};
 #[cfg(all(feature = "uefivars", not(test)))]
 use crate::protocols::SVSM_UEFI_MM_PROTOCOL;
 use crate::protocols::apic::{APIC_PROTOCOL_VERSION_MAX, APIC_PROTOCOL_VERSION_MIN};
@@ -404,9 +404,8 @@ fn core_pvalidate_one(entry: u64) -> Result<(), SvsmReqError> {
 
 fn core_pvalidate(params: &RequestParams) -> Result<(), SvsmReqError> {
     let gpa = PhysAddr::from(params.rcx);
-    let header_region = MemoryRegion::checked_new(gpa, 8).ok_or(SvsmReqError::invalid_address())?;
 
-    if !gpa.is_aligned(8) || !valid_phys_region(&header_region) {
+    if !gpa.is_aligned(8) {
         return Err(SvsmReqError::invalid_parameter());
     }
 
@@ -417,12 +416,9 @@ fn core_pvalidate(params: &RequestParams) -> Result<(), SvsmReqError> {
     let _lock = PVALIDATE_LOCK.lock_read();
 
     let guard = PerCPUPageMappingGuard::create_4k(paddr)?;
-    let start = guard.virt_addr();
 
-    let guest_page = TryPtr::<PValidateRequest>::new(start + offset);
-    // SAFETY: start is a new mapped page address, thus valid.
-    // offset can't exceed a page size, so guest_page belongs to mapped memory.
-    let mut request = unsafe { guest_page.read()? };
+    let request_ptr = guard.guest_ptr::<PValidateRequest>(offset)?;
+    let mut request = request_ptr.read()?;
 
     let entries = request.entries;
     let next = request.next;
@@ -436,22 +432,13 @@ fn core_pvalidate(params: &RequestParams) -> Result<(), SvsmReqError> {
         return Err(SvsmReqError::invalid_parameter());
     }
 
-    let entries_len = ((entries + 1) * 8) as usize;
-    let region =
-        MemoryRegion::checked_new(gpa, entries_len).ok_or(SvsmReqError::invalid_address())?;
-    if !valid_phys_region(&region) {
-        return Err(SvsmReqError::invalid_parameter());
-    }
+    let entries_offset = offset + size_of::<PValidateRequest>();
+    let entries_ptr = guard.guest_slice::<u64>(entries_offset, entries as usize)?;
 
     let mut loop_result = Ok(());
 
-    let guest_entries = guest_page.offset(1).cast::<u64>();
     for i in next..entries {
-        let index = i as isize;
-        // SAFETY: guest_entries comes from guest_page which is a new mapped
-        // page. index is between [next, entries) and both values have been
-        // validated.
-        let entry = match unsafe { guest_entries.offset(index).read() } {
+        let entry = match entries_ptr.read(i as usize) {
             Ok(v) => v,
             Err(e) => {
                 loop_result = Err(e.into());
@@ -467,11 +454,7 @@ fn core_pvalidate(params: &RequestParams) -> Result<(), SvsmReqError> {
         }
     }
 
-    // SAFETY: guest_page is obtained from a guest-provided physical address
-    // (untrusted), so it needs to be valid (ie. belongs to the guest and only
-    // the guest). The physical address is validated by valid_phys_region()
-    // called at the beginning of SVSM_CORE_PVALIDATE handler (this one).
-    if let Err(e) = unsafe { guest_page.write(request) } {
+    if let Err(e) = request_ptr.write(request) {
         loop_result = Err(e.into());
     }
 
@@ -480,9 +463,8 @@ fn core_pvalidate(params: &RequestParams) -> Result<(), SvsmReqError> {
 
 fn core_remap_ca(params: &RequestParams) -> Result<(), SvsmReqError> {
     let gpa = PhysAddr::from(params.rcx);
-    let region = MemoryRegion::checked_new(gpa, PAGE_SIZE).ok_or(SvsmReqError::invalid_address())?;
 
-    if !gpa.is_page_aligned() || !valid_phys_region(&region) {
+    if !gpa.is_page_aligned() {
         return Err(SvsmReqError::invalid_parameter());
     }
 
@@ -490,12 +472,9 @@ fn core_remap_ca(params: &RequestParams) -> Result<(), SvsmReqError> {
     let _lock = PVALIDATE_LOCK.lock_write();
 
     // Temporarily map new CAA to clear it
-    let mapping_guard = PerCPUPageMappingGuard::create_4k(gpa)?;
-    let vaddr = mapping_guard.virt_addr();
-
-    let pending = TryPtr::<SvsmCaa>::new(vaddr);
-    // SAFETY: pending points to a new allocated page
-    unsafe { pending.write(SvsmCaa::zeroed())? };
+    PerCPUPageMappingGuard::create_4k(gpa)?
+        .guest_ptr::<SvsmCaa>(0)?
+        .write(SvsmCaa::zeroed())?;
 
     // Clear any pending interrupt state before remapping the calling area to
     // ensure that any pending lazy EOI has been processed.

--- a/kernel/src/syscall/class0.rs
+++ b/kernel/src/syscall/class0.rs
@@ -25,8 +25,8 @@ pub fn sys_exit(exit_code: u32) -> ! {
 }
 
 pub fn sys_exec(file: usize, root: usize, _flags: usize) -> Result<u64, SysCallError> {
-    let user_file_ptr = UserPtr::<c_char>::new(VirtAddr::from(file));
-    let user_root_ptr = UserPtr::<c_char>::new(VirtAddr::from(root));
+    let user_file_ptr = UserPtr::<c_char>::new(VirtAddr::from(file))?;
+    let user_root_ptr = UserPtr::<c_char>::new(VirtAddr::from(root))?;
 
     let file_str = user_file_ptr.read_c_string()?;
     let root_str = user_root_ptr.read_c_string()?;

--- a/kernel/src/syscall/class1.rs
+++ b/kernel/src/syscall/class1.rs
@@ -123,7 +123,7 @@ pub fn sys_opendir(path: usize) -> Result<u64, SysCallError> {
 pub fn sys_readdir(obj_id: u32, dirents: usize, size: usize) -> Result<u64, SysCallError> {
     let fsobj = obj_get(obj_id.into())?;
     let fsobj = fsobj.as_fs().ok_or(ENOTSUPP)?;
-    let user_dirents_ptr = UserPtr::<DirEnt>::new(VirtAddr::from(dirents))?;
+    let user_dirents = UserPtr::<[DirEnt]>::new(VirtAddr::from(dirents), size)?;
 
     for i in 0..size {
         let Some((name, dirent)) = fsobj.readdir()? else {
@@ -153,8 +153,7 @@ pub fn sys_readdir(obj_id: u32, dirents: usize, size: usize) -> Result<u64, SysC
             new_entry.file_size = 0;
         }
 
-        let user_dirents_ptr = user_dirents_ptr.offset(i.try_into().unwrap())?;
-        user_dirents_ptr.write(new_entry)?
+        user_dirents.write(i, new_entry)?;
     }
     Ok(size as u64)
 }

--- a/kernel/src/syscall/class1.rs
+++ b/kernel/src/syscall/class1.rs
@@ -23,7 +23,7 @@ use syscall::SysCallError::*;
 use syscall::*;
 
 pub fn sys_open(path: usize, mode: usize, flags: usize) -> Result<u64, SysCallError> {
-    let user_path_ptr = UserPtr::<c_char>::new(VirtAddr::from(path));
+    let user_path_ptr = UserPtr::<c_char>::new(VirtAddr::from(path))?;
     let user_path = user_path_ptr.read_c_string()?;
     let file_mode = FileModes::from_bits(mode).ok_or(SysCallError::EINVAL)?;
     let file_flags = FileFlags::from_bits(flags).ok_or(SysCallError::EINVAL)?;
@@ -103,7 +103,7 @@ pub fn sys_truncate(obj_id: u32, length: usize) -> Result<u64, SysCallError> {
 }
 
 pub fn sys_unlink(path: usize) -> Result<u64, SysCallError> {
-    let user_path_ptr = UserPtr::<c_char>::new(VirtAddr::from(path));
+    let user_path_ptr = UserPtr::<c_char>::new(VirtAddr::from(path))?;
     let user_path = user_path_ptr.read_c_string()?;
 
     unlink_root(current_task().rootdir(), &user_path).map_err(SysCallError::from)?;
@@ -112,7 +112,7 @@ pub fn sys_unlink(path: usize) -> Result<u64, SysCallError> {
 }
 
 pub fn sys_opendir(path: usize) -> Result<u64, SysCallError> {
-    let user_path_ptr = UserPtr::<c_char>::new(VirtAddr::from(path));
+    let user_path_ptr = UserPtr::<c_char>::new(VirtAddr::from(path))?;
     let user_path = user_path_ptr.read_c_string()?;
     let dir = find_dir(current_task().rootdir(), &user_path)?;
     let id = obj_add(Arc::new(FsObj::new_dir(&dir)))?;
@@ -123,7 +123,7 @@ pub fn sys_opendir(path: usize) -> Result<u64, SysCallError> {
 pub fn sys_readdir(obj_id: u32, dirents: usize, size: usize) -> Result<u64, SysCallError> {
     let fsobj = obj_get(obj_id.into())?;
     let fsobj = fsobj.as_fs().ok_or(ENOTSUPP)?;
-    let user_dirents_ptr = UserPtr::<DirEnt>::new(VirtAddr::from(dirents));
+    let user_dirents_ptr = UserPtr::<DirEnt>::new(VirtAddr::from(dirents))?;
 
     for i in 0..size {
         let Some((name, dirent)) = fsobj.readdir()? else {
@@ -153,14 +153,14 @@ pub fn sys_readdir(obj_id: u32, dirents: usize, size: usize) -> Result<u64, SysC
             new_entry.file_size = 0;
         }
 
-        let user_dirents_ptr = user_dirents_ptr.offset(i.try_into().unwrap());
+        let user_dirents_ptr = user_dirents_ptr.offset(i.try_into().unwrap())?;
         user_dirents_ptr.write(new_entry)?
     }
     Ok(size as u64)
 }
 
 pub fn sys_mkdir(path: usize) -> Result<u64, SysCallError> {
-    let user_path_ptr = UserPtr::<c_char>::new(VirtAddr::from(path));
+    let user_path_ptr = UserPtr::<c_char>::new(VirtAddr::from(path))?;
     let user_path = user_path_ptr.read_c_string()?;
 
     mkdir_root(current_task().rootdir(), &user_path).map_err(SysCallError::from)?;
@@ -169,7 +169,7 @@ pub fn sys_mkdir(path: usize) -> Result<u64, SysCallError> {
 }
 
 pub fn sys_rmdir(path: usize) -> Result<u64, SysCallError> {
-    let user_path_ptr = UserPtr::<c_char>::new(VirtAddr::from(path));
+    let user_path_ptr = UserPtr::<c_char>::new(VirtAddr::from(path))?;
     let user_path = user_path_ptr.read_c_string()?;
 
     rmdir_root(current_task().rootdir(), &user_path).map_err(SysCallError::from)?;

--- a/kernel/src/vmm/execloop.rs
+++ b/kernel/src/vmm/execloop.rs
@@ -7,7 +7,7 @@
 use super::GuestExitMessage;
 use crate::cpu::percpu::{GuestVmsaRef, this_cpu};
 use crate::cpu::{IrqGuard, flush_tlb_global_sync};
-use crate::mm::GuestPtr;
+use crate::mm::TryPtr;
 use crate::protocols::errors::SvsmReqError;
 use crate::protocols::{RequestOutput, RequestParams};
 use crate::requests::SvsmCaa;
@@ -20,7 +20,7 @@ use cpuarch::vmsa::GuestVMExit;
 
 fn get_and_clear_caa_request_flag(vmsa_ref: &GuestVmsaRef) -> Result<bool, SvsmReqError> {
     if let Some(caa) = vmsa_ref.caa() {
-        let calling_area = GuestPtr::<SvsmCaa>::from(caa);
+        let calling_area = TryPtr::<SvsmCaa>::from(caa);
         // SAFETY: guest vmsa and ca are always validated before beeing updated
         // (core_remap_ca(), core_create_vcpu() or prepare_fw_launch()) so
         // they're safe to use.


### PR DESCRIPTION
Rework the `GuestPtr` and `UserPtr` interfaces.

The SVSM kernel accesses three distinct categories of memory that require different safety properties: its own kernel address space, lower-VMPL guest physical memory, and SVSM userspace. The existing `GuestPtr<T>` type conflates all of these under a single (misleading) name and does not enforce the different invariants each category requires.

Rework the code as follows:
* Rename `GuestPtr` to `TryPtr`, a low level primitive with fault handling and unsafe methods.
* `UserPtr`: a `TryPtr` wrapper for userspace access, with address space bounds checks, SMAP handling and safe methods.
* The new `GuestPtr`: a `TryPtr` wrapper for lower-VMPL memory access, with address space bounds checks, an explicit lifetime bound to a `PerCPUPageMappingGuard` and safe methods.
* Add slice support for `TryPtr`, `UserPtr` and `GuestPtr`.
* Migrate existing users to the new APIs.

I believe this PR addresses everything noted in #659