### PR TITLE
CONTRIBUTING.md Updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,8 @@ This repository integrates formal verification using **Verus**.
 
 ## General coding guidelines
 
+* Follow the rules in [CONTRIBUTING.md](Documentation/docs/developer/CONTRIBUTING.md)
+  and linked files.
 * Wrap accesses to guest memory with `GuestPtr`. This type makes sure that an
   access fault is handled and returned as a regular error.
 * Be exceedingly careful when accessing guest and host-shared memory. In

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing
+
+See [Documentation/docs/developer/CONTRIBUTING.md](Documentation/docs/developer/CONTRIBUTING.md).

--- a/Documentation/docs/developer/CONTRIBUTING.md
+++ b/Documentation/docs/developer/CONTRIBUTING.md
@@ -42,10 +42,9 @@ and self-contained commits.
 
 ## Coding Style
 
-Submitted changes must be checked with `cargo fmt --check` before submitting
-and submitted code must not introduce new warnings in the build process. With
-`cargo fmt` (without `--check`) cargo will automatically update the formatting
-of the changes to match the requirements.
+Changes must be checked with `cargo fmt --check` before submitting. With `cargo
+fmt` (without `--check`) cargo will automatically update the formatting of the
+changes to match the requirements.
 
 Make sure to format the code according to Rust edition 2024. There is a
 git-hook in the scripts directory which checks any changes with `rustfmt`
@@ -56,6 +55,11 @@ before allowing them to be committed. It can be installed by running
 ```
 
 from the projects root directory.
+
+New code must not introduce warnings in the build process. An exception are
+warnings which are caused by differences between the Rust stable and nightly
+toolchains. In these cases the changes must make sure to not issue warnings
+when built with stable Rust only while they are acceptable with nightly Rust.
 
 For detailed instructions on documentation guidelines please have a look at
 [RUSTDOC-GUIDELINES.md](RUSTDOC-GUIDELINES.md).

--- a/Documentation/docs/developer/CONTRIBUTING.md
+++ b/Documentation/docs/developer/CONTRIBUTING.md
@@ -30,6 +30,16 @@ to the `Author` field of the patch. By adding `Signed-off-by`
 the submitter attests that the contribution fulfills the requirements of
 the [Developer Certificate of Origin](https://developercertificate.org/).
 
+## Commit Bisectability
+
+When a submission has multiple commits, then after each commit the code-base
+must compile, boot and pass all tests, including `cargo fmt --check` and `make
+clippy`. This is important to maintain bisectability of the changes so that
+developers and maintainers can later find where an issue was introduced.
+
+In general it is good practice to structure a submission as a series of small
+and self-contained commits.
+
 ## Coding Style
 
 Submitted changes must be checked with `cargo fmt --check` before submitting

--- a/Documentation/docs/developer/CONTRIBUTING.md
+++ b/Documentation/docs/developer/CONTRIBUTING.md
@@ -1,5 +1,4 @@
-CONTRIBUTING
-============
+# CONTRIBUTING
 
 Submissions to the project are accepted via pull-requests on
 GitHub against this repository: [https://github.com/coconut-svsm/svsm](https://github.com/coconut-svsm/svsm)
@@ -7,40 +6,39 @@ GitHub against this repository: [https://github.com/coconut-svsm/svsm](https://g
 Patches may also be sent to the development mailing list
 (coconut-svsm@lists.linux.dev) for review.
 
-Patch Format
-------------
+## Commit Format
 
-Each patch must start with a subject line that contains the component
-the patch changes and a short description of the change, separated by a
-colon.
-For example:
+Each commit description must start with a subject line that contains the
+component changed and a one-line description of the change, separated by a
+colon. For example:
 
 ```
 SVSM/locking: Annotate spin-loops with core::hint::spin_loop()
 ```
 
-A detailed description is also required for every patch. The description
+A detailed description is also required for every commit. The description
 should state what the change is about and optionally why the change was
 necessary.
 
-At the end of the patch, it needs to be signed off with a
-```Signed-off-by``` tag as created by ```git commit -s```. If a patch
+At the end of the commit, it needs to be signed off with a
+`Signed-off-by` tag as created by `git commit -s`. If a commit
 was written by more than one person, then additional developers can be
-added via a ```Co-developed-by``` tag.
+added via a `Co-developed-by` tag.
 
-The user and email stated in the  ```Signed-off-by``` tag must be equal
-to the ```Author``` field of the patch. By adding ```Signed-off-by```
+The user and email stated in the  `Signed-off-by` tag must be equal
+to the `Author` field of the patch. By adding `Signed-off-by`
 the submitter attests that the contribution fulfills the requirements of
 the [Developer Certificate of Origin](https://developercertificate.org/).
 
-Coding Style
-------------
+## Coding Style
 
-Submitted changes must be checked with ```rustfmt``` before submitting
-and submitted code must not introduce new warnings in the build process.
+Submitted changes must be checked with `cargo fmt --check` before submitting
+and submitted code must not introduce new warnings in the build process. With
+`cargo fmt` (without `--check`) cargo will automatically update the formatting
+of the changes to match the requirements.
 
 Make sure to format the code according to Rust edition 2024. There is a
-git-hook in the scripts directory which checks any changes with rustfmt
+git-hook in the scripts directory which checks any changes with `rustfmt`
 before allowing them to be committed. It can be installed by running
 
 ```
@@ -52,33 +50,45 @@ from the projects root directory.
 For detailed instructions on documentation guidelines please have a look at
 [RUSTDOC-GUIDELINES.md](RUSTDOC-GUIDELINES.md).
 
-Linting
--------
+## Linting
 
-In addition to ```rustfmt```, it is recommended to run ```clippy``` before
-submitting changes to catch common mistakes and improve code quality.
-The Makefile provides a ```clippy``` target that runs it with the
-appropriate target and options for each crate:
+In addition to `rustfmt`, it is required to run `clippy` before submitting
+changes to catch common mistakes and improve code quality.  The Makefile
+provides a `clippy` target that runs it with the appropriate target and
+options for each crate:
 
 ```
 make clippy
 ```
 
-To check all feature combinations using ```cargo-hack```:
+To check all feature combinations using `cargo-hack`:
 
 ```
 make clippy CARGO_HACK=1
 ```
 
-This requires ```cargo-hack``` to be installed:
+This requires `cargo-hack` to be installed:
 
 ```
 cargo install cargo-hack
 ```
 
-Fuzzing
--------
+## Fuzzing
 
 The SVSM project includes a number of fuzzing targets to test parts of the
 code-base. For details on how to run the fuzzers and extend the fuzzing
 functionality, please have a look at [FUZZING.md](FUZZING.md).
+
+For the impatient a script is provided to run all available fuzzers in the background for a configurable amount of time:
+
+```
+./scripts/run-fuzzers.sh
+```
+
+This will run all fuzzers for the default of 10 minutes. The runtime can be
+configured with the `-r` option, which takes a number of seconds to run each
+fuzzing target. To run all fuzzers for an hour, do:
+
+```
+./scripts/run-fuzzers.sh -r 3600
+```


### PR DESCRIPTION
Update `CONTRIBUTING.md` to match current requirements:

- Update formatting and wording
- Add bisectability section
- Update warnings policy
- Create `CONTRIBUTING.md` in the repository root which links to the real one