### PR TITLE
kernel/persistence: update usable inode start to 16

### DIFF
--- a/kernel/src/persistence.rs
+++ b/kernel/src/persistence.rs
@@ -1077,7 +1077,7 @@ pub fn persistence_read_inode_sync(inode: u64) -> Result<Option<Zeroizing<Vec<u8
 
 /// Persistence inode numbers allocated statically for specific SVSM uses.
 ///
-/// Usable inode numbers start at `6`.
+/// Usable inode numbers start at `16`.
 #[derive(Debug)]
 #[repr(u64)]
 pub enum SvsmPersistenceStaticInode {


### PR DESCRIPTION
CocoonFS reserves inodes 0 through 15 for internal filesystem use (SpecialInode::ReservedLast = 15 in cocoon-tpm-storage src/fs/cocoonfs/inode_index.rs). The Demo inode was already correctly allocated at 16; update the comment to match.