### PR TITLE
kernel: test: do not force-exclude vtpm and uefivars

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -59,7 +59,7 @@ pub mod virtio;
 pub mod vmm;
 #[cfg(feature = "vsock")]
 pub mod vsock;
-#[cfg(all(feature = "vtpm", not(test)))]
+#[cfg(feature = "vtpm")]
 pub mod vtpm;
 
 #[test]

--- a/kernel/src/protocols/attest.rs
+++ b/kernel/src/protocols/attest.rs
@@ -17,11 +17,11 @@ use crate::greq::{
     services::get_regular_report,
 };
 use crate::mm::guestmem::{copy_slice_to_guest, read_bytes_from_guest, read_from_guest};
-#[cfg(all(feature = "uefivars", not(test)))]
+#[cfg(feature = "uefivars")]
 use crate::protocols::uefivars::uefi_mm_get_manifest;
 use crate::protocols::{RequestParams, errors::SvsmReqError};
 use crate::utils::MemoryRegion;
-#[cfg(all(feature = "vtpm", not(test)))]
+#[cfg(feature = "vtpm")]
 use crate::vtpm::vtpm_get_manifest;
 
 use crate::sev::ghcb::GhcbError;
@@ -38,9 +38,9 @@ const GUID_HEADER_ENTRY_SIZE: usize = 24;
 const SVSM_ATTEST_SERVICES: u32 = 0;
 const SVSM_ATTEST_SINGLE_SERVICE: u32 = 1;
 
-#[cfg(all(feature = "vtpm", not(test)))]
+#[cfg(feature = "vtpm")]
 const SVSM_ATTEST_VTPM_GUID: Uuid = uuid!("c476f1eb-0123-45a5-9641-b4e7dde5bfe3");
-#[cfg(all(feature = "uefivars", not(test)))]
+#[cfg(feature = "uefivars")]
 const SVSM_ATTEST_UEFI_MM_GUID: Uuid = uuid!("a4453a59-9e1b-4787-a033-1986d6adbe55");
 
 // According to
@@ -214,8 +214,7 @@ impl GuidTable {
         }
     }
 
-    // Only used when features are enabled.
-    #[allow(dead_code)]
+    #[cfg(any(feature = "vtpm", feature = "uefivars"))]
     fn push(&mut self, guid: uuid::Uuid, data: Vec<u8>) {
         self.entries.push(GuidTableEntry { guid, data })
     }
@@ -473,7 +472,7 @@ fn get_attestation_report(
     )
 }
 
-#[allow(dead_code)]
+#[cfg(any(feature = "vtpm", feature = "uefivars"))]
 fn attest_single_service(
     manifest: &[u8],
     params: &mut RequestParams,
@@ -489,7 +488,7 @@ fn attest_single_service(
     get_attestation_report(hash.as_slice(), manifest, params, &ops.op)
 }
 
-#[cfg(all(feature = "vtpm", not(test)))]
+#[cfg(feature = "vtpm")]
 fn attest_single_vtpm(
     params: &mut RequestParams,
     ops: &AttestSingleServiceOp,
@@ -508,10 +507,10 @@ fn attest_multiple_services(params: &mut RequestParams) -> Result<(), SvsmReqErr
     #[allow(unused_mut)]
     let mut services = GuidTable::new();
 
-    #[cfg(all(feature = "vtpm", not(test)))]
+    #[cfg(feature = "vtpm")]
     services.push(SVSM_ATTEST_VTPM_GUID, vtpm_get_manifest()?);
 
-    #[cfg(all(feature = "uefivars", not(test)))]
+    #[cfg(feature = "uefivars")]
     services.push(SVSM_ATTEST_UEFI_MM_GUID, uefi_mm_get_manifest()?);
 
     let manifest = services.to_vec()?;
@@ -536,9 +535,9 @@ fn attest_single_service_handler(params: &mut RequestParams) -> Result<(), SvsmR
     // Extract the GUID from the Attest Single Service Operation structure.
     // The GUID is used to determine the specific service to be attested.
     match attest_op.get_guid() {
-        #[cfg(all(feature = "vtpm", not(test)))]
+        #[cfg(feature = "vtpm")]
         SVSM_ATTEST_VTPM_GUID => attest_single_vtpm(params, &attest_op),
-        #[cfg(all(feature = "uefivars", not(test)))]
+        #[cfg(feature = "uefivars")]
         SVSM_ATTEST_UEFI_MM_GUID => {
             attest_single_service(uefi_mm_get_manifest()?.as_slice(), params, &attest_op)
         }

--- a/kernel/src/protocols/core.rs
+++ b/kernel/src/protocols/core.rs
@@ -12,17 +12,17 @@ use crate::locking::RWLock;
 use crate::mm::virtualrange::{VIRT_ALIGN_2M, VIRT_ALIGN_4K};
 use crate::mm::{PerCPUMapping, PerCPUPageMappingGuard};
 use crate::mm::{valid_phys_region, writable_phys_addr};
-#[cfg(all(feature = "uefivars", not(test)))]
+#[cfg(feature = "uefivars")]
 use crate::protocols::SVSM_UEFI_MM_PROTOCOL;
 use crate::protocols::apic::{APIC_PROTOCOL_VERSION_MAX, APIC_PROTOCOL_VERSION_MIN};
 use crate::protocols::attest::{ATTEST_PROTOCOL_VERSION_MAX, ATTEST_PROTOCOL_VERSION_MIN};
 use crate::protocols::errors::SvsmReqError;
-#[cfg(all(feature = "uefivars", not(test)))]
+#[cfg(feature = "uefivars")]
 use crate::protocols::uefivars::{UEFI_MM_PROTOCOL_VERSION_MAX, UEFI_MM_PROTOCOL_VERSION_MIN};
 use crate::protocols::{
     RequestParams, SVSM_APIC_PROTOCOL, SVSM_ATTEST_PROTOCOL, SVSM_CORE_PROTOCOL,
 };
-#[cfg(all(feature = "vtpm", not(test)))]
+#[cfg(feature = "vtpm")]
 use crate::protocols::{
     SVSM_VTPM_PROTOCOL,
     vtpm::{VTPM_PROTOCOL_VERSION_MAX, VTPM_PROTOCOL_VERSION_MIN},
@@ -265,13 +265,13 @@ fn core_query_protocol(params: &mut RequestParams) -> Result<(), SvsmReqError> {
             ATTEST_PROTOCOL_VERSION_MIN,
             ATTEST_PROTOCOL_VERSION_MAX,
         ),
-        #[cfg(all(feature = "vtpm", not(test)))]
+        #[cfg(feature = "vtpm")]
         SVSM_VTPM_PROTOCOL => protocol_supported(
             version,
             VTPM_PROTOCOL_VERSION_MIN,
             VTPM_PROTOCOL_VERSION_MAX,
         ),
-        #[cfg(all(feature = "uefivars", not(test)))]
+        #[cfg(feature = "uefivars")]
         SVSM_UEFI_MM_PROTOCOL => protocol_supported(
             version,
             UEFI_MM_PROTOCOL_VERSION_MIN,

--- a/kernel/src/protocols/mod.rs
+++ b/kernel/src/protocols/mod.rs
@@ -8,9 +8,9 @@ pub mod apic;
 pub mod attest;
 pub mod core;
 pub mod errors;
-#[cfg(all(feature = "uefivars", not(test)))]
+#[cfg(feature = "uefivars")]
 pub mod uefivars;
-#[cfg(all(feature = "vtpm", not(test)))]
+#[cfg(feature = "vtpm")]
 pub mod vtpm;
 
 use cpuarch::vmsa::VMSA;

--- a/kernel/src/protocols/uefivars.rs
+++ b/kernel/src/protocols/uefivars.rs
@@ -103,7 +103,7 @@ pub fn uefi_mm_protocol_init() -> Result<(), SvsmReqError> {
     let mut store = STORE.lock();
     store.reset();
 
-    #[cfg(all(feature = "secureboot", not(test)))]
+    #[cfg(feature = "secureboot")]
     {
         // hard coded configuration for now.
         store.enroll_pk_mgmt();

--- a/kernel/src/requests.rs
+++ b/kernel/src/requests.rs
@@ -15,9 +15,9 @@ use crate::protocols::attest::attest_protocol_request;
 use crate::protocols::{
     RequestOutput, RequestParams, SVSM_APIC_PROTOCOL, SVSM_ATTEST_PROTOCOL, SVSM_CORE_PROTOCOL,
 };
-#[cfg(all(feature = "uefivars", not(test)))]
+#[cfg(feature = "uefivars")]
 use crate::protocols::{SVSM_UEFI_MM_PROTOCOL, uefivars::uefi_mm_protocol_request};
-#[cfg(all(feature = "vtpm", not(test)))]
+#[cfg(feature = "vtpm")]
 use crate::protocols::{SVSM_VTPM_PROTOCOL, vtpm::vtpm_protocol_request};
 
 use zerocopy::{FromBytes, IntoBytes};
@@ -79,10 +79,10 @@ fn request_loop_once(
     match protocol {
         SVSM_CORE_PROTOCOL => core_protocol_request(request, params),
         SVSM_ATTEST_PROTOCOL => attest_protocol_request(request, params),
-        #[cfg(all(feature = "vtpm", not(test)))]
+        #[cfg(feature = "vtpm")]
         SVSM_VTPM_PROTOCOL => vtpm_protocol_request(request, params),
         SVSM_APIC_PROTOCOL => apic_protocol_request(request, params),
-        #[cfg(all(feature = "uefivars", not(test)))]
+        #[cfg(feature = "uefivars")]
         SVSM_UEFI_MM_PROTOCOL => uefi_mm_protocol_request(request, params),
         _ => Err(SvsmReqError::unsupported_protocol()),
     }

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -61,7 +61,7 @@ use svsm::platform::SvsmPlatform;
 use svsm::platform::SvsmPlatformCell;
 use svsm::platform::init_capabilities;
 use svsm::platform::init_platform_type;
-#[cfg(all(feature = "uefivars", not(test)))]
+#[cfg(feature = "uefivars")]
 use svsm::protocols::uefivars::uefi_mm_protocol_init;
 use svsm::sev::secrets_page_mut;
 use svsm::svsm_paging::enumerate_early_boot_regions;
@@ -73,7 +73,7 @@ use svsm::utils::ScopedMut;
 use svsm::utils::round_to_pages;
 #[cfg(all(feature = "virtio-drivers", any(feature = "block", feature = "vsock")))]
 use svsm::virtio::probe_mmio_slots;
-#[cfg(all(feature = "vtpm", not(test)))]
+#[cfg(feature = "vtpm")]
 use svsm::vtpm::vtpm_init;
 
 use release::COCONUT_VERSION;
@@ -572,10 +572,10 @@ fn svsm_init(launch_info: &KernelLaunchInfo) {
         }
     }
 
-    #[cfg(all(feature = "vtpm", not(test)))]
+    #[cfg(feature = "vtpm")]
     vtpm_init().expect("vTPM failed to initialize");
 
-    #[cfg(all(feature = "uefivars", not(test)))]
+    #[cfg(feature = "uefivars")]
     uefi_mm_protocol_init().expect("uefi mm protocol failed to initialize");
 
     virt_log_usage();


### PR DESCRIPTION
Do not force-exclude building the vtpm and uefivars code for testing, as there is no particular reason to do so. In the past, vtpm code caused issues when building userspace tests, but this was fixed with 7c3b3c656063 ("libtcgtpm: do not link libcrt for userspace targets").

Remove the special handling for these modules, and use only the existing features to gate building the code, ensuring that the functionality is not broken in the future for test builds.

The user can always disable building these modules via e.g. `FEATURES_TEST` in the Makefile.