### PR TITLE
tools: simplify target cfg in Cargo.toml files

### DIFF
--- a/tools/aproxy/Cargo.toml
+++ b/tools/aproxy/Cargo.toml
@@ -3,7 +3,9 @@ name = "aproxy"
 version = "0.1.0"
 edition.workspace = true
 
-[target.'cfg(all(target_os = "linux"))'.dependencies]
+# specify dependencies' target to avoid feature unification with SVSM
+# see https://doc.rust-lang.org/cargo/reference/features.html#feature-unification
+[target.'cfg(target_os = "linux")'.dependencies]
 reqwest = { version = "0.12.9", default-features = false, features = [
     "blocking",
     "cookies",

--- a/tools/igvmbuilder/Cargo.toml
+++ b/tools/igvmbuilder/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 
 # specify dependencies' target to avoid feature unification with SVSM
 # see https://doc.rust-lang.org/cargo/reference/features.html#feature-unification
-[target.'cfg(all(target_os = "linux"))'.dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
 bootdefs.workspace = true
 bootimg.workspace = true
 clap = { workspace = true, default-features = true, features = ["derive"] }

--- a/tools/igvmmeasure/Cargo.toml
+++ b/tools/igvmmeasure/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 
 # specify dependencies' target to avoid feature unification with SVSM
 # see https://doc.rust-lang.org/cargo/reference/features.html#feature-unification
-[target.'cfg(all(target_os = "linux"))'.dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
 clap = { workspace = true, default-features = true, features = ["derive"] }
 sha2 = { workspace = true, default-features = true }
 igvm.workspace = true


### PR DESCRIPTION
Replace `cfg(all(target_os = "linux"))` with `cfg(target_os = "linux")` in the Cargo.toml files for aproxy, igvmbuilder, and igvmmeasure. The `all()` combinator with a single predicate is redundant.

Also add the missing comment explaining why target-specific dependencies are used to aproxy/Cargo.toml, like in igvmbuilder and igvmmeasure.