### PR TITLE
kernel: mm/vm: consolidate VMR mapping guards

### DIFF
--- a/kernel/src/cpu/percpu.rs
+++ b/kernel/src/cpu/percpu.rs
@@ -1190,7 +1190,7 @@ impl PerCpu {
     /// the mapping which remains valid until the ['VRMapping'] is dropped.
     ///
     /// On error, an ['SvsmError'].
-    pub fn new_mapping(&self, mapping: Mapping) -> Result<VMRMapping<'_>, SvsmError> {
+    pub fn new_mapping(&self, mapping: Mapping) -> Result<VMRMapping<&VMR>, SvsmError> {
         VMRMapping::new(&self.vm_range, mapping)
     }
 

--- a/kernel/src/mm/mappings.rs
+++ b/kernel/src/mm/mappings.rs
@@ -7,41 +7,11 @@
 use crate::address::VirtAddr;
 use crate::error::SvsmError;
 use crate::fs::FileHandle;
-use crate::mm::vm::{Mapping, VMFileMapping, VMFileMappingFlags, VMR, VMalloc};
+use crate::mm::vm::{Mapping, VMFileMapping, VMFileMappingFlags, VMalloc};
 use crate::task::current_task;
-
-use core::ops::Deref;
 
 extern crate alloc;
 use alloc::sync::Arc;
-
-#[derive(Debug)]
-pub struct VMMappingGuard<'a> {
-    vmr: &'a VMR,
-    start: VirtAddr,
-}
-
-impl<'a> VMMappingGuard<'a> {
-    pub fn new(vmr: &'a VMR, start: VirtAddr) -> Self {
-        VMMappingGuard { vmr, start }
-    }
-}
-
-impl Deref for VMMappingGuard<'_> {
-    type Target = VirtAddr;
-
-    fn deref(&self) -> &VirtAddr {
-        &self.start
-    }
-}
-
-impl Drop for VMMappingGuard<'_> {
-    fn drop(&mut self) {
-        self.vmr
-            .remove(self.start)
-            .expect("Fatal error: Failed to unmap region from MappingGuard");
-    }
-}
 
 pub fn create_file_mapping(
     file: &FileHandle,

--- a/kernel/src/mm/mod.rs
+++ b/kernel/src/mm/mod.rs
@@ -33,4 +33,4 @@ pub use global_memory::{
     GlobalRangeGuard, map_global_range, map_global_range_2m_private, map_global_range_2m_shared,
     map_global_range_4k_private, map_global_range_4k_shared,
 };
-pub use mappings::{VMMappingGuard, mmap_kernel, mmap_user, munmap_kernel, munmap_user};
+pub use mappings::{mmap_kernel, mmap_user, munmap_kernel, munmap_user};

--- a/kernel/src/mm/vm/range.rs
+++ b/kernel/src/mm/vm/range.rs
@@ -15,6 +15,8 @@ use crate::utils::{MemoryRegion, align_down, align_up};
 
 use core::borrow::Borrow;
 use core::cmp::max;
+use core::mem::ManuallyDrop;
+use core::ops::Deref;
 
 use intrusive_collections::Bound;
 use intrusive_collections::rbtree::{CursorMut, RBTree};
@@ -532,8 +534,31 @@ impl<V: Borrow<VMR>> VMRMapping<V> {
         Ok(Self { vmr, va })
     }
 
+    pub fn new_at(vmr: V, addr: VirtAddr, mapping: Mapping) -> Result<Self, SvsmError> {
+        let va = vmr.borrow().insert_at(addr, mapping)?;
+        Ok(Self { vmr, va })
+    }
+
+    pub fn new_hint(vmr: V, addr: VirtAddr, mapping: Mapping) -> Result<Self, SvsmError> {
+        let va = vmr.borrow().insert_hint(addr, mapping)?;
+        Ok(Self { vmr, va })
+    }
+
+    pub fn leak(self) -> VirtAddr {
+        let md = ManuallyDrop::new(self);
+        md.va
+    }
+
     pub fn virt_addr(&self) -> VirtAddr {
         self.va
+    }
+}
+
+impl<V: Borrow<VMR>> Deref for VMRMapping<V> {
+    type Target = VirtAddr;
+
+    fn deref(&self) -> &VirtAddr {
+        &self.va
     }
 }
 

--- a/kernel/src/mm/vm/range.rs
+++ b/kernel/src/mm/vm/range.rs
@@ -13,6 +13,7 @@ use crate::mm::virt_from_idx;
 use crate::types::{PAGE_SHIFT, PAGE_SIZE, PageSize};
 use crate::utils::{MemoryRegion, align_down, align_up};
 
+use core::borrow::Borrow;
 use core::cmp::max;
 
 use intrusive_collections::Bound;
@@ -517,15 +518,17 @@ impl VMR {
     }
 }
 
+/// A mapping in a [`VMR`], holding a reference `V` to that `VMR`.
+/// The mapping is torn down on drop.
 #[derive(Debug)]
-pub struct VMRMapping<'a> {
-    vmr: &'a VMR,
+pub struct VMRMapping<V: Borrow<VMR>> {
+    vmr: V,
     va: VirtAddr,
 }
 
-impl<'a> VMRMapping<'a> {
-    pub fn new(vmr: &'a VMR, mapping: Mapping) -> Result<Self, SvsmError> {
-        let va = vmr.insert(mapping)?;
+impl<V: Borrow<VMR>> VMRMapping<V> {
+    pub fn new(vmr: V, mapping: Mapping) -> Result<Self, SvsmError> {
+        let va = vmr.borrow().insert(mapping)?;
         Ok(Self { vmr, va })
     }
 
@@ -534,9 +537,10 @@ impl<'a> VMRMapping<'a> {
     }
 }
 
-impl Drop for VMRMapping<'_> {
+impl<V: Borrow<VMR>> Drop for VMRMapping<V> {
     fn drop(&mut self) {
         self.vmr
+            .borrow()
             .remove(self.va)
             .expect("Error removing VRMapping virtual memory range");
     }

--- a/kernel/src/task/task_mm.rs
+++ b/kernel/src/task/task_mm.rs
@@ -6,13 +6,15 @@
 // Author: Joerg Roedel <joerg.roedel@amd.com>
 
 extern crate alloc;
+use core::borrow::Borrow;
+
 use alloc::sync::Arc;
 
 use crate::address::VirtAddr;
 use crate::error::SvsmError;
 use crate::locking::SpinLock;
 use crate::mm::pagetable::PTEntryFlags;
-use crate::mm::vm::{Mapping, VMR, VMReserved};
+use crate::mm::vm::{VMR, VMReserved};
 use crate::mm::{SIZE_LEVEL3, SVSM_PERTASK_BASE, SVSM_PERTASK_END, alloc::AllocError};
 use crate::utils::MemoryRegion;
 use crate::utils::bitmap_allocator::{BitmapAllocator, BitmapAllocator1024};
@@ -50,6 +52,7 @@ impl Drop for TaskVirtualRegionGuard {
     }
 }
 
+#[derive(Debug)]
 pub struct TaskMM {
     /// Virtual address region that has been allocated for this task.
     /// This is not referenced but must be stored so that it is dropped when
@@ -129,46 +132,8 @@ impl TaskMM {
     }
 }
 
-/// Guard a per-task kernel mapping and unmap it when going out of scope.
-pub struct TaskKernelMapping {
-    /// Pointer the struct `[TaskMM]` which contains the mapping.
-    mm: Arc<TaskMM>,
-    /// Virtual address of the mapping.
-    va: VirtAddr,
-}
-
-impl TaskKernelMapping {
-    /// Insert a given `[Mapping]` into the kernel address part of the task and
-    /// return a new `[TaskKernelMapping]`.
-    ///
-    /// # Arguments
-    ///
-    /// * `mm` - Pointer to struct `[TaskMM]` to map into.
-    /// * `mapping` - Pointer to `[Mapping]` to put into the kernel-part of the `TaskMM`.
-    ///
-    /// # Returns
-    ///
-    /// `Some(TaskKernelMapping)` on success, `Err(SvsmError)` on failure.
-    pub fn new(mm: Arc<TaskMM>, mapping: Mapping) -> Result<Self, SvsmError> {
-        let va = mm.kernel_range().insert(mapping)?;
-        Ok(Self { mm, va })
-    }
-
-    /// Get the virtual address the guarded mapping starts at.
-    ///
-    /// # Returns
-    ///
-    /// Virtual start address of contained mapping.
-    pub fn virt_addr(&self) -> VirtAddr {
-        self.va
-    }
-}
-
-impl Drop for TaskKernelMapping {
-    fn drop(&mut self) {
-        self.mm
-            .kernel_range()
-            .remove(self.va)
-            .expect("Error removing TaskKernelMapping");
+impl Borrow<VMR> for Arc<TaskMM> {
+    fn borrow(&self) -> &VMR {
+        self.kernel_range()
     }
 }

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -38,7 +38,7 @@ use crate::locking::RWLock;
 use crate::locking::SpinLock;
 use crate::locking::SpinLockIrqSafe;
 use crate::mm::pagetable::{PTEntryFlags, PageTable};
-use crate::mm::vm::{Mapping, VMFileMappingFlags, VMKernelStack, VMR};
+use crate::mm::vm::{Mapping, VMFileMappingFlags, VMKernelStack, VMR, VMRMapping};
 use crate::mm::{
     PageBox, SVSM_PERTASK_BASE, SVSM_PERTASK_END, USER_MEM_END, USER_MEM_START, VMMappingGuard,
     mappings::create_anon_mapping, mappings::create_file_mapping,
@@ -51,7 +51,7 @@ use intrusive_collections::{LinkedList, LinkedListAtomicLink, intrusive_adapter}
 use super::exec::exec;
 use super::schedule::complete_task_switch;
 use super::schedule::terminate;
-use super::task_mm::{TaskKernelMapping, TaskMM};
+use super::task_mm::TaskMM;
 use super::{UserExecInfo, WaitQueue};
 
 pub const INITIAL_TASK_ID: u32 = 1;
@@ -354,10 +354,10 @@ pub struct Task {
     pub page_table: SpinLock<PageBox<PageTable>>,
 
     /// Task kernel stack mapping
-    _kernel_stack: TaskKernelMapping,
+    _kernel_stack: VMRMapping<Arc<TaskMM>>,
 
     /// Task shadow stack mapping
-    _shadow_stack: Option<TaskKernelMapping>,
+    _shadow_stack: Option<VMRMapping<Arc<TaskMM>>>,
 
     /// Task memory management state
     mm: Arc<TaskMM>,
@@ -500,7 +500,7 @@ impl Task {
             let base_token_addr;
 
             // Map shadow stack into virtual address range
-            let mapping = TaskKernelMapping::new(task_mm.clone(), Arc::new(shadow_stack))?;
+            let mapping = VMRMapping::new(task_mm.clone(), Arc::new(shadow_stack))?;
             let stack_base = mapping.virt_addr();
 
             // Initialize shadow stack
@@ -534,7 +534,7 @@ impl Task {
                 info.start_parameter,
             )?,
         };
-        let kernel_stack_mapping = TaskKernelMapping::new(task_mm.clone(), stack)?;
+        let kernel_stack_mapping = VMRMapping::new(task_mm.clone(), stack)?;
         let stack_start = kernel_stack_mapping.virt_addr();
 
         task_mm.kernel_range().populate(&mut pgtable);

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -40,7 +40,7 @@ use crate::locking::SpinLockIrqSafe;
 use crate::mm::pagetable::{PTEntryFlags, PageTable};
 use crate::mm::vm::{Mapping, VMFileMappingFlags, VMKernelStack, VMR, VMRMapping};
 use crate::mm::{
-    PageBox, SVSM_PERTASK_BASE, SVSM_PERTASK_END, USER_MEM_END, USER_MEM_START, VMMappingGuard,
+    PageBox, SVSM_PERTASK_BASE, SVSM_PERTASK_END, USER_MEM_END, USER_MEM_START,
     mappings::create_anon_mapping, mappings::create_file_mapping,
 };
 use crate::syscall::{Obj, ObjError, ObjHandle};
@@ -868,14 +868,14 @@ impl Task {
         Some(guard)
     }
 
-    pub fn mmap_common(
-        vmr: &VMR,
+    pub fn mmap_common<'a>(
+        vmr: &'a VMR,
         addr: VirtAddr,
         file: Option<&FileHandle>,
         offset: usize,
         size: usize,
         flags: VMFileMappingFlags,
-    ) -> Result<VirtAddr, SvsmError> {
+    ) -> Result<VMRMapping<&'a VMR>, SvsmError> {
         let mapping = if let Some(f) = file {
             create_file_mapping(f, offset, size, flags)?
         } else {
@@ -883,9 +883,9 @@ impl Task {
         };
 
         if flags.contains(VMFileMappingFlags::Fixed) {
-            Ok(vmr.insert_at(addr, mapping)?)
+            VMRMapping::new_at(vmr, addr, mapping)
         } else {
-            Ok(vmr.insert_hint(addr, mapping)?)
+            VMRMapping::new_hint(vmr, addr, mapping)
         }
     }
 
@@ -897,7 +897,8 @@ impl Task {
         size: usize,
         flags: VMFileMappingFlags,
     ) -> Result<VirtAddr, SvsmError> {
-        Self::mmap_common(self.mm.kernel_range(), addr, file, offset, size, flags)
+        let guard = Self::mmap_common(self.mm.kernel_range(), addr, file, offset, size, flags)?;
+        Ok(guard.leak())
     }
 
     pub fn mmap_kernel_guard<'a>(
@@ -907,9 +908,8 @@ impl Task {
         offset: usize,
         size: usize,
         flags: VMFileMappingFlags,
-    ) -> Result<VMMappingGuard<'a>, SvsmError> {
-        let vaddr = Self::mmap_common(self.mm.kernel_range(), addr, file, offset, size, flags)?;
-        Ok(VMMappingGuard::new(self.mm.kernel_range(), vaddr))
+    ) -> Result<VMRMapping<&'a VMR>, SvsmError> {
+        Self::mmap_common(self.mm.kernel_range(), addr, file, offset, size, flags)
     }
 
     pub fn mmap_user(
@@ -921,7 +921,8 @@ impl Task {
         flags: VMFileMappingFlags,
     ) -> Result<VirtAddr, SvsmError> {
         let vmr = self.mm.user_range().ok_or(SvsmError::Mem)?;
-        Self::mmap_common(vmr, addr, file, offset, size, flags)
+        let guard = Self::mmap_common(vmr, addr, file, offset, size, flags)?;
+        Ok(guard.leak())
     }
 
     pub fn munmap_kernel(&self, addr: VirtAddr) -> Result<(), SvsmError> {


### PR DESCRIPTION
There are 3 distinct types implementing the functionality of holding a mapping in a `VMR` and tearing it down on drop:
* `VMRMapping`: holds a `&VMR`, and inserts the mapping on construction.
* `TaskKernelMapping`: holds an `Arc<TaskMM>`, and inserts the mapping into the `TaskMM`'s kernel-mode `VMR` on construction.
* `VMMappingGuard`: holds a `&VMR`, and the caller must insert the mapping before constructing the type.

Merge all these three into a single type. Keep `VMRMapping`, as it has the most logical construction/destruction flow (insert mapping on construction, unmap on drop), and make it generic enough so that it can hold any type which allows access into a `VMR`.