### PR TITLE
kernel/svsm: log CPU vendor after buffer logger initialization

### DIFF
--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -340,7 +340,6 @@ unsafe fn svsm_start(
     platform
         .env_setup(debug_serial_port, launch_info.vtom.try_into().unwrap())
         .expect("Early environment setup failed");
-    log::info!("CPU vendor {:?}", platform.get_cpu_vendor());
 
     // Load symbol info now that there is a console
     // SAFETY: the launch info here is the launch info passed by the boot
@@ -415,6 +414,7 @@ unsafe fn svsm_start(
     // has been already created and console is
     // initialized in env_setup_late() before this
     install_buffer_logger();
+    log::info!("CPU vendor: {:?}", platform.get_cpu_vendor());
     dump_cpuid_table();
 
     let mem_info = memory_info();


### PR DESCRIPTION
The CPU vendor log was being called before install_buffer_logger() was executed, causing the message to be lost. Move the log statement to after the logger is installed so CPU vendor information appears in test output.